### PR TITLE
fix(apigatewayv2,codedeploy): deterministic connection map + ARN-parse guard

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/state.rs
+++ b/crates/fakecloud-apigatewayv2/src/state.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -16,7 +16,7 @@ pub type SharedWebSocketRegistry = Arc<parking_lot::RwLock<WebSocketRegistry>>;
 
 #[derive(Debug, Default)]
 pub struct WebSocketRegistry {
-    pub connections: HashMap<String, ConnectionInfo>,
+    pub connections: BTreeMap<String, ConnectionInfo>,
 }
 
 impl WebSocketRegistry {

--- a/crates/fakecloud-codedeploy/src/service.rs
+++ b/crates/fakecloud-codedeploy/src/service.rs
@@ -2310,7 +2310,15 @@ impl CodeDeployService {
     /// `deploymentgroup:<app>/<group>`, or `deploymentconfig:<name>`.
     fn require_resource_exists(st: &CodeDeployState, arn: &str) -> Result<(), AwsServiceError> {
         let parts: Vec<&str> = arn.splitn(7, ':').collect();
-        let (kind, rest) = (parts[5], parts.get(6).copied().unwrap_or(""));
+        // A malformed ARN with fewer than six colon-separated segments must not
+        // index-panic; AWS rejects it as an invalid ARN.
+        let kind = parts.get(5).copied().ok_or_else(|| {
+            e(
+                "InvalidArnException",
+                format!("Invalid resource ARN: {arn}"),
+            )
+        })?;
+        let rest = parts.get(6).copied().unwrap_or("");
         let group_exists = |rest: &str| {
             let (app, group) = rest.split_once('/').unwrap_or((rest, ""));
             st.deployment_groups
@@ -2654,6 +2662,17 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(got["Tags"][0]["Key"], "env");
+    }
+
+    #[test]
+    fn require_resource_exists_rejects_short_arn() {
+        // Regression: a resource ARN with fewer than six colon segments must
+        // return InvalidArnException rather than index-panicking on parts[5].
+        let s = svc();
+        let mut guard = s.state.write();
+        let st = guard.get_or_create("000000000000");
+        let r = CodeDeployService::require_resource_exists(st, "arn:aws:codedeploy:us-east-1:0");
+        assert_eq!(r.unwrap_err().code(), "InvalidArnException");
     }
 
     // Finding 7: TagResource / UntagResource reject a syntactically valid ARN


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (inconsistencies category):

- **apigatewayv2** — `WebSocketRegistry.connections` was the only `HashMap` outlier in otherwise all-`BTreeMap` service state (non-deterministic iteration). Switched to `BTreeMap` for determinism + 40-service consistency. String-keyed; every call site is insert/get/remove/contains — no behavior change.
- **codedeploy** — `require_resource_exists` indexed `parts[5]` on a `splitn`-ed ARN with no local length guarantee. Hardened to return `InvalidArnException` on a malformed (short) ARN rather than depending on callers validating first.

## Test plan

- New `require_resource_exists_rejects_short_arn` asserts the guard.
- `cargo test -p fakecloud-apigatewayv2 -p fakecloud-codedeploy` green; `cargo clippy --all-targets -D warnings` clean; `cargo fmt` applied.

## Surface impact

Internal only — a non-persisted runtime map's type and a defensive guard. No wire/SDK/docs/conformance/count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make WebSocket connection tracking deterministic and harden CodeDeploy ARN parsing to reject malformed ARNs instead of panicking.

- **Refactors**
  - `fakecloud-apigatewayv2`: Switch `WebSocketRegistry.connections` from `HashMap` to `BTreeMap` for deterministic iteration, matching other services.

- **Bug Fixes**
  - `fakecloud-codedeploy`: `require_resource_exists` now validates ARN segments and returns `InvalidArnException` for short/malformed ARNs; added a regression test.

<sup>Written for commit 15c0e151d4246f431671c5071c57660187d2e927. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

