### PR TITLE
fix(route53): consume pagination markers instead of looping on page 1

### DIFF
--- a/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
+++ b/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
@@ -138,7 +138,7 @@ async fn list_hosted_zones_by_vpc_paginates() {
             .list_hosted_zones_by_vpc()
             .vpc_id("vpc-page")
             .vpc_region(VpcRegion::UsEast1)
-            .max_items("2");
+            .max_items(2);
         if let Some(t) = &token {
             req = req.next_token(t);
         }

--- a/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
+++ b/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
@@ -107,6 +107,74 @@ async fn vpc_association_lifecycle() {
     assert!(revoke_again.is_err());
 }
 
+/// Regression: ListHostedZonesByVPC must honor maxitems + NextToken. It
+/// previously ignored both and returned every zone with a hardcoded
+/// MaxItems=100, so a paginating client either got everything in one page or
+/// (for the traffic-policy/query-logging siblings) looped forever. Here we
+/// page one-at-a-time and require every zone to be reached exactly once with
+/// the loop terminating.
+#[tokio::test]
+async fn list_hosted_zones_by_vpc_paginates() {
+    let server = TestServer::start().await;
+    let shared = vpc("vpc-page");
+    let mut expected = std::collections::BTreeSet::new();
+    for i in 0..5 {
+        let id = make_private_zone(
+            &server,
+            &format!("z{i}.paging.example.com"),
+            &format!("pg-{i}"),
+            shared.clone(),
+        )
+        .await;
+        expected.insert(id.trim_start_matches("/hostedzone/").to_string());
+    }
+    let r53 = server.route53_client().await;
+
+    let mut seen = std::collections::BTreeSet::new();
+    let mut token: Option<String> = None;
+    let mut pages = 0;
+    loop {
+        let mut req = r53
+            .list_hosted_zones_by_vpc()
+            .vpc_id("vpc-page")
+            .vpc_region(VpcRegion::UsEast1)
+            .max_items("2");
+        if let Some(t) = &token {
+            req = req.next_token(t);
+        }
+        let resp = req.send().await.expect("list by vpc page");
+        let page: Vec<String> = resp
+            .hosted_zone_summaries()
+            .iter()
+            .map(|s| s.hosted_zone_id().to_string())
+            .collect();
+        assert!(
+            page.len() <= 2,
+            "maxitems=2 must cap the page, got {}",
+            page.len()
+        );
+        for id in page {
+            assert!(
+                seen.insert(id.clone()),
+                "zone {id} returned on more than one page"
+            );
+        }
+        pages += 1;
+        assert!(
+            pages <= 10,
+            "pagination did not terminate (infinite-loop regression)"
+        );
+        match resp.next_token() {
+            Some(t) => token = Some(t.to_string()),
+            None => break,
+        }
+    }
+    assert_eq!(
+        seen, expected,
+        "every zone must be reachable across pages exactly once"
+    );
+}
+
 #[tokio::test]
 async fn associate_vpc_rejects_public_zone() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -1121,8 +1121,11 @@ impl Route53Service {
         };
         let rest = &summaries[start..];
         let page: Vec<&(String, String)> = rest.iter().take(max_items).collect();
+        // Token is the LAST id emitted on this page; the next request resumes
+        // strictly after it (`id > token`). Emitting the first *excluded* id
+        // here would skip it, since resume is strict-greater.
         let next_token = if page.len() < rest.len() {
-            Some(rest[page.len()].0.clone())
+            page.last().map(|(id, _)| id.clone())
         } else {
             None
         };

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -1105,11 +1105,32 @@ impl Route53Service {
         }
         drop(state);
         summaries.sort_by(|a, b| a.0.cmp(&b.0));
+        // Honor maxitems + nexttoken instead of returning the whole set with a
+        // hardcoded MaxItems=100. Resume after the inbound token (last zone id).
+        let max_items: usize = req
+            .query_params
+            .get("maxitems")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(100);
+        let start = match req.query_params.get("nexttoken") {
+            Some(t) => summaries
+                .iter()
+                .position(|(id, _)| id.as_str() > t.as_str())
+                .unwrap_or(summaries.len()),
+            None => 0,
+        };
+        let rest = &summaries[start..];
+        let page: Vec<&(String, String)> = rest.iter().take(max_items).collect();
+        let next_token = if page.len() < rest.len() {
+            Some(rest[page.len()].0.clone())
+        } else {
+            None
+        };
         let mut body = String::with_capacity(512);
         body.push_str(XML_DECL);
         body.push_str(&format!("<ListHostedZonesByVPCResponse xmlns=\"{NS}\">"));
         body.push_str("<HostedZoneSummaries>");
-        for (id, name) in &summaries {
+        for (id, name) in &page {
             body.push_str("<HostedZoneSummary>");
             // HostedZoneId in a summary is the bare id (no `/hostedzone/`
             // prefix); the SDK validates the id pattern and rejects the prefix.
@@ -1121,7 +1142,10 @@ impl Route53Service {
             body.push_str("</HostedZoneSummary>");
         }
         body.push_str("</HostedZoneSummaries>");
-        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<MaxItems>{max_items}</MaxItems>"));
+        if let Some(t) = &next_token {
+            body.push_str(&format!("<NextToken>{}</NextToken>", esc(t)));
+        }
         body.push_str("</ListHostedZonesByVPCResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }

--- a/crates/fakecloud-route53/src/service/query_logging.rs
+++ b/crates/fakecloud-route53/src/service/query_logging.rs
@@ -149,9 +149,20 @@ impl Route53Service {
             configs.retain(|c| c.hosted_zone_id == z);
         }
         configs.sort_by(|a, b| a.id.cmp(&b.id));
-        let slice: Vec<&StoredQueryLoggingConfig> = configs.iter().take(max_items).collect();
-        let next = if slice.len() < configs.len() {
-            Some(configs[slice.len()].id.clone())
+        // Resume after the inbound NextToken (the id of the last config
+        // returned on the previous page). Previously the token was accepted
+        // but never applied, so paging re-returned page 1 forever.
+        let start = match req.query_params.get("nexttoken") {
+            Some(t) => configs
+                .iter()
+                .position(|c| c.id.as_str() > t.as_str())
+                .unwrap_or(configs.len()),
+            None => 0,
+        };
+        let remaining = &configs[start..];
+        let slice: Vec<&StoredQueryLoggingConfig> = remaining.iter().take(max_items).collect();
+        let next = if slice.len() < remaining.len() {
+            Some(remaining[slice.len()].id.clone())
         } else {
             None
         };

--- a/crates/fakecloud-route53/src/service/query_logging.rs
+++ b/crates/fakecloud-route53/src/service/query_logging.rs
@@ -161,8 +161,11 @@ impl Route53Service {
         };
         let remaining = &configs[start..];
         let slice: Vec<&StoredQueryLoggingConfig> = remaining.iter().take(max_items).collect();
+        // Token is the last id emitted; the next request resumes strictly
+        // after it (`id > token`). Emitting the first excluded id would skip
+        // it under strict-greater resume.
         let next = if slice.len() < remaining.len() {
-            Some(remaining[slice.len()].id.clone())
+            slice.last().map(|c| c.id.clone())
         } else {
             None
         };

--- a/crates/fakecloud-route53/src/service/traffic_policies.rs
+++ b/crates/fakecloud-route53/src/service/traffic_policies.rs
@@ -734,7 +734,14 @@ impl Route53Service {
         };
         let rest = &instances[start..];
         let slice: Vec<&StoredTrafficPolicyInstance> = rest.iter().take(max_items).collect();
-        let truncated = slice.len() < rest.len();
+        // Resume is strict-greater (`id > marker`), so the marker must be the
+        // LAST id emitted on this page, not the first excluded one.
+        let next_marker = if slice.len() < rest.len() {
+            slice.last().map(|i| i.id.clone())
+        } else {
+            None
+        };
+        let truncated = next_marker.is_some();
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!(
@@ -747,10 +754,10 @@ impl Route53Service {
         body.push_str("</TrafficPolicyInstances>");
         body.push_str(&format!("<IsTruncated>{}</IsTruncated>", truncated));
         body.push_str(&format!("<MaxItems>{}</MaxItems>", max_items));
-        if truncated {
+        if let Some(nm) = &next_marker {
             body.push_str(&format!(
                 "<TrafficPolicyInstanceNameMarker>{}</TrafficPolicyInstanceNameMarker>",
-                esc(&rest[slice.len()].id)
+                esc(nm)
             ));
         }
         body.push_str("</ListTrafficPolicyInstancesByHostedZoneResponse>");
@@ -841,7 +848,14 @@ impl Route53Service {
         };
         let rest = &instances[start..];
         let slice: Vec<&StoredTrafficPolicyInstance> = rest.iter().take(max_items).collect();
-        let truncated = slice.len() < rest.len();
+        // Resume is strict-greater (`id > marker`), so the marker must be the
+        // LAST id emitted on this page, not the first excluded one.
+        let next_marker = if slice.len() < rest.len() {
+            slice.last().map(|i| i.id.clone())
+        } else {
+            None
+        };
+        let truncated = next_marker.is_some();
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!(
@@ -854,10 +868,10 @@ impl Route53Service {
         body.push_str("</TrafficPolicyInstances>");
         body.push_str(&format!("<IsTruncated>{}</IsTruncated>", truncated));
         body.push_str(&format!("<MaxItems>{}</MaxItems>", max_items));
-        if truncated {
+        if let Some(nm) = &next_marker {
             body.push_str(&format!(
                 "<TrafficPolicyInstanceNameMarker>{}</TrafficPolicyInstanceNameMarker>",
-                esc(&rest[slice.len()].id)
+                esc(nm)
             ));
         }
         body.push_str("</ListTrafficPolicyInstancesByPolicyResponse>");

--- a/crates/fakecloud-route53/src/service/traffic_policies.rs
+++ b/crates/fakecloud-route53/src/service/traffic_policies.rs
@@ -722,8 +722,19 @@ impl Route53Service {
             .collect();
         drop(state);
         instances.sort_by(|a, b| a.id.cmp(&b.id));
-        let slice: Vec<&StoredTrafficPolicyInstance> = instances.iter().take(max_items).collect();
-        let truncated = slice.len() < instances.len();
+        // Resume after the inbound marker (the id of the last instance on the
+        // previous page). Previously the marker was accepted but ignored, so
+        // paging looped on page 1 and instances past it were unreachable.
+        let start = match req.query_params.get("trafficpolicyinstancenamemarker") {
+            Some(m) => instances
+                .iter()
+                .position(|i| i.id.as_str() > m.as_str())
+                .unwrap_or(instances.len()),
+            None => 0,
+        };
+        let rest = &instances[start..];
+        let slice: Vec<&StoredTrafficPolicyInstance> = rest.iter().take(max_items).collect();
+        let truncated = slice.len() < rest.len();
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!(
@@ -739,7 +750,7 @@ impl Route53Service {
         if truncated {
             body.push_str(&format!(
                 "<TrafficPolicyInstanceNameMarker>{}</TrafficPolicyInstanceNameMarker>",
-                esc(&instances[slice.len()].id)
+                esc(&rest[slice.len()].id)
             ));
         }
         body.push_str("</ListTrafficPolicyInstancesByHostedZoneResponse>");
@@ -820,8 +831,17 @@ impl Route53Service {
             .unwrap_or_default();
         drop(state);
         instances.sort_by(|a, b| a.id.cmp(&b.id));
-        let slice: Vec<&StoredTrafficPolicyInstance> = instances.iter().take(max_items).collect();
-        let truncated = slice.len() < instances.len();
+        // Resume after the inbound marker; previously ignored -> infinite loop.
+        let start = match req.query_params.get("trafficpolicyinstancenamemarker") {
+            Some(m) => instances
+                .iter()
+                .position(|i| i.id.as_str() > m.as_str())
+                .unwrap_or(instances.len()),
+            None => 0,
+        };
+        let rest = &instances[start..];
+        let slice: Vec<&StoredTrafficPolicyInstance> = rest.iter().take(max_items).collect();
+        let truncated = slice.len() < rest.len();
         let mut body = String::with_capacity(1024);
         body.push_str(XML_DECL);
         body.push_str(&format!(
@@ -837,7 +857,7 @@ impl Route53Service {
         if truncated {
             body.push_str(&format!(
                 "<TrafficPolicyInstanceNameMarker>{}</TrafficPolicyInstanceNameMarker>",
-                esc(&instances[slice.len()].id)
+                esc(&rest[slice.len()].id)
             ));
         }
         body.push_str("</ListTrafficPolicyInstancesByPolicyResponse>");


### PR DESCRIPTION
## Summary
Bug-hunt (2026-07-15), Tier-1. Three route53 list ops emitted a pagination marker but never applied the inbound one → an SDK auto-paginator re-fetched page 1 forever; rows past the first page were unreachable.

- **ListQueryLoggingConfigs** — `nexttoken` accepted then ignored.
- **ListTrafficPolicyInstancesByHostedZone / ByPolicy** — `TrafficPolicyInstanceNameMarker` emitted, inbound one ignored.
- **ListHostedZonesByVPC** — ignored `maxitems` AND `nexttoken`, always returned the full set with a hardcoded `<MaxItems>100</MaxItems>`.

All three now sort by id and resume at the first id strictly greater than the inbound marker (last-key cursor), cap at `maxitems`, and emit the next marker only when truncated. ListHostedZonesByVPC additionally honors `maxitems` and emits a real `NextToken`.

## Surface impact
No new API surface — behavioral fix to existing pagination on documented params. No SDK/docs/metadata changes.

## Test plan
- e2e `list_hosted_zones_by_vpc_paginates`: 5 zones on one VPC, page at maxitems=2, assert each zone returned exactly once and the loop terminates (regression guard against the infinite loop).
- `cargo clippy -p fakecloud-route53` clean; e2e compiles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Route53 pagination to apply inbound markers and honor maxitems, preventing infinite page-1 loops and off-by-one skips so all items are reachable. No API changes.

- **Bug Fixes**
  - ListQueryLoggingConfigs: apply `NextToken`, resume after it, cap at `maxitems`, and emit the last included id as `NextToken` only when truncated.
  - ListTrafficPolicyInstancesByHostedZone/ByPolicy: apply `TrafficPolicyInstanceNameMarker`, resume after it, cap at `maxitems`, and emit the last included id as the marker only when truncated.
  - ListHostedZonesByVPC: honor `maxitems` and `NextToken`, remove hardcoded `<MaxItems>100</MaxItems>`, and emit a real `NextToken` as the last included id when truncated.
  - Tests: add e2e pagination test for ListHostedZonesByVPC; correct `max_items` argument type to i32.

<sup>Written for commit 2e3123f2513f3450ad7b62ae5d69b5a0988ab317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

