### PR TITLE
refactor(api-surface): demote leaked service/state modules to pub(crate)

### DIFF
--- a/crates/fakecloud-backup/src/lib.rs
+++ b/crates/fakecloud-backup/src/lib.rs
@@ -1,8 +1,8 @@
 //! AWS Backup (`backup`) implementation for FakeCloud.
 
 pub mod persistence;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use service::{BackupService, BACKUP_ACTIONS};
 pub use state::{BackupSnapshot, BackupState, SharedBackupState, BACKUP_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-codebuild/src/lib.rs
+++ b/crates/fakecloud-codebuild/src/lib.rs
@@ -17,8 +17,8 @@
 
 pub mod persistence;
 pub mod runtime;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 mod validate;
 
 pub use service::{CodeBuildService, CODEBUILD_ACTIONS};

--- a/crates/fakecloud-codecommit/src/lib.rs
+++ b/crates/fakecloud-codecommit/src/lib.rs
@@ -17,7 +17,7 @@
 //! the same control-plane-only shape the sibling `Code*` services use.
 
 pub mod persistence;
-pub mod service;
+pub(crate) mod service;
 pub mod state;
 mod validate;
 

--- a/crates/fakecloud-codedeploy/src/lib.rs
+++ b/crates/fakecloud-codedeploy/src/lib.rs
@@ -11,8 +11,8 @@
 //! deployment configurations are always resolvable.
 
 pub mod persistence;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 mod validate;
 
 pub use service::{CodeDeployService, CODEDEPLOY_ACTIONS};

--- a/crates/fakecloud-config/src/lib.rs
+++ b/crates/fakecloud-config/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod model_validate;
 pub(crate) mod persistence;
 pub mod provision;
 pub(crate) mod service;
-pub mod state;
+pub(crate) mod state;
 pub mod validate;
 
 #[cfg(test)]

--- a/crates/fakecloud-dms/src/lib.rs
+++ b/crates/fakecloud-dms/src/lib.rs
@@ -21,8 +21,8 @@
 //! round-trip verbatim.
 
 pub mod persistence;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use service::DmsService;
 pub use state::{DmsData, SharedDmsState, DMS_SNAPSHOT_SCHEMA_VERSION};

--- a/crates/fakecloud-docdb/src/lib.rs
+++ b/crates/fakecloud-docdb/src/lib.rs
@@ -15,8 +15,8 @@
 //! (lifecycle, snapshots, restore, parameter/subnet/global groups, event
 //! subscriptions, tagging) is real and persisted.
 
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 pub(crate) mod validation;
 pub(crate) mod xml;
 

--- a/crates/fakecloud-eks/src/lib.rs
+++ b/crates/fakecloud-eks/src/lib.rs
@@ -1,7 +1,7 @@
 //! AWS EKS (`eks`) implementation for FakeCloud.
 
 pub mod persistence;
-pub mod service;
+pub(crate) mod service;
 pub mod state;
 
 pub use service::{EksService, EKS_ACTIONS};

--- a/crates/fakecloud-elasticbeanstalk/src/lib.rs
+++ b/crates/fakecloud-elasticbeanstalk/src/lib.rs
@@ -18,7 +18,7 @@
 //! and status are derived from the real modeled state, never faked - the same
 //! control-plane-complete posture ELBv2 shipped with.
 
-pub mod service;
+pub(crate) mod service;
 pub mod state;
 
 pub use service::ElasticBeanstalkService;

--- a/crates/fakecloud-kafka/src/lib.rs
+++ b/crates/fakecloud-kafka/src/lib.rs
@@ -35,9 +35,9 @@ pub mod builders;
 pub mod cfn_provision;
 pub mod persistence;
 pub mod runtime;
-pub mod service;
+pub(crate) mod service;
 pub mod shared;
-pub mod state;
+pub(crate) mod state;
 mod validate;
 
 pub use runtime::KafkaRuntime;

--- a/crates/fakecloud-kinesisanalyticsv2/src/lib.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/lib.rs
@@ -4,8 +4,8 @@
 pub mod builders;
 pub mod persistence;
 pub mod runtime;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 
 pub use runtime::FlinkRuntime;
 pub use service::{Ka2Service, KA2_ACTIONS};

--- a/crates/fakecloud-neptune/src/lib.rs
+++ b/crates/fakecloud-neptune/src/lib.rs
@@ -15,8 +15,8 @@
 //! endpoints, snapshots, restore, parameter/subnet/global groups, IAM role
 //! associations, event subscriptions, tagging) is real and persisted.
 
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 pub(crate) mod validation;
 pub(crate) mod xml;
 

--- a/crates/fakecloud-opensearch/src/lib.rs
+++ b/crates/fakecloud-opensearch/src/lib.rs
@@ -11,8 +11,8 @@
 //! `DomainStatus` shape).
 
 pub mod persistence;
-pub mod service;
-pub mod state;
+pub(crate) mod service;
+pub(crate) mod state;
 mod validation_gen;
 
 pub use service::{OpenSearchService, ES_ACTIONS, OPENSEARCH_ACTIONS};

--- a/crates/fakecloud-servicediscovery/src/lib.rs
+++ b/crates/fakecloud-servicediscovery/src/lib.rs
@@ -1,7 +1,7 @@
 //! AWS Cloud Map (`servicediscovery`) implementation for FakeCloud.
 
 pub mod persistence;
-pub mod service;
+pub(crate) mod service;
 pub mod state;
 
 pub use service::{ServiceDiscoveryService, SERVICEDISCOVERY_ACTIONS};


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (public-API-surface category) found 61 crates leak `pub mod service;` / `pub mod state;`, publishing every internal handler, helper, and raw state map as crates.io semver surface for no reason. Cross-crate access to these crates goes exclusively through the crate-root `pub use service::{XService, X_ACTIONS}` / `pub use state::…` re-exports and the `AwsService` trait.

This demotes the **23 modules with zero cross-crate consumer** to `pub(crate)` (verified: no `fakecloud_*::service::` / `::state::` module-path reference anywhere else in the workspace):

- **`service`** (13): eks, codecommit, codebuild, codedeploy, dms, opensearch, neptune, backup, servicediscovery, elasticbeanstalk, kafka, kinesisanalyticsv2, docdb
- **`state`** (10): codebuild, codedeploy, dms, opensearch, neptune, backup, kafka, kinesisanalyticsv2, config, docdb

The root `pub use` re-exports still expose the public types (re-exporting from a `pub(crate)` module is allowed), so server/reset wiring is unchanged. Demoting also stops the all-`pub` raw-BTreeMap state fields from being external surface.

The 5 `state` modules still reached directly by the cloudformation `resource_provisioner` (eks, codecommit, servicediscovery, elasticbeanstalk, route53resolver) are intentionally left public — they need a root-reexport migration first (follow-up within this audit's scope, tracked in the report as the MEDIUM tier).

## Test plan

- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt` applied

## Surface impact

Internal-visibility only. No public type is removed (root re-exports unchanged), no SDK / docs / website / conformance / count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted internal `service` and `state` modules to `pub(crate)` across multiple FakeCloud crates to reduce the public API surface without changing behavior. Root `pub use` re-exports still expose all public types, so consumers remain unaffected.

- **Refactors**
  - `service` to `pub(crate)`: eks, codecommit, codebuild, codedeploy, dms, opensearch, neptune, backup, servicediscovery, elasticbeanstalk, kafka, kinesisanalyticsv2, docdb.
  - `state` to `pub(crate)`: codebuild, codedeploy, dms, opensearch, neptune, backup, kafka, kinesisanalyticsv2, config, docdb.
  - Left `state` public for eks, codecommit, servicediscovery, elasticbeanstalk, route53resolver (still used by CloudFormation `resource_provisioner`; follow-up planned).
  - No public types removed; use crate-root re-exports and the `AwsService` trait as before.

<sup>Written for commit fa1c7835dd0ae90d97e370a3ecdd79b9719ab983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

