### PR TITLE
fix(sts): validate RoleSessionName against AWS pattern (reject XML injection)

### DIFF
--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -21,6 +21,7 @@ impl StsService {
             )
         })?;
         validate_string_length("roleSessionName", role_session_name, 2, 64)?;
+        validate_session_name(role_session_name)?;
 
         // Validate optional DurationSeconds (used below for expiration)
         if let Some(ds) = req.query_params.get("DurationSeconds") {
@@ -305,6 +306,7 @@ impl StsService {
             )
         })?;
         validate_string_length("roleSessionName", role_session_name, 2, 64)?;
+        validate_session_name(role_session_name)?;
 
         // WebIdentityToken is required
         let web_identity_token = req.query_params.get("WebIdentityToken").ok_or_else(|| {
@@ -657,6 +659,9 @@ impl StsService {
         // the issuer/audience claims used for trust-policy enforcement.
         let role_session_name =
             extract_saml_session_name(saml_assertion).unwrap_or_else(|| "saml-session".to_string());
+        // The SAML-derived session name is attacker-influenced; reject any that
+        // breaks the AWS pattern rather than injecting it raw into the response XML.
+        validate_session_name(&role_session_name)?;
         let saml_claims = extract_saml_claims(saml_assertion);
 
         let partition = partition_for_region(&req.region);

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -54,6 +54,28 @@ fn format_expiration(ts: DateTime<Utc>) -> String {
     ts.format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
+/// Enforce the AWS `RoleSessionName` pattern `[\w+=,.@-]*`. Without this, a
+/// name containing `<`, `>` or `&` is interpolated raw into the AssumedRoleId /
+/// assumed-role ARN in the XML response, producing malformed (and, for the
+/// attacker-controlled SAML session name, injectable) XML that SDK parsers
+/// reject. AWS rejects such input up front with a ValidationError.
+fn validate_session_name(name: &str) -> Result<(), AwsServiceError> {
+    if name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '+' | '=' | ',' | '.' | '@' | '-'))
+    {
+        return Ok(());
+    }
+    Err(AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ValidationError",
+        format!(
+            "1 validation error detected: Value '{name}' at 'roleSessionName' failed to satisfy \
+             constraint: Member must satisfy regular expression pattern: [\\w+=,.@-]*"
+        ),
+    ))
+}
+
 /// Test-only wrapper around [`compute_expiration_at`] used by the existing
 /// duration unit tests.
 #[cfg(test)]
@@ -588,6 +610,20 @@ fn extract_saml_session_name(saml_b64: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_name_pattern_accepts_valid_and_rejects_xml_metacharacters() {
+        // AWS-legal characters pass.
+        for ok in ["testuser", "role.session-1", "a+b=c,d.e@f", "user_123"] {
+            assert!(validate_session_name(ok).is_ok(), "should accept {ok}");
+        }
+        // XML metacharacters (and anything else off-pattern) are rejected with
+        // ValidationError rather than injected raw into the response XML.
+        for bad in ["a<b", "a>b", "a&b", "a\"b", "a b", "a/b"] {
+            let err = validate_session_name(bad).unwrap_err();
+            assert_eq!(err.code(), "ValidationError", "should reject {bad:?}");
+        }
+    }
 
     #[test]
     fn test_partition_for_region() {


### PR DESCRIPTION
## Summary
Pre-HN behavioral hardening (tier-5). `AssumeRole`/`AssumeRoleWithWebIdentity`/`AssumeRoleWithSAML` interpolated `RoleSessionName` raw into `<AssumedRoleId>` and the assumed-role ARN of the XML response, guarded only by a length check. A name with `<`/`>`/`&`/`"` produced malformed — and, for the attacker-controlled SAML-derived session name, injectable — XML that SDK parsers reject. AWS rejects such input up front with `ValidationError` (pattern `[\w+=,.@-]*`).

Added `validate_session_name` and call it in all three assume paths (including the SAML-derived name).

Note: STS core was found solid by the hunt — trust policy is evaluated unconditionally, temp-cred expiry is honored downstream, no request-path panics. Remaining lower-severity items (role `MaxSessionDuration` enforcement, phantom-account creation on bogus RoleArn, unstable WebIdentity/SAML `AssumedRoleId`) will follow on this branch.

## Test plan
- Unit test: pattern accepts AWS-legal names, rejects XML metacharacters with `ValidationError`.
- Conformance sts.rs uses `test-session`/`web-session` (both legal) — unaffected.
- `cargo clippy -p fakecloud-iam --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `RoleSessionName` against AWS pattern `[\w+=,.@-]*` across STS assume calls to block XML injection and malformed XML, returning `ValidationError` to match AWS behavior.

- **Bug Fixes**
  - Added `validate_session_name` and applied it in `AssumeRole`, `AssumeRoleWithWebIdentity`, and the SAML-derived session name in `AssumeRoleWithSAML`.
  - Unit test covers valid names and rejects XML metacharacters with `ValidationError`.

<sup>Written for commit 8115a30e3f3bee7390fe61f083e9407cbbd2b890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

