### PR TITLE
fix(ecr): validate blob PATCH Content-Range, real pull-through validation, stable pagination cursors

### DIFF
--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -713,6 +713,16 @@ fn blob_upload_start(
     Ok(resp)
 }
 
+/// Parse the start offset from a blob-upload `Content-Range` header. Accepts
+/// the OCI form `<start>-<end>` and the HTTP form `bytes <start>-<end>/<total>`;
+/// returns `None` when no leading integer can be read.
+fn parse_content_range_start(value: &str) -> Option<u64> {
+    let v = value.trim();
+    let v = v.strip_prefix("bytes").map(str::trim).unwrap_or(v);
+    let start = v.split('-').next()?.trim();
+    start.parse::<u64>().ok()
+}
+
 async fn blob_upload_patch(
     service: &EcrService,
     request: &AwsRequest,
@@ -722,7 +732,7 @@ async fn blob_upload_patch(
     // Resolve the upload + spool path under a short-lived read guard
     // so the streaming append below doesn't hold a Send-unfriendly
     // `parking_lot::RwLockWriteGuard` across `.await`.
-    let spool = {
+    let (spool, expected_start) = {
         let accounts = service.state_handle().read();
         let state = accounts
             .get(&request.account_id)
@@ -734,8 +744,33 @@ async fn blob_upload_patch(
         if upload.repository_name != name {
             return Err(upload_unknown(upload_id));
         }
-        PathBuf::from(&upload.spool_path)
+        (PathBuf::from(&upload.spool_path), upload.last_byte_received)
     };
+
+    // A chunked PATCH carries a Content-Range whose start must equal the
+    // number of bytes already received. Docker retries a failed chunk by
+    // re-sending the same range; without this check the retry appends the
+    // chunk a second time and silently corrupts the blob (detected only at
+    // the finishing digest). Reject a non-contiguous range with 416 so the
+    // client resumes from the right offset instead of double-appending.
+    if let Some(cr) = request
+        .headers
+        .get("content-range")
+        .and_then(|v| v.to_str().ok())
+    {
+        if let Some(start) = parse_content_range_start(cr) {
+            if start != expected_start {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::RANGE_NOT_SATISFIABLE,
+                    "BLOB_UPLOAD_INVALID",
+                    format!(
+                        "blob upload PATCH Content-Range start {start} does not match the current \
+                         upload offset {expected_start}"
+                    ),
+                ));
+            }
+        }
+    }
 
     // Streaming-only: dispatch flags blob-upload PATCH/PUT to keep
     // `body_stream` populated, so we always consume it here. A 1 GiB
@@ -1218,6 +1253,17 @@ mod immutability_tests {
     // tests isolate the immutability behaviour.
     fn manifest(tag_hint: &str) -> String {
         format!("{{\"schemaVersion\":2,\"config\":{{\"digest\":\"sha256:{tag_hint}\"}}}}")
+    }
+
+    #[test]
+    fn parse_content_range_start_handles_both_forms() {
+        assert_eq!(super::parse_content_range_start("0-1023"), Some(0));
+        assert_eq!(super::parse_content_range_start("1024-2047"), Some(1024));
+        assert_eq!(
+            super::parse_content_range_start("bytes 512-1023/*"),
+            Some(512)
+        );
+        assert_eq!(super::parse_content_range_start("not-a-range"), None);
     }
 
     #[test]

--- a/crates/fakecloud-ecr/src/service/images.rs
+++ b/crates/fakecloud-ecr/src/service/images.rs
@@ -450,16 +450,10 @@ impl EcrService {
             }
             None => DEFAULT_PAGE_SIZE,
         };
-        let offset = match body.get("nextToken").and_then(|v| v.as_str()) {
-            Some(raw) => raw.parse::<usize>().map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidParameterException",
-                    "The specified parameter is invalid: nextToken",
-                )
-            })?,
-            None => 0,
-        };
+        // Key-based cursor (base64 of the last-emitted image digest) instead of
+        // a numeric offset, so pages stay stable when images are added/deleted
+        // between calls rather than skipping or duplicating rows.
+        let cursor = decode_page_token(body.get("nextToken").and_then(|v| v.as_str()))?;
         let account = target_account_id(request, &body);
         let accounts = self.state.read();
         let state = accounts
@@ -473,14 +467,21 @@ impl EcrService {
         let mut details: Vec<Value> = Vec::new();
         let mut next_token: Option<String> = None;
         if ids.is_empty() {
-            let all: Vec<&Image> = repo.images.values().collect();
-            let start = offset.min(all.len());
+            // repo.images is a BTreeMap, so keys() is sorted by digest.
+            let all: Vec<(&String, &Image)> = repo.images.iter().collect();
+            let start = match &cursor {
+                None => 0,
+                Some(c) => all
+                    .iter()
+                    .position(|(k, _)| k.as_str() > c.as_str())
+                    .unwrap_or(all.len()),
+            };
             let end = (start + max_results).min(all.len());
-            for img in &all[start..end] {
+            for (_, img) in &all[start..end] {
                 details.push(image_to_details(repo, img, &repo.registry_id));
             }
             if end < all.len() {
-                next_token = Some(end.to_string());
+                next_token = Some(encode_page_token(all[end - 1].0));
             }
         } else {
             for id in &ids {
@@ -518,16 +519,9 @@ impl EcrService {
             }
             None => DEFAULT_PAGE_SIZE,
         };
-        let offset = match body.get("nextToken").and_then(|v| v.as_str()) {
-            Some(raw) => raw.parse::<usize>().map_err(|_| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidParameterException",
-                    "The specified parameter is invalid: nextToken",
-                )
-            })?,
-            None => 0,
-        };
+        // Key-based cursor over the sorted (digest, tag) list — stable across
+        // concurrent add/delete, unlike the previous numeric offset.
+        let cursor = decode_page_token(body.get("nextToken").and_then(|v| v.as_str()))?;
         let account = target_account_id(request, &body);
         let accounts = self.state.read();
         let state = accounts
@@ -557,7 +551,13 @@ impl EcrService {
         });
         all.sort();
 
-        let start = offset.min(all.len());
+        let start = match &cursor {
+            None => 0,
+            Some(c) => all
+                .iter()
+                .position(|(d, t)| list_image_key(d, t.as_deref()).as_str() > c.as_str())
+                .unwrap_or(all.len()),
+        };
         let end = (start + max_results).min(all.len());
         let ids: Vec<Value> = all[start..end]
             .iter()
@@ -571,7 +571,8 @@ impl EcrService {
             .collect();
         let mut response = json!({ "imageIds": ids });
         if end < all.len() {
-            response["nextToken"] = json!(end.to_string());
+            let (d, t) = &all[end - 1];
+            response["nextToken"] = json!(encode_page_token(&list_image_key(d, t.as_deref())));
         }
         Ok(AwsResponse::ok_json(response))
     }
@@ -870,5 +871,204 @@ impl EcrService {
             "imageId": image_id,
             "imageStatus": new_status,
         })))
+    }
+}
+
+/// Encode a pagination cursor: base64 of the last-emitted item's sort key.
+/// AWS ECR nextTokens are opaque strings; a stable key (image digest, or
+/// `digest\0tag` for ListImages) survives concurrent add/delete between pages
+/// where a numeric offset would skip or duplicate rows.
+fn encode_page_token(key: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(key.as_bytes())
+}
+
+/// Decode a pagination cursor produced by [`encode_page_token`]. A malformed
+/// token yields the same `InvalidParameterException` AWS returns.
+fn decode_page_token(raw: Option<&str>) -> Result<Option<String>, AwsServiceError> {
+    use base64::Engine;
+    let Some(s) = raw else { return Ok(None) };
+    let invalid = || {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterException",
+            "The specified parameter is invalid: nextToken",
+        )
+    };
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(s)
+        .map_err(|_| invalid())?;
+    let key = String::from_utf8(bytes).map_err(|_| invalid())?;
+    Ok(Some(key))
+}
+
+/// Sort/cursor key for a ListImages `(digest, tag)` row. A NUL separator keeps
+/// the ordering identical to the tuple sort (untagged `None` -> empty suffix,
+/// which sorts before any tagged variant of the same digest).
+fn list_image_key(digest: &str, tag: Option<&str>) -> String {
+    format!("{digest}\u{0}{}", tag.unwrap_or(""))
+}
+
+#[cfg(test)]
+mod pagination_and_validation_tests {
+    use super::*;
+    use crate::state::{EcrState, PullThroughCacheRule, Repository};
+    use crate::EcrService;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const ACCT: &str = "111111111111";
+
+    fn svc() -> EcrService {
+        let mut mas: MultiAccountState<EcrState> =
+            MultiAccountState::new(ACCT, "us-east-1", "http://fakecloud:4566");
+        let s = mas.get_or_create(ACCT);
+        let arn = s.repository_arn("app");
+        s.repositories.insert(
+            "app".into(),
+            Repository::new("app", arn, ACCT, "fakecloud:4566"),
+        );
+        EcrService::new(Arc::new(RwLock::new(mas)))
+    }
+
+    fn req(action: &str, body: serde_json::Value) -> AwsRequest {
+        AwsRequest {
+            service: "ecr".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: ACCT.into(),
+            request_id: "r".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body_of(resp: AwsResponse) -> serde_json::Value {
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    #[test]
+    fn page_token_round_trips_and_rejects_garbage() {
+        let t = encode_page_token("sha256:abc");
+        assert_eq!(
+            decode_page_token(Some(&t)).unwrap().as_deref(),
+            Some("sha256:abc")
+        );
+        assert!(decode_page_token(Some("!!!not-base64!!!")).is_err());
+        assert_eq!(decode_page_token(None).unwrap(), None);
+    }
+
+    #[test]
+    fn describe_images_paginates_by_stable_digest_cursor() {
+        let svc = svc();
+        for i in 0..3 {
+            svc.put_image(&req(
+                "PutImage",
+                serde_json::json!({
+                    "repositoryName": "app",
+                    "imageManifest": format!("{{\"schemaVersion\":2,\"n\":{i}}}"),
+                }),
+            ))
+            .unwrap();
+        }
+        // Page 1: 2 of 3, with a nextToken.
+        let p1 = body_of(
+            svc.describe_images(&req(
+                "DescribeImages",
+                serde_json::json!({"repositoryName": "app", "maxResults": 2}),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(p1["imageDetails"].as_array().unwrap().len(), 2);
+        let token = p1["nextToken"].as_str().expect("nextToken on page 1");
+        // Page 2: the remaining 1, no overlap with page 1.
+        let p2 = body_of(
+            svc.describe_images(&req(
+                "DescribeImages",
+                serde_json::json!({"repositoryName": "app", "maxResults": 2, "nextToken": token}),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(p2["imageDetails"].as_array().unwrap().len(), 1);
+        assert!(p2.get("nextToken").is_none());
+        let d1: Vec<&str> = p1["imageDetails"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["imageDigest"].as_str().unwrap())
+            .collect();
+        let d2 = p2["imageDetails"][0]["imageDigest"].as_str().unwrap();
+        assert!(
+            !d1.contains(&d2),
+            "page 2 must not duplicate a page-1 image"
+        );
+    }
+
+    #[test]
+    fn validate_pull_through_reflects_credential_requirement() {
+        let svc = svc();
+        {
+            let state = svc.state_handle();
+            let mut accounts = state.write();
+            let s = accounts.get_mut(ACCT).unwrap();
+            // Docker Hub upstream requires credentials.
+            s.pull_through_cache_rules.insert(
+                "dockerhub".into(),
+                PullThroughCacheRule {
+                    ecr_repository_prefix: "dockerhub".into(),
+                    upstream_registry_url: "registry-1.docker.io".into(),
+                    upstream_registry: Some("docker-hub".into()),
+                    credential_arn: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    custom_role_arn: None,
+                },
+            );
+            // Public ECR needs none.
+            s.pull_through_cache_rules.insert(
+                "ecr-public".into(),
+                PullThroughCacheRule {
+                    ecr_repository_prefix: "ecr-public".into(),
+                    upstream_registry_url: "public.ecr.aws".into(),
+                    upstream_registry: Some("ecr-public".into()),
+                    credential_arn: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    custom_role_arn: None,
+                },
+            );
+        }
+        let invalid = body_of(
+            svc.validate_pull_through_cache_rule(&req(
+                "ValidatePullThroughCacheRule",
+                serde_json::json!({"ecrRepositoryPrefix": "dockerhub"}),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(invalid["isValid"], serde_json::json!(false));
+        assert!(invalid.get("failure").is_some());
+
+        let valid = body_of(
+            svc.validate_pull_through_cache_rule(&req(
+                "ValidatePullThroughCacheRule",
+                serde_json::json!({"ecrRepositoryPrefix": "ecr-public"}),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(valid["isValid"], serde_json::json!(true));
     }
 }

--- a/crates/fakecloud-ecr/src/service/pull_through.rs
+++ b/crates/fakecloud-ecr/src/service/pull_through.rs
@@ -151,8 +151,26 @@ impl EcrService {
                 )
             })?;
         let registry_id = state.map(|s| s.account_id.clone()).unwrap_or_default();
+        // Validate the rule's configuration the way AWS does: the public
+        // upstreams (ECR Public, registry.k8s.io, Quay) need no credentials,
+        // but Docker Hub / GitHub / Azure / GitLab require a credentialArn (or
+        // customRoleArn). A creds-requiring upstream with neither is invalid.
+        let url = rule.upstream_registry_url.to_ascii_lowercase();
+        let is_public_upstream = url.is_empty()
+            || url.contains("public.ecr.aws")
+            || url.contains("registry.k8s.io")
+            || url.contains("quay.io");
+        let has_credentials = rule.credential_arn.is_some() || rule.custom_role_arn.is_some();
+        let is_valid = is_public_upstream || has_credentials;
         let mut base = pull_through_rule_json(&registry_id, rule);
-        base["isValid"] = json!(true);
+        base["isValid"] = json!(is_valid);
+        if !is_valid {
+            base["failure"] = json!(format!(
+                "The pull through cache rule for upstream registry '{}' requires credentials, \
+                 but no credentialArn or customRoleArn is configured.",
+                rule.upstream_registry_url
+            ));
+        }
         Ok(AwsResponse::ok_json(base))
     }
 }


### PR DESCRIPTION
## Summary

Tier-5 LOW follow-ups on ECR:

- **L2 — blob PATCH ignored Content-Range.** A client retrying a failed chunk (docker resends the same range) had it appended a second time, silently corrupting the blob (detected only at the finishing digest). Now rejects a `Content-Range` whose start doesn't match the current upload offset with `416`.
- **L3 — ValidatePullThroughCacheRule always isValid=true.** Now reflects the rule's config the way AWS does: public upstreams (ECR Public, `registry.k8s.io`, Quay) validate without credentials, but Docker Hub / GitHub / Azure / GitLab require a `credentialArn` or `customRoleArn` — a creds-requiring upstream with neither is reported invalid with a `failure` reason.
- **L4 — unstable pagination cursors.** `DescribeImages`/`ListImages` paginated with a plaintext numeric offset into a BTreeMap, so an image added/deleted between pages shifted the offset and skipped or duplicated rows. Now uses an opaque base64 cursor over the stable sort key (digest for DescribeImages, digest+tag for ListImages), resuming by key.

## Test plan

- New unit/integration tests: Content-Range parsing, page-token round-trip + garbage rejection, a `DescribeImages` two-page walk with no overlap, and `ValidatePullThroughCacheRule` invalid for a credential-less Docker Hub rule / valid for ECR Public. All 75 `fakecloud-ecr` lib tests pass.
- `cargo clippy -p fakecloud-ecr --all-targets` clean, `cargo fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blob upload corruption by validating PATCH Content-Range, aligns pull-through rule validation with AWS behavior, and stabilizes pagination with opaque cursors.

- **Bug Fixes**
  - Rejects blob PATCH when `Content-Range` start ≠ current offset; returns 416 to prevent double-append.
  - `ValidatePullThroughCacheRule` now requires creds for Docker Hub/GitHub/Azure/GitLab; allows ECR Public, `registry.k8s.io`, and Quay without creds; adds a failure reason when invalid.
  - Replaces numeric `nextToken` with base64 cursors over stable keys (digest; digest+tag) to avoid skipped/duplicated rows; invalid tokens return `InvalidParameterException`.

<sup>Written for commit 54c67be9ae17ee7e2775dbb61a31e6d6ba4e8204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

