### PR TITLE
fix(ec2): stop SG-rule/volume data loss, apply filters+pagination, persist modify/assign ops

### DIFF
--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -179,6 +179,26 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
             "InvalidAMIID.NotFound",
             "InvalidAMIID.Malformed",
             "InvalidAMIID.Unavailable",
+            // Resource-not-found / wrong-state codes the hardened handlers now
+            // return for the probes' synthetic (non-existent / in-use / invalid)
+            // ids, each verbatim from the EC2 "Error codes" reference. AWS uses
+            // the `.NotFound` suffix per resource family; a handler returning one
+            // of these to a bogus id ran correctly.
+            "InvalidGroup.NotFound",
+            "InvalidVolume.NotFound",
+            "VolumeInUse",
+            "InvalidSnapshot.NotFound",
+            "InvalidNetworkInterfaceID.NotFound",
+            "InvalidKeyPair.Duplicate",
+            "InvalidAddress.NotFound",
+            "InvalidAllocationID.NotFound",
+            "InvalidFleetId.NotFound",
+            "InvalidSpotFleetRequestId.NotFound",
+            "InvalidCapacityReservationId.NotFound",
+            "InvalidCapacityReservationFleetId.NotFound",
+            "InvalidTransitGatewayAttachmentID.NotFound",
+            "InvalidVpcEndpointId.NotFound",
+            "InvalidID",
         ],
         // EKS under-declares two client errors that the real API returns for
         // sub-resource operations:

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -17,9 +17,11 @@ async fn ec2_create_tags() {
     let server = TestServer::start().await;
     let client = server.ec2_client().await;
 
+    // CreateTags rejects a phantom resource id, so tag a real VPC.
+    let vpc = make_vpc(&client).await;
     client
         .create_tags()
-        .resources("vpc-0123456789abcdef0")
+        .resources(vpc)
         .tags(
             aws_sdk_ec2::types::Tag::builder()
                 .key("Name")
@@ -45,9 +47,10 @@ async fn ec2_delete_tags() {
     let server = TestServer::start().await;
     let client = server.ec2_client().await;
 
+    let vpc = make_vpc(&client).await;
     client
         .create_tags()
-        .resources("i-0123456789abcdef0")
+        .resources(&vpc)
         .tags(
             aws_sdk_ec2::types::Tag::builder()
                 .key("env")
@@ -61,7 +64,7 @@ async fn ec2_delete_tags() {
     // Key-only delete removes the tag regardless of value.
     client
         .delete_tags()
-        .resources("i-0123456789abcdef0")
+        .resources(&vpc)
         .tags(aws_sdk_ec2::types::Tag::builder().key("env").build())
         .send()
         .await
@@ -77,9 +80,10 @@ async fn ec2_describe_tags() {
     let server = TestServer::start().await;
     let client = server.ec2_client().await;
 
+    let subnet = make_subnet(&client).await;
     client
         .create_tags()
-        .resources("subnet-0123456789abcdef0")
+        .resources(&subnet)
         .tags(
             aws_sdk_ec2::types::Tag::builder()
                 .key("tier")
@@ -97,7 +101,7 @@ async fn ec2_describe_tags() {
         .filters(
             aws_sdk_ec2::types::Filter::builder()
                 .name("resource-id")
-                .values("subnet-0123456789abcdef0")
+                .values(&subnet)
                 .build(),
         )
         .send()
@@ -2061,6 +2065,34 @@ async fn ec2_get_groups_for_capacity_reservation() {
 
 // ---- Network interfaces ----
 
+async fn make_vpc(c: &aws_sdk_ec2::Client) -> String {
+    c.create_vpc()
+        .cidr_block("10.0.0.0/16")
+        .send()
+        .await
+        .unwrap()
+        .vpc()
+        .unwrap()
+        .vpc_id()
+        .unwrap()
+        .to_string()
+}
+
+async fn make_subnet(c: &aws_sdk_ec2::Client) -> String {
+    let vpc = make_vpc(c).await;
+    c.create_subnet()
+        .vpc_id(vpc)
+        .cidr_block("10.0.1.0/24")
+        .send()
+        .await
+        .unwrap()
+        .subnet()
+        .unwrap()
+        .subnet_id()
+        .unwrap()
+        .to_string()
+}
+
 async fn make_eni(c: &aws_sdk_ec2::Client) -> String {
     c.create_network_interface()
         .subnet_id("subnet-1")
@@ -2358,14 +2390,15 @@ async fn ec2_delete_eni_permission() {
 async fn ec2_assign_private_ips() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let eni = make_eni(&c).await;
     let r = c
         .assign_private_ip_addresses()
-        .network_interface_id("eni-1")
+        .network_interface_id(&eni)
         .private_ip_addresses("10.0.0.31")
         .send()
         .await
         .unwrap();
-    assert_eq!(r.network_interface_id(), Some("eni-1"));
+    assert_eq!(r.network_interface_id(), Some(eni.as_str()));
 }
 
 #[test_action("ec2", "UnassignPrivateIpAddresses", checksum = "65c70924")]
@@ -2373,8 +2406,15 @@ async fn ec2_assign_private_ips() {
 async fn ec2_unassign_private_ips() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let eni = make_eni(&c).await;
+    c.assign_private_ip_addresses()
+        .network_interface_id(&eni)
+        .private_ip_addresses("10.0.0.31")
+        .send()
+        .await
+        .unwrap();
     c.unassign_private_ip_addresses()
-        .network_interface_id("eni-1")
+        .network_interface_id(&eni)
         .private_ip_addresses("10.0.0.31")
         .send()
         .await
@@ -3029,6 +3069,13 @@ async fn ec2_describe_volumes_modifications() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
     let id = make_vol(&c).await;
+    // A modification record only exists after an actual ModifyVolume.
+    c.modify_volume()
+        .volume_id(&id)
+        .size(16)
+        .send()
+        .await
+        .unwrap();
     let r = c
         .describe_volumes_modifications()
         .volume_ids(&id)

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -2061,6 +2061,19 @@ async fn ec2_get_groups_for_capacity_reservation() {
 
 // ---- Network interfaces ----
 
+async fn make_eni(c: &aws_sdk_ec2::Client) -> String {
+    c.create_network_interface()
+        .subnet_id("subnet-1")
+        .send()
+        .await
+        .unwrap()
+        .network_interface()
+        .unwrap()
+        .network_interface_id()
+        .unwrap()
+        .to_string()
+}
+
 #[test_action("ec2", "CreateNetworkInterface", checksum = "fb8b07c5")]
 #[tokio::test]
 async fn ec2_create_network_interface() {
@@ -2373,14 +2386,15 @@ async fn ec2_unassign_private_ips() {
 async fn ec2_assign_ipv6() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let eni = make_eni(&c).await;
     let r = c
         .assign_ipv6_addresses()
-        .network_interface_id("eni-1")
+        .network_interface_id(&eni)
         .ipv6_addresses("2600:1f00::5")
         .send()
         .await
         .unwrap();
-    assert_eq!(r.network_interface_id(), Some("eni-1"));
+    assert_eq!(r.network_interface_id(), Some(eni.as_str()));
 }
 
 #[test_action("ec2", "UnassignIpv6Addresses", checksum = "0c460cb5")]
@@ -2388,14 +2402,21 @@ async fn ec2_assign_ipv6() {
 async fn ec2_unassign_ipv6() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
-    let r = c
-        .unassign_ipv6_addresses()
-        .network_interface_id("eni-1")
+    let eni = make_eni(&c).await;
+    c.assign_ipv6_addresses()
+        .network_interface_id(&eni)
         .ipv6_addresses("2600:1f00::5")
         .send()
         .await
         .unwrap();
-    assert_eq!(r.network_interface_id(), Some("eni-1"));
+    let r = c
+        .unassign_ipv6_addresses()
+        .network_interface_id(&eni)
+        .ipv6_addresses("2600:1f00::5")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.network_interface_id(), Some(eni.as_str()));
 }
 
 // ---- Instances ----
@@ -3165,8 +3186,10 @@ async fn ec2_reset_ebs_default_kms_key_id() {
 // ---- EBS snapshots ----
 
 async fn make_snap(c: &aws_sdk_ec2::Client) -> String {
+    // AWS rejects a snapshot of a phantom volume, so seed a real one first.
+    let vol = make_vol(c).await;
     c.create_snapshot()
-        .volume_id("vol-0123456789abcdef0")
+        .volume_id(vol)
         .send()
         .await
         .unwrap()
@@ -3180,9 +3203,10 @@ async fn make_snap(c: &aws_sdk_ec2::Client) -> String {
 async fn ec2_create_snapshot() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let vol = make_vol(&c).await;
     let r = c
         .create_snapshot()
-        .volume_id("vol-1")
+        .volume_id(vol)
         .description("snap")
         .send()
         .await
@@ -3195,11 +3219,22 @@ async fn ec2_create_snapshot() {
 async fn ec2_create_snapshots() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    // CreateSnapshots snapshots every volume attached to a real instance, so
+    // seed an instance with an attached volume first.
+    let instance = run_one(&c).await;
+    let vol = make_vol(&c).await;
+    c.attach_volume()
+        .volume_id(&vol)
+        .instance_id(&instance)
+        .device("/dev/sdf")
+        .send()
+        .await
+        .unwrap();
     let r = c
         .create_snapshots()
         .instance_specification(
             aws_sdk_ec2::types::InstanceSpecification::builder()
-                .instance_id("i-1")
+                .instance_id(instance)
                 .build(),
         )
         .send()
@@ -5224,9 +5259,18 @@ async fn ec2_cancel_capacity_reservation_fleets() {
 async fn ec2_modify_capacity_reservation_fleet() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let id = c
+        .create_capacity_reservation_fleet()
+        .total_target_capacity(1)
+        .send()
+        .await
+        .unwrap()
+        .capacity_reservation_fleet_id()
+        .unwrap()
+        .to_string();
     let r = c
         .modify_capacity_reservation_fleet()
-        .capacity_reservation_fleet_id("crf-1")
+        .capacity_reservation_fleet_id(id)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-ec2/src/lib.rs
+++ b/crates/fakecloud-ec2/src/lib.rs
@@ -17,3 +17,43 @@ pub mod state;
 pub use runtime::Ec2Runtime;
 pub use service::Ec2Service;
 pub use state::{Ec2Snapshot, Ec2State, SharedEc2State, EC2_SNAPSHOT_SCHEMA_VERSION};
+
+/// Shared test helpers for the in-crate handler unit tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+    /// Extract the error from a handler result (AwsResponse is not `Debug`, so
+    /// `unwrap_err` cannot be used directly).
+    pub(crate) fn err_of(r: Result<AwsResponse, AwsServiceError>) -> AwsServiceError {
+        match r {
+            Ok(_) => panic!("expected an error, got Ok"),
+            Err(e) => e,
+        }
+    }
+
+    /// Build a minimal query-protocol [`AwsRequest`] for handler unit tests.
+    pub(crate) fn ec2_request(action: &str, query: &[(&str, &str)]) -> AwsRequest {
+        AwsRequest {
+            service: "ec2".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+}

--- a/crates/fakecloud-ec2/src/service/capacity.rs
+++ b/crates/fakecloud-ec2/src/service/capacity.rs
@@ -56,6 +56,15 @@ fn cr_xml(r: &CapacityReservation, tags: &[Tag], owner: &str) -> String {
     )
 }
 
+/// `InvalidCapacityReservationId.NotFound` — the reservation does not exist.
+fn cr_not_found(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "InvalidCapacityReservationId.NotFound",
+        format!("The capacity reservation ID '{id}' does not exist"),
+    )
+}
+
 fn region_of(r: &CapacityReservation) -> String {
     r.availability_zone
         .trim_end_matches(|c: char| c.is_alphabetic())
@@ -159,13 +168,12 @@ pub(crate) fn cancel_capacity_reservation(
     )?;
     {
         let mut accounts = svc.state.write();
-        if let Some(r) = accounts
+        let r = accounts
             .get_or_create(&req.account_id)
             .capacity_reservations
             .get_mut(&id)
-        {
-            r.state = "cancelled".to_string();
-        }
+            .ok_or_else(|| cr_not_found(&id))?;
+        r.state = "cancelled".to_string();
     }
     Ok(Ec2Service::respond(
         "CancelCapacityReservation",
@@ -211,19 +219,18 @@ pub(crate) fn modify_capacity_reservation(
     )?;
     {
         let mut accounts = svc.state.write();
-        if let Some(r) = accounts
+        let r = accounts
             .get_or_create(&req.account_id)
             .capacity_reservations
             .get_mut(&id)
+            .ok_or_else(|| cr_not_found(&id))?;
+        if let Some(c) = req
+            .query_params
+            .get("InstanceCount")
+            .and_then(|v| v.parse().ok())
         {
-            if let Some(c) = req
-                .query_params
-                .get("InstanceCount")
-                .and_then(|v| v.parse().ok())
-            {
-                r.total_instance_count = c;
-                r.available_instance_count = c;
-            }
+            r.total_instance_count = c;
+            r.available_instance_count = c;
         }
     }
     Ok(Ec2Service::respond(
@@ -285,10 +292,12 @@ pub(crate) fn create_capacity_reservation_fleet(
         .unwrap_or_else(|| "1".to_string());
     {
         let mut accounts = svc.state.write();
+        // The map value stores the fleet's TotalTargetCapacity so Describe /
+        // Modify can round-trip it rather than reporting a hardcoded 1.
         accounts
             .get_or_create(&req.account_id)
             .capacity_reservation_fleets
-            .insert(id.clone(), id.clone());
+            .insert(id.clone(), cap.clone());
     }
     let body = format!(
         "{}{}<totalTargetCapacity>{}</totalTargetCapacity><totalFulfilledCapacity>{}</totalFulfilledCapacity>{}{}{}{}",
@@ -318,13 +327,14 @@ pub(crate) fn describe_capacity_reservation_fleets(
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
     let mut items: Vec<String> = state
         .capacity_reservation_fleets
-        .keys()
-        .filter(|id| wanted.is_empty() || wanted.contains(id))
-        .map(|id| {
+        .iter()
+        .filter(|(id, _)| wanted.is_empty() || wanted.contains(id))
+        .map(|(id, cap)| {
             format!(
-                "{}{}<totalTargetCapacity>1</totalTargetCapacity>",
+                "{}{}<totalTargetCapacity>{}</totalTargetCapacity>",
                 ec2_elem("capacityReservationFleetId", id),
-                ec2_elem("state", "active")
+                ec2_elem("state", "active"),
+                cap,
             )
         })
         .collect();
@@ -365,10 +375,27 @@ pub(crate) fn cancel_capacity_reservation_fleets(
 }
 
 pub(crate) fn modify_capacity_reservation_fleet(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "CapacityReservationFleetId")?;
+    let id = require(&req.query_params, "CapacityReservationFleetId")?;
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let cap = state
+            .capacity_reservation_fleets
+            .get_mut(&id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    http::StatusCode::BAD_REQUEST,
+                    "InvalidCapacityReservationFleetId.NotFound",
+                    format!("The capacity reservation fleet ID '{id}' does not exist"),
+                )
+            })?;
+        if let Some(tc) = req.query_params.get("TotalTargetCapacity") {
+            *cap = tc.clone();
+        }
+    }
     Ok(Ec2Service::respond(
         "ModifyCapacityReservationFleet",
         &req.request_id,
@@ -706,4 +733,87 @@ pub(crate) fn update_interruptible_capacity_reservation_allocation(
         &req.request_id,
         &body,
     ))
+}
+
+#[cfg(test)]
+mod crfleet_tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn cr_fleet_total_target_capacity_round_trips() {
+        let svc = Ec2Service::new();
+        let resp = create_capacity_reservation_fleet(
+            &svc,
+            &req(
+                "CreateCapacityReservationFleet",
+                &[
+                    ("TotalTargetCapacity", "10"),
+                    ("Tenancy", "default"),
+                    ("InstanceMatchCriteria", "open"),
+                ],
+            ),
+        )
+        .unwrap();
+        let created = body(resp);
+        let id = created
+            .split("<capacityReservationFleetId>")
+            .nth(1)
+            .unwrap()
+            .split("</capacityReservationFleetId>")
+            .next()
+            .unwrap()
+            .to_string();
+        let desc = body(
+            describe_capacity_reservation_fleets(
+                &svc,
+                &req("DescribeCapacityReservationFleets", &[]),
+            )
+            .unwrap(),
+        );
+        assert!(
+            desc.contains("<totalTargetCapacity>10</totalTargetCapacity>"),
+            "{desc}"
+        );
+
+        modify_capacity_reservation_fleet(
+            &svc,
+            &req(
+                "ModifyCapacityReservationFleet",
+                &[
+                    ("CapacityReservationFleetId", &id),
+                    ("TotalTargetCapacity", "20"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc2 = body(
+            describe_capacity_reservation_fleets(
+                &svc,
+                &req("DescribeCapacityReservationFleets", &[]),
+            )
+            .unwrap(),
+        );
+        assert!(
+            desc2.contains("<totalTargetCapacity>20</totalTargetCapacity>"),
+            "{desc2}"
+        );
+    }
+
+    #[test]
+    fn modify_cr_fleet_missing_errors() {
+        let svc = Ec2Service::new();
+        let err = err_of(modify_capacity_reservation_fleet(
+            &svc,
+            &req(
+                "ModifyCapacityReservationFleet",
+                &[("CapacityReservationFleetId", "crf-nope")],
+            ),
+        ));
+        assert_eq!(err.code(), "InvalidCapacityReservationFleetId.NotFound");
+    }
 }

--- a/crates/fakecloud-ec2/src/service/dhcp.rs
+++ b/crates/fakecloud-ec2/src/service/dhcp.rs
@@ -5,7 +5,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_max_results,
+    Filter,
 };
 use crate::state::{DhcpConfig, DhcpOptions, Ec2State, Tag};
 
@@ -150,11 +151,13 @@ fn dhcp_matches(opts: &DhcpOptions, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 

--- a/crates/fakecloud-ec2/src/service/eip.rs
+++ b/crates/fakecloud-ec2/src/service/eip.rs
@@ -5,7 +5,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, not_found, parse_filters, require, validate_enum,
+    validate_max_results, Filter,
 };
 use crate::state::{Ec2State, ElasticIp, KeyPair, PlacementGroup, Tag};
 
@@ -99,7 +100,9 @@ pub(crate) fn release_address(
     let mut accounts = svc.state.write();
     let state = accounts.get_or_create(&req.account_id);
     if let Some(id) = req.query_params.get("AllocationId") {
-        state.elastic_ips.remove(id);
+        if state.elastic_ips.remove(id).is_none() {
+            return Err(not_found("InvalidAllocationID.NotFound", id));
+        }
         state.tags.remove(id);
     } else if let Some(ip) = req.query_params.get("PublicIp") {
         let ids: Vec<String> = state
@@ -108,6 +111,13 @@ pub(crate) fn release_address(
             .filter(|e| &e.public_ip == ip)
             .map(|e| e.allocation_id.clone())
             .collect();
+        if ids.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidAddress.NotFound",
+                format!("Address '{ip}' not found."),
+            ));
+        }
         for id in ids {
             state.elastic_ips.remove(&id);
         }
@@ -159,11 +169,13 @@ fn addr_match(e: &ElasticIp, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 
@@ -387,6 +399,15 @@ pub(crate) fn describe_moving_addresses(
 
 // ---- Key pairs ----
 
+/// `InvalidKeyPair.Duplicate` — a key pair with this name already exists.
+fn duplicate_key_pair(name: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "InvalidKeyPair.Duplicate",
+        format!("The keypair '{name}' already exists."),
+    )
+}
+
 const FAKE_KEY_MATERIAL: &str =
     "-----BEGIN RSA PRIVATE KEY-----\nMIIfakefakefakefakefake\n-----END RSA PRIVATE KEY-----";
 
@@ -412,6 +433,9 @@ pub(crate) fn create_key_pair(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        if state.key_pairs.contains_key(&key_name) {
+            return Err(duplicate_key_pair(&key_name));
+        }
         crate::service::tags::apply_tag_specifications(
             state,
             &req.query_params,
@@ -441,6 +465,9 @@ pub(crate) fn import_key_pair(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        if state.key_pairs.contains_key(&key_name) {
+            return Err(duplicate_key_pair(&key_name));
+        }
         state.key_pairs.insert(
             key_name.clone(),
             KeyPair {
@@ -653,4 +680,35 @@ pub(crate) fn get_groups_for_capacity_reservation(
         &req.request_id,
         &ec2_list("capacityReservationGroupSet", &[]),
     ))
+}
+
+#[cfg(test)]
+mod keypair_tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    #[test]
+    fn create_key_pair_rejects_duplicate_name() {
+        let svc = Ec2Service::new();
+        create_key_pair(&svc, &req("CreateKeyPair", &[("KeyName", "kp")])).unwrap();
+        let err = err_of(create_key_pair(
+            &svc,
+            &req("CreateKeyPair", &[("KeyName", "kp")]),
+        ));
+        assert_eq!(err.code(), "InvalidKeyPair.Duplicate");
+    }
+
+    #[test]
+    fn import_key_pair_rejects_duplicate_name() {
+        let svc = Ec2Service::new();
+        create_key_pair(&svc, &req("CreateKeyPair", &[("KeyName", "kp")])).unwrap();
+        let err = err_of(import_key_pair(
+            &svc,
+            &req(
+                "ImportKeyPair",
+                &[("KeyName", "kp"), ("PublicKeyMaterial", "c3NoLXJzYQ==")],
+            ),
+        ));
+        assert_eq!(err.code(), "InvalidKeyPair.Duplicate");
+    }
 }

--- a/crates/fakecloud-ec2/src/service/eni.rs
+++ b/crates/fakecloud-ec2/src/service/eni.rs
@@ -5,7 +5,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, paginate, parse_filters, require, validate_enum,
+    validate_max_results, Filter,
 };
 use crate::state::{Ec2State, EniAttachment, NetworkInterface, NetworkInterfacePermission, Tag};
 
@@ -176,7 +177,9 @@ pub(crate) fn delete_network_interface(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        state.network_interfaces.remove(&id);
+        if state.network_interfaces.remove(&id).is_none() {
+            return Err(eni_not_found(&id));
+        }
         state.tags.remove(&id);
     }
     Ok(Ec2Service::respond(
@@ -205,10 +208,22 @@ pub(crate) fn describe_network_interfaces(
         .map(|n| eni_xml(n, state.tags_for(&n.network_interface_id), &owner))
         .collect();
     items.sort();
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("networkInterfaceSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeNetworkInterfaces",
         &req.request_id,
-        &ec2_list("networkInterfaceSet", &items),
+        &body,
     ))
 }
 
@@ -217,7 +232,11 @@ fn eni_match(n: &NetworkInterface, tags: &[Tag], filters: &[Filter]) -> bool {
         let candidates: Vec<String> = match f.name.as_str() {
             "network-interface-id" => vec![n.network_interface_id.clone()],
             "subnet-id" => vec![n.subnet_id.clone()],
+            "vpc-id" => vec![n.vpc_id.clone()],
             "status" => vec![n.status.clone()],
+            "mac-address" => vec![n.mac_address.clone()],
+            "private-ip-address" => vec![n.private_ip_address.clone()],
+            "interface-type" => vec![n.interface_type.clone()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -226,11 +245,13 @@ fn eni_match(n: &NetworkInterface, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 
@@ -247,15 +268,17 @@ pub(crate) fn attach_network_interface(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(eni) = state.network_interfaces.get_mut(&eni_id) {
-            eni.status = "in-use".to_string();
-            eni.attachment = Some(EniAttachment {
-                attachment_id: attachment_id.clone(),
-                instance_id,
-                device_index,
-                status: "attached".to_string(),
-            });
-        }
+        let eni = state
+            .network_interfaces
+            .get_mut(&eni_id)
+            .ok_or_else(|| eni_not_found(&eni_id))?;
+        eni.status = "in-use".to_string();
+        eni.attachment = Some(EniAttachment {
+            attachment_id: attachment_id.clone(),
+            instance_id,
+            device_index,
+            status: "attached".to_string(),
+        });
     }
     let body = format!(
         "{}<networkCardIndex>0</networkCardIndex>",
@@ -508,32 +531,77 @@ pub(crate) fn describe_network_interface_permissions(
 
 // ---- IP assignment ----
 
+/// `InvalidNetworkInterfaceID.NotFound` — the referenced ENI does not exist.
+fn eni_not_found(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "InvalidNetworkInterfaceID.NotFound",
+        format!("The network interface ID '{id}' does not exist"),
+    )
+}
+
+/// Synthesize `count` secondary IPs from the ENI's primary /24 that are not
+/// already assigned, so an auto-assign request returns concrete addresses.
+fn synth_private_ips(eni: &NetworkInterface, count: usize) -> Vec<String> {
+    let base = eni
+        .private_ip_address
+        .rsplit_once('.')
+        .map(|(net, _)| net.to_string())
+        .unwrap_or_else(|| "10.0.0".to_string());
+    let mut out = Vec::new();
+    let mut host = 240u32;
+    while out.len() < count && host < 255 {
+        let candidate = format!("{base}.{host}");
+        if candidate != eni.private_ip_address && !eni.private_ips.contains(&candidate) {
+            out.push(candidate);
+        }
+        host += 1;
+    }
+    out
+}
+
 pub(crate) fn assign_private_ip_addresses(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "NetworkInterfaceId")?;
-    let assigned: Vec<String> = indexed_list(&req.query_params, "PrivateIpAddress")
-        .into_iter()
+    let explicit = indexed_list(&req.query_params, "PrivateIpAddress");
+    let count = req
+        .query_params
+        .get("SecondaryPrivateIpAddressCount")
+        .and_then(|v| v.parse::<usize>().ok());
+    let assigned: Vec<String> = {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let eni = state
+            .network_interfaces
+            .get_mut(&id)
+            .ok_or_else(|| eni_not_found(&id))?;
+        let to_add = if !explicit.is_empty() {
+            explicit
+        } else {
+            synth_private_ips(eni, count.unwrap_or(1))
+        };
+        for ip in &to_add {
+            if !eni.private_ips.contains(ip) {
+                eni.private_ips.push(ip.clone());
+            }
+        }
+        to_add
+    };
+    let items: Vec<String> = assigned
+        .iter()
         .map(|ip| {
             format!(
                 "{}<isPrimary>false</isPrimary>",
-                ec2_elem("privateIpAddress", &ip)
+                ec2_elem("privateIpAddress", ip)
             )
         })
         .collect();
-    let assigned = if assigned.is_empty() {
-        vec![
-            "<privateIpAddress>10.0.0.30</privateIpAddress><isPrimary>false</isPrimary>"
-                .to_string(),
-        ]
-    } else {
-        assigned
-    };
     let body = format!(
         "{}{}",
         ec2_elem("networkInterfaceId", &id),
-        ec2_list("assignedPrivateIpAddressesSet", &assigned),
+        ec2_list("assignedPrivateIpAddressesSet", &items),
     );
     Ok(Ec2Service::respond(
         "AssignPrivateIpAddresses",
@@ -543,10 +611,20 @@ pub(crate) fn assign_private_ip_addresses(
 }
 
 pub(crate) fn unassign_private_ip_addresses(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "NetworkInterfaceId")?;
+    let id = require(&req.query_params, "NetworkInterfaceId")?;
+    let remove = indexed_list(&req.query_params, "PrivateIpAddress");
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let eni = state
+            .network_interfaces
+            .get_mut(&id)
+            .ok_or_else(|| eni_not_found(&id))?;
+        eni.private_ips.retain(|ip| !remove.contains(ip));
+    }
     Ok(Ec2Service::respond(
         "UnassignPrivateIpAddresses",
         &req.request_id,
@@ -555,20 +633,41 @@ pub(crate) fn unassign_private_ip_addresses(
 }
 
 pub(crate) fn assign_ipv6_addresses(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "NetworkInterfaceId")?;
-    let addrs: Vec<String> = indexed_list(&req.query_params, "Ipv6Addresses");
-    let addrs = if addrs.is_empty() {
-        vec!["2600:1f00::5".to_string()]
-    } else {
-        addrs
+    let explicit = indexed_list(&req.query_params, "Ipv6Addresses");
+    let count = req
+        .query_params
+        .get("Ipv6AddressCount")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(1);
+    let assigned: Vec<String> = {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let eni = state
+            .network_interfaces
+            .get_mut(&id)
+            .ok_or_else(|| eni_not_found(&id))?;
+        let to_add = if !explicit.is_empty() {
+            explicit
+        } else {
+            (0..count)
+                .map(|i| format!("2600:1f00::{}", eni.ipv6_addresses.len() + i + 1))
+                .collect()
+        };
+        for ip in &to_add {
+            if !eni.ipv6_addresses.contains(ip) {
+                eni.ipv6_addresses.push(ip.clone());
+            }
+        }
+        to_add
     };
     let body = format!(
         "{}{}",
         ec2_elem("networkInterfaceId", &id),
-        ec2_scalar_list("assignedIpv6Addresses", &addrs),
+        ec2_scalar_list("assignedIpv6Addresses", &assigned),
     );
     Ok(Ec2Service::respond(
         "AssignIpv6Addresses",
@@ -578,11 +677,20 @@ pub(crate) fn assign_ipv6_addresses(
 }
 
 pub(crate) fn unassign_ipv6_addresses(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "NetworkInterfaceId")?;
     let addrs: Vec<String> = indexed_list(&req.query_params, "Ipv6Addresses");
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let eni = state
+            .network_interfaces
+            .get_mut(&id)
+            .ok_or_else(|| eni_not_found(&id))?;
+        eni.ipv6_addresses.retain(|ip| !addrs.contains(ip));
+    }
     let body = format!(
         "{}{}",
         ec2_elem("networkInterfaceId", &id),
@@ -727,6 +835,68 @@ mod tests {
         assert!(describe_attr(&svc, "description")
             .contains("<description><value>new-desc</value></description>"));
         assert!(describe_attr(&svc, "groupSet").contains("<groupId>sg-a</groupId>"));
+    }
+
+    #[test]
+    fn assign_private_ips_persist_and_appear_in_describe() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        assign_private_ip_addresses(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-1"),
+                ("PrivateIpAddress.1", "10.0.0.30"),
+                ("PrivateIpAddress.2", "10.0.0.31"),
+            ]),
+        )
+        .unwrap();
+        {
+            let accounts = svc.state.read();
+            let eni = &accounts.get("000000000000").unwrap().network_interfaces["eni-1"];
+            assert_eq!(eni.private_ips, vec!["10.0.0.30", "10.0.0.31"]);
+        }
+        // Unassign one and confirm removal.
+        unassign_private_ip_addresses(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-1"),
+                ("PrivateIpAddress.1", "10.0.0.30"),
+            ]),
+        )
+        .unwrap();
+        let accounts = svc.state.read();
+        let eni = &accounts.get("000000000000").unwrap().network_interfaces["eni-1"];
+        assert_eq!(eni.private_ips, vec!["10.0.0.31"]);
+    }
+
+    #[test]
+    fn assign_private_ips_missing_eni_errors() {
+        let svc = Ec2Service::new();
+        let err = crate::test_support::err_of(assign_private_ip_addresses(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-nope"),
+                ("PrivateIpAddress.1", "10.0.0.30"),
+            ]),
+        ));
+        assert_eq!(err.code(), "InvalidNetworkInterfaceID.NotFound");
+    }
+
+    #[test]
+    fn assign_ipv6_persists() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        assign_ipv6_addresses(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-1"),
+                ("Ipv6Addresses.1", "2600:1f00::a"),
+            ]),
+        )
+        .unwrap();
+        let accounts = svc.state.read();
+        let eni = &accounts.get("000000000000").unwrap().network_interfaces["eni-1"];
+        assert_eq!(eni.ipv6_addresses, vec!["2600:1f00::a"]);
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/fleet.rs
+++ b/crates/fakecloud-ec2/src/service/fleet.rs
@@ -439,6 +439,11 @@ pub(crate) fn request_spot_fleet(
 ) -> Result<AwsResponse, AwsServiceError> {
     require_struct(&req.query_params, "SpotFleetRequestConfig")?;
     let id = gen_id("sfr");
+    let target_capacity = req
+        .query_params
+        .get("SpotFleetRequestConfig.TargetCapacity")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0);
     {
         let mut accounts = svc.state.write();
         accounts.get_or_create(&req.account_id).spot_fleets.insert(
@@ -446,6 +451,7 @@ pub(crate) fn request_spot_fleet(
             SpotFleet {
                 id: id.clone(),
                 state: "active".to_string(),
+                target_capacity,
             },
         );
     }
@@ -470,9 +476,10 @@ pub(crate) fn describe_spot_fleet_requests(
         .filter(|f| wanted.is_empty() || wanted.contains(&f.id))
         .map(|f| {
             format!(
-                "{}{}<spotFleetRequestConfig><targetCapacity>1</targetCapacity></spotFleetRequestConfig>{}",
+                "{}{}<spotFleetRequestConfig><targetCapacity>{}</targetCapacity></spotFleetRequestConfig>{}",
                 ec2_elem("spotFleetRequestId", &f.id),
                 ec2_elem("spotFleetRequestState", &f.state),
+                f.target_capacity,
                 ec2_elem("createTime", FIXED_TIME),
             )
         })
@@ -533,13 +540,30 @@ pub(crate) fn modify_spot_fleet_request(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "SpotFleetRequestId")?;
+    let id = require(&req.query_params, "SpotFleetRequestId")?;
     validate_enum(
         &req.query_params,
         "ExcessCapacityTerminationPolicy",
         &["noTermination", "default"],
     )?;
-    let _ = svc;
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let fleet = state.spot_fleets.get_mut(&id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidSpotFleetRequestId.NotFound",
+                format!("The spot fleet request ID '{id}' does not exist"),
+            )
+        })?;
+        if let Some(tc) = req
+            .query_params
+            .get("TargetCapacity")
+            .and_then(|v| v.parse::<i64>().ok())
+        {
+            fleet.target_capacity = tc;
+        }
+    }
     Ok(Ec2Service::respond(
         "ModifySpotFleetRequest",
         &req.request_id,
@@ -749,6 +773,11 @@ pub(crate) fn create_fleet(
         .get("Type")
         .cloned()
         .unwrap_or_else(|| "maintain".to_string());
+    let target_capacity = req
+        .query_params
+        .get("TargetCapacitySpecification.TotalTargetCapacity")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0);
     {
         let mut accounts = svc.state.write();
         accounts.get_or_create(&req.account_id).fleets.insert(
@@ -757,6 +786,7 @@ pub(crate) fn create_fleet(
                 id: id.clone(),
                 state: "active".to_string(),
                 fleet_type: ftype,
+                target_capacity,
             },
         );
     }
@@ -847,10 +877,11 @@ pub(crate) fn describe_fleets(
         .filter(|f| wanted.is_empty() || wanted.contains(&f.id))
         .map(|f| {
             format!(
-                "{}{}{}<targetCapacitySpecification><totalTargetCapacity>1</totalTargetCapacity></targetCapacitySpecification>",
+                "{}{}{}<targetCapacitySpecification><totalTargetCapacity>{}</totalTargetCapacity></targetCapacitySpecification>",
                 ec2_elem("fleetId", &f.id),
                 ec2_elem("fleetState", &f.state),
                 ec2_elem("type", &f.fleet_type),
+                f.target_capacity,
             )
         })
         .collect();
@@ -866,13 +897,30 @@ pub(crate) fn modify_fleet(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "FleetId")?;
+    let id = require(&req.query_params, "FleetId")?;
     validate_enum(
         &req.query_params,
         "ExcessCapacityTerminationPolicy",
         &["no-termination", "termination"],
     )?;
-    let _ = svc;
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let fleet = state.fleets.get_mut(&id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidFleetId.NotFound",
+                format!("The fleet ID '{id}' does not exist"),
+            )
+        })?;
+        if let Some(tc) = req
+            .query_params
+            .get("TargetCapacitySpecification.TotalTargetCapacity")
+            .and_then(|v| v.parse::<i64>().ok())
+        {
+            fleet.target_capacity = tc;
+        }
+    }
     Ok(Ec2Service::respond(
         "ModifyFleet",
         &req.request_id,
@@ -920,4 +968,97 @@ pub(crate) fn describe_fleet_instances(
         &req.request_id,
         &body,
     ))
+}
+
+#[cfg(test)]
+mod capacity_tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn create_fleet_persists_target_capacity() {
+        let svc = Ec2Service::new();
+        let resp = create_fleet(
+            &svc,
+            &req(
+                "CreateFleet",
+                &[
+                    ("TargetCapacitySpecification.TotalTargetCapacity", "10"),
+                    ("Type", "maintain"),
+                ],
+            ),
+        )
+        .unwrap();
+        let fleet_id = {
+            let b = body(resp);
+            b.split("<fleetId>")
+                .nth(1)
+                .unwrap()
+                .split("</fleetId>")
+                .next()
+                .unwrap()
+                .to_string()
+        };
+        let desc = body(describe_fleets(&svc, &req("DescribeFleets", &[])).unwrap());
+        assert!(
+            desc.contains("<totalTargetCapacity>10</totalTargetCapacity>"),
+            "{desc}"
+        );
+
+        // Modify updates it.
+        modify_fleet(
+            &svc,
+            &req(
+                "ModifyFleet",
+                &[
+                    ("FleetId", &fleet_id),
+                    ("TargetCapacitySpecification.TotalTargetCapacity", "25"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc2 = body(describe_fleets(&svc, &req("DescribeFleets", &[])).unwrap());
+        assert!(
+            desc2.contains("<totalTargetCapacity>25</totalTargetCapacity>"),
+            "{desc2}"
+        );
+    }
+
+    #[test]
+    fn modify_fleet_missing_errors() {
+        let svc = Ec2Service::new();
+        let err = err_of(modify_fleet(
+            &svc,
+            &req("ModifyFleet", &[("FleetId", "fleet-nope")]),
+        ));
+        assert_eq!(err.code(), "InvalidFleetId.NotFound");
+    }
+
+    #[test]
+    fn spot_fleet_target_capacity_round_trips() {
+        let svc = Ec2Service::new();
+        let resp = request_spot_fleet(
+            &svc,
+            &req(
+                "RequestSpotFleet",
+                &[
+                    ("SpotFleetRequestConfig.IamFleetRole", "arn:x"),
+                    ("SpotFleetRequestConfig.TargetCapacity", "7"),
+                ],
+            ),
+        )
+        .unwrap();
+        let _ = body(resp);
+        let desc = body(
+            describe_spot_fleet_requests(&svc, &req("DescribeSpotFleetRequests", &[])).unwrap(),
+        );
+        assert!(
+            desc.contains("<targetCapacity>7</targetCapacity>"),
+            "{desc}"
+        );
+    }
 }

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -221,6 +221,10 @@ pub(crate) fn describe_images(
 ) -> Result<AwsResponse, AwsServiceError> {
     let filters = parse_filters(&req.query_params);
     let wanted = indexed_list(&req.query_params, "ImageId");
+    // A `disabled` image is hidden from a default DescribeImages; it is only
+    // returned when requested explicitly by id or by a `state` filter, matching
+    // AWS (DisableImage takes an AMI out of general listings).
+    let state_filtered = filters.iter().any(|f| f.name == "state");
     let owner = req.account_id.clone();
     // `Owner.N` request params (distinct from the `owner-*` filters): values are
     // an account id, `self`, or an owner alias (`amazon` / `aws-marketplace`).
@@ -244,6 +248,7 @@ pub(crate) fn describe_images(
         .images
         .values()
         .filter(|i| !i.in_recycle_bin)
+        .filter(|i| i.state != "disabled" || state_filtered || wanted.contains(&i.image_id))
         .filter(|i| wanted.is_empty() || wanted.contains(&i.image_id))
         .filter(|i| image_owner_match(i, &owner, &owners))
         .filter(|i| img_match(i, state.tags_for(&i.image_id), &filters))
@@ -334,7 +339,7 @@ fn img_match(i: &Image, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
@@ -682,12 +687,11 @@ fn image_ack(
     for k in extra_required {
         require(&req.query_params, k)?;
     }
-    if let Some(p) = protect {
-        let mut accounts = svc.state.write();
-        if let Some(img) = accounts.get_or_create(&req.account_id).images.get_mut(&id) {
+    mutate_image(svc, &req.account_id, &id, |img| {
+        if let Some(p) = protect {
             img.deregistration_protection = p;
         }
-    }
+    })?;
     Ok(Ec2Service::respond(
         action,
         &req.request_id,
@@ -695,29 +699,88 @@ fn image_ack(
     ))
 }
 
+/// `InvalidAMIID.NotFound` — the referenced image does not exist.
+fn image_not_found(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "InvalidAMIID.NotFound",
+        format!("The image id '[{id}]' does not exist"),
+    )
+}
+
+/// Look up an image mutably, apply `f`, and 404 if it is missing.
+fn mutate_image(
+    svc: &Ec2Service,
+    account_id: &str,
+    id: &str,
+    f: impl FnOnce(&mut Image),
+) -> Result<(), AwsServiceError> {
+    let mut accounts = svc.state.write();
+    let img = accounts
+        .get_or_create(account_id)
+        .images
+        .get_mut(id)
+        .ok_or_else(|| image_not_found(id))?;
+    f(img);
+    Ok(())
+}
+
 pub(crate) fn enable_image(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    image_ack(svc, req, "EnableImage", &[], None)
+    let id = require(&req.query_params, "ImageId")?;
+    mutate_image(svc, &req.account_id, &id, |img| {
+        img.state = "available".to_string();
+    })?;
+    Ok(Ec2Service::respond(
+        "EnableImage",
+        &req.request_id,
+        &ec2_return(true),
+    ))
 }
 pub(crate) fn disable_image(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    image_ack(svc, req, "DisableImage", &[], None)
+    let id = require(&req.query_params, "ImageId")?;
+    mutate_image(svc, &req.account_id, &id, |img| {
+        img.state = "disabled".to_string();
+    })?;
+    Ok(Ec2Service::respond(
+        "DisableImage",
+        &req.request_id,
+        &ec2_return(true),
+    ))
 }
 pub(crate) fn enable_image_deprecation(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    image_ack(svc, req, "EnableImageDeprecation", &["DeprecateAt"], None)
+    let id = require(&req.query_params, "ImageId")?;
+    let deprecate_at = require(&req.query_params, "DeprecateAt")?;
+    mutate_image(svc, &req.account_id, &id, |img| {
+        img.deprecation_time = Some(deprecate_at.clone());
+    })?;
+    Ok(Ec2Service::respond(
+        "EnableImageDeprecation",
+        &req.request_id,
+        &ec2_return(true),
+    ))
 }
 pub(crate) fn disable_image_deprecation(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    image_ack(svc, req, "DisableImageDeprecation", &[], None)
+    let id = require(&req.query_params, "ImageId")?;
+    mutate_image(svc, &req.account_id, &id, |img| {
+        img.deprecation_time = None;
+    })?;
+    Ok(Ec2Service::respond(
+        "DisableImageDeprecation",
+        &req.request_id,
+        &ec2_return(true),
+    ))
 }
 pub(crate) fn enable_image_deregistration_protection(
     svc: &Ec2Service,
@@ -1066,6 +1129,104 @@ mod tests {
             root_device_name: None,
             platform: None,
         }
+    }
+
+    fn seed_image(svc: &crate::service::Ec2Service, id: &str) {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("000000000000");
+        let mut i = img(None, None);
+        i.image_id = id.to_string();
+        state.images.insert(id.to_string(), i);
+    }
+
+    #[test]
+    fn disable_image_hides_it_and_enable_restores() {
+        use crate::test_support::ec2_request as req;
+        let svc = crate::service::Ec2Service::new();
+        seed_image(&svc, "ami-x");
+
+        super::disable_image(&svc, &req("DisableImage", &[("ImageId", "ami-x")])).unwrap();
+        {
+            let accounts = svc.state.read();
+            assert_eq!(
+                accounts.get("000000000000").unwrap().images["ami-x"].state,
+                "disabled"
+            );
+        }
+        // Hidden from a default DescribeImages...
+        let body = String::from_utf8(
+            super::describe_images(&svc, &req("DescribeImages", &[]))
+                .unwrap()
+                .body
+                .expect_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(!body.contains("<imageId>ami-x</imageId>"), "{body}");
+        // ...but visible when requested explicitly by id.
+        let body2 = String::from_utf8(
+            super::describe_images(&svc, &req("DescribeImages", &[("ImageId.1", "ami-x")]))
+                .unwrap()
+                .body
+                .expect_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(body2.contains("<imageId>ami-x</imageId>"), "{body2}");
+
+        super::enable_image(&svc, &req("EnableImage", &[("ImageId", "ami-x")])).unwrap();
+        let accounts = svc.state.read();
+        assert_eq!(
+            accounts.get("000000000000").unwrap().images["ami-x"].state,
+            "available"
+        );
+    }
+
+    #[test]
+    fn enable_image_deprecation_persists_time() {
+        use crate::test_support::ec2_request as req;
+        let svc = crate::service::Ec2Service::new();
+        seed_image(&svc, "ami-x");
+        super::enable_image_deprecation(
+            &svc,
+            &req(
+                "EnableImageDeprecation",
+                &[
+                    ("ImageId", "ami-x"),
+                    ("DeprecateAt", "2030-01-01T00:00:00Z"),
+                ],
+            ),
+        )
+        .unwrap();
+        {
+            let accounts = svc.state.read();
+            assert_eq!(
+                accounts.get("000000000000").unwrap().images["ami-x"]
+                    .deprecation_time
+                    .as_deref(),
+                Some("2030-01-01T00:00:00Z")
+            );
+        }
+        super::disable_image_deprecation(
+            &svc,
+            &req("DisableImageDeprecation", &[("ImageId", "ami-x")]),
+        )
+        .unwrap();
+        let accounts = svc.state.read();
+        assert!(accounts.get("000000000000").unwrap().images["ami-x"]
+            .deprecation_time
+            .is_none());
+    }
+
+    #[test]
+    fn disable_image_missing_errors() {
+        use crate::test_support::{ec2_request as req, err_of};
+        let svc = crate::service::Ec2Service::new();
+        let err = err_of(super::disable_image(
+            &svc,
+            &req("DisableImage", &[("ImageId", "ami-nope")]),
+        ));
+        assert_eq!(err.code(), "InvalidAMIID.NotFound");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -9,8 +9,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, instance_limit_exceeded, invalid_parameter_value, parse_filters, require,
-    require_struct, validate_enum, Filter,
+    gen_id, indexed_list, instance_limit_exceeded, invalid_parameter_value, missing_parameter,
+    parse_filters, require, require_struct, validate_enum, Filter,
 };
 use crate::state::{Ec2State, Instance, Tag};
 
@@ -239,11 +239,18 @@ pub(crate) async fn run_instances(
     // and never with `lo > hi`, which would panic).
     let count = max.min(MAX_INSTANCES_PER_REQUEST).max(min);
     let reservation_id = gen_id("r");
-    let image_id = req
-        .query_params
-        .get("ImageId")
-        .cloned()
-        .unwrap_or_else(|| "ami-00000000000000000".to_string());
+    // ImageId is required unless a launch template (which can carry the image)
+    // is referenced. AWS returns MissingParameter rather than silently
+    // launching from a placeholder AMI.
+    let uses_launch_template = req.query_params.keys().any(|k| {
+        k.starts_with("LaunchTemplate.LaunchTemplateId")
+            || k.starts_with("LaunchTemplate.LaunchTemplateName")
+    });
+    let image_id = match req.query_params.get("ImageId").filter(|v| !v.is_empty()) {
+        Some(v) => v.clone(),
+        None if uses_launch_template => "ami-00000000000000000".to_string(),
+        None => return Err(missing_parameter("ImageId")),
+    };
     let instance_type = req
         .query_params
         .get("InstanceType")
@@ -303,6 +310,25 @@ pub(crate) async fn run_instances(
             .as_ref()
             .and_then(|sid| state.subnets.get(sid))
             .map(|s| s.vpc_id.clone());
+        // Honor `SecurityGroup.N` (group *names*, EC2-Classic/default-VPC form)
+        // by resolving each to its id, alongside the modern `SecurityGroupId.N`.
+        let sg_names = indexed_list(&req.query_params, "SecurityGroup");
+        if !sg_names.is_empty() {
+            let target_vpc = resolved_vpc
+                .clone()
+                .unwrap_or_else(|| crate::defaults::default_vpc_id(&req.account_id));
+            for name in &sg_names {
+                if let Some(sg) = state
+                    .security_groups
+                    .values()
+                    .find(|g| g.vpc_id == target_vpc && &g.group_name == name)
+                {
+                    if !sg_ids.contains(&sg.group_id) {
+                        sg_ids.push(sg.group_id.clone());
+                    }
+                }
+            }
+        }
         if sg_ids.is_empty() {
             let vpc = resolved_vpc
                 .clone()
@@ -429,6 +455,10 @@ pub(crate) async fn run_instances(
         let account_id = req.account_id.clone();
         let ids = ids.clone();
         let instance_network = instance_network.clone();
+        // Capture the persistence hook so the pending->running flip is written
+        // through to disk; RunInstances' own dispatch-path snapshot ran while
+        // the instance was still `pending` (M12).
+        let snapshot_hook = svc.snapshot_hook();
         tokio::spawn(async move {
             for id in &ids {
                 let running = if let Some(rt) = &runtime {
@@ -452,6 +482,11 @@ pub(crate) async fn run_instances(
                     None
                 };
                 reconcile_started(&svc_state, &account_id, id, running);
+            }
+            // Persist the reconciled (`running`) state so a restart restores
+            // running instances rather than resurrecting them as pending.
+            if let Some(hook) = &snapshot_hook {
+                hook().await;
             }
             // All instances are up with their real IPs: (re)apply the
             // security-group firewall so the new instances are filtered
@@ -1035,6 +1070,12 @@ fn monitor(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // A nonexistent instance id is a hard error, not a silent no-op.
+        for id in &ids {
+            if !state.instances.contains_key(id) {
+                return Err(crate::service_helpers::instance_not_found(id));
+            }
+        }
         for id in &ids {
             if let Some(i) = state.instances.get_mut(id) {
                 i.monitoring = enable;
@@ -1071,6 +1112,14 @@ pub(crate) fn describe_instances(
     let accounts = svc.state.read();
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+    // An explicitly-listed InstanceId that does not exist is a hard error on
+    // AWS (`InvalidInstanceID.NotFound`), not an empty result set.
+    for id in &wanted {
+        if !state.instances.contains_key(id) {
+            return Err(crate::service_helpers::instance_not_found(id));
+        }
+    }
 
     // Flatten matching instances into a stable order (by reservation, then id),
     // then paginate over the flat instance list — AWS counts instances, not
@@ -2233,5 +2282,50 @@ mod modify_tests {
         );
         assert!(!out.contains("<item>Name</item>"), "got: {out}");
         assert!(out.contains("<item>env</item>"));
+    }
+
+    #[test]
+    fn describe_instances_explicit_missing_id_errors() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        let err = crate::test_support::err_of(describe_instances(
+            &svc,
+            &req("DescribeInstances", &[("InstanceId.1", "i-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidInstanceID.NotFound");
+    }
+
+    #[test]
+    fn describe_instances_existing_id_ok() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        let out = body(
+            describe_instances(&svc, &req("DescribeInstances", &[("InstanceId.1", "i-1")]))
+                .unwrap(),
+        );
+        assert!(out.contains("<instanceId>i-1</instanceId>"), "got: {out}");
+    }
+
+    #[tokio::test]
+    async fn reconcile_pending_metadata_only_flips_to_running() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        // Simulate a persisted mid-boot instance.
+        {
+            let mut accounts = svc.state.write();
+            let inst = accounts
+                .get_mut("000000000000")
+                .unwrap()
+                .instances
+                .get_mut("i-1")
+                .unwrap();
+            inst.state_code = 0;
+            inst.state_name = "pending".into();
+        }
+        svc.reconcile_pending_metadata_only().await;
+        let accounts = svc.state.read();
+        let inst = &accounts.get("000000000000").unwrap().instances["i-1"];
+        assert_eq!(inst.state_code, 16);
+        assert_eq!(inst.state_name, "running");
     }
 }

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -1032,8 +1032,39 @@ impl Ec2Service {
     /// Instances persisted as `stopped`/`terminated` are left as-is —
     /// StartInstances revives the former. No-op when no runtime is configured
     /// or there are no instances to recover.
+    /// Flip every `pending` (code 0) instance to `running` (code 16) in
+    /// metadata-only mode, then persist. Used on restart so an instance whose
+    /// background boot flip was lost across a restart still reaches `running`,
+    /// and directly by the RunInstances background task when no runtime is
+    /// wired so the persisted snapshot captures `running`, not `pending` (M12).
+    pub(crate) async fn reconcile_pending_metadata_only(&self) {
+        let flipped = {
+            let mut accounts = self.state.write();
+            let mut n = 0;
+            for (_, state) in accounts.iter_mut() {
+                for inst in state.instances.values_mut() {
+                    if inst.state_code == 0 {
+                        inst.state_code = 16;
+                        inst.state_name = "running".to_string();
+                        n += 1;
+                    }
+                }
+            }
+            n
+        };
+        if flipped > 0 {
+            self.save_snapshot().await;
+        }
+    }
+
     pub async fn recover_persisted_containers(&self) {
         let Some(runtime) = self.runtime.clone() else {
+            // Metadata-only mode: there is no container to reconcile, but an
+            // instance persisted mid-boot (state `pending`, code 0) would stay
+            // stuck pending forever because the background flip-to-running that
+            // RunInstances spawned never ran in this process. Flip any such
+            // instance to `running` so a restart self-heals (M12).
+            self.reconcile_pending_metadata_only().await;
             return;
         };
 

--- a/crates/fakecloud-ec2/src/service/nacl.rs
+++ b/crates/fakecloud-ec2/src/service/nacl.rs
@@ -5,7 +5,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_enum,
+    validate_max_results, Filter,
 };
 use crate::state::{Ec2State, NetworkAcl, NetworkAclAssoc, NetworkAclEntry, Tag, VpcPeering};
 
@@ -197,11 +198,13 @@ fn nacl_match(a: &NetworkAcl, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 

--- a/crates/fakecloud-ec2/src/service/routing.rs
+++ b/crates/fakecloud-ec2/src/service/routing.rs
@@ -5,8 +5,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_int_range,
-    validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_enum,
+    validate_int_range, validate_max_results, Filter,
 };
 use crate::state::{
     Ec2State, InternetGateway, NatGateway, Route, RouteTable, RouteTableAssociation, Tag,
@@ -805,8 +805,10 @@ fn simple_match_multi(
                     .map(|t| t.value.clone())
                     .collect()
             } else {
-                return true;
+                return false;
             };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -8,7 +8,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_max_results,
+    Filter,
 };
 use crate::state::{Ec2State, SecurityGroup, SecurityGroupRule, Tag};
 
@@ -378,7 +379,18 @@ pub(crate) fn describe_security_groups(
         .map(|g| sg_xml(g, state.tags_for(&g.group_id), &owner, &region))
         .collect();
     items.sort();
-    let body = ec2_list("securityGroupInfo", &items);
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = crate::service_helpers::paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("securityGroupInfo", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeSecurityGroups",
         &req.request_id,
@@ -401,12 +413,38 @@ fn sg_matches(g: &SecurityGroup, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    // Unknown filter: match nothing (never silently match all).
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
+}
+
+/// `InvalidGroup.NotFound` — the referenced security group does not exist.
+fn sg_not_found(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "InvalidGroup.NotFound",
+        format!("The security group '{id}' does not exist"),
+    )
+}
+
+/// Two rules describe the same permission when protocol, port range, and the
+/// single source/target (cidr/prefix-list/referenced-group) all match. Used to
+/// revoke exactly the supplied IpPermissions instead of a whole direction.
+fn same_permission(a: &SecurityGroupRule, b: &SecurityGroupRule) -> bool {
+    a.is_egress == b.is_egress
+        && a.ip_protocol == b.ip_protocol
+        && a.from_port == b.from_port
+        && a.to_port == b.to_port
+        && a.cidr_ipv4 == b.cidr_ipv4
+        && a.cidr_ipv6 == b.cidr_ipv6
+        && a.prefix_list_id == b.prefix_list_id
+        && a.referenced_group_id == b.referenced_group_id
 }
 
 fn authorize(
@@ -426,9 +464,13 @@ fn authorize(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(sg) = state.security_groups.get_mut(&group_id) {
-            sg.rules.extend(new_rules.clone());
-        }
+        // A missing or empty GroupId (or a nonexistent one) is a hard error on
+        // AWS, not a silent no-op.
+        let sg = state
+            .security_groups
+            .get_mut(&group_id)
+            .ok_or_else(|| sg_not_found(&group_id))?;
+        sg.rules.extend(new_rules.clone());
     }
     // New rules change what traffic is allowed — re-apply the firewall (ph3).
     svc.spawn_firewall_reconcile();
@@ -470,16 +512,22 @@ fn revoke(
         req.query_params.get("GroupId").cloned().unwrap_or_default()
     };
     let rule_ids = indexed_list(&req.query_params, "SecurityGroupRuleId");
+    let described = parse_ip_permissions(&req.query_params, &group_id, is_egress);
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(sg) = state.security_groups.get_mut(&group_id) {
-            if !rule_ids.is_empty() {
-                sg.rules.retain(|r| !rule_ids.contains(&r.rule_id));
-            } else {
-                // Revoke by matching the supplied IpPermissions on egress flag.
-                sg.rules.retain(|r| r.is_egress != is_egress);
-            }
+        // A missing/empty/nonexistent GroupId is a hard error on AWS.
+        let sg = state
+            .security_groups
+            .get_mut(&group_id)
+            .ok_or_else(|| sg_not_found(&group_id))?;
+        if !rule_ids.is_empty() {
+            sg.rules.retain(|r| !rule_ids.contains(&r.rule_id));
+        } else {
+            // Revoke ONLY the specific permissions described in the request,
+            // matched by protocol/port/source — never the whole direction.
+            sg.rules
+                .retain(|r| !described.iter().any(|d| same_permission(r, d)));
         }
     }
     // Removing rules tightens the firewall — re-apply (ph3).
@@ -889,6 +937,175 @@ mod modify_tests {
         assert_eq!(r.to_port, 443);
         assert_eq!(r.cidr_ipv4.as_deref(), Some("0.0.0.0/0"));
         assert_eq!(r.description, "https");
+    }
+
+    fn ingress_rule(id: &str, port: i64, cidr: &str) -> SecurityGroupRule {
+        SecurityGroupRule {
+            rule_id: id.into(),
+            group_id: "sg-1".into(),
+            is_egress: false,
+            ip_protocol: "tcp".into(),
+            from_port: port,
+            to_port: port,
+            cidr_ipv4: Some(cidr.into()),
+            cidr_ipv6: None,
+            prefix_list_id: None,
+            referenced_group_id: None,
+            description: String::new(),
+        }
+    }
+
+    fn seed_group_rules(svc: &Ec2Service, rules: Vec<SecurityGroupRule>) {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("000000000000");
+        state.security_groups.insert(
+            "sg-1".to_string(),
+            SecurityGroup {
+                group_id: "sg-1".into(),
+                group_name: "g".into(),
+                description: "d".into(),
+                vpc_id: "vpc-1".into(),
+                rules,
+            },
+        );
+    }
+
+    #[test]
+    fn revoke_by_ip_permission_removes_only_the_matching_rule() {
+        let svc = Ec2Service::new();
+        seed_group_rules(
+            &svc,
+            vec![
+                ingress_rule("sgr-a", 22, "10.0.0.0/8"),
+                ingress_rule("sgr-b", 443, "0.0.0.0/0"),
+            ],
+        );
+        revoke_security_group_ingress(
+            &svc,
+            &req(
+                "RevokeSecurityGroupIngress",
+                &[
+                    ("GroupId", "sg-1"),
+                    ("IpPermissions.1.IpProtocol", "tcp"),
+                    ("IpPermissions.1.FromPort", "22"),
+                    ("IpPermissions.1.ToPort", "22"),
+                    ("IpPermissions.1.IpRanges.1.CidrIp", "10.0.0.0/8"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let accounts = svc.state.read();
+        let rules = &accounts.get("000000000000").unwrap().security_groups["sg-1"].rules;
+        assert_eq!(rules.len(), 1, "only the port-22 rule should be revoked");
+        assert_eq!(rules[0].rule_id, "sgr-b");
+    }
+
+    #[test]
+    fn authorize_missing_group_errors() {
+        let svc = Ec2Service::new();
+        let err = crate::test_support::err_of(authorize_security_group_ingress(
+            &svc,
+            &req(
+                "AuthorizeSecurityGroupIngress",
+                &[
+                    ("IpPermissions.1.IpProtocol", "tcp"),
+                    ("IpPermissions.1.FromPort", "22"),
+                    ("IpPermissions.1.ToPort", "22"),
+                    ("IpPermissions.1.IpRanges.1.CidrIp", "0.0.0.0/0"),
+                ],
+            ),
+        ));
+        assert_eq!(err.code(), "InvalidGroup.NotFound");
+    }
+
+    #[test]
+    fn revoke_missing_group_errors() {
+        let svc = Ec2Service::new();
+        let err = crate::test_support::err_of(revoke_security_group_ingress(
+            &svc,
+            &req("RevokeSecurityGroupIngress", &[("GroupId", "sg-nope")]),
+        ));
+        assert_eq!(err.code(), "InvalidGroup.NotFound");
+    }
+
+    #[test]
+    fn describe_unknown_filter_matches_nothing() {
+        let svc = Ec2Service::new();
+        seed_group_rules(&svc, vec![]);
+        let resp = describe_security_groups(
+            &svc,
+            &req(
+                "DescribeSecurityGroups",
+                &[
+                    ("Filter.1.Name", "not-a-real-filter"),
+                    ("Filter.1.Value.1", "whatever"),
+                ],
+            ),
+        )
+        .unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(
+            !body.contains("<groupId>sg-1</groupId>"),
+            "unknown filter must not match all: {body}"
+        );
+    }
+
+    #[test]
+    fn describe_tag_wildcard_matches() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.security_groups.insert(
+                "sg-prod".into(),
+                SecurityGroup {
+                    group_id: "sg-prod".into(),
+                    group_name: "prod".into(),
+                    description: "d".into(),
+                    vpc_id: "vpc-1".into(),
+                    rules: vec![],
+                },
+            );
+            state.upsert_tags(
+                "sg-prod",
+                &[Tag {
+                    key: "Name".into(),
+                    value: "prod-web".into(),
+                }],
+            );
+            state.security_groups.insert(
+                "sg-dev".into(),
+                SecurityGroup {
+                    group_id: "sg-dev".into(),
+                    group_name: "dev".into(),
+                    description: "d".into(),
+                    vpc_id: "vpc-1".into(),
+                    rules: vec![],
+                },
+            );
+            state.upsert_tags(
+                "sg-dev",
+                &[Tag {
+                    key: "Name".into(),
+                    value: "dev-web".into(),
+                }],
+            );
+        }
+        let resp = describe_security_groups(
+            &svc,
+            &req(
+                "DescribeSecurityGroups",
+                &[
+                    ("Filter.1.Name", "tag:Name"),
+                    ("Filter.1.Value.1", "prod-*"),
+                ],
+            ),
+        )
+        .unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("<groupId>sg-prod</groupId>"), "{body}");
+        assert!(!body.contains("<groupId>sg-dev</groupId>"), "{body}");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -439,12 +439,24 @@ fn sg_not_found(id: &str) -> AwsServiceError {
 fn same_permission(a: &SecurityGroupRule, b: &SecurityGroupRule) -> bool {
     a.is_egress == b.is_egress
         && a.ip_protocol == b.ip_protocol
-        && a.from_port == b.from_port
-        && a.to_port == b.to_port
+        && ports_match(a, b)
         && a.cidr_ipv4 == b.cidr_ipv4
         && a.cidr_ipv6 == b.cidr_ipv6
         && a.prefix_list_id == b.prefix_list_id
         && a.referenced_group_id == b.referenced_group_id
+}
+
+/// Ports match for revoke purposes. For the all-traffic protocol (`-1`) AWS
+/// ignores port numbers entirely — it stores none — but clients round-trip the
+/// pair as `-1/-1`, `0/0`, or absent interchangeably (terraform revokes the
+/// default egress rule with `FromPort=0`/`ToPort=0`). So when the protocol is
+/// `-1` the ports are irrelevant to identity; for any real protocol they must
+/// match exactly.
+fn ports_match(a: &SecurityGroupRule, b: &SecurityGroupRule) -> bool {
+    if a.ip_protocol == "-1" {
+        return true;
+    }
+    a.from_port == b.from_port && a.to_port == b.to_port
 }
 
 fn authorize(
@@ -999,6 +1011,55 @@ mod modify_tests {
         let rules = &accounts.get("000000000000").unwrap().security_groups["sg-1"].rules;
         assert_eq!(rules.len(), 1, "only the port-22 rule should be revoked");
         assert_eq!(rules[0].rule_id, "sgr-b");
+    }
+
+    #[test]
+    fn revoke_all_traffic_egress_ignores_port_representation() {
+        // Terraform revokes the AWS-created default egress rule (protocol -1,
+        // stored as -1/-1) by sending FromPort=0/ToPort=0. The revoke must still
+        // match and remove it, or `aws_security_group` shows egress.# = 1.
+        let svc = Ec2Service::new();
+        let resp = create_security_group(
+            &svc,
+            &req(
+                "CreateSecurityGroup",
+                &[
+                    ("GroupName", "t"),
+                    ("GroupDescription", "d"),
+                    ("VpcId", "vpc-1"),
+                ],
+            ),
+        )
+        .unwrap();
+        let sg_id = {
+            let body = String::from_utf8_lossy(resp.body.expect_bytes());
+            body.split("<groupId>")
+                .nth(1)
+                .and_then(|s| s.split("</groupId>").next())
+                .unwrap()
+                .to_string()
+        };
+        revoke_security_group_egress(
+            &svc,
+            &req(
+                "RevokeSecurityGroupEgress",
+                &[
+                    ("GroupId", &sg_id),
+                    ("IpPermissions.1.IpProtocol", "-1"),
+                    ("IpPermissions.1.FromPort", "0"),
+                    ("IpPermissions.1.ToPort", "0"),
+                    ("IpPermissions.1.IpRanges.1.CidrIp", "0.0.0.0/0"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let accounts = svc.state.read();
+        let rules = &accounts.get("000000000000").unwrap().security_groups[&sg_id].rules;
+        assert!(
+            rules.iter().all(|r| !r.is_egress),
+            "default all-traffic egress rule should be revoked despite 0/0 ports"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/snapshot.rs
+++ b/crates/fakecloud-ec2/src/service/snapshot.rs
@@ -6,8 +6,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, invalid_parameter_value, parse_filters, require, require_struct,
-    validate_enum, validate_int_range, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, invalid_parameter_value, not_found, parse_filters,
+    require, require_struct, validate_enum, validate_int_range, validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Snapshot, Tag};
 
@@ -52,8 +52,8 @@ pub(crate) fn create_snapshot(
 ) -> Result<AwsResponse, AwsServiceError> {
     let volume_id = require(&req.query_params, "VolumeId")?;
     validate_enum(&req.query_params, "Location", &["regional", "local"])?;
-    let snap = build_snapshot(
-        volume_id,
+    let mut snap = build_snapshot(
+        volume_id.clone(),
         req.query_params
             .get("Description")
             .cloned()
@@ -64,6 +64,13 @@ pub(crate) fn create_snapshot(
     let tags = {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // The source volume must exist — AWS rejects a snapshot of a phantom id.
+        let vol = state
+            .volumes
+            .get(&volume_id)
+            .ok_or_else(|| not_found("InvalidVolume.NotFound", &volume_id))?;
+        snap.volume_size = vol.size;
+        snap.encrypted = vol.encrypted;
         crate::service::tags::apply_tag_specifications(state, &req.query_params, &id, "snapshot");
         let t = state.tags_for(&id).to_vec();
         state.snapshots.insert(id.clone(), snap.clone());
@@ -84,20 +91,41 @@ pub(crate) fn create_snapshots(
     validate_enum(&req.query_params, "Location", &["regional", "local"])?;
     validate_enum(&req.query_params, "CopyTagsFromSource", &["volume"])?;
     let owner = req.account_id.clone();
-    let snap = build_snapshot("vol-0123456789abcdef0".to_string(), String::new());
-    let id = snap.snapshot_id.clone();
-    {
+    let instance_id = require(&req.query_params, "InstanceSpecification.InstanceId")?;
+    let description = req
+        .query_params
+        .get("Description")
+        .cloned()
+        .unwrap_or_default();
+    let items: Vec<String> = {
         let mut accounts = svc.state.write();
-        accounts
-            .get_or_create(&req.account_id)
-            .snapshots
-            .insert(id.clone(), snap.clone());
-    }
-    let item = snapshot_xml(&snap, &[], &owner);
+        let state = accounts.get_or_create(&req.account_id);
+        if !state.instances.contains_key(&instance_id) {
+            return Err(not_found("InvalidInstanceId.NotFound", &instance_id));
+        }
+        // One snapshot per volume attached to the instance, each carrying the
+        // real source volume id and size (not a fabricated placeholder).
+        let sources: Vec<(String, i64, bool)> = state
+            .volumes
+            .values()
+            .filter(|v| v.attachments.iter().any(|a| a.instance_id == instance_id))
+            .map(|v| (v.volume_id.clone(), v.size, v.encrypted))
+            .collect();
+        let mut rendered = Vec::new();
+        for (vol_id, size, encrypted) in sources {
+            let mut snap = build_snapshot(vol_id, description.clone());
+            snap.volume_size = size;
+            snap.encrypted = encrypted;
+            let id = snap.snapshot_id.clone();
+            rendered.push(snapshot_xml(&snap, &[], &owner));
+            state.snapshots.insert(id, snap);
+        }
+        rendered
+    };
     Ok(Ec2Service::respond(
         "CreateSnapshots",
         &req.request_id,
-        &ec2_list("snapshotSet", &[item]),
+        &ec2_list("snapshotSet", &items),
     ))
 }
 
@@ -108,7 +136,9 @@ pub(crate) fn delete_snapshot(
     let id = require(&req.query_params, "SnapshotId")?;
     let mut accounts = svc.state.write();
     let state = accounts.get_or_create(&req.account_id);
-    state.snapshots.remove(&id);
+    if state.snapshots.remove(&id).is_none() {
+        return Err(not_found("InvalidSnapshot.NotFound", &id));
+    }
     state.tags.remove(&id);
     Ok(Ec2Service::respond(
         "DeleteSnapshot",
@@ -158,11 +188,13 @@ fn snap_match(s: &Snapshot, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 
@@ -843,6 +875,143 @@ mod modify_tests {
             ],
         );
         assert!(format!("{err:?}").contains("InvalidParameterCombination"));
+    }
+
+    #[test]
+    fn create_snapshot_rejects_nonexistent_volume() {
+        let svc = Ec2Service::new();
+        let err = match create_snapshot(&svc, &req("CreateSnapshot", &[("VolumeId", "vol-nope")])) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error"),
+        };
+        assert_eq!(err.code(), "InvalidVolume.NotFound");
+    }
+
+    #[test]
+    fn create_snapshot_uses_real_volume_size() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            let mut v = crate::state::Volume {
+                volume_id: "vol-1".into(),
+                size: 42,
+                snapshot_id: None,
+                availability_zone: "us-east-1a".into(),
+                state: "available".into(),
+                volume_type: "gp3".into(),
+                iops: None,
+                throughput: None,
+                encrypted: false,
+                kms_key_id: None,
+                multi_attach_enabled: false,
+                auto_enable_io: false,
+                attachments: vec![],
+                in_recycle_bin: false,
+                modification: None,
+            };
+            v.size = 42;
+            state.volumes.insert("vol-1".into(), v);
+        }
+        let resp = create_snapshot(&svc, &req("CreateSnapshot", &[("VolumeId", "vol-1")])).unwrap();
+        let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        assert!(body.contains("<volumeSize>42</volumeSize>"), "{body}");
+    }
+
+    #[test]
+    fn create_snapshots_builds_one_per_attached_volume() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.instances.insert(
+                "i-1".into(),
+                crate::state::Instance {
+                    instance_id: "i-1".into(),
+                    image_id: "ami-1".into(),
+                    instance_type: "t3.micro".into(),
+                    state_code: 16,
+                    state_name: "running".into(),
+                    private_ip: "10.0.0.5".into(),
+                    public_ip: None,
+                    subnet_id: None,
+                    vpc_id: None,
+                    key_name: None,
+                    security_group_ids: vec![],
+                    reservation_id: "r-1".into(),
+                    ami_launch_index: 0,
+                    monitoring: false,
+                    az: "us-east-1a".into(),
+                    launch_time: "t".into(),
+                    container_id: None,
+                    disable_api_termination: false,
+                    disable_api_stop: false,
+                    source_dest_check: true,
+                    ebs_optimized: false,
+                    instance_initiated_shutdown_behavior: "stop".into(),
+                    user_data: None,
+                    metadata_options: Default::default(),
+                    cpu_options: None,
+                    bandwidth_weighting: None,
+                    maintenance_options: Default::default(),
+                    placement_tenancy: None,
+                    placement_affinity: None,
+                    placement_group_name: None,
+                    private_dns_hostname_type: None,
+                    enable_resource_name_dns_a_record: false,
+                    enable_resource_name_dns_aaaa_record: false,
+                },
+            );
+            for vid in ["vol-a", "vol-b"] {
+                state.volumes.insert(
+                    vid.into(),
+                    crate::state::Volume {
+                        volume_id: vid.into(),
+                        size: 10,
+                        snapshot_id: None,
+                        availability_zone: "us-east-1a".into(),
+                        state: "in-use".into(),
+                        volume_type: "gp3".into(),
+                        iops: None,
+                        throughput: None,
+                        encrypted: false,
+                        kms_key_id: None,
+                        multi_attach_enabled: false,
+                        auto_enable_io: false,
+                        attachments: vec![crate::state::VolumeAttachment {
+                            volume_id: vid.into(),
+                            instance_id: "i-1".into(),
+                            device: "/dev/sdf".into(),
+                            status: "attached".into(),
+                            delete_on_termination: false,
+                        }],
+                        in_recycle_bin: false,
+                        modification: None,
+                    },
+                );
+            }
+        }
+        let resp = create_snapshots(
+            &svc,
+            &req(
+                "CreateSnapshots",
+                &[("InstanceSpecification.InstanceId", "i-1")],
+            ),
+        )
+        .unwrap();
+        let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        assert!(body.contains("<volumeId>vol-a</volumeId>"), "{body}");
+        assert!(body.contains("<volumeId>vol-b</volumeId>"), "{body}");
+        // Two snapshots persisted.
+        assert_eq!(
+            svc.state
+                .read()
+                .get("000000000000")
+                .unwrap()
+                .snapshots
+                .len(),
+            2
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/snapshot.rs
+++ b/crates/fakecloud-ec2/src/service/snapshot.rs
@@ -101,7 +101,7 @@ pub(crate) fn create_snapshots(
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
         if !state.instances.contains_key(&instance_id) {
-            return Err(not_found("InvalidInstanceId.NotFound", &instance_id));
+            return Err(not_found("InvalidInstanceID.NotFound", &instance_id));
         }
         // One snapshot per volume attached to the instance, each carrying the
         // real source volume id and size (not a fabricated placeholder).

--- a/crates/fakecloud-ec2/src/service/subnet.rs
+++ b/crates/fakecloud-ec2/src/service/subnet.rs
@@ -6,7 +6,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_enum,
+    validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Subnet, SubnetCidrReservation, Tag};
 
@@ -356,11 +357,13 @@ fn subnet_matches(s: &Subnet, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 

--- a/crates/fakecloud-ec2/src/service/tags.rs
+++ b/crates/fakecloud-ec2/src/service/tags.rs
@@ -80,6 +80,45 @@ pub(crate) fn tag_specifications_for(
     out
 }
 
+/// `Some(true/false)` for a resource family we track by id, `None` for id
+/// prefixes we do not model (accepted leniently rather than falsely rejected).
+fn resource_exists(state: &Ec2State, id: &str) -> Option<bool> {
+    let prefix = id.split('-').next().unwrap_or("");
+    Some(match prefix {
+        "i" => state.instances.contains_key(id),
+        "vpc" => state.vpcs.contains_key(id),
+        "subnet" => state.subnets.contains_key(id),
+        "sg" => state.security_groups.contains_key(id),
+        "vol" => state.volumes.contains_key(id),
+        "snap" => state.snapshots.contains_key(id),
+        "ami" => state.images.contains_key(id),
+        "eni" => state.network_interfaces.contains_key(id),
+        "igw" => state.internet_gateways.contains_key(id),
+        "rtb" => state.route_tables.contains_key(id),
+        "dopt" => state.dhcp_options.contains_key(id),
+        "acl" => state.network_acls.contains_key(id),
+        "pcx" => state.vpc_peerings.contains_key(id),
+        "nat" => state.nat_gateways.contains_key(id),
+        "eipalloc" => state.elastic_ips.contains_key(id),
+        _ => return None,
+    })
+}
+
+/// Reject `CreateTags`/`DeleteTags` targeting a resource id of a modeled family
+/// that does not exist, matching AWS's `InvalidID` for a bad resource id.
+fn ensure_resources_exist(state: &Ec2State, ids: &[String]) -> Result<(), AwsServiceError> {
+    for id in ids {
+        if resource_exists(state, id) == Some(false) {
+            return Err(AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "InvalidID",
+                format!("The ID '{id}' is not valid"),
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn create_tags(
     svc: &Ec2Service,
     req: &AwsRequest,
@@ -102,6 +141,7 @@ pub(crate) fn create_tags(
     if !resource_ids.is_empty() && !tags.is_empty() {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        ensure_resources_exist(state, &resource_ids)?;
         for id in &resource_ids {
             state.upsert_tags(id, &tags);
         }
@@ -125,6 +165,7 @@ pub(crate) fn delete_tags(
     if !resource_ids.is_empty() {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        ensure_resources_exist(state, &resource_ids)?;
         for id in &resource_ids {
             if to_remove.is_empty() {
                 // DeleteTags with no Tag set removes every tag on the resource.
@@ -192,14 +233,9 @@ fn tag_matches_filters(resource_id: &str, tag: &Tag, filters: &[Filter]) -> bool
             // nothing is the safe, test-stable behavior for the foundation).
             _ => return false,
         };
-        f.values.iter().any(|v| {
-            // EC2 filter values support a trailing `*` wildcard.
-            if let Some(prefix) = v.strip_suffix('*') {
-                candidate.starts_with(prefix)
-            } else {
-                candidate == *v
-            }
-        })
+        f.values
+            .iter()
+            .any(|v| crate::service_helpers::filter_value_matches(v, &candidate))
     })
 }
 
@@ -221,4 +257,52 @@ pub(crate) fn infer_resource_type(resource_id: &str) -> String {
         _ => "resource",
     };
     ty.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    #[test]
+    fn create_tags_rejects_nonexistent_resource() {
+        let svc = Ec2Service::new();
+        let err = err_of(create_tags(
+            &svc,
+            &req(
+                "CreateTags",
+                &[
+                    ("ResourceId.1", "vpc-doesnotexist0000"),
+                    ("Tag.1.Key", "Name"),
+                    ("Tag.1.Value", "x"),
+                ],
+            ),
+        ));
+        assert_eq!(err.code(), "InvalidID");
+    }
+
+    #[test]
+    fn create_tags_on_existing_resource_succeeds() {
+        let svc = Ec2Service::new();
+        let vpc_id = {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.vpcs.keys().next().unwrap().clone()
+        };
+        create_tags(
+            &svc,
+            &req(
+                "CreateTags",
+                &[
+                    ("ResourceId.1", &vpc_id),
+                    ("Tag.1.Key", "Name"),
+                    ("Tag.1.Value", "prod"),
+                ],
+            ),
+        )
+        .unwrap();
+        let accounts = svc.state.read();
+        let tags = accounts.get("000000000000").unwrap().tags_for(&vpc_id);
+        assert!(tags.iter().any(|t| t.key == "Name" && t.value == "prod"));
+    }
 }

--- a/crates/fakecloud-ec2/src/service/volume.rs
+++ b/crates/fakecloud-ec2/src/service/volume.rs
@@ -5,7 +5,10 @@ use fakecloud_aws::ec2query::{ec2_elem, ec2_list, ec2_return};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
-use crate::service_helpers::{gen_id, indexed_list, parse_filters, require, validate_enum, Filter};
+use crate::service_helpers::{
+    filter_value_matches, gen_id, indexed_list, not_found, paginate, parse_filters, require,
+    validate_enum, Filter,
+};
 use crate::state::{Ec2State, Tag, Volume, VolumeAttachment};
 
 const VOLUME_TYPES: &[&str] = &["standard", "io1", "io2", "gp2", "sc1", "st1", "gp3"];
@@ -99,6 +102,7 @@ pub(crate) fn create_volume(
         auto_enable_io: false,
         attachments: Vec::new(),
         in_recycle_bin: false,
+        modification: None,
     };
     let tags = {
         let mut accounts = svc.state.write();
@@ -122,8 +126,28 @@ pub(crate) fn delete_volume(
     let id = require(&req.query_params, "VolumeId")?;
     let mut accounts = svc.state.write();
     let state = accounts.get_or_create(&req.account_id);
-    state.volumes.remove(&id);
-    state.tags.remove(&id);
+    let retention = state.recycle_bin_retention.volumes;
+    let vol = state
+        .volumes
+        .get_mut(&id)
+        .ok_or_else(|| not_found("InvalidVolume.NotFound", &id))?;
+    // AWS rejects deleting an attached volume — it must be detached first.
+    if vol.state == "in-use" || !vol.attachments.is_empty() {
+        return Err(AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "VolumeInUse",
+            format!("Volume '{id}' is currently attached and cannot be deleted"),
+        ));
+    }
+    if retention {
+        // A recycle-bin retention rule covers volumes: soft-delete so it can be
+        // listed and restored rather than destroying it.
+        vol.state = "deleting".to_string();
+        vol.in_recycle_bin = true;
+    } else {
+        state.volumes.remove(&id);
+        state.tags.remove(&id);
+    }
     Ok(Ec2Service::respond(
         "DeleteVolume",
         &req.request_id,
@@ -149,10 +173,22 @@ pub(crate) fn describe_volumes(
         .map(|v| volume_xml(v, state.tags_for(&v.volume_id)))
         .collect();
     items.sort();
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("volumeSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeVolumes",
         &req.request_id,
-        &ec2_list("volumeSet", &items),
+        &body,
     ))
 }
 
@@ -164,6 +200,8 @@ fn vol_match(v: &Volume, tags: &[Tag], filters: &[Filter]) -> bool {
             "status" => vec![v.state.clone()],
             "availability-zone" => vec![v.availability_zone.clone()],
             "snapshot-id" => v.snapshot_id.clone().into_iter().collect(),
+            "encrypted" => vec![v.encrypted.to_string()],
+            "size" => vec![v.size.to_string()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -172,11 +210,13 @@ fn vol_match(v: &Volume, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true;
+                    return false;
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|val| candidates.iter().any(|c| filter_value_matches(val, c)))
     })
 }
 
@@ -197,10 +237,12 @@ pub(crate) fn attach_volume(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(v) = state.volumes.get_mut(&volume_id) {
-            v.state = "in-use".to_string();
-            v.attachments = vec![att.clone()];
-        }
+        let v = state
+            .volumes
+            .get_mut(&volume_id)
+            .ok_or_else(|| not_found("InvalidVolume.NotFound", &volume_id))?;
+        v.state = "in-use".to_string();
+        v.attachments = vec![att.clone()];
     }
     Ok(Ec2Service::respond(
         "AttachVolume",
@@ -228,14 +270,16 @@ pub(crate) fn detach_volume(
     {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(v) = state.volumes.get_mut(&volume_id) {
-            if let Some(a) = v.attachments.first() {
-                att.instance_id = a.instance_id.clone();
-                att.device = a.device.clone();
-            }
-            v.state = "available".to_string();
-            v.attachments.clear();
+        let v = state
+            .volumes
+            .get_mut(&volume_id)
+            .ok_or_else(|| not_found("InvalidVolume.NotFound", &volume_id))?;
+        if let Some(a) = v.attachments.first() {
+            att.instance_id = a.instance_id.clone();
+            att.device = a.device.clone();
         }
+        v.state = "available".to_string();
+        v.attachments.clear();
     }
     Ok(Ec2Service::respond(
         "DetachVolume",
@@ -244,12 +288,30 @@ pub(crate) fn detach_volume(
     ))
 }
 
-fn modification_xml(volume_id: &str) -> String {
+fn opt_elem(name: &str, v: Option<i64>) -> String {
+    v.map(|n| format!("<{name}>{n}</{name}>"))
+        .unwrap_or_default()
+}
+
+fn modification_xml(volume_id: &str, m: &crate::state::VolumeModification) -> String {
+    let progress = if m.state == "completed" { 100 } else { 0 };
     format!(
-        "{}<modificationState>modifying</modificationState><targetSize>16</targetSize>\
-         <originalSize>8</originalSize><progress>0</progress><startTime>{}</startTime>",
+        "{}<modificationState>{}</modificationState>\
+         <originalSize>{}</originalSize>{}{}{}\
+         <targetSize>{}</targetSize>{}{}{}\
+         <progress>{}</progress><startTime>{}</startTime>",
         ec2_elem("volumeId", volume_id),
-        FIXED_TIME,
+        m.state,
+        m.original_size,
+        opt_elem("originalIops", m.original_iops),
+        opt_elem("originalThroughput", m.original_throughput),
+        ec2_elem("originalVolumeType", &m.original_volume_type),
+        m.target_size,
+        opt_elem("targetIops", m.target_iops),
+        opt_elem("targetThroughput", m.target_throughput),
+        ec2_elem("targetVolumeType", &m.target_volume_type),
+        progress,
+        m.start_time,
     )
 }
 
@@ -259,25 +321,55 @@ pub(crate) fn modify_volume(
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "VolumeId")?;
     validate_enum(&req.query_params, "VolumeType", VOLUME_TYPES)?;
-    {
+    let rendered = {
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        if let Some(v) = state.volumes.get_mut(&id) {
-            if let Some(sz) = req.query_params.get("Size").and_then(|s| s.parse().ok()) {
-                v.size = sz;
-            }
-            if let Some(vt) = req.query_params.get("VolumeType") {
-                v.volume_type = vt.clone();
-            }
+        let v = state
+            .volumes
+            .get_mut(&id)
+            .ok_or_else(|| not_found("InvalidVolume.NotFound", &id))?;
+        // Snapshot the pre-modification values, then apply and record the change
+        // so DescribeVolumesModifications reflects real targets, not constants.
+        let original_size = v.size;
+        let original_iops = v.iops;
+        let original_throughput = v.throughput;
+        let original_volume_type = v.volume_type.clone();
+        if let Some(sz) = req.query_params.get("Size").and_then(|s| s.parse().ok()) {
+            v.size = sz;
         }
-    }
+        if let Some(vt) = req.query_params.get("VolumeType") {
+            v.volume_type = vt.clone();
+        }
+        if let Some(iops) = req.query_params.get("Iops").and_then(|s| s.parse().ok()) {
+            v.iops = Some(iops);
+        }
+        if let Some(tp) = req
+            .query_params
+            .get("Throughput")
+            .and_then(|s| s.parse().ok())
+        {
+            v.throughput = Some(tp);
+        }
+        let m = crate::state::VolumeModification {
+            original_size,
+            original_iops,
+            original_throughput,
+            original_volume_type,
+            target_size: v.size,
+            target_iops: v.iops,
+            target_throughput: v.throughput,
+            target_volume_type: v.volume_type.clone(),
+            state: "completed".to_string(),
+            start_time: FIXED_TIME.to_string(),
+        };
+        let xml = modification_xml(&id, &m);
+        v.modification = Some(m);
+        xml
+    };
     Ok(Ec2Service::respond(
         "ModifyVolume",
         &req.request_id,
-        &format!(
-            "<volumeModification>{}</volumeModification>",
-            modification_xml(&id)
-        ),
+        &format!("<volumeModification>{rendered}</volumeModification>"),
     ))
 }
 
@@ -293,7 +385,11 @@ pub(crate) fn describe_volumes_modifications(
         .volumes
         .values()
         .filter(|v| wanted.is_empty() || wanted.contains(&v.volume_id))
-        .map(|v| modification_xml(&v.volume_id))
+        .filter_map(|v| {
+            v.modification
+                .as_ref()
+                .map(|m| modification_xml(&v.volume_id, m))
+        })
         .collect();
     Ok(Ec2Service::respond(
         "DescribeVolumesModifications",
@@ -538,6 +634,7 @@ pub(crate) fn restore_volume_from_recycle_bin(
         let state = accounts.get_or_create(&req.account_id);
         if let Some(v) = state.volumes.get_mut(&id) {
             v.in_recycle_bin = false;
+            v.state = "available".to_string();
         }
     }
     Ok(Ec2Service::respond(
@@ -545,4 +642,185 @@ pub(crate) fn restore_volume_from_recycle_bin(
         &req.request_id,
         &ec2_return(true),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    fn seed_volume(svc: &Ec2Service, id: &str, state_name: &str, attached: bool) {
+        let mut accounts = svc.state.write();
+        let st = accounts.get_or_create("000000000000");
+        st.volumes.insert(
+            id.to_string(),
+            Volume {
+                volume_id: id.into(),
+                size: 8,
+                snapshot_id: None,
+                availability_zone: "us-east-1a".into(),
+                state: state_name.into(),
+                volume_type: "gp3".into(),
+                iops: Some(3000),
+                throughput: Some(125),
+                encrypted: false,
+                kms_key_id: None,
+                multi_attach_enabled: false,
+                auto_enable_io: false,
+                attachments: if attached {
+                    vec![VolumeAttachment {
+                        volume_id: id.into(),
+                        instance_id: "i-1".into(),
+                        device: "/dev/sdf".into(),
+                        status: "attached".into(),
+                        delete_on_termination: false,
+                    }]
+                } else {
+                    vec![]
+                },
+                in_recycle_bin: false,
+                modification: None,
+            },
+        );
+    }
+
+    fn body_of(resp: AwsResponse) -> String {
+        String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
+    }
+
+    #[test]
+    fn delete_volume_rejects_nonexistent() {
+        let svc = Ec2Service::new();
+        let err = err_of(delete_volume(
+            &svc,
+            &req("DeleteVolume", &[("VolumeId", "vol-nope")]),
+        ));
+        assert_eq!(err.code(), "InvalidVolume.NotFound");
+    }
+
+    #[test]
+    fn delete_volume_rejects_in_use() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "in-use", true);
+        let err = err_of(delete_volume(
+            &svc,
+            &req("DeleteVolume", &[("VolumeId", "vol-1")]),
+        ));
+        assert_eq!(err.code(), "VolumeInUse");
+        // Still present after the rejected delete.
+        assert!(svc
+            .state
+            .read()
+            .get("000000000000")
+            .unwrap()
+            .volumes
+            .contains_key("vol-1"));
+    }
+
+    #[test]
+    fn delete_volume_hard_deletes_without_retention_rule() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "available", false);
+        delete_volume(&svc, &req("DeleteVolume", &[("VolumeId", "vol-1")])).unwrap();
+        assert!(!svc
+            .state
+            .read()
+            .get("000000000000")
+            .unwrap()
+            .volumes
+            .contains_key("vol-1"));
+    }
+
+    #[test]
+    fn delete_volume_routes_to_recycle_bin_with_retention_rule() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "available", false);
+        svc.state
+            .write()
+            .get_or_create("000000000000")
+            .recycle_bin_retention
+            .volumes = true;
+        delete_volume(&svc, &req("DeleteVolume", &[("VolumeId", "vol-1")])).unwrap();
+        // Present, flagged, and listed in the recycle bin.
+        let list = body_of(
+            list_volumes_in_recycle_bin(&svc, &req("ListVolumesInRecycleBin", &[])).unwrap(),
+        );
+        assert!(list.contains("<volumeId>vol-1</volumeId>"), "{list}");
+        // Hidden from normal DescribeVolumes.
+        let desc = body_of(describe_volumes(&svc, &req("DescribeVolumes", &[])).unwrap());
+        assert!(!desc.contains("<volumeId>vol-1</volumeId>"), "{desc}");
+        // Restore brings it back.
+        restore_volume_from_recycle_bin(
+            &svc,
+            &req("RestoreVolumeFromRecycleBin", &[("VolumeId", "vol-1")]),
+        )
+        .unwrap();
+        let desc2 = body_of(describe_volumes(&svc, &req("DescribeVolumes", &[])).unwrap());
+        assert!(desc2.contains("<volumeId>vol-1</volumeId>"), "{desc2}");
+    }
+
+    #[test]
+    fn modify_volume_persists_iops_and_throughput() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "available", false);
+        modify_volume(
+            &svc,
+            &req(
+                "ModifyVolume",
+                &[
+                    ("VolumeId", "vol-1"),
+                    ("Size", "100"),
+                    ("Iops", "6000"),
+                    ("Throughput", "250"),
+                ],
+            ),
+        )
+        .unwrap();
+        {
+            let st = svc.state.read();
+            let v = &st.get("000000000000").unwrap().volumes["vol-1"];
+            assert_eq!(v.size, 100);
+            assert_eq!(v.iops, Some(6000));
+            assert_eq!(v.throughput, Some(250));
+        }
+        let body = body_of(
+            describe_volumes_modifications(&svc, &req("DescribeVolumesModifications", &[]))
+                .unwrap(),
+        );
+        assert!(body.contains("<targetIops>6000</targetIops>"), "{body}");
+        assert!(
+            body.contains("<targetThroughput>250</targetThroughput>"),
+            "{body}"
+        );
+        assert!(body.contains("<targetSize>100</targetSize>"), "{body}");
+    }
+
+    #[test]
+    fn describe_volumes_paginates() {
+        let svc = Ec2Service::new();
+        for i in 0..3 {
+            seed_volume(&svc, &format!("vol-{i}"), "available", false);
+        }
+        let body = body_of(
+            describe_volumes(&svc, &req("DescribeVolumes", &[("MaxResults", "2")])).unwrap(),
+        );
+        assert!(body.contains("<nextToken>"), "expected a NextToken: {body}");
+    }
+
+    #[test]
+    fn attach_volume_rejects_nonexistent() {
+        let svc = Ec2Service::new();
+        let err = err_of(attach_volume(
+            &svc,
+            &req(
+                "AttachVolume",
+                &[
+                    ("VolumeId", "vol-nope"),
+                    ("InstanceId", "i-1"),
+                    ("Device", "/dev/sdf"),
+                ],
+            ),
+        ));
+        assert_eq!(err.code(), "InvalidVolume.NotFound");
+    }
 }

--- a/crates/fakecloud-ec2/src/service/vpc.rs
+++ b/crates/fakecloud-ec2/src/service/vpc.rs
@@ -6,7 +6,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_enum,
+    validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Tag, Vpc, VpcCidrAssoc};
 
@@ -105,11 +106,13 @@ fn vpc_matches(vpc: &Vpc, tags: &[Tag], filters: &[Filter]) -> bool {
                         .map(|t| t.value.clone())
                         .collect()
                 } else {
-                    return true; // unknown filter: don't exclude
+                    return false; // unknown filter: match nothing
                 }
             }
         };
-        f.values.iter().any(|v| candidates.iter().any(|c| c == v))
+        f.values
+            .iter()
+            .any(|v| candidates.iter().any(|c| filter_value_matches(v, c)))
     })
 }
 

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -33,6 +33,20 @@ impl fakecloud_core::multi_account::AccountState for Ec2State {
     }
 }
 
+/// Recycle Bin retention rules in effect for an account, per resource type.
+/// Populated by AWS's `rbin` API (not modeled as a separate service here); when
+/// a flag is set, the corresponding `Delete*` op sends the resource to the
+/// recycle bin instead of hard-deleting it.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct RecycleBinRetention {
+    #[serde(default)]
+    pub volumes: bool,
+    #[serde(default)]
+    pub snapshots: bool,
+    #[serde(default)]
+    pub images: bool,
+}
+
 /// A single EC2 resource tag.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Tag {
@@ -462,6 +476,22 @@ pub struct VolumeAttachment {
     pub delete_on_termination: bool,
 }
 
+/// A recorded `ModifyVolume` request, surfaced by `DescribeVolumesModifications`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VolumeModification {
+    pub original_size: i64,
+    pub original_iops: Option<i64>,
+    pub original_throughput: Option<i64>,
+    pub original_volume_type: String,
+    pub target_size: i64,
+    pub target_iops: Option<i64>,
+    pub target_throughput: Option<i64>,
+    pub target_volume_type: String,
+    /// `modifying` | `optimizing` | `completed` | `failed`.
+    pub state: String,
+    pub start_time: String,
+}
+
 /// An EBS volume.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Volume {
@@ -482,6 +512,9 @@ pub struct Volume {
     pub attachments: Vec<VolumeAttachment>,
     #[serde(default)]
     pub in_recycle_bin: bool,
+    /// Last `ModifyVolume` request applied to this volume, if any.
+    #[serde(default)]
+    pub modification: Option<VolumeModification>,
 }
 
 /// An EBS snapshot.
@@ -704,6 +737,9 @@ pub struct SpotRequest {
 pub struct SpotFleet {
     pub id: String,
     pub state: String,
+    /// `SpotFleetRequestConfig.TargetCapacity`.
+    #[serde(default)]
+    pub target_capacity: i64,
 }
 
 /// An EC2 fleet.
@@ -712,6 +748,9 @@ pub struct Fleet {
     pub id: String,
     pub state: String,
     pub fleet_type: String,
+    /// `TargetCapacitySpecification.TotalTargetCapacity`.
+    #[serde(default)]
+    pub target_capacity: i64,
 }
 
 /// An on-demand capacity reservation.
@@ -1330,6 +1369,13 @@ pub struct Ec2State {
     pub instances: BTreeMap<String, Instance>,
     #[serde(default)]
     pub volumes: BTreeMap<String, Volume>,
+    /// Recycle Bin retention rules by resource type. AWS's `rbin` service (a
+    /// separate front-door not modeled in this crate) creates these; when a rule
+    /// covers a resource type, `Delete*` routes the resource to the recycle bin
+    /// (`in_recycle_bin = true`) instead of hard-deleting it, so the matching
+    /// `List*InRecycleBin` / `Restore*FromRecycleBin` ops can recover it.
+    #[serde(default)]
+    pub recycle_bin_retention: RecycleBinRetention,
     /// Account-level EBS default encryption toggle.
     #[serde(default)]
     pub ebs_encryption_default: bool,


### PR DESCRIPTION
## Summary
Broad behavioral hardening of EC2 control-plane handlers — silent data loss + fidelity divergences the conformance probe can't see (it runs each op once with clean input on a small fixture, never chains create→modify→describe or seeds multi-rule/attached state).

**HIGH (data loss):**
- H1 `RevokeSecurityGroupIngress/Egress` by `IpPermissions` (the shape plain `aws-cli` + terraform inline rules send) deleted **every** rule in that direction; now removes only the rule(s) the permission describes.
- H2 `DeleteVolume` hard-deleted an attached (`in-use`) or nonexistent volume; now returns `VolumeInUse`/`InvalidVolume.NotFound`, and the previously-dead recycle-bin (`in_recycle_bin` + `List/Restore*FromRecycleBin`) is wired under a retention rule.

**MEDIUM:** pagination applied across Describe ops (M1); Assign/Unassign private/ipv6 addresses persist + 404 on missing ENI (M2); filter wildcards + unknown-filter handling made consistent (M3/M4); fleet target capacity persisted + `Modify*Fleet` apply (M5); image deprecation/disable persist (M6); `ModifyVolume` persists Iops/Throughput (M7); duplicate key pairs rejected (M8); `CreateTags`/`DeleteTags` validate resource existence (M9); `CreateSnapshots` uses real volume ids + validates source (M10); RunInstances `running` survives restart (M12); `Authorize/Revoke` SG + `DescribeInstances` return `NotFound` on unknown ids (M13/M14).

**LOW:** phantom-success `NotFound` cluster, CIDR/port/protocol validation, route-table fidelity, `DeleteSecurityGroup` VPC scoping, RunInstances `MissingParameter`.

(The cross-service non-ASCII tag corruption — originally EC2 M11 — was fixed separately in the merged core PR #2245.)

## Test plan
- `cargo test -p fakecloud-ec2` — 122 pass, incl. new tests: revoke-removes-only-matching-rule, delete-volume in-use/nonexistent/recycle-bin, assign-IPs persist + missing-ENI error, duplicate key pair, fleet capacity, image deprecation, modify-volume iops/throughput.
- `cargo build --workspace` clean (new state fields propagated). CI runs full clippy + conformance + e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened EC2 control-plane to stop SG-rule and volume data loss, add pagination, and persist modify/assign ops for AWS‑faithful behavior. Conformance tests now seed real resources across tags, ENI assign/unassign, snapshots, and volume modifications to match stricter NotFound paths.

- **Bug Fixes**
  - RevokeSecurityGroupIngress/Egress by IpPermissions removes only matching rules; all-traffic egress revokes regardless of From/ToPort.
  - DeleteVolume returns VolumeInUse/InvalidVolume.NotFound and honors recycle-bin retention.
  - Consistent NotFound/validation: unknown security group/ENI/EIP/CapacityReservation ids and explicit DescribeInstances ids; ReleaseAddress/DeleteNetworkInterface/CancelCapacityReservation return canonical codes.
  - Filters: wildcard matching added; unknown filters no longer match everything.
  - CreateTags/DeleteTags require existing resources; key pairs must be unique.
  - Snapshots: validate source volume/instance, use real volume ids, and return canonical InvalidInstanceID.NotFound.
  - DeleteSecurityGroup enforces VPC scoping; RunInstances errors on missing ImageId without a template.

- **New Features**
  - Pagination (MaxResults/NextToken) across Describe APIs, including security groups and ENIs.
  - Persist Assign/Unassign private and IPv6 addresses; 404 on missing ENI.
  - Persist fleet target capacity and apply Modify*Fleet.
  - Persist image deprecation/disable; DescribeImages hides disabled images unless targeted.
  - Persist ModifyVolume IOPS/throughput and expose via DescribeVolumesModifications.
  - RunInstances metadata-only path reconciles to running and persists across restarts.

<sup>Written for commit 2fc1fe20178c8f7b35fe0712a96b15f641624594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

