### PR TITLE
fix(core): bound + memoize container-CLI probe so local conformance probes don't hang

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -70,7 +70,8 @@ static CLI_AVAILABLE_CACHE: std::sync::OnceLock<
 /// and memoized per process so a dozen runtimes probing at startup don't each
 /// pay that bound.
 pub fn cli_available(cli: &str) -> bool {
-    let cache = CLI_AVAILABLE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let cache =
+        CLI_AVAILABLE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     if let Some(&cached) = cache.lock().unwrap().get(cli) {
         return cached;
     }

--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -42,16 +42,68 @@ pub fn detect_container_cli() -> Option<String> {
     }
 }
 
-/// True when the CLI responds to `<cli> info` with success — the same
-/// liveness probe every runtime used before this module existed.
+/// How long to wait for `<cli> info` before giving up and treating the
+/// runtime as unavailable. A healthy daemon answers in well under a second;
+/// an unreachable or wedged daemon (stale `DOCKER_HOST`, Docker Desktop mid
+/// start, a broken socket) can leave the CLI blocked on connect *forever*,
+/// which would hang fakecloud startup and the test harness. Bounding the
+/// probe turns "daemon wedged" into "no runtime detected" instead of a hang.
+pub const CLI_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Process-global memo of `<cli> info` results, keyed by CLI name/path.
+///
+/// Container-runtime liveness is fixed for the life of a process, but every
+/// service runtime (Lambda, ECS, RDS, ElastiCache, EC2, MQ, MSK, ...) probes
+/// it independently at startup — a dozen-plus `detect_container_cli()` calls.
+/// Without a memo each probe re-runs `docker info`; when the daemon is wedged
+/// (see [`CLI_PROBE_TIMEOUT`]) those probes are serial 10s hangs that stack
+/// into minutes, wedging server startup and the conformance `*_probe` tests.
+/// Caching the first answer collapses that to a single probe.
+static CLI_AVAILABLE_CACHE: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<String, bool>>,
+> = std::sync::OnceLock::new();
+
+/// True when the CLI responds to `<cli> info` with success within
+/// [`CLI_PROBE_TIMEOUT`] — the same liveness probe every runtime used before
+/// this module existed, but bounded so an unreachable daemon can't hang the
+/// caller indefinitely (the CLI blocks on connect with no timeout of its own),
+/// and memoized per process so a dozen runtimes probing at startup don't each
+/// pay that bound.
 pub fn cli_available(cli: &str) -> bool {
-    std::process::Command::new(cli)
+    let cache = CLI_AVAILABLE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(&cached) = cache.lock().unwrap().get(cli) {
+        return cached;
+    }
+    let result = probe_cli(cli);
+    cache.lock().unwrap().insert(cli.to_string(), result);
+    result
+}
+
+/// Run the bounded `<cli> info` liveness probe once (uncached).
+fn probe_cli(cli: &str) -> bool {
+    let child = std::process::Command::new(cli)
         .arg("info")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .spawn();
+    let Ok(mut child) = child else {
+        return false;
+    };
+    let deadline = std::time::Instant::now() + CLI_PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if std::time::Instant::now() >= deadline {
+            // Daemon is wedged: kill the blocked probe and report unavailable.
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
 }
 
 /// True when `cli` is podman or a podman-compatible binary. Matches on the
@@ -212,6 +264,41 @@ pub fn registry_auth_hosts(server_port: u16) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cli_available_false_for_missing_binary() {
+        // A binary that doesn't exist fails to spawn -> unavailable, fast.
+        assert!(!cli_available("definitely-not-a-real-cli-binary-xyz-123"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_available_bounds_a_hanging_probe() {
+        // A CLI whose `info` invocation blocks forever (like `docker info`
+        // against an unreachable daemon) must not hang the caller: the probe
+        // is killed at CLI_PROBE_TIMEOUT and reported unavailable. Regression
+        // test for the local-conformance-probe hang.
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("fc-clitest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("hangcli");
+        std::fs::write(&script, "#!/bin/sh\nsleep 600\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::io::stdout().flush().ok();
+
+        let start = std::time::Instant::now();
+        let available = cli_available(script.to_str().unwrap());
+        let elapsed = start.elapsed();
+
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(!available, "a hanging probe must report unavailable");
+        assert!(
+            elapsed < CLI_PROBE_TIMEOUT + std::time::Duration::from_secs(5),
+            "probe took {elapsed:?}, expected it bounded near {CLI_PROBE_TIMEOUT:?}"
+        );
+    }
 
     #[test]
     fn is_podman_binary_matches_bare_name() {

--- a/crates/fakecloud-server/src/reaper.rs
+++ b/crates/fakecloud-server/src/reaper.rs
@@ -21,7 +21,11 @@ use std::process::{Command, Stdio};
 /// If no container CLI is available this is a silent no-op — fakecloud is
 /// expected to start fine without docker.
 pub fn reap_stale_containers() {
-    let Some(cli) = detect_cli() else {
+    // Uses the shared, *bounded+memoized* detection in `container_net`: an
+    // unreachable/wedged daemon leaves a raw `docker info` blocked on connect
+    // forever, and this reaper runs at startup, so a naive probe here would
+    // hang the server (and every conformance `*_probe` test) indefinitely.
+    let Some(cli) = fakecloud_core::container_net::detect_container_cli() else {
         return;
     };
 
@@ -96,29 +100,6 @@ fn reap_orphans(cli: &str, list_args: &[&str], remove_argv: impl Fn(&str) -> Vec
     reaped
 }
 
-fn detect_cli() -> Option<String> {
-    if let Ok(cli) = std::env::var("FAKECLOUD_CONTAINER_CLI") {
-        return cli_works(&cli).then_some(cli);
-    }
-    if cli_works("docker") {
-        return Some("docker".to_string());
-    }
-    if cli_works("podman") {
-        return Some("podman".to_string());
-    }
-    None
-}
-
-fn cli_works(cli: &str) -> bool {
-    Command::new(cli)
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
 /// True if the given PID is a live process on this host.
 ///
 /// On Unix we use `kill(pid, 0)`: it returns 0 if the process exists
@@ -145,7 +126,7 @@ pub fn pid_alive(_pid: u32) -> bool {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{cli_works, pid_alive};
+    use super::pid_alive;
 
     #[test]
     fn self_is_alive() {
@@ -161,10 +142,5 @@ mod tests {
     fn huge_pid_is_dead() {
         // Max u32 is far outside any reasonable PID range on any OS.
         assert!(!pid_alive(u32::MAX - 1));
-    }
-
-    #[test]
-    fn cli_works_false_for_unknown_binary() {
-        assert!(!cli_works("definitely-not-a-real-cli-name-xyz123"));
     }
 }

--- a/crates/fakecloud-testkit/src/lib.rs
+++ b/crates/fakecloud-testkit/src/lib.rs
@@ -593,14 +593,49 @@ fn detect_container_cli() -> String {
     }
 }
 
+/// True when `<cli> info` succeeds within a bounded window. A healthy daemon
+/// answers in well under a second; an unreachable or wedged daemon (stale
+/// `DOCKER_HOST`, Docker Desktop mid start, a broken socket) can leave the CLI
+/// blocked on connect *forever*. Without this bound, `detect_container_cli`
+/// hangs the whole test harness — a conformance `*_probe` that only calls
+/// `TestServer::start()` would never return. Mirrors
+/// `fakecloud_core::container_net::cli_available` (testkit can't depend on
+/// core, so the bounded pattern is duplicated here on purpose).
 fn cli_available(cli: &str) -> bool {
-    Command::new(cli)
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, bool>>> =
+        std::sync::OnceLock::new();
+    let cache = CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(&cached) = cache.lock().unwrap().get(cli) {
+        return cached;
+    }
+    let result = probe_cli(cli);
+    cache.lock().unwrap().insert(cli.to_string(), result);
+    result
+}
+
+fn probe_cli(cli: &str) -> bool {
+    let Ok(mut child) = Command::new(cli)
         .arg("info")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .spawn()
+    else {
+        return false;
+    };
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
 }
 
 /// Prefix that `fakecloud-server` prints before the bound port on stdout.


### PR DESCRIPTION
## Problem

The container-CLI liveness probe ran `<cli> info` with **no timeout**. When the docker daemon is unreachable, the CLI blocks on connect indefinitely — which made every conformance `*_probe` test (and server startup) hang forever when run locally.

Three stacked hang sites, one root cause:

1. **`reaper::reap_stale_containers()`** runs synchronously *before* `axum::serve` and had its own duplicated unbounded `docker info` probe. With it wedged, the HTTP server never started, so testkit's `wait_for_http` timed out (30s) and retried the whole spawn 3× → ~90s → the observed "hang".
2. **~11 service runtimes** (lambda/ecs/rds/elasticache/ec2/mq/msk/kafka/codebuild/elbv2/kinesisanalyticsv2) each call `detect_container_cli()` at startup — without a memo that's a dozen serial probes stacking into minutes even once bounded.
3. testkit's own `detect_container_cli`.

## Fix

Bound the probe (10s deadline: poll `try_wait` + `child.kill()`) **and memoize the result per process**, in the shared `container_net::cli_available`.

- `crates/fakecloud-core/src/container_net.rs` — bounded + `OnceLock<Mutex<HashMap>>` memo; extracted `probe_cli`.
- `crates/fakecloud-server/src/reaper.rs` — deleted its duplicate `detect_cli`/`cli_works`; reuses `container_net::detect_container_cli`.
- `crates/fakecloud-testkit/src/lib.rs` — same bounded+memoized pattern (can't depend on core).

Beyond fixing local test runs, this is a genuine robustness+efficiency win: a wedged docker daemon no longer hangs server startup, and runtimes stop re-running `docker info` a dozen times at boot.

## Verification

- New regression test `cli_available_bounds_a_hanging_probe`: a CLI whose `info` blocks forever returns `false`, bounded near the timeout (passes in ~10s).
- `backup_probe` / `account_probe` now **PASS locally in ~26s** (were infinite).
- Server startup: HTTP up ~10s with an unreachable daemon (was never).
- `fakecloud-core` container_net tests + `fakecloud` reaper tests pass; clippy clean on all three crates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound and memoized the container CLI liveness probe so a wedged Docker/Podman no longer hangs server startup or local conformance `*_probe` runs. Reused the shared probe across the codebase and added a regression test.

- **Bug Fixes**
  - Bounded `<cli> info` to 10s using `try_wait` + `kill`; treat timeouts as unavailable in `fakecloud-core` (`container_net::cli_available`).
  - Memoized probe results per process via `OnceLock<Mutex<HashMap>>` to avoid a dozen serial probes at startup.
  - Removed the reaper’s duplicate probe and switched `fakecloud-server` (`reaper::reap_stale_containers`) to `fakecloud_core::container_net::detect_container_cli()`.
  - Mirrored the bounded+memoized probe in `fakecloud-testkit` (cannot depend on `fakecloud-core`).
  - Added a regression test to ensure a hanging `<cli> info` is bounded and returns `false`.

<sup>Written for commit 8209384360bb953a3e00d3dc550fcc02056274fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

