### PR TITLE
refactor(redshift): use core::query::optional_query_param

### DIFF
--- a/crates/fakecloud-redshift/src/service/helpers.rs
+++ b/crates/fakecloud-redshift/src/service/helpers.rs
@@ -57,10 +57,7 @@ pub(crate) fn opt_elem(name: &str, value: Option<&str>) -> String {
 }
 
 pub(crate) fn param(req: &AwsRequest, name: &str) -> Option<String> {
-    req.query_params
-        .get(name)
-        .cloned()
-        .filter(|v| !v.is_empty())
+    fakecloud_core::query::optional_query_param(req, name)
 }
 
 pub(crate) fn param_or(req: &AwsRequest, name: &str, default: &str) -> String {


### PR DESCRIPTION
## Summary

Quality-audit 2026-07-13 (duplication M1). redshift's local `param` helper was byte-for-byte identical to `fakecloud_core::query::optional_query_param` — delegate to it.

On closer inspection the other helpers the audit grouped under M1 are **not** the same abstraction and are deliberately left alone:
- sns `param` parses a **JSON** body fallback; rds/cfn `get_param` parse a **form-encoded** body fallback — and rds+cfn are only 2 instances, below the audit's own 3-instance extraction threshold ("premature abstraction beats duplication").
- ses `required_param` uses an intentional SES-specific `ValidationError` code (prior audit D4).

## Test plan

- `cargo clippy -p fakecloud-redshift --all-targets -- -D warnings` clean; `cargo test -p fakecloud-redshift` green (24 passed); `cargo fmt` applied.

## Surface impact

Internal refactor, behavior identical. No SDK / docs / conformance / count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the Redshift request param helper by delegating to `fakecloud_core::query::optional_query_param`. Behavior is unchanged with no API or surface impact.

- **Refactors**
  - Replace `fakecloud-redshift` local `param` with `fakecloud_core::query::optional_query_param`.
  - Leave other service helpers as-is (they parse JSON/form bodies or use SES-specific errors).

<sup>Written for commit d1d8446866787dca48d5cd258dc62771f6c29e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

