### PR TITLE
fix(ecs): reject phantom clusters, over-limit count, negative desiredCount, phantom task-set service

### DIFF
--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -760,6 +760,21 @@ impl EcsService {
         let accounts = self.state.read();
         let mut found = Vec::new();
         let mut failures = Vec::new();
+        {
+            // AWS validates the referenced cluster + service exist, returning
+            // ClusterNotFoundException / ServiceNotFoundException rather than an
+            // empty task-set list.
+            let state = accounts
+                .get(&request.account_id)
+                .ok_or_else(|| service_not_found(&service_name))?;
+            if !state.clusters.contains_key(&cluster_name) {
+                return Err(cluster_not_found(&cluster_name));
+            }
+            let svc_key = EcsState::service_key(&cluster_name, &service_name);
+            if !state.services.contains_key(&svc_key) {
+                return Err(service_not_found(&service_name));
+            }
+        }
         if let Some(state) = accounts.get(&request.account_id) {
             if filter_refs.is_empty() {
                 for ts in state.task_sets.values() {

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -20,11 +20,17 @@ impl EcsService {
         let td_ref = req_str(&body, "taskDefinition")?;
         let cluster_ref = opt_str(&body, "cluster");
         let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
-        let desired_count = body
-            .get("desiredCount")
-            .and_then(|v| v.as_i64())
-            .filter(|n| *n >= 0)
-            .unwrap_or(1) as i32;
+        // AWS rejects a negative desiredCount with InvalidParameterException
+        // rather than silently defaulting it to 1.
+        let desired_count = match body.get("desiredCount").and_then(|v| v.as_i64()) {
+            Some(n) if n >= 0 => n as i32,
+            Some(n) => {
+                return Err(invalid_parameter(format!(
+                    "desiredCount cannot be negative. desiredCount={n}"
+                )))
+            }
+            None => 1,
+        };
         let launch_type = opt_str(&body, "launchType")
             .unwrap_or("FARGATE")
             .to_string();
@@ -133,11 +139,13 @@ impl EcsService {
             let td_arn = td.task_definition_arn.clone();
             let td_family = td.family.clone();
             let td_revision = td.revision;
+            // A phantom cluster is a ClusterNotFoundException on AWS, not an
+            // auto-created cluster.
             let cluster_arn = state
                 .clusters
                 .get(&cluster_name)
                 .map(|c| c.cluster_arn.clone())
-                .unwrap_or_else(|| state.cluster_arn(&cluster_name));
+                .ok_or_else(|| cluster_not_found(&cluster_name))?;
             let service_arn = state.service_arn(&cluster_name, &service_name);
             let key = EcsState::service_key(&cluster_name, &service_name);
             if let Some(existing) = state.services.get(&key) {

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -76,11 +76,17 @@ impl EcsService {
             .and_then(|v| v.as_array())
             .cloned()
             .unwrap_or_default();
-        let count = body
-            .get("count")
-            .and_then(|v| v.as_i64())
-            .filter(|n| (1..=10).contains(n))
-            .unwrap_or(1) as usize;
+        // AWS caps RunTask at 1..=10 tasks per call and rejects anything else
+        // with InvalidParameterException — it does NOT silently clamp to 1.
+        let count = match body.get("count").and_then(|v| v.as_i64()) {
+            Some(n) if (1..=10).contains(&n) => n as usize,
+            Some(n) => {
+                return Err(invalid_parameter(format!(
+                    "count should be between 1 and 10, inclusive. count={n}"
+                )))
+            }
+            None => 1,
+        };
         let group = opt_str(&body, "group").map(String::from);
         let started_by = opt_str(&body, "startedBy").map(String::from);
         let enable_execute_command = body
@@ -124,11 +130,13 @@ impl EcsService {
         let runtime = self.runtime.clone();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
+        // AWS rejects RunTask against a cluster that does not exist rather than
+        // synthesizing one; a phantom cluster returns ClusterNotFoundException.
         let cluster_arn = state
             .clusters
             .get(&cluster_name)
             .map(|c| c.cluster_arn.clone())
-            .unwrap_or_else(|| state.cluster_arn(&cluster_name));
+            .ok_or_else(|| cluster_not_found(&cluster_name))?;
         let (_, family, rev) = resolve_task_definition_ref(td_ref)?;
         let revisions = state
             .task_definitions
@@ -577,6 +585,47 @@ mod multi_container_tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[test]
+    fn run_task_count_over_ten_is_invalid_parameter() {
+        let svc = fresh_service();
+        // count is validated before the cluster/task-def are dereferenced.
+        let err = match svc.run_task(&make_request(
+            "RunTask",
+            json!({"taskDefinition": "x", "count": 50}),
+        )) {
+            Ok(_) => panic!("expected InvalidParameterException for count > 10"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), "InvalidParameterException");
+    }
+
+    #[test]
+    fn create_service_negative_desired_count_is_invalid_parameter() {
+        let svc = fresh_service();
+        // desiredCount is validated before the cluster/task-def are resolved.
+        let err = match svc.create_service(&make_request(
+            "CreateService",
+            json!({"serviceName": "s", "taskDefinition": "x", "desiredCount": -3}),
+        )) {
+            Ok(_) => panic!("expected InvalidParameterException for negative desiredCount"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), "InvalidParameterException");
+    }
+
+    #[test]
+    fn run_task_on_missing_cluster_is_cluster_not_found() {
+        let svc = fresh_service();
+        let err = match svc.run_task(&make_request(
+            "RunTask",
+            json!({"taskDefinition": "x", "cluster": "ghost", "count": 1}),
+        )) {
+            Ok(_) => panic!("expected ClusterNotFoundException for a phantom cluster"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), "ClusterNotFoundException");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Pre-HN behavioral hardening (tier-5). The ECS task/service paths accepted input real AWS rejects — inconsistent with the already-correct `CreateExpressGatewayService` cluster guard.

- **M1** RunTask/StartTask + CreateService synthesized an ARN for a non-existent cluster and proceeded (200). Now `ClusterNotFoundException`.
- **M2** RunTask silently clamped `count` outside 1..=10 to 1. Now `InvalidParameterException` (AWS caps at 10/call and rejects the rest — ask 50, get 1, no error was the bug).
- **LM4** CreateService silently defaulted a negative `desiredCount` to 1. Now `InvalidParameterException`.
- **L9** DescribeTaskSets returned an empty list for a non-existent cluster/service. Now `ClusterNotFoundException` / `ServiceNotFoundException`.

Conformance ecs tests seed clusters/services via bootstrap fixtures, and AWS Batch creates its ECS cluster before RunTask — so the stricter validation only rejects genuinely-invalid input.

## Test plan
- New unit tests: RunTask count>10 → `InvalidParameterException`, RunTask phantom cluster → `ClusterNotFoundException`, CreateService negative desiredCount → `InvalidParameterException`. 111 ecs lib tests pass.
- `cargo clippy -p fakecloud-ecs --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns ECS RunTask, CreateService, and DescribeTaskSets with AWS behavior by rejecting non-existent clusters/services and invalid counts instead of silently succeeding. Prevents phantom resources and returns AWS-matching errors.

- **Bug Fixes**
  - RunTask/CreateService: non-existent cluster now returns `ClusterNotFoundException` (no synthetic ARN).
  - RunTask: `count` outside 1..10 now returns `InvalidParameterException` (no clamping to 1).
  - CreateService: negative `desiredCount` now returns `InvalidParameterException` (not defaulting to 1).
  - DescribeTaskSets: non-existent cluster/service now returns `ClusterNotFoundException` / `ServiceNotFoundException` (not empty list).

<sup>Written for commit 6c3a43082da74cd5d326fdee735f32cda1846b30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

