### PR TITLE
test(cloudfront): bounded-poll status transition instead of fixed sleep

### DIFF
--- a/crates/fakecloud-e2e/tests/cloudfront_status.rs
+++ b/crates/fakecloud-e2e/tests/cloudfront_status.rs
@@ -86,21 +86,33 @@ async fn create_distribution_status_transitions_to_deployed() {
         "CreateDistribution must return InProgress synchronously"
     );
 
-    // Yield so the spawned `schedule_distribution_deploy` task gets a
-    // chance to run; 200ms is more than enough headroom for the 0s tick.
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    let got = cf
-        .get_distribution()
-        .id(&id)
-        .send()
-        .await
-        .expect("get_distribution");
-    assert_eq!(
-        got.distribution().unwrap().status(),
-        "Deployed",
+    // Poll (bounded) for the spawned `schedule_distribution_deploy` task to
+    // flip the status, rather than racing a single fixed sleep under CI load.
+    assert!(
+        poll_for_status(&cf, &id, "Deployed").await,
         "GetDistribution after the tick should report Deployed"
     );
+}
+
+/// Poll `GetDistribution` until the distribution reports `want` or a bounded
+/// deadline elapses; returns whether the status was observed. Replaces a fixed
+/// sleep so the assertion doesn't race the spawned deploy task under CI load.
+async fn poll_for_status(cf: &aws_sdk_cloudfront::Client, id: &str, want: &str) -> bool {
+    for _ in 0..50 {
+        let st = cf
+            .get_distribution()
+            .id(id)
+            .send()
+            .await
+            .expect("get_distribution")
+            .distribution()
+            .map(|d| d.status().to_string());
+        if st.as_deref() == Some(want) {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    false
 }
 
 /// With a long delay, the auto-tick can't race the assertion, so we use


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (test-quality T4). `create_distribution_status_transitions_to_deployed` raced a single fixed `sleep(200ms)` against the spawned `schedule_distribution_deploy` task before asserting `Deployed` — a real flake under CI load. Replaced with a bounded poll (up to 50×100ms) on `GetDistribution`'s status, mirroring the `wait_for_status` pattern already used in `cloudfront_persistence.rs`.

## Test plan

- `cargo clippy -p fakecloud-e2e --test cloudfront_status -- -D warnings` clean; `cargo fmt` applied.

## Surface impact

Test-only. No source/SDK/docs/count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the fixed 200ms sleep in the CloudFront distribution status test with a bounded poll (up to 50×100ms) of `GetDistribution` to prevent CI race flakes. Test-only change; no runtime, SDK, or docs impact.

<sup>Written for commit 1b01d2dd71fcf1f560d12be5ac2a41c65c7f1915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

