### PR TITLE
refactor(core): finish short-id migration + drop dead code

### DIFF
--- a/crates/fakecloud-acmpca/src/service.rs
+++ b/crates/fakecloud-acmpca/src/service.rs
@@ -1682,13 +1682,6 @@ fn parse_tags(v: Option<&Value>) -> Result<Vec<TagEntry>, AwsServiceError> {
     Ok(out)
 }
 
-// ─── Timestamp ──────────────────────────────────────────────────────
-
-#[allow(dead_code)]
-fn epoch_f64(dt: DateTime<Utc>) -> f64 {
-    dt.timestamp() as f64
-}
-
 // ─── Error constructors (declared shape names) ──────────────────────
 
 fn invalid_args(msg: impl Into<String>) -> AwsServiceError {

--- a/crates/fakecloud-appconfig/src/handlers.rs
+++ b/crates/fakecloud-appconfig/src/handlers.rs
@@ -146,7 +146,7 @@ fn page_response(items: Vec<Value>, req: &AwsRequest) -> Result<AwsResponse, Aws
 
 /// A 7-character lowercase alphanumeric id, AppConfig's resource-id shape.
 fn gen_id7() -> String {
-    uuid::Uuid::new_v4().simple().to_string()[..7].to_string()
+    fakecloud_core::ids::short_id(7).to_string()
 }
 
 fn gen_token() -> String {

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::{json, Value};
-use uuid::Uuid;
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
@@ -20,7 +19,7 @@ pub(crate) fn create_inference_profile(
     // An application inference profile gets a lowercase-alphanumeric id and an
     // `application-inference-profile/<id>` ARN (system-defined profiles use the
     // bare `inference-profile/` resource); the provider asserts this shape.
-    let profile_id = Uuid::new_v4().simple().to_string()[..12].to_string();
+    let profile_id = fakecloud_core::ids::short_id(12).to_string();
     let profile_arn = format!(
         "arn:aws:bedrock:{}:{}:application-inference-profile/{}",
         req.region, req.account_id, profile_id

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/eventbridge.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/eventbridge.rs
@@ -504,7 +504,7 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let endpoint_id = Uuid::new_v4().simple().to_string()[..16].to_string();
+        let endpoint_id = fakecloud_core::ids::short_id(16).to_string();
         let arn = format!(
             "arn:aws:events:{}:{}:endpoint/{name}",
             self.region, self.account_id

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
@@ -291,7 +291,7 @@ impl ResourceProvisioner {
         let statement_id = format!(
             "cfn-{}-{}",
             resource.logical_id,
-            &Uuid::new_v4().simple().to_string()[..8]
+            &fakecloud_core::ids::short_id(8)
         );
         self.append_lambda_permission_statement(&function_name, &statement_id, props)?;
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/lambda.rs
@@ -291,7 +291,7 @@ impl ResourceProvisioner {
         let statement_id = format!(
             "cfn-{}-{}",
             resource.logical_id,
-            &fakecloud_core::ids::short_id(8)
+            fakecloud_core::ids::short_id(8)
         );
         self.append_lambda_permission_statement(&function_name, &statement_id, props)?;
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -4370,7 +4370,7 @@ impl ResourceProvisioner {
             "arn:aws:application-autoscaling:{}:{}:scalable-target/{}",
             self.region,
             self.account_id,
-            &fakecloud_core::ids::short_id(10)
+            fakecloud_core::ids::short_id(10)
         );
         let role = role_arn.unwrap_or_else(|| {
             let suffix = match service_namespace.as_str() {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -4370,7 +4370,7 @@ impl ResourceProvisioner {
             "arn:aws:application-autoscaling:{}:{}:scalable-target/{}",
             self.region,
             self.account_id,
-            &Uuid::new_v4().simple().to_string()[..10]
+            &fakecloud_core::ids::short_id(10)
         );
         let role = role_arn.unwrap_or_else(|| {
             let suffix = match service_namespace.as_str() {
@@ -5346,14 +5346,8 @@ impl ResourceProvisioner {
             .to_string();
         let caller_reference = format!("cfn-{}", resource.logical_id);
 
-        let id = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..13].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("E{}", fakecloud_core::ids::short_id(13).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
         let s3_canonical_user_id = format!(
             "{:0<64}",
             Uuid::new_v4().simple().to_string().to_lowercase()
@@ -5564,14 +5558,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let id = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..13].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("E{}", fakecloud_core::ids::short_id(13).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
         let oac = StoredOriginAccessControl {
             id: id.clone(),
             etag,
@@ -5631,14 +5619,8 @@ impl ResourceProvisioner {
             caller_reference
         };
 
-        let id = format!(
-            "K{}",
-            Uuid::new_v4().simple().to_string()[..13].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("K{}", fakecloud_core::ids::short_id(13).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
 
         let pk = StoredPublicKey {
             id: id.clone(),
@@ -5693,14 +5675,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let id = format!(
-            "KG{}",
-            Uuid::new_v4().simple().to_string()[..12].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("KG{}", fakecloud_core::ids::short_id(12).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
 
         let kg = StoredKeyGroup {
             id: id.clone(),
@@ -5752,14 +5728,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let id = format!(
-            "FN{}",
-            Uuid::new_v4().simple().to_string()[..12].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("FN{}", fakecloud_core::ids::short_id(12).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
         let function_arn =
             Arn::global("cloudfront", &self.account_id, &format!("function/{name}")).to_string();
 
@@ -5833,14 +5803,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let id = format!(
-            "CP{}",
-            Uuid::new_v4().simple().to_string()[..12].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("CP{}", fakecloud_core::ids::short_id(12).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
 
         let cache_policy = StoredCachePolicy {
             id: id.clone(),
@@ -5907,14 +5871,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let id = format!(
-            "ORP{}",
-            Uuid::new_v4().simple().to_string()[..11].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("ORP{}", fakecloud_core::ids::short_id(11).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
 
         let policy = StoredOriginRequestPolicy {
             id: id.clone(),
@@ -5971,14 +5929,8 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        let id = format!(
-            "RHP{}",
-            Uuid::new_v4().simple().to_string()[..11].to_uppercase()
-        );
-        let etag = format!(
-            "E{}",
-            Uuid::new_v4().simple().to_string()[..7].to_uppercase()
-        );
+        let id = format!("RHP{}", fakecloud_core::ids::short_id(11).to_uppercase());
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
 
         let policy = StoredResponseHeadersPolicy {
             id: id.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -338,7 +338,7 @@ impl ResourceProvisioner {
                 format!(
                     "cfn-{}-{}",
                     resource.logical_id.to_lowercase(),
-                    Uuid::new_v4().simple().to_string()[..8].to_lowercase()
+                    fakecloud_core::ids::short_id(8).to_lowercase()
                 )
             });
         let class = props
@@ -668,7 +668,7 @@ impl ResourceProvisioner {
                 format!(
                     "cfn-cluster-{}-{}",
                     resource.logical_id.to_lowercase(),
-                    Uuid::new_v4().simple().to_string()[..8].to_lowercase()
+                    fakecloud_core::ids::short_id(8).to_lowercase()
                 )
             });
         let engine = props

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route.rs
@@ -49,10 +49,7 @@ impl ResourceProvisioner {
             })
             .unwrap_or_default();
 
-        let id = format!(
-            "Z{}",
-            Uuid::new_v4().simple().to_string()[..14].to_uppercase()
-        );
+        let id = format!("Z{}", fakecloud_core::ids::short_id(14).to_uppercase());
         let name_servers = (1..=4)
             .map(|i| format!("ns-{}.awsdns-{:02}.com", 100 + i, i))
             .collect::<Vec<_>>();

--- a/crates/fakecloud-redshift/src/service/access.rs
+++ b/crates/fakecloud-redshift/src/service/access.rs
@@ -190,7 +190,7 @@ impl RedshiftService {
         if acct.endpoint_access.contains_key(&name) {
             return Err(endpoint_already_exists(&name));
         }
-        let token = &Uuid::new_v4().simple().to_string()[..12];
+        let token = &fakecloud_core::ids::short_id(12);
         let cluster_id = param(req, "ClusterIdentifier").unwrap_or_default();
         // When the caller supplies no security groups, Redshift attaches the
         // cluster's effective VPC security groups (the VPC default group when
@@ -755,7 +755,7 @@ impl RedshiftService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let offering = param(req, "ReservedNodeOfferingId").unwrap_or_default();
-        let id = format!("rn-{}", &Uuid::new_v4().simple().to_string()[..12]);
+        let id = format!("rn-{}", fakecloud_core::ids::short_id(12));
         let node = ReservedNode {
             reserved_node_id: id.clone(),
             reserved_node_offering_id: offering,
@@ -857,7 +857,7 @@ impl RedshiftService {
             "redshift",
             &req.region,
             &req.account_id,
-            &format!("integration:{}", &Uuid::new_v4().simple().to_string()[..12]),
+            &format!("integration:{}", fakecloud_core::ids::short_id(12)),
         )
         .to_string();
         let mut guard = self.state.write();
@@ -983,7 +983,7 @@ impl RedshiftService {
             &req.account_id,
             &format!(
                 "redshiftidcapplication:{}",
-                &Uuid::new_v4().simple().to_string()[..12]
+                fakecloud_core::ids::short_id(12)
             ),
         )
         .to_string();

--- a/crates/fakecloud-redshift/src/service/clusters.rs
+++ b/crates/fakecloud-redshift/src/service/clusters.rs
@@ -12,7 +12,7 @@ use crate::state::Cluster;
 
 /// Build the synthetic-but-well-formed public endpoint address for a cluster.
 fn endpoint_address(cluster_id: &str, region: &str) -> String {
-    let token = &Uuid::new_v4().simple().to_string()[..12];
+    let token = &fakecloud_core::ids::short_id(12);
     format!("{cluster_id}.{token}.{region}.redshift.amazonaws.com")
 }
 

--- a/crates/fakecloud-redshift/src/service/resources.rs
+++ b/crates/fakecloud-redshift/src/service/resources.rs
@@ -448,7 +448,7 @@ impl RedshiftService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = param(req, "ScheduleIdentifier")
-            .unwrap_or_else(|| format!("schedule-{}", &Uuid::new_v4().simple().to_string()[..8]));
+            .unwrap_or_else(|| format!("schedule-{}", fakecloud_core::ids::short_id(8)));
         let mut guard = self.state.write();
         let acct = guard.account(&req.account_id);
         if acct.snapshot_schedules.contains_key(&id) {
@@ -678,7 +678,7 @@ impl RedshiftService {
         let cluster = param(req, "ClusterIdentifier").unwrap_or_default();
         let feature = param(req, "FeatureType").unwrap_or_default();
         let limit_type = param(req, "LimitType").unwrap_or_default();
-        let id = format!("usagelimit-{}", &Uuid::new_v4().simple().to_string()[..12]);
+        let id = format!("usagelimit-{}", fakecloud_core::ids::short_id(12));
         let mut guard = self.state.write();
         let acct = guard.account(&req.account_id);
         // Reject duplicate feature/limit-type on the same cluster (AWS behavior).

--- a/crates/fakecloud-redshift/src/service/snapshots.rs
+++ b/crates/fakecloud-redshift/src/service/snapshots.rs
@@ -372,7 +372,7 @@ impl RedshiftService {
         }
         // Seed the restored cluster from the source snapshot when available.
         let source = param(req, "SnapshotIdentifier").and_then(|s| acct.snapshots.get(&s).cloned());
-        let token = &Uuid::new_v4().simple().to_string()[..12];
+        let token = &fakecloud_core::ids::short_id(12);
         let cluster = Cluster {
             cluster_identifier: id.clone(),
             node_type: param(req, "NodeType")

--- a/crates/fakecloud-ssoadmin/src/service.rs
+++ b/crates/fakecloud-ssoadmin/src/service.rs
@@ -449,11 +449,11 @@ fn now() -> i64 {
 }
 
 fn hex16() -> String {
-    Uuid::new_v4().simple().to_string()[..16].to_string()
+    fakecloud_core::ids::short_id(16).to_string()
 }
 
 fn hex10() -> String {
-    Uuid::new_v4().simple().to_string()[..10].to_string()
+    fakecloud_core::ids::short_id(10).to_string()
 }
 
 /// Validate pagination inputs, then window an ordered slice of result rows.


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (duplication L1 + Dead Code), following #2267:

- **L1** — sweep the 36 remaining inline `Uuid::new_v4().simple().to_string()[..N]` sites onto `fakecloud_core::ids::short_id(N)` (cloudformation resource_provisioner, redshift, ssoadmin, appconfig, bedrock, ...). Behavior identical — same random hex, same length. Removes the now-dead `uuid::Uuid` import where that idiom was its only user.
- **Dead code** — delete acmpca's unused `epoch_f64` helper (dead behind `#[allow(dead_code)]`). The 4 remaining `#[allow(dead_code)]` in `codecommit/validate.rs` sit on AWS enum-vocabulary constants kept for completeness — verified legitimate, left as-is.

Completes the M4/L1 dedup finding: the UUID-truncation id idiom now has a single source in `core::ids`.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Surface impact

Internal refactor. Resource-id formats unchanged (same length/charset). No SDK / docs / conformance / count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes the short-id migration by replacing inline UUID truncation with `fakecloud_core::ids::short_id(N)` and removing a small piece of dead code. No behavior or ID format changes.

- **Refactors**
  - Replaced `Uuid::new_v4().simple().to_string()[..N]` with `fakecloud_core::ids::short_id(N)` across CloudFormation provisioner, Redshift, SSO Admin, AppConfig, and Bedrock; preserved prefixes and case.
  - Removed now-unused `uuid::Uuid` imports and deleted ACMPCA’s unused `epoch_f64`.
  - Dropped redundant borrows of `short_id(...)` in two CloudFormation `format!` calls; clippy clean.

<sup>Written for commit f3a7930522d64ece68d1d0e032d3a3e039285e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

