### PR TITLE
fix(elbv2): parse query-string rule conditions + validate ModifyTargetGroup

### DIFF
--- a/crates/fakecloud-elbv2/src/service.rs
+++ b/crates/fakecloud-elbv2/src/service.rs
@@ -1120,6 +1120,22 @@ impl Elbv2Service {
 
     fn modify_target_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let arn = required_query_param(req, "TargetGroupArn")?;
+        // AWS enforces the same @range / enum bounds on Modify as on Create;
+        // the previous code accepted out-of-range values Create rejects.
+        validate_range_i32(req, "HealthCheckIntervalSeconds", 5, 300)?;
+        validate_range_i32(req, "HealthCheckTimeoutSeconds", 2, 120)?;
+        validate_range_i32(req, "HealthyThresholdCount", 2, 10)?;
+        validate_range_i32(req, "UnhealthyThresholdCount", 2, 10)?;
+        if let Some(hp) = optional_query_param(req, "HealthCheckProtocol") {
+            const VALID: &[&str] = &[
+                "HTTP", "HTTPS", "TCP", "TLS", "UDP", "TCP_UDP", "GENEVE", "QUIC", "TCP_QUIC",
+            ];
+            if !VALID.contains(&hp.as_str()) {
+                return Err(invalid_param(format!(
+                    "HealthCheckProtocol '{hp}' is not valid"
+                )));
+            }
+        }
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         let tg = st

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -42,6 +42,26 @@ pub(crate) fn parse_member_list(req: &AwsRequest, prefix: &str) -> Vec<String> {
     out
 }
 
+/// Parse a rule condition's `QueryStringConfig.Values.member.N.{Key,Value}`
+/// pairs. Key is optional in AWS (a bare value matches any key), so a member
+/// with only a Value is valid.
+pub(crate) fn parse_query_string_pairs(
+    req: &AwsRequest,
+    prefix: &str,
+) -> Vec<crate::state::QueryStringKeyValuePair> {
+    let mut out = Vec::new();
+    for n in 1..=100 {
+        let base = format!("{prefix}.member.{n}");
+        let key = req.query_params.get(&format!("{base}.Key")).cloned();
+        let value = req.query_params.get(&format!("{base}.Value")).cloned();
+        if key.is_none() && value.is_none() {
+            break;
+        }
+        out.push(crate::state::QueryStringKeyValuePair { key, value });
+    }
+    out
+}
+
 pub(crate) fn parse_subnet_mappings(req: &AwsRequest) -> Vec<SubnetMapping> {
     let mut out = Vec::new();
     for n in 1..=20 {
@@ -713,7 +733,10 @@ pub(crate) fn parse_conditions(req: &AwsRequest) -> Vec<crate::state::RuleCondit
                     .get(&format!("{p}.HttpHeaderConfig.HttpHeaderName"))
                     .cloned(),
                 http_header_values: parse_member_list(req, &format!("{p}.HttpHeaderConfig.Values")),
-                query_string_values: Vec::new(),
+                query_string_values: parse_query_string_pairs(
+                    req,
+                    &format!("{p}.QueryStringConfig.Values"),
+                ),
                 http_request_method_values: parse_member_list(
                     req,
                     &format!("{p}.HttpRequestMethodConfig.Values"),
@@ -1322,4 +1345,62 @@ pub(crate) fn taggable_not_found(arn: &str) -> AwsServiceError {
         code,
         format!("{label} '{arn}' not found"),
     )
+}
+
+#[cfg(test)]
+mod query_string_tests {
+    use super::*;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+    use std::collections::HashMap;
+
+    fn req(pairs: &[(&str, &str)]) -> AwsRequest {
+        let mut query_params = HashMap::new();
+        for (k, v) in pairs {
+            query_params.insert((*k).to_string(), (*v).to_string());
+        }
+        AwsRequest {
+            service: "elasticloadbalancing".into(),
+            action: "CreateRule".into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "r".into(),
+            headers: HeaderMap::new(),
+            query_params,
+            body: bytes::Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: true,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    #[test]
+    fn query_string_condition_pairs_are_parsed_not_dropped() {
+        let r = req(&[
+            (
+                "Conditions.member.1.QueryStringConfig.Values.member.1.Key",
+                "version",
+            ),
+            (
+                "Conditions.member.1.QueryStringConfig.Values.member.1.Value",
+                "v1",
+            ),
+            (
+                "Conditions.member.1.QueryStringConfig.Values.member.2.Value",
+                "bare",
+            ),
+        ]);
+        let pairs = parse_query_string_pairs(&r, "Conditions.member.1.QueryStringConfig.Values");
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].key.as_deref(), Some("version"));
+        assert_eq!(pairs[0].value.as_deref(), Some("v1"));
+        // Key is optional: a bare value (no Key) is a valid pair.
+        assert_eq!(pairs[1].key, None);
+        assert_eq!(pairs[1].value.as_deref(), Some("bare"));
+    }
 }


### PR DESCRIPTION
## Summary

Two behavioral divergences from tier-5 hunt on ELBv2:

- **M1 — query-string condition values dropped on parse.** `CreateRule`/`ModifyRule` accepted a `query-string` condition but `parse_conditions` hardcoded `query_string_values: Vec::new()`, so the pairs round-tripped as an empty `<QueryStringConfig><Values/></>`. The renderer (`render_rule_condition_xml`) already emits them — only the parse side was blind. Terraform `aws_lb_listener_rule` with a `query_string {}` block therefore showed a perpetual diff. New `parse_query_string_pairs` reads `.member.N.Key`/`.Value` (Key optional, matching AWS).
- **M3 — ModifyTargetGroup skipped range/enum validation.** `CreateTargetGroup` enforces HealthCheckIntervalSeconds (5..300), TimeoutSeconds (2..120), Healthy/UnhealthyThresholdCount (2..10), and the HealthCheckProtocol enum; `ModifyTargetGroup` enforced none, so a value AWS rejects on modify was accepted and persisted. Now mirrors the Create validation up front.

## Test plan

- New unit test `query_string_condition_pairs_are_parsed_not_dropped` (passes).
- `cargo clippy -p fakecloud-elbv2 --all-targets` clean, `cargo fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ELBv2 rule parsing and target group validation to match AWS behavior. Query-string condition pairs now round-trip correctly, and `ModifyTargetGroup` rejects invalid health check settings.

- **Bug Fixes**
  - Parse `QueryStringConfig.Values.member.N.{Key,Value}` for rule conditions (Key optional) to prevent empty values and remove Terraform `aws_lb_listener_rule` perpetual diffs.
  - Enforce the same bounds in `ModifyTargetGroup` as `CreateTargetGroup` (interval 5–300, timeout 2–120, healthy/unhealthy 2–10, and valid `HealthCheckProtocol`).

<sup>Written for commit df02ca650bac9b84c8fba1129d2e9f90c7bf05ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

