### PR TITLE
fix(ecs): real DescribeServiceRevisions + opaque List pagination cursors

### DIFF
--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -76,6 +76,47 @@ pub(crate) fn opt_str<'a>(body: &'a Value, field: &str) -> Option<&'a str> {
     body.get(field).and_then(|v| v.as_str())
 }
 
+/// Paginate a list of ARN-like strings with a key-based cursor instead of a
+/// numeric offset. The list is sorted for a stable order (HashMap/BTreeMap
+/// value order is not a contract callers can rely on), and the returned
+/// `nextToken` is an opaque base64 of the last-emitted key. Resuming finds the
+/// first key strictly greater than the cursor, so pages stay correct even when
+/// items are added or removed between calls — a numeric offset would skip or
+/// duplicate rows there. A token that doesn't base64-decode restarts at the
+/// beginning (lenient, matching the previous behavior).
+pub(crate) fn paginate_arns(
+    mut arns: Vec<String>,
+    next_token: &str,
+    max_results: usize,
+) -> (Vec<String>, Option<String>) {
+    use base64::Engine;
+    arns.sort();
+    arns.dedup();
+    let cursor = if next_token.is_empty() {
+        None
+    } else {
+        base64::engine::general_purpose::STANDARD
+            .decode(next_token)
+            .ok()
+            .and_then(|b| String::from_utf8(b).ok())
+    };
+    let start = match &cursor {
+        Some(c) => arns
+            .iter()
+            .position(|a| a.as_str() > c.as_str())
+            .unwrap_or(arns.len()),
+        None => 0,
+    };
+    let end = (start + max_results).min(arns.len());
+    let page = arns[start..end].to_vec();
+    let next = if end < arns.len() {
+        Some(base64::engine::general_purpose::STANDARD.encode(arns[end - 1].as_bytes()))
+    } else {
+        None
+    };
+    (page, next)
+}
+
 /// Validate that an optional string field, if present, is one of the allowed
 /// enum values. Returns InvalidParameterException if the field is set to a
 /// value outside `allowed`. Absent or null fields are accepted.
@@ -1507,4 +1548,39 @@ pub(crate) fn task_protection_json(task: &Task) -> Value {
         "protectionEnabled": p.map(|p| p.enabled).unwrap_or(false),
         "expirationDate": p.and_then(|p| p.expiration).map(|e| e.timestamp()),
     })
+}
+
+#[cfg(test)]
+mod pagination_tests {
+    use super::paginate_arns;
+
+    #[test]
+    fn paginate_arns_key_cursor_is_stable_across_delete() {
+        let all: Vec<String> = (0..5).map(|i| format!("arn:{i}")).collect();
+        let (p1, next) = paginate_arns(all.clone(), "", 2);
+        assert_eq!(p1, vec!["arn:0", "arn:1"]);
+        let token = next.expect("nextToken after page 1");
+
+        // Delete the first item before fetching page 2. A numeric offset (2)
+        // would skip "arn:2"; the key cursor resumes correctly after "arn:1".
+        let after: Vec<String> = all.iter().filter(|a| *a != "arn:0").cloned().collect();
+        let (p2, next2) = paginate_arns(after, &token, 2);
+        assert_eq!(p2, vec!["arn:2", "arn:3"]);
+        assert!(next2.is_some());
+    }
+
+    #[test]
+    fn paginate_arns_sorts_and_dedups_and_tolerates_garbage_token() {
+        let dupes = vec![
+            "b".to_string(),
+            "a".to_string(),
+            "a".to_string(),
+            "c".to_string(),
+        ];
+        let (page, _) = paginate_arns(dupes, "", 10);
+        assert_eq!(page, vec!["a", "b", "c"]);
+        // A non-base64 token restarts from the beginning.
+        let (page, _) = paginate_arns(vec!["a".into(), "b".into()], "!!!not-base64", 1);
+        assert_eq!(page, vec!["a"]);
+    }
 }

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -82,8 +82,10 @@ pub(crate) fn opt_str<'a>(body: &'a Value, field: &str) -> Option<&'a str> {
 /// `nextToken` is an opaque base64 of the last-emitted key. Resuming finds the
 /// first key strictly greater than the cursor, so pages stay correct even when
 /// items are added or removed between calls — a numeric offset would skip or
-/// duplicate rows there. A token that doesn't base64-decode restarts at the
-/// beginning (lenient, matching the previous behavior).
+/// duplicate rows there. A non-empty token that doesn't base64-decode (a stale
+/// or corrupted cursor we never emitted) is treated as past the end and yields
+/// an empty page — restarting at the beginning would silently re-list page 1
+/// and risk an infinite pagination loop for the client.
 pub(crate) fn paginate_arns(
     mut arns: Vec<String>,
     next_token: &str,
@@ -100,12 +102,18 @@ pub(crate) fn paginate_arns(
             .ok()
             .and_then(|b| String::from_utf8(b).ok())
     };
-    let start = match &cursor {
-        Some(c) => arns
-            .iter()
-            .position(|a| a.as_str() > c.as_str())
-            .unwrap_or(arns.len()),
-        None => 0,
+    let start = if next_token.is_empty() {
+        0
+    } else {
+        match &cursor {
+            Some(c) => arns
+                .iter()
+                .position(|a| a.as_str() > c.as_str())
+                .unwrap_or(arns.len()),
+            // Non-empty but undecodable token: a cursor we never emitted.
+            // Treat as past the end (empty page) rather than restarting at 0.
+            None => arns.len(),
+        }
     };
     let end = (start + max_results).min(arns.len());
     let page = arns[start..end].to_vec();
@@ -1579,8 +1587,13 @@ mod pagination_tests {
         ];
         let (page, _) = paginate_arns(dupes, "", 10);
         assert_eq!(page, vec!["a", "b", "c"]);
-        // A non-base64 token restarts from the beginning.
-        let (page, _) = paginate_arns(vec!["a".into(), "b".into()], "!!!not-base64", 1);
+        // A non-empty, undecodable token is treated as past the end: empty
+        // page + no nextToken, never a silent restart at page 1.
+        let (page, next) = paginate_arns(vec!["a".into(), "b".into()], "!!!not-base64", 1);
+        assert!(page.is_empty());
+        assert!(next.is_none());
+        // An empty token still starts at the beginning.
+        let (page, _) = paginate_arns(vec!["a".into(), "b".into()], "", 1);
         assert_eq!(page, vec!["a"]);
     }
 }

--- a/crates/fakecloud-ecs/src/service_clusters.rs
+++ b/crates/fakecloud-ecs/src/service_clusters.rs
@@ -174,14 +174,7 @@ impl EcsService {
                 .collect(),
             None => Vec::new(),
         };
-        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
-        let end = (start + max_results).min(arns.len());
-        let page = arns[start..end].to_vec();
-        let next = if end < arns.len() {
-            Some(end.to_string())
-        } else {
-            None
-        };
+        let (page, next) = paginate_arns(arns, next_token, max_results);
         let mut out = json!({ "clusterArns": page });
         if let Some(n) = next {
             out.as_object_mut()

--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -201,14 +201,12 @@ impl EcsService {
             None => Vec::new(),
         };
         arns.sort();
-        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
-        let end = (start + max_results).min(arns.len());
-        let page = arns[start..end].to_vec();
+        let (page, next) = paginate_arns(arns, next_token, max_results);
         let mut out = json!({"containerInstanceArns": page});
-        if end < arns.len() {
+        if let Some(n) = next {
             out.as_object_mut()
                 .unwrap()
-                .insert("nextToken".into(), json!(end.to_string()));
+                .insert("nextToken".into(), json!(n));
         }
         Ok(AwsResponse::ok_json(out))
     }
@@ -1173,9 +1171,27 @@ impl EcsService {
             .iter()
             .filter_map(|v| v.as_str().map(String::from))
             .collect();
+        let account = request.account_id.clone();
+        let accounts = self.state.read();
+        let state = accounts.get(&account);
+        let mut found = Vec::new();
+        let mut failures = Vec::new();
+        for r in &refs {
+            match state.and_then(|s| s.service_revisions.get(r)) {
+                Some(rev) => found.push(json!({
+                    "serviceRevisionArn": rev.service_revision_arn,
+                    "serviceArn": rev.service_arn,
+                    "clusterArn": rev.cluster_arn,
+                    "taskDefinition": rev.task_definition_arn,
+                    "launchType": rev.launch_type,
+                    "createdAt": rev.created_at.timestamp(),
+                })),
+                None => failures.push(json!({"arn": r, "reason": "MISSING"})),
+            }
+        }
         Ok(AwsResponse::ok_json(json!({
-            "serviceRevisions": [],
-            "failures": refs.iter().map(|r| json!({"arn": r, "reason": "MISSING"})).collect::<Vec<_>>(),
+            "serviceRevisions": found,
+            "failures": failures,
         })))
     }
 }

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -238,6 +238,7 @@ impl EcsService {
                 volume_configurations: volume_configurations.clone(),
             };
             state.services.insert(key.clone(), service.clone());
+            state.record_service_revision(&service);
             if let Some(cluster) = state.clusters.get_mut(&cluster_name) {
                 cluster.active_services_count += 1;
             }
@@ -791,6 +792,14 @@ impl EcsService {
                 }),
             });
 
+            // A task-definition change mints a new service revision so
+            // DescribeServiceRevisions reflects the deployment history.
+            if new_deployment_triggered {
+                if let Some(svc) = state.services.get(&key).cloned() {
+                    state.record_service_revision(&svc);
+                }
+            }
+
             let svc = state.services.get(&key).unwrap();
             let mut service_json = service_to_json(svc);
             if controller == "CODE_DEPLOY" {
@@ -1080,14 +1089,12 @@ impl EcsService {
             None => Vec::new(),
         };
         arns.sort();
-        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
-        let end = (start + max_results).min(arns.len());
-        let page = arns[start..end].to_vec();
+        let (page, next) = paginate_arns(arns, next_token, max_results);
         let mut out = json!({"serviceArns": page});
-        if end < arns.len() {
+        if let Some(n) = next {
             out.as_object_mut()
                 .unwrap()
-                .insert("nextToken".into(), json!(end.to_string()));
+                .insert("nextToken".into(), json!(n));
         }
         Ok(AwsResponse::ok_json(out))
     }

--- a/crates/fakecloud-ecs/src/service_task_definitions.rs
+++ b/crates/fakecloud-ecs/src/service_task_definitions.rs
@@ -343,14 +343,12 @@ impl EcsService {
         } else {
             arns.sort();
         }
-        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
-        let end = (start + max_results).min(arns.len());
-        let page = arns[start..end].to_vec();
+        let (page, next) = paginate_arns(arns, next_token, max_results);
         let mut out = json!({"taskDefinitionArns": page});
-        if end < arns.len() {
+        if let Some(n) = next {
             out.as_object_mut()
                 .unwrap()
-                .insert("nextToken".into(), json!(end.to_string()));
+                .insert("nextToken".into(), json!(n));
         }
         Ok(AwsResponse::ok_json(out))
     }
@@ -395,14 +393,12 @@ impl EcsService {
             }
         }
         families.sort();
-        let start = next_token.parse::<usize>().unwrap_or(0).min(families.len());
-        let end = (start + max_results).min(families.len());
-        let page = families[start..end].to_vec();
+        let (page, next) = paginate_arns(families, next_token, max_results);
         let mut out = json!({"families": page});
-        if end < families.len() {
+        if let Some(n) = next {
             out.as_object_mut()
                 .unwrap()
-                .insert("nextToken".into(), json!(end.to_string()));
+                .insert("nextToken".into(), json!(n));
         }
         Ok(AwsResponse::ok_json(out))
     }

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -563,14 +563,12 @@ impl EcsService {
             None => Vec::new(),
         };
         arns.sort();
-        let start = next_token.parse::<usize>().unwrap_or(0).min(arns.len());
-        let end = (start + max_results).min(arns.len());
-        let page = arns[start..end].to_vec();
+        let (page, next) = paginate_arns(arns, next_token, max_results);
         let mut out = json!({"taskArns": page});
-        if end < arns.len() {
+        if let Some(n) = next {
             out.as_object_mut()
                 .unwrap()
-                .insert("nextToken".into(), json!(end.to_string()));
+                .insert("nextToken".into(), json!(n));
         }
         Ok(AwsResponse::ok_json(out))
     }
@@ -759,6 +757,55 @@ mod multi_container_tests {
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert_eq!(body["tasks"].as_array().unwrap().len(), 1);
         assert_eq!(body["failures"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn describe_service_revisions_returns_stored_revision_or_missing() {
+        let svc = fresh_service();
+        svc.register_task_definition(&make_request(
+            "RegisterTaskDefinition",
+            json!({"family": "web", "containerDefinitions": [{"name": "app", "image": "alpine"}]}),
+        ))
+        .unwrap();
+        let created = svc
+            .create_service(&make_request(
+                "CreateService",
+                json!({"serviceName": "s", "taskDefinition": "web", "desiredCount": 0}),
+            ))
+            .unwrap();
+        let cbody: Value = serde_json::from_slice(created.body.expect_bytes()).unwrap();
+        let service_arn = cbody["service"]["serviceArn"].as_str().unwrap().to_string();
+
+        // CreateService minted revision 1.
+        let rev1 = format!("{service_arn}:1");
+        let d = svc
+            .describe_service_revisions(&make_request(
+                "DescribeServiceRevisions",
+                json!({"serviceRevisionArns": [rev1.clone()]}),
+            ))
+            .unwrap();
+        let dbody: Value = serde_json::from_slice(d.body.expect_bytes()).unwrap();
+        assert_eq!(dbody["serviceRevisions"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            dbody["serviceRevisions"][0]["serviceRevisionArn"],
+            json!(rev1)
+        );
+        assert!(dbody["serviceRevisions"][0]["taskDefinition"]
+            .as_str()
+            .unwrap()
+            .ends_with("web:1"));
+        assert_eq!(dbody["failures"].as_array().unwrap().len(), 0);
+
+        // Unknown revision -> MISSING.
+        let d2 = svc
+            .describe_service_revisions(&make_request(
+                "DescribeServiceRevisions",
+                json!({"serviceRevisionArns": [format!("{service_arn}:99")]}),
+            ))
+            .unwrap();
+        let d2body: Value = serde_json::from_slice(d2.body.expect_bytes()).unwrap();
+        assert_eq!(d2body["serviceRevisions"].as_array().unwrap().len(), 0);
+        assert_eq!(d2body["failures"][0]["reason"], "MISSING");
     }
 
     #[test]

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -94,6 +94,25 @@ pub struct EcsState {
     /// with built-in load balancing and autoscaling.
     #[serde(default)]
     pub express_gateway_services: BTreeMap<String, ExpressGatewayService>,
+    /// Service revisions keyed by `serviceRevisionArn` (`{service_arn}:{n}`).
+    /// A revision is minted on CreateService and on each UpdateService that
+    /// changes the task definition, so DescribeServiceRevisions can return the
+    /// real configuration snapshot instead of an empty stub.
+    #[serde(default)]
+    pub service_revisions: BTreeMap<String, ServiceRevision>,
+}
+
+/// A point-in-time snapshot of a service's configuration, addressable by
+/// `serviceRevisionArn`. Mirrors the subset of AWS's ServiceRevision that
+/// callers key on when auditing a deployment.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ServiceRevision {
+    pub service_revision_arn: String,
+    pub service_arn: String,
+    pub cluster_arn: String,
+    pub task_definition_arn: String,
+    pub launch_type: String,
+    pub created_at: DateTime<Utc>,
 }
 
 impl EcsState {
@@ -118,6 +137,7 @@ impl EcsState {
             daemons: BTreeMap::new(),
             daemon_deployments: BTreeMap::new(),
             express_gateway_services: BTreeMap::new(),
+            service_revisions: BTreeMap::new(),
         }
     }
 
@@ -139,6 +159,32 @@ impl EcsState {
         self.daemons.clear();
         self.daemon_deployments.clear();
         self.express_gateway_services.clear();
+        self.service_revisions.clear();
+    }
+
+    /// Mint and store a new service revision for `service`, numbered by how
+    /// many revisions already exist for that service (`{service_arn}:{n}`).
+    /// Returns the new serviceRevisionArn.
+    pub fn record_service_revision(&mut self, service: &Service) -> String {
+        let n = self
+            .service_revisions
+            .values()
+            .filter(|r| r.service_arn == service.service_arn)
+            .count() as i32
+            + 1;
+        let arn = format!("{}:{}", service.service_arn, n);
+        self.service_revisions.insert(
+            arn.clone(),
+            ServiceRevision {
+                service_revision_arn: arn.clone(),
+                service_arn: service.service_arn.clone(),
+                cluster_arn: service.cluster_arn.clone(),
+                task_definition_arn: service.task_definition_arn.clone(),
+                launch_type: service.launch_type.clone(),
+                created_at: Utc::now(),
+            },
+        );
+        arn
     }
 
     /// Services are uniquely identified by `(cluster, name)` within an


### PR DESCRIPTION
## Summary

Tier-5 hardening for ECS. Two bug-hunt findings:

- **M3 — DescribeServiceRevisions stub.** The op returned a synthetic/empty shape regardless of input (write/read asymmetry: revisions were never recorded). Now `create_service` and each new deployment in `update_service` record a `ServiceRevision` into `EcsState.service_revisions`, and `DescribeServiceRevisions` returns the stored revision (`serviceRevisionArn`, `serviceArn`, `clusterArn`, `taskDefinition`, `launchType`, `createdAt`) per requested ARN, or a `MISSING` failure when unknown — matching AWS's per-ARN success/failure split.
- **L5 — List pagination offset bug.** All six List ops (`ListClusters`, `ListTasks`, `ListServices`, `ListTaskDefinitions`, `ListTaskDefinitionFamilies`, `ListContainerInstances`) used a numeric `next_token` offset that skips or duplicates rows when items are added/deleted between pages. Replaced with `paginate_arns`: sort + dedup + base64 last-key cursor, resuming at the first key strictly greater than the decoded token (lenient: an undecodable token restarts at 0).

New `service_revisions` map is `#[serde(default)]` so it persists and restores cleanly with no migration.

## Surface impact
No new API surface, endpoint, field, flag, or introspection change — both are behavioral fixes to existing ops, so no SDK/website/docs/metadata updates apply. `DescribeServiceRevisions` now returns real data in its already-documented shape.

## Test plan
- `cargo test -p fakecloud-ecs --lib` — 116 pass (incl. new `paginate_arns` pagination tests + `describe_service_revisions_returns_stored_revision_or_missing`).
- `cargo fmt -p fakecloud-ecs` + `cargo clippy -p fakecloud-ecs --all-targets` — clean.
- `cargo build -p fakecloud` — downstream bin links clean with the new EcsState field.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two ECS correctness issues: `DescribeServiceRevisions` now returns real, persisted data, and all List operations use stable, opaque pagination cursors that avoid skipped/duplicated rows and treat bad tokens as end-of-list. No API shape changes.

- **Bug Fixes**
  - Service revisions: record a `ServiceRevision` on `CreateService` and on `UpdateService` when the task definition changes; `DescribeServiceRevisions` returns stored fields (serviceRevisionArn, serviceArn, clusterArn, taskDefinition, launchType, createdAt) per ARN or a `MISSING` failure; state persists via a new `service_revisions` map with `#[serde(default)]`.
  - Pagination: replaced numeric `nextToken` offsets with a sorted, deduped, base64 last-key cursor that resumes after the last key; a non-empty, undecodable token returns an empty page with no `nextToken` (treated as past the end); applied to `ListClusters`, `ListServices`, `ListTasks`, `ListTaskDefinitions`, `ListTaskDefinitionFamilies`, and `ListContainerInstances`.

<sup>Written for commit 86279c54172091434368c66451b390f2a24f8cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

