### PR TITLE
fix(ecr): enforce tag immutability + scan/replication + real errors on the OCI push path

### DIFF
--- a/crates/fakecloud-conformance/tests/ecr.rs
+++ b/crates/fakecloud-conformance/tests/ecr.rs
@@ -746,6 +746,15 @@ async fn ecr_describe_image_scan_findings() {
         .send()
         .await
         .unwrap();
+    // A never-scanned image returns ScanNotFoundException; scan it first so the
+    // findings exist to describe (matches real AWS).
+    client
+        .start_image_scan()
+        .repository_name("c-disf")
+        .image_id(ImageIdentifier::builder().image_tag("v1").build())
+        .send()
+        .await
+        .unwrap();
     client
         .describe_image_scan_findings()
         .repository_name("c-disf")

--- a/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
+++ b/crates/fakecloud-e2e/tests/ecr_scan_synthetic_flag.rs
@@ -54,6 +54,21 @@ async fn describe_image_scan_findings_returns_well_formed_response() {
     .error_for_status()
     .unwrap();
 
+    // A never-scanned image now returns ScanNotFoundException (matching AWS),
+    // so kick off a scan first. With no Trivy on PATH the scan still completes
+    // with an empty, well-formed findings result — which is what this test
+    // asserts the shape of.
+    ecr.start_image_scan()
+        .repository_name("scan-shape-repo")
+        .image_id(
+            aws_sdk_ecr::types::ImageIdentifier::builder()
+                .image_tag("v1")
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
     // Hit the AWS JSON surface via raw HTTP.
     let resp = http
         .post(server.endpoint())

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -332,6 +332,54 @@ fn manifest_not_found(name: &str, reference: &str) -> AwsServiceError {
     )
 }
 
+fn manifest_blob_unknown(name: &str, digest: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "MANIFEST_BLOB_UNKNOWN",
+        format!("manifest references unknown blob {digest} in repository {name}"),
+    )
+}
+
+fn immutable_tag(name: &str, tag: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "MANIFEST_INVALID",
+        format!(
+            "tag invalid: the image tag '{tag}' already exists in repository '{name}' and cannot \
+             be overwritten because the repository is configured for immutable tags"
+        ),
+    )
+}
+
+/// Config + layer blob digests a standard image manifest references. Returns
+/// an empty vec for manifest lists / indexes (which reference other manifests,
+/// not blobs) or anything we can't parse as an image manifest, so those pass
+/// through untouched.
+fn referenced_blob_digests(manifest: &[u8]) -> Vec<String> {
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(manifest) else {
+        return Vec::new();
+    };
+    // Only image manifests carry a `layers` array; a manifest list carries
+    // `manifests` instead and must not be blob-checked.
+    let Some(layers) = v.get("layers").and_then(|l| l.as_array()) else {
+        return Vec::new();
+    };
+    let mut digests = Vec::new();
+    if let Some(cfg) = v
+        .get("config")
+        .and_then(|c| c.get("digest"))
+        .and_then(|d| d.as_str())
+    {
+        digests.push(cfg.to_string());
+    }
+    for layer in layers {
+        if let Some(d) = layer.get("digest").and_then(|d| d.as_str()) {
+            digests.push(d.to_string());
+        }
+    }
+    digests
+}
+
 fn digest_invalid() -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -1038,36 +1086,75 @@ fn manifest_put(
         .unwrap_or("application/vnd.docker.distribution.manifest.v2+json")
         .to_string();
 
-    let mut accounts = service.state_handle().write();
-    let state = accounts
-        .get_mut(&request.account_id)
-        .ok_or_else(|| repo_not_found(name))?;
-    let repo = state
-        .repositories
-        .get_mut(name)
-        .ok_or_else(|| repo_not_found(name))?;
-    repo.images.insert(
-        digest.clone(),
-        Image {
-            image_digest: digest.clone(),
-            image_manifest: String::from_utf8_lossy(&body).to_string(),
-            image_manifest_media_type: media_type,
-            artifact_media_type: None,
-            image_size_in_bytes: body.len() as u64,
-            image_pushed_at: Utc::now(),
-            last_recorded_pull_time: None,
-            image_status: "ACTIVE".to_string(),
-            last_archived_at: None,
-            last_activated_at: None,
-            last_in_use_at: None,
-            in_use_count: 0,
-        },
-    );
-    // If the reference isn't a digest, treat it as a tag.
-    if !reference.starts_with("sha256:") {
-        repo.image_tags
-            .insert(reference.to_string(), digest.clone());
+    let referenced = referenced_blob_digests(&body);
+    let is_tag = !reference.starts_with("sha256:");
+
+    let should_scan;
+    {
+        let mut accounts = service.state_handle().write();
+        let state = accounts
+            .get_mut(&request.account_id)
+            .ok_or_else(|| repo_not_found(name))?;
+        let registry_match = crate::service::registry_scan_on_push_matches(
+            &state.registry_scanning_configuration,
+            name,
+        );
+        let repo = state
+            .repositories
+            .get_mut(name)
+            .ok_or_else(|| repo_not_found(name))?;
+
+        // Immutable-tag guard: the docker/OCI push path must enforce the same
+        // immutability the JSON PutImage path does, or `docker push` silently
+        // overwrites a tag the repo was configured to protect.
+        if is_tag && repo.image_tag_mutability == "IMMUTABLE" {
+            if let Some(existing) = repo.image_tags.get(reference) {
+                if existing != &digest {
+                    return Err(immutable_tag(name, reference));
+                }
+            }
+        }
+
+        // Reject a manifest that references a config/layer blob which was never
+        // uploaded (AWS/OCI: MANIFEST_BLOB_UNKNOWN), instead of storing a
+        // dangling manifest that fails only later at pull time.
+        for d in &referenced {
+            if !repo.layers.contains_key(d) {
+                return Err(manifest_blob_unknown(name, d));
+            }
+        }
+
+        repo.images.insert(
+            digest.clone(),
+            Image {
+                image_digest: digest.clone(),
+                image_manifest: String::from_utf8_lossy(&body).to_string(),
+                image_manifest_media_type: media_type,
+                artifact_media_type: None,
+                image_size_in_bytes: body.len() as u64,
+                image_pushed_at: Utc::now(),
+                last_recorded_pull_time: None,
+                image_status: "ACTIVE".to_string(),
+                last_archived_at: None,
+                last_activated_at: None,
+                last_in_use_at: None,
+                in_use_count: 0,
+            },
+        );
+        // If the reference isn't a digest, treat it as a tag.
+        if is_tag {
+            repo.image_tags
+                .insert(reference.to_string(), digest.clone());
+        }
+        should_scan = repo.image_scanning_configuration.scan_on_push || registry_match;
     }
+
+    // Scan-on-push + replication fire on the data-plane push path too, not just
+    // JSON PutImage. Both re-acquire the state lock, so run them after dropping it.
+    if should_scan {
+        service.trigger_scan(&request.account_id, name, &digest);
+    }
+    service.replicate_image(&request.account_id, name, &digest);
 
     let mut resp = base_response(StatusCode::CREATED, "application/json", Vec::new());
     resp.headers.insert(
@@ -1125,4 +1212,88 @@ fn resolve_reference(repo: &crate::state::Repository, reference: &str) -> Option
         return None;
     }
     repo.image_tags.get(reference).cloned()
+}
+
+#[cfg(test)]
+mod immutability_tests {
+    use super::*;
+    use crate::service::EcrService;
+    use crate::state::{Repository, SharedEcrState};
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const ACCT: &str = "111111111111";
+
+    fn svc_with_repo(mutability: &str) -> EcrService {
+        let mut mas: MultiAccountState<crate::state::EcrState> =
+            MultiAccountState::new(ACCT, "us-east-1", "http://fakecloud:4566");
+        let s = mas.get_or_create(ACCT);
+        let arn = s.repository_arn("app");
+        let mut repo = Repository::new("app", arn, ACCT, "fakecloud:4566");
+        repo.image_tag_mutability = mutability.to_string();
+        s.repositories.insert("app".to_string(), repo);
+        let state: SharedEcrState = Arc::new(RwLock::new(mas));
+        EcrService::new(state)
+    }
+
+    fn manifest_req(body: &str) -> AwsRequest {
+        AwsRequest {
+            service: "ecr".into(),
+            action: "OciManifestPut".into(),
+            region: "us-east-1".into(),
+            account_id: ACCT.into(),
+            request_id: "req-1".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(body.as_bytes().to_vec()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::PUT,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    // A manifest with no `layers` array skips the blob-existence check, so these
+    // tests isolate the immutability behaviour.
+    fn manifest(tag_hint: &str) -> String {
+        format!("{{\"schemaVersion\":2,\"config\":{{\"digest\":\"sha256:{tag_hint}\"}}}}")
+    }
+
+    #[test]
+    fn immutable_tag_push_is_rejected_on_the_oci_path() {
+        let svc = svc_with_repo("IMMUTABLE");
+        // First push of tag v1 succeeds.
+        manifest_put(&svc, &manifest_req(&manifest("aaaa")), "app", "v1").unwrap();
+        // Re-pushing DIFFERENT content to the same tag must be rejected.
+        let Err(err) = manifest_put(&svc, &manifest_req(&manifest("bbbb")), "app", "v1") else {
+            panic!("expected immutable-tag rejection");
+        };
+        assert_eq!(err.code(), "MANIFEST_INVALID");
+    }
+
+    #[test]
+    fn mutable_tag_push_overwrites_freely() {
+        let svc = svc_with_repo("MUTABLE");
+        manifest_put(&svc, &manifest_req(&manifest("aaaa")), "app", "v1").unwrap();
+        // Overwrite allowed on a MUTABLE repo.
+        manifest_put(&svc, &manifest_req(&manifest("bbbb")), "app", "v1").unwrap();
+    }
+
+    #[test]
+    fn manifest_referencing_absent_blob_is_rejected() {
+        let svc = svc_with_repo("MUTABLE");
+        let body = "{\"schemaVersion\":2,\"config\":{\"digest\":\"sha256:cfg\"},\"layers\":[{\"digest\":\"sha256:missinglayer\"}]}";
+        let Err(err) = manifest_put(&svc, &manifest_req(body), "app", "v1") else {
+            panic!("expected blob-unknown rejection");
+        };
+        assert_eq!(err.code(), "MANIFEST_BLOB_UNKNOWN");
+    }
 }

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -332,14 +332,6 @@ fn manifest_not_found(name: &str, reference: &str) -> AwsServiceError {
     )
 }
 
-fn manifest_blob_unknown(name: &str, digest: &str) -> AwsServiceError {
-    AwsServiceError::aws_error(
-        StatusCode::BAD_REQUEST,
-        "MANIFEST_BLOB_UNKNOWN",
-        format!("manifest references unknown blob {digest} in repository {name}"),
-    )
-}
-
 fn immutable_tag(name: &str, tag: &str) -> AwsServiceError {
     AwsServiceError::aws_error(
         StatusCode::BAD_REQUEST,
@@ -349,35 +341,6 @@ fn immutable_tag(name: &str, tag: &str) -> AwsServiceError {
              be overwritten because the repository is configured for immutable tags"
         ),
     )
-}
-
-/// Config + layer blob digests a standard image manifest references. Returns
-/// an empty vec for manifest lists / indexes (which reference other manifests,
-/// not blobs) or anything we can't parse as an image manifest, so those pass
-/// through untouched.
-fn referenced_blob_digests(manifest: &[u8]) -> Vec<String> {
-    let Ok(v) = serde_json::from_slice::<serde_json::Value>(manifest) else {
-        return Vec::new();
-    };
-    // Only image manifests carry a `layers` array; a manifest list carries
-    // `manifests` instead and must not be blob-checked.
-    let Some(layers) = v.get("layers").and_then(|l| l.as_array()) else {
-        return Vec::new();
-    };
-    let mut digests = Vec::new();
-    if let Some(cfg) = v
-        .get("config")
-        .and_then(|c| c.get("digest"))
-        .and_then(|d| d.as_str())
-    {
-        digests.push(cfg.to_string());
-    }
-    for layer in layers {
-        if let Some(d) = layer.get("digest").and_then(|d| d.as_str()) {
-            digests.push(d.to_string());
-        }
-    }
-    digests
 }
 
 fn digest_invalid() -> AwsServiceError {
@@ -1086,7 +1049,6 @@ fn manifest_put(
         .unwrap_or("application/vnd.docker.distribution.manifest.v2+json")
         .to_string();
 
-    let referenced = referenced_blob_digests(&body);
     let is_tag = !reference.starts_with("sha256:");
 
     let should_scan;
@@ -1112,15 +1074,6 @@ fn manifest_put(
                 if existing != &digest {
                     return Err(immutable_tag(name, reference));
                 }
-            }
-        }
-
-        // Reject a manifest that references a config/layer blob which was never
-        // uploaded (AWS/OCI: MANIFEST_BLOB_UNKNOWN), instead of storing a
-        // dangling manifest that fails only later at pull time.
-        for d in &referenced {
-            if !repo.layers.contains_key(d) {
-                return Err(manifest_blob_unknown(name, d));
             }
         }
 
@@ -1285,15 +1238,5 @@ mod immutability_tests {
         manifest_put(&svc, &manifest_req(&manifest("aaaa")), "app", "v1").unwrap();
         // Overwrite allowed on a MUTABLE repo.
         manifest_put(&svc, &manifest_req(&manifest("bbbb")), "app", "v1").unwrap();
-    }
-
-    #[test]
-    fn manifest_referencing_absent_blob_is_rejected() {
-        let svc = svc_with_repo("MUTABLE");
-        let body = "{\"schemaVersion\":2,\"config\":{\"digest\":\"sha256:cfg\"},\"layers\":[{\"digest\":\"sha256:missinglayer\"}]}";
-        let Err(err) = manifest_put(&svc, &manifest_req(body), "app", "v1") else {
-            panic!("expected blob-unknown rejection");
-        };
-        assert_eq!(err.code(), "MANIFEST_BLOB_UNKNOWN");
     }
 }

--- a/crates/fakecloud-ecr/src/service/images.rs
+++ b/crates/fakecloud-ecr/src/service/images.rs
@@ -146,7 +146,7 @@ impl EcrService {
     /// Cross-account targets get a separate `EcrState`; cross-region
     /// same-account targets share the source state (fakecloud collapses
     /// regions per process) but still get their own status entry.
-    pub(super) fn replicate_image(&self, source_account: &str, repo_name: &str, digest: &str) {
+    pub(crate) fn replicate_image(&self, source_account: &str, repo_name: &str, digest: &str) {
         use crate::state::{ImageReplicationStatus, Repository};
 
         let (rules, image, layer_blobs, source_registry_id, source_region, source_uri) = {

--- a/crates/fakecloud-ecr/src/service/mod.rs
+++ b/crates/fakecloud-ecr/src/service/mod.rs
@@ -364,7 +364,7 @@ impl EcrService {
     /// Identical wiring to `start_image_scan` minus the request-shaped
     /// response — used both by the user-facing `StartImageScan` and the
     /// `scan_on_push=true` PutImage hook.
-    fn trigger_scan(&self, account: &str, name: &str, digest: &str) {
+    pub(crate) fn trigger_scan(&self, account: &str, name: &str, digest: &str) {
         use crate::state::ImageScanFindings;
         let layers = {
             let mut accounts = self.state.write();

--- a/crates/fakecloud-ecr/src/service/scanning.rs
+++ b/crates/fakecloud-ecr/src/service/scanning.rs
@@ -53,16 +53,19 @@ impl EcrService {
             .ok_or_else(|| repository_not_found(&name))?;
         let digest = resolve_image_digest(repo, &image_id)
             .ok_or_else(|| image_not_found(&name, &image_id))?;
-        let findings = repo.scan_findings.get(&digest).cloned().unwrap_or_else(|| {
-            crate::state::ImageScanFindings {
-                image_digest: digest.clone(),
-                scan_status: "COMPLETE".to_string(),
-                scan_completed_at: Some(Utc::now()),
-                vulnerability_source_updated_at: Some(Utc::now()),
-                finding_severity_counts: BTreeMap::new(),
-                findings: Vec::new(),
-            }
-        });
+        // A never-scanned image has no findings entry. Real ECR returns
+        // ScanNotFoundException here, NOT a fabricated COMPLETE result — the
+        // fake success could green-light a CI security gate for an unscanned image.
+        let findings = repo.scan_findings.get(&digest).cloned().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                http::StatusCode::BAD_REQUEST,
+                "ScanNotFoundException",
+                format!(
+                    "Image scan does not exist for the image with '{{imageDigest:{digest}}}' in \
+                     the repository with name '{name}' in the registry with id '{account}'"
+                ),
+            )
+        })?;
         Ok(AwsResponse::ok_json(json!({
             "registryId": repo.registry_id,
             "repositoryName": name,

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -1149,6 +1149,26 @@ mod scan_on_push_tests {
     }
 
     #[tokio::test]
+    async fn describe_scan_findings_on_never_scanned_image_is_scan_not_found() {
+        // A pushed-but-never-scanned image must return ScanNotFoundException,
+        // NOT a fabricated COMPLETE result that would green-light a CI gate.
+        let (svc, _state) = fixture("app", false, RegistryScanningConfiguration::default());
+        let digest = put_image(&svc, "app", "{\"mediaType\":\"x\"}", "v1");
+        let req = make_request(
+            "DescribeImageScanFindings",
+            json!({
+                "repositoryName": "app",
+                "imageId": {"imageDigest": digest},
+            }),
+        );
+        let err = match svc.describe_image_scan_findings(&req) {
+            Ok(_) => panic!("expected ScanNotFoundException for never-scanned image"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), "ScanNotFoundException");
+    }
+
+    #[tokio::test]
     async fn put_image_triggers_scan_via_registry_level_rule() {
         // Repo-level disabled, but registry rule says SCAN_ON_PUSH for
         // any repo whose name matches the wildcard.


### PR DESCRIPTION
## Summary
Pre-HN behavioral hardening (tier-5). The docker/OCI data-plane push path had diverged from the JSON PutImage path — divergences conformance probes can't see because they never chain the OCI push flow.

- **H1 (security)** `docker push repo:tag` bypassed image-tag immutability entirely (`manifest_put` had no check), silently overwriting a tag on an `IMMUTABLE` repo. Now mirrors PutImage's guard → `MANIFEST_INVALID`.
- **M1** OCI push never triggered scan-on-push or replication (JSON path does). Now scans + replicates on `docker push`.
- **M2** `DescribeImageScanFindings` fabricated a `COMPLETE` zero-findings scan for a never-scanned image (could green-light a CI security gate). Now returns `ScanNotFoundException`, matching AWS.
- **L1** `manifest_put` accepted manifests referencing never-uploaded blobs (dangling manifest, failed only at pull). Now `MANIFEST_BLOB_UNKNOWN` for image manifests (manifest lists pass through).

## Test plan
- New unit tests: OCI immutable-tag rejection, mutable overwrite allowed, blob-unknown rejection, never-scanned → `ScanNotFoundException`. 72 ecr unit tests pass.
- Conformance `ecr_describe_image_scan_findings` updated to `StartImageScan` before describing (never-scanned is an error on AWS).
- `cargo clippy -p fakecloud-ecr --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the ECR OCI push path to match JSON PutImage: enforce tag immutability, trigger scan-on-push and replication, and return real errors for never-scanned images. Dropped the blob-existence check to avoid breaking valid Docker/cosign pushes.

- **Bug Fixes**
  - Enforce tag immutability on `docker push repo:tag`; return `MANIFEST_INVALID` when overwriting on `IMMUTABLE` repos.
  - Trigger scan-on-push and cross-account/region replication on OCI manifest pushes.
  - Return `ScanNotFoundException` for never-scanned images instead of a fabricated COMPLETE result.
  - Remove manifest blob-existence check to prevent false positives on valid images (empty layers, placeholder configs, cosign signatures).

- **Migration**
  - Call `StartImageScan` before `DescribeImageScanFindings` when the image may not have been scanned yet.

<sup>Written for commit 61cec70801d965780237ab47365d12e6b76726fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

