### PR TITLE
fix(route53): traffic-policy persistence + record materialization + change-batch/health-check validation

### DIFF
--- a/crates/fakecloud-conformance/tests/route53_dnssec_querylog_cidr.rs
+++ b/crates/fakecloud-conformance/tests/route53_dnssec_querylog_cidr.rs
@@ -83,6 +83,19 @@ async fn r53_enable_hosted_zone_dnssec() {
     )
     .await;
     let r53 = server.route53_client().await;
+    // AWS refuses to enable signing until the zone has an ACTIVE
+    // key-signing key, so create one first.
+    r53.create_key_signing_key()
+        .caller_reference("conf-enable-dnssec-ksk")
+        .hosted_zone_id(&zone)
+        .key_management_service_arn(
+            "arn:aws:kms:us-east-1:000000000000:key/enabledns-0000-0000-0000-000000000000",
+        )
+        .name("conf_enable_dnssec_ksk")
+        .status("ACTIVE")
+        .send()
+        .await
+        .unwrap();
     r53.enable_hosted_zone_dnssec()
         .hosted_zone_id(&zone)
         .send()

--- a/crates/fakecloud-e2e/tests/route53.rs
+++ b/crates/fakecloud-e2e/tests/route53.rs
@@ -824,7 +824,7 @@ async fn test_dns_answer_alias_target_resolves_against_s3_bucket_state() {
     // synthetic A record only when the bucket exists.
     let dns_name = format!("{bucket}.s3-website-us-east-1.amazonaws.com");
     let alias = ResourceRecordSet::builder()
-        .name("static.alias.example.com.")
+        .name("static.alias-s3.example.com.")
         .r#type(RrType::A)
         .alias_target(
             AliasTarget::builder()
@@ -842,7 +842,7 @@ async fn test_dns_answer_alias_target_resolves_against_s3_bucket_state() {
     let answer = r53
         .test_dns_answer()
         .hosted_zone_id(&zid)
-        .record_name("static.alias.example.com")
+        .record_name("static.alias-s3.example.com")
         .record_type(RrType::A)
         .send()
         .await

--- a/crates/fakecloud-e2e/tests/route53_dnssec_querylog_cidr.rs
+++ b/crates/fakecloud-e2e/tests/route53_dnssec_querylog_cidr.rs
@@ -41,6 +41,19 @@ async fn dnssec_status_default_and_toggle() {
         Some("NOT_SIGNING")
     );
 
+    // AWS requires an ACTIVE key-signing key before signing can be enabled.
+    r53.create_key_signing_key()
+        .caller_reference("dnssec-toggle-ksk")
+        .hosted_zone_id(&zone)
+        .key_management_service_arn(
+            "arn:aws:kms:us-east-1:000000000000:key/toggle00-0000-0000-0000-000000000000",
+        )
+        .name("dnssec_toggle_ksk")
+        .status("ACTIVE")
+        .send()
+        .await
+        .expect("create ksk");
+
     r53.enable_hosted_zone_dnssec()
         .hosted_zone_id(&zone)
         .send()
@@ -455,12 +468,8 @@ async fn dnssec_rrsig_signs_and_verifies_against_dnskey() {
     let zone = make_zone(&server, "signed.example.com", "signed-zone").await;
     let r53 = server.route53_client().await;
 
-    // Enable DNSSEC + create an ACTIVE KSK for the zone.
-    r53.enable_hosted_zone_dnssec()
-        .hosted_zone_id(&zone)
-        .send()
-        .await
-        .expect("enable dnssec");
+    // Create an ACTIVE KSK first — AWS refuses to enable signing until the
+    // zone has one — then enable DNSSEC.
     r53.create_key_signing_key()
         .caller_reference("ksk-rrsig")
         .hosted_zone_id(&zone)
@@ -472,6 +481,11 @@ async fn dnssec_rrsig_signs_and_verifies_against_dnskey() {
         .send()
         .await
         .expect("create ksk");
+    r53.enable_hosted_zone_dnssec()
+        .hosted_zone_id(&zone)
+        .send()
+        .await
+        .expect("enable dnssec");
 
     // Fetch the public key + DS digest via the admin endpoint.
     let material = server

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -70,8 +70,137 @@ pub(crate) fn rrset_matches(a: &ResourceRecordSet, b: &ResourceRecordSet) -> boo
     a.name == b.name && a.record_type == b.record_type && a.set_identifier == b.set_identifier
 }
 
+/// Sorted multiset of a record set's values (resource records + an alias
+/// target rendered as `ALIAS <zone>:<dns>`), used to compare whether two
+/// record sets carry the same data. Route 53's `DELETE` change action
+/// requires the caller to submit the record set's *current* values (and
+/// TTL) exactly; a name+type+set-identifier match alone is insufficient.
+fn rrset_value_key(r: &ResourceRecordSet) -> Vec<String> {
+    let mut vals: Vec<String> = r
+        .resource_records
+        .as_ref()
+        .map(|rr| rr.resource_record.iter().map(|x| x.value.clone()).collect())
+        .unwrap_or_default();
+    if let Some(at) = &r.alias_target {
+        vals.push(format!("ALIAS {}:{}", at.hosted_zone_id, at.dns_name));
+    }
+    vals.sort();
+    vals
+}
+
+/// True when two record sets carry identical TTL and value data, in
+/// addition to name/type/set-identifier. Used to gate `DELETE`.
+pub(crate) fn rrset_values_match(current: &ResourceRecordSet, want: &ResourceRecordSet) -> bool {
+    // AliasTarget-backed records have no TTL; only compare TTL when the
+    // caller supplied one (real Route 53 ignores TTL for alias deletes).
+    let ttl_ok = want.ttl.is_none() || current.ttl == want.ttl;
+    ttl_ok && rrset_value_key(current) == rrset_value_key(want)
+}
+
+/// Validate a record set submitted to `ChangeResourceRecordSets` for a
+/// `CREATE`/`UPSERT`. Enforces the three checks AWS applies that fakecloud
+/// previously skipped: the record name must sit within the zone, the type
+/// must be a known RR type, and value-bearing types must carry either
+/// `ResourceRecords` or an `AliasTarget`.
+pub(crate) fn validate_rrset_in_zone(
+    r: &ResourceRecordSet,
+    zone_name: &str,
+) -> Result<(), AwsServiceError> {
+    // `r.name` and `zone_name` are already normalized to a trailing dot.
+    let in_zone = r.name == zone_name
+        || r.name
+            .to_ascii_lowercase()
+            .ends_with(&format!(".{}", zone_name.to_ascii_lowercase()));
+    if !in_zone {
+        return Err(invalid_change_batch(format!(
+            "RRSet with DNS name {} is not permitted in zone {}",
+            r.name, zone_name
+        )));
+    }
+    if !RR_TYPES.contains(&r.record_type.as_str()) {
+        return Err(invalid_change_batch(format!(
+            "Invalid resource record set type: {}",
+            r.record_type
+        )));
+    }
+    let has_values = r
+        .resource_records
+        .as_ref()
+        .map(|rr| !rr.resource_record.is_empty())
+        .unwrap_or(false);
+    if !has_values && r.alias_target.is_none() {
+        return Err(invalid_change_batch(format!(
+            "Invalid resource record set [name='{}', type='{}']: must specify either ResourceRecords or AliasTarget",
+            r.name, r.record_type
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn is_default_record(r: &ResourceRecordSet, zone_name: &str) -> bool {
     r.name == zone_name && (r.record_type == "SOA" || r.record_type == "NS")
+}
+
+/// Reversed-label sort key for a DNS name (`www.example.com.` ->
+/// `com.example.www`). Route 53's `ListHostedZonesByName` orders zones by
+/// this key rather than plain lexicographic name order.
+pub(crate) fn reverse_dns_key(name: &str) -> String {
+    let trimmed = name.trim_end_matches('.');
+    let mut labels: Vec<&str> = trimmed.split('.').collect();
+    labels.reverse();
+    labels.join(".").to_ascii_lowercase()
+}
+
+/// Materialize a traffic-policy document into the record set AWS creates for
+/// a traffic policy instance. Real Route 53 expands the policy's rule/endpoint
+/// DAG into one or more record sets; fakecloud resolves the leaf endpoint
+/// values into a single record set carrying the instance name, type, TTL, the
+/// endpoint values, and the `TrafficPolicyInstanceId` link, so the instance's
+/// DNS shows up in `ListResourceRecordSets` exactly like any other record.
+pub(crate) fn materialize_policy_rrset(
+    document: &str,
+    name: &str,
+    record_type: &str,
+    ttl: i64,
+    instance_id: &str,
+) -> ResourceRecordSet {
+    let values = extract_endpoint_values(document);
+    ResourceRecordSet {
+        name: name.to_string(),
+        record_type: record_type.to_string(),
+        ttl: Some(ttl),
+        resource_records: if values.is_empty() {
+            None
+        } else {
+            Some(crate::model::ResourceRecords {
+                resource_record: values
+                    .into_iter()
+                    .map(|value| crate::model::ResourceRecord { value })
+                    .collect(),
+            })
+        },
+        traffic_policy_instance_id: Some(instance_id.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Collect the leaf `Value` of every endpoint declared in a traffic policy
+/// document. Value endpoints carry a literal record value; ELB/S3/CloudFront
+/// endpoints carry the target DNS name as their `Value` — either way the
+/// `Value` is the record data to publish.
+fn extract_endpoint_values(document: &str) -> Vec<String> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(document) else {
+        return Vec::new();
+    };
+    let Some(endpoints) = v.get("Endpoints").and_then(|e| e.as_object()) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = endpoints
+        .values()
+        .filter_map(|ep| ep.get("Value").and_then(|x| x.as_str()).map(String::from))
+        .collect();
+    out.sort();
+    out
 }
 
 pub(crate) fn push_hosted_zone(out: &mut String, z: &StoredHostedZone) {
@@ -2078,5 +2207,103 @@ mod log_arn_tests {
     fn rejects_non_logs_arn() {
         assert!(parse_log_group_arn("arn:aws:s3:::my-bucket").is_none());
         assert!(parse_log_group_arn("not-an-arn").is_none());
+    }
+}
+
+#[cfg(test)]
+mod hardening_tests {
+    use super::*;
+
+    fn rr(vals: &[&str]) -> Option<crate::model::ResourceRecords> {
+        Some(crate::model::ResourceRecords {
+            resource_record: vals
+                .iter()
+                .map(|v| crate::model::ResourceRecord {
+                    value: v.to_string(),
+                })
+                .collect(),
+        })
+    }
+
+    #[test]
+    fn reverse_dns_key_reverses_labels() {
+        assert_eq!(reverse_dns_key("www.example.com."), "com.example.www");
+        assert_eq!(reverse_dns_key("example.com"), "com.example");
+        // Zone apex sorts before its subdomains under the reversed key.
+        assert!(reverse_dns_key("example.com.") < reverse_dns_key("a.example.com."));
+    }
+
+    #[test]
+    fn rrset_values_match_requires_exact_values_and_ttl() {
+        let cur = ResourceRecordSet {
+            name: "a.example.com.".into(),
+            record_type: "A".into(),
+            ttl: Some(300),
+            resource_records: rr(&["1.2.3.4"]),
+            ..Default::default()
+        };
+        let same = ResourceRecordSet {
+            resource_records: rr(&["1.2.3.4"]),
+            ..cur.clone()
+        };
+        let diff_val = ResourceRecordSet {
+            resource_records: rr(&["9.9.9.9"]),
+            ..cur.clone()
+        };
+        let diff_ttl = ResourceRecordSet {
+            ttl: Some(60),
+            ..cur.clone()
+        };
+        assert!(rrset_values_match(&cur, &same));
+        assert!(!rrset_values_match(&cur, &diff_val));
+        assert!(!rrset_values_match(&cur, &diff_ttl));
+    }
+
+    #[test]
+    fn validate_rrset_rejects_out_of_zone_bad_type_and_empty() {
+        let good = ResourceRecordSet {
+            name: "a.example.com.".into(),
+            record_type: "A".into(),
+            resource_records: rr(&["1.2.3.4"]),
+            ..Default::default()
+        };
+        assert!(validate_rrset_in_zone(&good, "example.com.").is_ok());
+
+        let out_of_zone = ResourceRecordSet {
+            name: "a.other.org.".into(),
+            ..good.clone()
+        };
+        assert!(validate_rrset_in_zone(&out_of_zone, "example.com.").is_err());
+
+        let bad_type = ResourceRecordSet {
+            record_type: "ZZZ".into(),
+            ..good.clone()
+        };
+        assert!(validate_rrset_in_zone(&bad_type, "example.com.").is_err());
+
+        let empty = ResourceRecordSet {
+            name: "a.example.com.".into(),
+            record_type: "A".into(),
+            resource_records: None,
+            alias_target: None,
+            ..Default::default()
+        };
+        assert!(validate_rrset_in_zone(&empty, "example.com.").is_err());
+    }
+
+    #[test]
+    fn materialize_policy_rrset_extracts_endpoint_values() {
+        let doc = r#"{"AWSPolicyFormatVersion":"2015-10-01","RecordType":"A","Endpoints":{"a":{"Type":"value","Value":"1.1.1.1"},"b":{"Type":"value","Value":"2.2.2.2"}},"StartEndpoint":"a"}"#;
+        let rs = materialize_policy_rrset(doc, "app.example.com.", "A", 60, "tpi-1");
+        assert_eq!(rs.traffic_policy_instance_id.as_deref(), Some("tpi-1"));
+        assert_eq!(rs.ttl, Some(60));
+        let vals: Vec<String> = rs
+            .resource_records
+            .unwrap()
+            .resource_record
+            .into_iter()
+            .map(|r| r.value)
+            .collect();
+        assert_eq!(vals, vec!["1.1.1.1".to_string(), "2.2.2.2".to_string()]);
     }
 }

--- a/crates/fakecloud-route53/src/service/dnssec.rs
+++ b/crates/fakecloud-route53/src/service/dnssec.rs
@@ -207,6 +207,19 @@ impl Route53Service {
         if !account.hosted_zones.contains_key(&zone_id) {
             return Err(no_such_hosted_zone(&zone_id));
         }
+        // AWS refuses to enable signing until the zone has at least one
+        // ACTIVE key-signing key.
+        let has_active_ksk = account
+            .key_signing_keys
+            .values()
+            .any(|k| k.hosted_zone_id == zone_id && k.status.eq_ignore_ascii_case("ACTIVE"));
+        if !has_active_ksk {
+            return Err(aws_error(
+                StatusCode::BAD_REQUEST,
+                "KeySigningKeyWithActiveStatusNotFound",
+                format!("No ACTIVE key-signing key found for hosted zone {zone_id}"),
+            ));
+        }
         account
             .dnssec_status
             .insert(zone_id.clone(), "SIGNING".to_string());

--- a/crates/fakecloud-route53/src/service/health_checks.rs
+++ b/crates/fakecloud-route53/src/service/health_checks.rs
@@ -15,6 +15,7 @@ impl Route53Service {
         if cfg.health_check_config.health_check_type.is_empty() {
             return Err(invalid_argument("HealthCheckConfig.Type is required"));
         }
+        validate_health_check_config(&cfg.health_check_config)?;
         let mut state = self.state.write();
         let account = state
             .accounts
@@ -412,5 +413,116 @@ impl Route53Service {
         body.push_str("</CheckerIpRanges>");
         body.push_str("</GetCheckerIpRangesResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
+    }
+}
+
+/// Every Route 53 health-check type and the per-type fields AWS requires.
+const HEALTH_CHECK_TYPES: &[&str] = &[
+    "HTTP",
+    "HTTPS",
+    "HTTP_STR_MATCH",
+    "HTTPS_STR_MATCH",
+    "TCP",
+    "CALCULATED",
+    "CLOUDWATCH_METRIC",
+    "RECOVERY_CONTROL",
+];
+
+/// Validate a health-check config against AWS's type enum and the per-type
+/// required-field rules. Previously any string type was accepted and stored,
+/// so a `CALCULATED` check with no children (or a typo'd type) round-tripped
+/// as a broken health check instead of the `InvalidInput` AWS returns.
+fn validate_health_check_config(c: &HealthCheckConfig) -> Result<(), AwsServiceError> {
+    let ty = c.health_check_type.as_str();
+    if !HEALTH_CHECK_TYPES.contains(&ty) {
+        return Err(invalid_argument(format!("Invalid health check type: {ty}")));
+    }
+    let is_blank = |v: &Option<String>| v.as_deref().unwrap_or("").is_empty();
+    match ty {
+        "HTTP" | "HTTPS" | "HTTP_STR_MATCH" | "HTTPS_STR_MATCH" | "TCP" => {
+            if is_blank(&c.ip_address) && is_blank(&c.fully_qualified_domain_name) {
+                return Err(invalid_argument(
+                    "Endpoint health checks require IPAddress or FullyQualifiedDomainName",
+                ));
+            }
+            if matches!(ty, "HTTP_STR_MATCH" | "HTTPS_STR_MATCH") && is_blank(&c.search_string) {
+                return Err(invalid_argument(
+                    "HTTP_STR_MATCH/HTTPS_STR_MATCH health checks require SearchString",
+                ));
+            }
+        }
+        "CALCULATED" => {
+            let has_children = c
+                .child_health_checks
+                .as_ref()
+                .map(|ch| !ch.child_health_check.is_empty())
+                .unwrap_or(false);
+            if !has_children || c.health_threshold.is_none() {
+                return Err(invalid_argument(
+                    "CALCULATED health checks require ChildHealthChecks and HealthThreshold",
+                ));
+            }
+        }
+        "CLOUDWATCH_METRIC" if c.alarm_identifier.is_none() => {
+            return Err(invalid_argument(
+                "CLOUDWATCH_METRIC health checks require AlarmIdentifier",
+            ));
+        }
+        "RECOVERY_CONTROL" if is_blank(&c.routing_control_arn) => {
+            return Err(invalid_argument(
+                "RECOVERY_CONTROL health checks require RoutingControlArn",
+            ));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod hc_validation_tests {
+    use super::*;
+
+    fn cfg(ty: &str) -> HealthCheckConfig {
+        HealthCheckConfig {
+            health_check_type: ty.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unknown_type_is_rejected() {
+        assert!(validate_health_check_config(&cfg("BOGUS")).is_err());
+    }
+
+    #[test]
+    fn endpoint_type_requires_target() {
+        assert!(validate_health_check_config(&cfg("HTTP")).is_err());
+        let mut c = cfg("HTTP");
+        c.ip_address = Some("1.2.3.4".into());
+        assert!(validate_health_check_config(&c).is_ok());
+    }
+
+    #[test]
+    fn str_match_requires_search_string() {
+        let mut c = cfg("HTTP_STR_MATCH");
+        c.fully_qualified_domain_name = Some("x.example.com".into());
+        assert!(validate_health_check_config(&c).is_err());
+        c.search_string = Some("ok".into());
+        assert!(validate_health_check_config(&c).is_ok());
+    }
+
+    #[test]
+    fn calculated_requires_children_and_threshold() {
+        assert!(validate_health_check_config(&cfg("CALCULATED")).is_err());
+    }
+
+    #[test]
+    fn recovery_control_requires_arn() {
+        assert!(validate_health_check_config(&cfg("RECOVERY_CONTROL")).is_err());
+        let mut c = cfg("RECOVERY_CONTROL");
+        c.routing_control_arn = Some(
+            "arn:aws:route53-recovery-control::111122223333:controlpanel/x/routingcontrol/y".into(),
+        );
+        assert!(validate_health_check_config(&c).is_ok());
     }
 }

--- a/crates/fakecloud-route53/src/service/hosted_zones.rs
+++ b/crates/fakecloud-route53/src/service/hosted_zones.rs
@@ -283,6 +283,16 @@ impl Route53Service {
             ],
         )?;
         let dns_name = req.query_params.get("dnsname").cloned();
+        let start_id = req
+            .query_params
+            .get("hostedzoneid")
+            .map(|s| strip_zone_prefix(s));
+        let max_items: usize = req
+            .query_params
+            .get("maxitems")
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
         let state = self.state.read();
         let mut zones: Vec<StoredHostedZone> = state
             .accounts
@@ -290,28 +300,61 @@ impl Route53Service {
             .map(|a| a.hosted_zones.values().cloned().collect())
             .unwrap_or_default();
         drop(state);
-        zones.sort_by(|a, b| a.name.cmp(&b.name));
-        if let Some(name) = &dns_name {
-            let normalized = if name.ends_with('.') {
-                name.clone()
-            } else {
-                format!("{name}.")
-            };
-            zones.retain(|z| z.name >= normalized);
-        }
+        // Route 53 orders by reversed DNS labels (com.example before
+        // com.example.a), tie-broken by zone id.
+        zones.sort_by(|a, b| {
+            reverse_dns_key(&a.name)
+                .cmp(&reverse_dns_key(&b.name))
+                .then(a.id.cmp(&b.id))
+        });
+        // Resolve the start offset from the (dnsname, hostedzoneid) cursor.
+        // A follow-up page echoes both from the prior NextDNSName /
+        // NextHostedZoneId; the first page may pass dnsname alone.
+        let start_idx = match (&dns_name, &start_id) {
+            (_, Some(hz)) => zones
+                .iter()
+                .position(|z| &z.id == hz)
+                .unwrap_or(zones.len()),
+            (Some(name), None) => {
+                let normalized = if name.ends_with('.') {
+                    name.clone()
+                } else {
+                    format!("{name}.")
+                };
+                let key = reverse_dns_key(&normalized);
+                zones
+                    .iter()
+                    .position(|z| reverse_dns_key(&z.name) >= key)
+                    .unwrap_or(zones.len())
+            }
+            (None, None) => 0,
+        };
+        let page: Vec<&StoredHostedZone> = zones.iter().skip(start_idx).take(max_items).collect();
+        let next = zones.get(start_idx + page.len());
+
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!("<ListHostedZonesByNameResponse xmlns=\"{NS}\">"));
         body.push_str("<HostedZones>");
-        for z in &zones {
+        for z in &page {
             push_hosted_zone(&mut body, z);
         }
         body.push_str("</HostedZones>");
         if let Some(name) = &dns_name {
             body.push_str(&format!("<DNSName>{}</DNSName>", esc(name)));
         }
-        body.push_str("<MaxItems>100</MaxItems>");
-        body.push_str("<IsTruncated>false</IsTruncated>");
+        if let Some(id) = &start_id {
+            body.push_str(&format!("<HostedZoneId>{}</HostedZoneId>", esc(id)));
+        }
+        body.push_str(&format!("<MaxItems>{max_items}</MaxItems>"));
+        body.push_str(&format!("<IsTruncated>{}</IsTruncated>", next.is_some()));
+        if let Some(n) = next {
+            body.push_str(&format!("<NextDNSName>{}</NextDNSName>", esc(&n.name)));
+            body.push_str(&format!(
+                "<NextHostedZoneId>{}</NextHostedZoneId>",
+                esc(&n.id)
+            ));
+        }
         body.push_str("</ListHostedZonesByNameResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }

--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -280,6 +280,7 @@ const MUTATING_ACTIONS: &[&str] = &[
     "CreateTrafficPolicy",
     "CreateTrafficPolicyVersion",
     "DeleteTrafficPolicy",
+    "UpdateTrafficPolicyComment",
     "CreateTrafficPolicyInstance",
     "UpdateTrafficPolicyInstance",
     "DeleteTrafficPolicyInstance",

--- a/crates/fakecloud-route53/src/service/records.rs
+++ b/crates/fakecloud-route53/src/service/records.rs
@@ -35,6 +35,7 @@ impl Route53Service {
             let rec = normalize_rrset(&ch.resource_record_set);
             match action.as_str() {
                 "CREATE" => {
+                    validate_rrset_in_zone(&rec, &zone.name)?;
                     if working.iter().any(|r| rrset_matches(r, &rec)) {
                         return Err(invalid_change_batch(format!(
                             "Tried to create resource record set [name='{}', type='{}'] but it already exists",
@@ -44,6 +45,7 @@ impl Route53Service {
                     working.push(rec);
                 }
                 "UPSERT" => {
+                    validate_rrset_in_zone(&rec, &zone.name)?;
                     let pos = working.iter().position(|r| rrset_matches(r, &rec));
                     if let Some(p) = pos {
                         working[p] = rec;
@@ -63,6 +65,15 @@ impl Route53Service {
                         return Err(invalid_change_batch(
                             "Cannot delete default SOA or NS record",
                         ));
+                    }
+                    // Route 53 requires a DELETE to submit the record set's
+                    // current values (and TTL) exactly, not just a matching
+                    // name/type/set-identifier.
+                    if !rrset_values_match(&working[p], &rec) {
+                        return Err(invalid_change_batch(format!(
+                            "Tried to delete resource record set [name='{}', type='{}'] but the values provided do not match the current values",
+                            rec.name, rec.record_type
+                        )));
                     }
                     working.remove(p);
                 }
@@ -171,14 +182,18 @@ impl Route53Service {
         body.push_str("</ResourceRecordSets>");
         body.push_str(&format!("<IsTruncated>{}</IsTruncated>", next.is_some()));
         if let Some(n) = next {
-            body.push_str(&format!("<NextRecordName>{}</NextRecordName>", n.name));
+            body.push_str(&format!(
+                "<NextRecordName>{}</NextRecordName>",
+                esc(&n.name)
+            ));
             body.push_str(&format!(
                 "<NextRecordType>{}</NextRecordType>",
-                n.record_type
+                esc(&n.record_type)
             ));
             if let Some(si) = &n.set_identifier {
                 body.push_str(&format!(
-                    "<NextRecordIdentifier>{si}</NextRecordIdentifier>"
+                    "<NextRecordIdentifier>{}</NextRecordIdentifier>",
+                    esc(si)
                 ));
             }
         }

--- a/crates/fakecloud-route53/src/service/traffic_policies.rs
+++ b/crates/fakecloud-route53/src/service/traffic_policies.rs
@@ -433,12 +433,26 @@ impl Route53Service {
             message: String::new(),
             traffic_policy_id: cfg.traffic_policy_id,
             traffic_policy_version: cfg.traffic_policy_version,
-            traffic_policy_type: policy.policy_type,
+            traffic_policy_type: policy.policy_type.clone(),
             created_time: Utc::now(),
         };
+        // Materialize the policy document into the zone's record set so the
+        // instance's DNS is visible via ListResourceRecordSets, like AWS.
+        let rrset = materialize_policy_rrset(
+            &policy.document,
+            &stored.name,
+            &stored.traffic_policy_type,
+            stored.ttl,
+            &stored.id,
+        );
         account
             .traffic_policy_instances
             .insert(id.clone(), stored.clone());
+        if let Some(zone) = account.hosted_zones.get_mut(&stored.hosted_zone_id) {
+            zone.resource_record_sets
+                .retain(|r| r.traffic_policy_instance_id.as_deref() != Some(stored.id.as_str()));
+            zone.resource_record_sets.push(rrset);
+        }
         drop(state);
         let mut body = String::with_capacity(512);
         body.push_str(XML_DECL);
@@ -507,9 +521,22 @@ impl Route53Service {
         i.ttl = cfg.ttl;
         i.traffic_policy_id = cfg.traffic_policy_id;
         i.traffic_policy_version = cfg.traffic_policy_version;
-        i.traffic_policy_type = policy.policy_type;
+        i.traffic_policy_type = policy.policy_type.clone();
         i.state = "Applied".to_string();
         let snap = i.clone();
+        // Re-materialize the instance's record set from the new policy doc.
+        let rrset = materialize_policy_rrset(
+            &policy.document,
+            &snap.name,
+            &snap.traffic_policy_type,
+            snap.ttl,
+            &snap.id,
+        );
+        if let Some(zone) = account.hosted_zones.get_mut(&snap.hosted_zone_id) {
+            zone.resource_record_sets
+                .retain(|r| r.traffic_policy_instance_id.as_deref() != Some(snap.id.as_str()));
+            zone.resource_record_sets.push(rrset);
+        }
         drop(state);
         let mut body = String::with_capacity(512);
         body.push_str(XML_DECL);
@@ -531,8 +558,13 @@ impl Route53Service {
             .accounts
             .get_mut(DEFAULT_ACCOUNT)
             .ok_or_else(|| no_such_traffic_policy_instance(&id))?;
-        if account.traffic_policy_instances.remove(&id).is_none() {
+        let Some(removed) = account.traffic_policy_instances.remove(&id) else {
             return Err(no_such_traffic_policy_instance(&id));
+        };
+        // Tear down the materialized record set for this instance.
+        if let Some(zone) = account.hosted_zones.get_mut(&removed.hosted_zone_id) {
+            zone.resource_record_sets
+                .retain(|r| r.traffic_policy_instance_id.as_deref() != Some(id.as_str()));
         }
         drop(state);
         let mut body = String::with_capacity(128);


### PR DESCRIPTION
## Summary

Tier-5 behavioral hunt on Route 53 (8 findings, all correctness/persistence on existing ops — no new API surface, so no SDK/docs changes needed).

- **M1** `UpdateTrafficPolicyComment` was missing from `MUTATING_ACTIONS`, so the updated comment mutated in memory but never snapshotted and was lost on restart. It was the only 1 of 7 write handlers missing.
- **M2** `CreateTrafficPolicyInstance` validated then dropped the request — no record materialization, so the instance DNS never showed in `ListResourceRecordSets`. Now materializes the policy document's endpoint values into a record set carrying the instance name/type/TTL + `TrafficPolicyInstanceId`, kept in sync on Update/Delete.
- **LM3** `ChangeResourceRecordSets` `DELETE` matched only name+type+set-identifier; a DELETE with stale values/TTL succeeded. AWS requires exact value/TTL match → now `InvalidChangeBatch`.
- **L4** `CREATE`/`UPSERT` never checked the record was within the zone, validated the Type enum, or required `ResourceRecords`/`AliasTarget`. Now enforces all three.
- **L5** `NextRecordName`/`Type`/`Identifier` continuation tokens were emitted unescaped → an XML-metachar in a record name broke the next paginated call. Now escaped.
- **L6** `ListHostedZonesByName` ignored `maxitems`, emitted all zones with hardcoded `IsTruncated=false`, sorted lexicographically instead of reversed-DNS-label, and ignored the `hostedzoneid` cursor. Now paginates with reverse-DNS ordering + `NextDNSName`/`NextHostedZoneId`.
- **L7** `EnableHostedZoneDNSSEC` accepted a zone with no ACTIVE KSK; now returns `KeySigningKeyWithActiveStatusNotFound`.
- **L8** `CreateHealthCheck` accepted any Type string and skipped per-type required fields; now validates the type enum + required fields per type.

## Test plan

- Unit tests for the new pure helpers (reverse-DNS key, exact value match, in-zone validation, policy materialization) and health-check validation — all 49 lib tests pass.
- Verified end-to-end against a running server: DELETE value-mismatch → 400 `InvalidChangeBatch`, out-of-zone CREATE → 400, invalid health-check type → 400 `InvalidInput`, valid → 201, `ListHostedZonesByName` shape correct.
- `cargo clippy -p fakecloud-route53 --all-targets` clean, `cargo fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Route 53 behavior to match AWS. Fixes traffic-policy persistence, materializes policy instances into zone records, tightens validation, and corrects pagination/escaping.

- **Bug Fixes**
  - Persist updated traffic policy comments across restarts.
  - Materialize `CreateTrafficPolicyInstance` into a zone record (with `TrafficPolicyInstanceId`); keep in sync on update/delete.
  - `ChangeResourceRecordSets`: `DELETE` now requires exact values and TTL, otherwise `InvalidChangeBatch`. `CREATE`/`UPSERT` now require in-zone names, valid types, and either `ResourceRecords` or `AliasTarget`.
  - Escape `NextRecordName`/`NextRecordType`/`NextRecordIdentifier` pagination tokens in `ListResourceRecordSets`.
  - `ListHostedZonesByName`: honor `maxitems`, support `dnsname`/`hostedzoneid` cursors, order by reverse DNS, emit `NextDNSName`/`NextHostedZoneId`.
  - `EnableHostedZoneDNSSEC` now requires an ACTIVE key-signing key.
  - `CreateHealthCheck` validates the type enum and per-type required fields; rejects invalid configs with `InvalidInput`.

<sup>Written for commit c24108c11623433d09f711d1b205c33e7ab60ba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

