### PR TITLE
refactor(core): add core::ids and dedupe the short-id idiom

### DIFF
--- a/crates/fakecloud-bedrock-agent/src/service/mod.rs
+++ b/crates/fakecloud-bedrock-agent/src/service/mod.rs
@@ -1022,11 +1022,9 @@ fn now() -> DateTime<Utc> {
 }
 
 fn short_id() -> String {
-    // Smithy ResourceIdentifier shape is @pattern("^[0-9a-zA-Z]{10}$").
-    // Use the first 10 hex chars of a v4 UUID (alphanumeric, deterministic
-    // length, no dashes).
-    let s = uuid::Uuid::new_v4().simple().to_string();
-    s[..10].to_string()
+    // Smithy ResourceIdentifier shape is @pattern("^[0-9a-zA-Z]{10}$"): the
+    // first 10 hex chars of a v4 UUID.
+    fakecloud_core::ids::short_id(10)
 }
 
 fn agent_json(a: &Agent) -> Value {

--- a/crates/fakecloud-config/src/provision.rs
+++ b/crates/fakecloud-config/src/provision.rs
@@ -4,12 +4,11 @@
 
 use chrono::Utc;
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::state::*;
 
 fn short_id() -> String {
-    Uuid::new_v4().to_string().replace('-', "")[..6].to_string()
+    fakecloud_core::ids::short_id(6)
 }
 
 /// `AWS::Config::ConfigurationRecorder` -> physical id (the recorder name).

--- a/crates/fakecloud-config/src/service.rs
+++ b/crates/fakecloud-config/src/service.rs
@@ -4192,7 +4192,7 @@ fn region(req: &AwsRequest) -> String {
 }
 
 fn short_id() -> String {
-    Uuid::new_v4().to_string().replace('-', "")[..6].to_string()
+    fakecloud_core::ids::short_id(6)
 }
 
 fn invalid(msg: impl Into<String>) -> AwsServiceError {

--- a/crates/fakecloud-core/src/ids.rs
+++ b/crates/fakecloud-core/src/ids.rs
@@ -1,0 +1,66 @@
+//! Shared random resource-id generation.
+//!
+//! Many services mint short resource ids by truncating a v4 UUID. Before this
+//! module each did it inline (`Uuid::new_v4().simple().to_string()[..N]`) or in
+//! a per-crate `short_id` helper with a slightly different length, which was a
+//! maintenance trap. These helpers centralise the idiom so a caller states the
+//! length it needs explicitly.
+
+/// A lowercase-hex id of `len` characters, drawn from a v4 UUID.
+///
+/// AWS short resource ids in this shape match `^[0-9a-f]{len}$`. `len` must be
+/// at most 32 (a UUID has 32 hex digits); larger values are clamped to 32.
+pub fn short_id(len: usize) -> String {
+    let hex = uuid::Uuid::new_v4().simple().to_string();
+    hex[..len.min(hex.len())].to_string()
+}
+
+/// A base-36 (`[0-9a-z]`) id of `len` characters, drawn from UUID entropy.
+///
+/// Used where AWS ids are lowercase-alphanumeric rather than hex. Draws from as
+/// many v4 UUIDs as needed to cover `len` characters.
+pub fn alnum_id(len: usize) -> String {
+    const ALPHABET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut out = String::with_capacity(len);
+    while out.len() < len {
+        for b in uuid::Uuid::new_v4().into_bytes() {
+            out.push(ALPHABET[(b as usize) % ALPHABET.len()] as char);
+            if out.len() == len {
+                break;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_has_requested_length_and_is_hex() {
+        for n in [6, 10, 12, 16, 20, 32] {
+            let id = short_id(n);
+            assert_eq!(id.len(), n);
+            assert!(id
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        }
+    }
+
+    #[test]
+    fn short_id_clamps_over_32() {
+        assert_eq!(short_id(64).len(), 32);
+    }
+
+    #[test]
+    fn alnum_id_has_requested_length_and_is_base36() {
+        for n in [1, 26, 40] {
+            let id = alnum_id(n);
+            assert_eq!(id.len(), n);
+            assert!(id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
+        }
+    }
+}

--- a/crates/fakecloud-core/src/lib.rs
+++ b/crates/fakecloud-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod container_net;
 pub mod delivery;
 pub mod dispatch;
 pub mod ecr_uri;
+pub mod ids;
 pub mod multi_account;
 pub mod pagination;
 pub mod protocol;

--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -1304,8 +1304,7 @@ fn extract_cookie<'a>(cookies: &'a str, name: &str) -> Option<&'a str> {
 }
 
 fn short_id() -> String {
-    let id = Uuid::new_v4();
-    id.simple().to_string()[0..16].to_string()
+    fakecloud_core::ids::short_id(16)
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -3257,7 +3257,7 @@ fn decode(s: &str) -> String {
 }
 
 fn short_id() -> String {
-    uuid::Uuid::new_v4().simple().to_string()[..20].to_string()
+    fakecloud_core::ids::short_id(20)
 }
 
 fn req_str(b: &Value, key: &str) -> Result<String, AwsServiceError> {

--- a/crates/fakecloud-xray/src/service.rs
+++ b/crates/fakecloud-xray/src/service.rs
@@ -1057,7 +1057,7 @@ fn not_found(msg: &str) -> AwsServiceError {
 }
 
 fn short_id() -> String {
-    Uuid::new_v4().simple().to_string()[..12].to_string()
+    fakecloud_core::ids::short_id(12)
 }
 
 fn group_arn(region: &str, account: &str, name: &str) -> String {


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (duplication M4). Six services each defined a `short_id` helper truncating a v4 UUID to a hardcoded length — same idiom, drifting lengths, a maintenance trap. Adds `fakecloud_core::ids::{short_id, alnum_id}` (hex / base36, caller states the length explicitly) and points each helper at it:

- bedrock-agent (10), config ×2 (6), elbv2 (16), opensearch (20), xray (12)

Behavior is identical — same random hex, same length — so no id format changes. The `short_id` in `codebuild/runtime.rs` and the cloudformation `resource_provisioner` are **not** id generators (they transform an existing id) and are deliberately left alone.

## Test plan

- New `core::ids` unit tests assert length + charset (hex / base36) and the 32-char clamp.
- `cargo clippy --all-targets -D warnings` clean for core + the 6 migrated crates; `cargo fmt` applied.

## Surface impact

Internal refactor. Resource-id formats unchanged (same length, same hex charset). No SDK / docs / conformance / count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes short random ID generation by adding `fakecloud_core::ids::{short_id, alnum_id}` and routing six services to it. Behavior is unchanged (same hex IDs and lengths), reducing duplication and drift.

- **Refactors**
  - Added `fakecloud_core::ids::{short_id, alnum_id}` (lowercase-hex up to 32 chars; base36).
  - Replaced local helpers in `fakecloud-bedrock-agent` (10), `fakecloud-config` (6, two call sites), `fakecloud-elbv2` (16), `fakecloud-opensearch` (20), `fakecloud-xray` (12).
  - Left `codebuild/runtime.rs` and CloudFormation resource_provisioner untouched (they transform existing IDs).
  - Added unit tests for length/charset and clamp behavior.

<sup>Written for commit 45c6d7bee81b13f251c9f1bbab8c286d75761d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

