### PR TITLE
fix(sts): enforce MaxSessionDuration, stop phantom-account creation, stable AssumedRoleId

### DIFF
--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -102,9 +102,15 @@ impl StsService {
         let account_id =
             extract_account_from_arn(role_arn).unwrap_or_else(|| req.account_id.clone());
 
-        // Look up role in the TARGET account's state to get its role_id
-        let target_state = accounts.get_or_create(&account_id);
         let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
+        // Look up the role WITHOUT creating the target account. An
+        // attacker-controlled RoleArn naming a non-existent account would
+        // otherwise insert an empty account that the next mutation persists
+        // (unbounded map growth + resolver-scan cost). The role-existence
+        // check below denies before any account is materialized.
+        let role = accounts
+            .get(&account_id)
+            .and_then(|s| s.roles.get(role_name).cloned());
 
         // Enforce the role's trust policy through the IAM evaluator.
         // The trust policy is a resource-style policy whose Principal
@@ -116,7 +122,8 @@ impl StsService {
         // exposes at AssumeRole time: sts:ExternalId,
         // sts:RoleSessionName, aws:MultiFactorAuthPresent, plus the
         // standard caller-identity keys.
-        if let Some(role) = target_state.roles.get(role_name).cloned() {
+        let role_id;
+        if let Some(role) = role {
             // Service-linked roles (`/aws-service-role/<service>/...`)
             // are only assumable by the matching service principal,
             // never by users or other roles. AWS rejects every other
@@ -209,6 +216,27 @@ impl StsService {
                     ));
                 }
             }
+
+            // Enforce the role's MaxSessionDuration: AWS rejects a
+            // DurationSeconds larger than the cap stored on the role,
+            // rather than silently honoring the generic 900..43200 range.
+            if let Some(ds) = req.query_params.get("DurationSeconds") {
+                if let Ok(v) = ds.parse::<i64>() {
+                    if v > role.max_session_duration as i64 {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "ValidationError",
+                            format!(
+                                "The requested DurationSeconds exceeds the MaxSessionDuration set for this role. \
+                                 The MaxSessionDuration for the role is {} seconds.",
+                                role.max_session_duration
+                            ),
+                        ));
+                    }
+                }
+            }
+
+            role_id = role.role_id.clone();
         } else {
             // AssumeRole against a role that does not exist must be denied
             // rather than fall through to credential minting with no trust
@@ -227,12 +255,6 @@ impl StsService {
                 ),
             ));
         }
-
-        let role_id = target_state
-            .roles
-            .get(role_name)
-            .map(|r| r.role_id.clone())
-            .unwrap_or_else(xml_responses::generate_role_id);
 
         let assumed_role_arn = format!(
             "arn:{}:sts::{}:assumed-role/{}/{}",
@@ -357,7 +379,6 @@ impl StsService {
 
         let partition = partition_for_region(&req.region);
         let creds = StsCredentials::generate();
-        let role_id = xml_responses::generate_role_id();
 
         let mut accounts = self.state.write();
         let caller_state = accounts.get_or_create(&req.account_id);
@@ -366,6 +387,13 @@ impl StsService {
             extract_account_from_arn(role_arn).unwrap_or_else(|| req.account_id.clone());
 
         let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
+        // Use the role's stable RoleId as the AssumedRoleId prefix (matching
+        // AWS), not a fresh random AROA on every assume. Fall back to a
+        // generated id only when the role isn't resolvable.
+        let role_id = accounts
+            .get(&account_id)
+            .and_then(|s| s.roles.get(role_name).map(|r| r.role_id.clone()))
+            .unwrap_or_else(xml_responses::generate_role_id);
         let assumed_role_arn = format!(
             "arn:{}:sts::{}:assumed-role/{}/{}",
             partition, account_id, role_name, role_session_name
@@ -666,7 +694,6 @@ impl StsService {
 
         let partition = partition_for_region(&req.region);
         let creds = StsCredentials::generate();
-        let role_id = xml_responses::generate_role_id();
 
         let mut accounts = self.state.write();
         let caller_state = accounts.get_or_create(&req.account_id);
@@ -675,6 +702,12 @@ impl StsService {
             extract_account_from_arn(role_arn).unwrap_or_else(|| req.account_id.clone());
 
         let role_name = role_arn.rsplit('/').next().unwrap_or("unknown");
+        // Use the role's stable RoleId as the AssumedRoleId prefix (matching
+        // AWS), not a fresh random AROA on every assume.
+        let role_id = accounts
+            .get(&account_id)
+            .and_then(|s| s.roles.get(role_name).map(|r| r.role_id.clone()))
+            .unwrap_or_else(xml_responses::generate_role_id);
         let assumed_role_arn = format!(
             "arn:{}:sts::{}:assumed-role/{}/{}",
             partition, account_id, role_name, role_session_name

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -998,6 +998,63 @@ mod tests {
         assert!(svc.handle(req).await.is_err());
     }
 
+    #[tokio::test]
+    async fn assume_role_duration_exceeding_max_session_is_rejected() {
+        // The role's MaxSessionDuration is 3600; a DurationSeconds of 7200 is
+        // within the generic 900..43200 range but over the role cap, so AWS
+        // rejects it with ValidationError.
+        let (svc, state) = make_sts_service();
+        let role_arn = create_role_in_state(&state, "capped-role");
+        let req = sts_request(
+            "AssumeRole",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "sess"),
+                ("DurationSeconds", "7200"),
+            ],
+        );
+        let err = match svc.handle(req).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected ValidationError for over-cap DurationSeconds"),
+        };
+        assert_eq!(err.code(), "ValidationError");
+        assert!(format!("{err:?}").contains("MaxSessionDuration"));
+    }
+
+    #[tokio::test]
+    async fn assume_role_within_max_session_duration_succeeds() {
+        let (svc, state) = make_sts_service();
+        let role_arn = create_role_in_state(&state, "capped-role-ok");
+        let req = sts_request(
+            "AssumeRole",
+            vec![
+                ("RoleArn", &role_arn),
+                ("RoleSessionName", "sess"),
+                ("DurationSeconds", "3000"),
+            ],
+        );
+        assert!(svc.handle(req).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn assume_role_unknown_account_arn_does_not_create_phantom_account() {
+        // A RoleArn naming an account that doesn't exist must be denied
+        // WITHOUT materializing that account (unbounded map growth guard).
+        let (svc, state) = make_sts_service();
+        let req = sts_request(
+            "AssumeRole",
+            vec![
+                ("RoleArn", "arn:aws:iam::999999999999:role/whatever"),
+                ("RoleSessionName", "sess"),
+            ],
+        );
+        assert!(svc.handle(req).await.is_err());
+        assert!(
+            state.read().get("999999999999").is_none(),
+            "attacker-controlled RoleArn must not insert a phantom account"
+        );
+    }
+
     // ── AssumeRoleWithWebIdentity ──
 
     #[tokio::test]
@@ -1076,6 +1133,42 @@ mod tests {
             format!("{err:?}").contains("AccessDenied"),
             "expected AccessDenied, got {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn assume_role_with_web_identity_uses_stable_role_id_prefix() {
+        // The AssumedRoleId prefix must be the role's stable RoleId, not a
+        // fresh random AROA on every assume (so it's identical across calls).
+        let (svc, state) = make_sts_service();
+        let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#;
+        let role_arn = create_role_in_state_with_trust(&state, "web-role", trust);
+        let role_id = state
+            .read()
+            .get("123456789012")
+            .unwrap()
+            .roles
+            .get("web-role")
+            .unwrap()
+            .role_id
+            .clone();
+        let expected = format!("<AssumedRoleId>{role_id}:web-session</AssumedRoleId>");
+
+        for _ in 0..2 {
+            let req = sts_request(
+                "AssumeRoleWithWebIdentity",
+                vec![
+                    ("RoleArn", &role_arn),
+                    ("RoleSessionName", "web-session"),
+                    ("WebIdentityToken", "fake-jwt-token"),
+                ],
+            );
+            let resp = svc.handle(req).await.unwrap();
+            let body = std::str::from_utf8(resp.body.expect_bytes()).unwrap();
+            assert!(
+                body.contains(&expected),
+                "AssumedRoleId prefix must be the role's stable RoleId; body = {body}"
+            );
+        }
     }
 
     // ── AssumeRoleWithSAML ──


### PR DESCRIPTION
## Summary

Tier-5 LOW follow-ups on the STS AssumeRole family:

- **LM2 — MaxSessionDuration not enforced.** `AssumeRole` validated `DurationSeconds` only against the generic 900..43200 range, never the role's `MaxSessionDuration`, so a 12h session was minted regardless of the cap. Now rejects a `DurationSeconds` over `role.max_session_duration` with `ValidationError`, matching AWS.
- **L3 — phantom account creation from attacker-controlled RoleArn.** The target account was resolved with `get_or_create` on the ARN-derived account id *before* the role-existence check, so a `RoleArn` naming a non-existent account inserted an empty account that the next mutation persists (unbounded map growth + resolver-scan cost). Now looks up the role via a non-creating `get`; a missing account/role denies with `AccessDenied` and materializes nothing.
- **L4 — unstable AssumedRoleId.** `AssumeRoleWithWebIdentity`/`WithSAML` used a fresh random AROA as the `AssumedRoleId` prefix on every call instead of the role's stable `RoleId`, so the id changed on each assume of the same role. Now uses `role.role_id` (falling back to a generated id only when the role isn't resolvable), matching plain `AssumeRole` and AWS.

## Test plan

- New unit tests: over-cap `DurationSeconds` rejected, within-cap accepted, unknown-account ARN denied without a phantom account, stable AROA prefix across two web-identity assumes. All 518 `fakecloud-iam` lib tests pass.
- `cargo clippy -p fakecloud-iam --all-targets` clean, `cargo fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes STS AssumeRole behavior to match AWS: enforces a role’s MaxSessionDuration, stops phantom account creation from crafted RoleArn, and stabilizes AssumedRoleId for WebIdentity/SAML.

- **Bug Fixes**
  - Reject DurationSeconds above the role’s MaxSessionDuration with ValidationError.
  - Avoid creating target accounts during lookup; missing account/role returns AccessDenied.
  - Use the role’s stable RoleId as the AssumedRoleId prefix for WebIdentity and SAML (fallback to generated only if the role can’t be resolved).

<sup>Written for commit 01794bd00b93ce20d42bc74c8b8c9e96ece054cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

