### PR TITLE
fix(dynamodb): honor list pagination tokens + numeric-aware batch dup-key

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -253,7 +253,11 @@ impl DynamoDbService {
                 } else {
                     continue;
                 };
-                if seen_keys.contains(&key) {
+                // Numeric-aware comparison: {"N":"1"} and {"N":"1.0"} are the
+                // same key to DynamoDB, so a raw HashMap `==` would miss that
+                // duplicate. keys_equal normalizes numbers (as BatchGetItem
+                // already does).
+                if seen_keys.iter().any(|k| keys_equal(table, k, &key)) {
                     return Err(AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "ValidationException",
@@ -606,7 +610,10 @@ impl DynamoDbService {
                 } else {
                     serde_json::from_value(op["Key"].clone()).unwrap_or_default()
                 };
-                if seen_keys.iter().any(|(t, k)| t == table_name && *k == key) {
+                if seen_keys
+                    .iter()
+                    .any(|(t, k)| t == table_name && keys_equal(table, k, &key))
+                {
                     return Err(AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "ValidationException",

--- a/crates/fakecloud-dynamodb/src/service/global_tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/global_tables.rs
@@ -150,15 +150,27 @@ impl DynamoDbService {
             3,
             255,
         )?;
-        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, i64::MAX)?;
+        validate_optional_range_i64("limit", body["Limit"].as_i64(), 1, 100)?;
         let limit = body["Limit"].as_i64().unwrap_or(100) as usize;
+        let start = body["ExclusiveStartGlobalTableName"].as_str();
 
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
-        let tables: Vec<Value> = state
+        // Resume after ExclusiveStartGlobalTableName (BTreeMap is name-ordered)
+        // and emit LastEvaluatedGlobalTableName when the page is truncated.
+        // Previously the marker was ignored and the remainder was unreachable.
+        let matched: Vec<_> = state
             .global_tables
             .values()
+            .filter(|gt| match start {
+                Some(s) => gt.global_table_name.as_str() > s,
+                None => true,
+            })
+            .collect();
+        let truncated = matched.len() > limit;
+        let tables: Vec<Value> = matched
+            .iter()
             .take(limit)
             .map(|gt| {
                 json!({
@@ -170,9 +182,11 @@ impl DynamoDbService {
             })
             .collect();
 
-        Self::ok_json(json!({
-            "GlobalTables": tables
-        }))
+        let mut resp = json!({ "GlobalTables": tables });
+        if truncated {
+            resp["LastEvaluatedGlobalTableName"] = json!(matched[limit - 1].global_table_name);
+        }
+        Self::ok_json(resp)
     }
 
     pub(super) fn update_global_table(

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -808,14 +808,20 @@ impl DynamoDbService {
         // ResourceNotFoundException; the strict probe rejects the latter.
         let table = get_table_with_code(&state.tables, table_name, "TableNotFoundException")?;
 
+        let now = Utc::now();
+        // AWS backup ARNs are `.../backup/<epoch-millis>-<hex>`. A
+        // second-resolution timestamp collides when several backups are
+        // created in the same second, and since `backups` is keyed by ARN the
+        // collision silently overwrote the earlier backup. Use epoch-millis
+        // plus a short unique suffix so every backup gets a distinct ARN.
         let backup_arn = format!(
-            "arn:aws:dynamodb:{}:{}:table/{}/backup/{}",
+            "arn:aws:dynamodb:{}:{}:table/{}/backup/{:013}-{}",
             state.region,
             state.account_id,
             table_name,
-            Utc::now().format("%Y%m%d%H%M%S")
+            now.timestamp_millis(),
+            &uuid::Uuid::new_v4().to_string().replace('-', "")[..8]
         );
-        let now = Utc::now();
 
         let backup = BackupDescription {
             backup_arn: backup_arn.clone(),

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -1009,31 +1009,48 @@ impl DynamoDbService {
             }
         }
         let table_name = body["TableName"].as_str();
+        let start = body["ExclusiveStartBackupArn"].as_str();
+        let limit = body["Limit"].as_i64().map(|l| l as usize);
 
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
-        let summaries: Vec<Value> = state
+        // Resume after ExclusiveStartBackupArn (backups are arn-ordered) and,
+        // when a Limit truncates the set, emit LastEvaluatedBackupArn.
+        // Previously every backup was returned with no continuation token.
+        let matched: Vec<(&str, Value)> = state
             .backups
             .values()
             .filter(|b| table_name.is_none() || table_name == Some(b.table_name.as_str()))
+            .filter(|b| match start {
+                Some(s) => b.backup_arn.as_str() > s,
+                None => true,
+            })
             .map(|b| {
-                json!({
-                    "TableName": b.table_name,
-                    "TableArn": b.table_arn,
-                    "BackupArn": b.backup_arn,
-                    "BackupName": b.backup_name,
-                    "BackupCreationDateTime": b.backup_creation_date.timestamp() as f64,
-                    "BackupStatus": b.backup_status,
-                    "BackupType": b.backup_type,
-                    "BackupSizeBytes": b.size_bytes
-                })
+                (
+                    b.backup_arn.as_str(),
+                    json!({
+                        "TableName": b.table_name,
+                        "TableArn": b.table_arn,
+                        "BackupArn": b.backup_arn,
+                        "BackupName": b.backup_name,
+                        "BackupCreationDateTime": b.backup_creation_date.timestamp() as f64,
+                        "BackupStatus": b.backup_status,
+                        "BackupType": b.backup_type,
+                        "BackupSizeBytes": b.size_bytes
+                    }),
+                )
             })
             .collect();
+        let truncated = limit.is_some_and(|l| matched.len() > l);
+        let take = limit.unwrap_or(matched.len());
+        let summaries: Vec<Value> = matched.iter().take(take).map(|(_, v)| v.clone()).collect();
 
-        Self::ok_json(json!({
-            "BackupSummaries": summaries
-        }))
+        let mut resp = json!({ "BackupSummaries": summaries });
+        if truncated {
+            resp["LastEvaluatedBackupArn"] = json!(matched[take - 1].0);
+        }
+        Self::ok_json(resp)
     }
 
     pub(super) fn restore_table_from_backup(
@@ -1532,26 +1549,42 @@ impl DynamoDbService {
         validate_optional_string_length("tableArn", body["TableArn"].as_str(), 1, 1024)?;
         validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 25)?;
         let table_arn = body["TableArn"].as_str();
+        let start = body["NextToken"].as_str();
+        let max = body["MaxResults"].as_i64().map(|m| m as usize);
 
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
-        let summaries: Vec<Value> = state
+        // Honor MaxResults + NextToken (export-arn cursor). Previously both
+        // were validated then ignored and every export returned in one page.
+        let matched: Vec<(&str, Value)> = state
             .exports
             .values()
             .filter(|e| table_arn.is_none() || table_arn == Some(e.table_arn.as_str()))
+            .filter(|e| match start {
+                Some(s) => e.export_arn.as_str() > s,
+                None => true,
+            })
             .map(|e| {
-                json!({
-                    "ExportArn": e.export_arn,
-                    "ExportStatus": e.export_status,
-                    "TableArn": e.table_arn
-                })
+                (
+                    e.export_arn.as_str(),
+                    json!({
+                        "ExportArn": e.export_arn,
+                        "ExportStatus": e.export_status,
+                        "TableArn": e.table_arn
+                    }),
+                )
             })
             .collect();
+        let truncated = max.is_some_and(|m| matched.len() > m);
+        let take = max.unwrap_or(matched.len());
+        let summaries: Vec<Value> = matched.iter().take(take).map(|(_, v)| v.clone()).collect();
 
-        Self::ok_json(json!({
-            "ExportSummaries": summaries
-        }))
+        let mut resp = json!({ "ExportSummaries": summaries });
+        if truncated {
+            resp["NextToken"] = json!(matched[take - 1].0);
+        }
+        Self::ok_json(resp)
     }
 
     pub(super) fn import_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1852,26 +1885,42 @@ impl DynamoDbService {
             }
         }
         let table_arn = body["TableArn"].as_str();
+        let start = body["NextToken"].as_str();
+        let max = body["PageSize"].as_i64().map(|m| m as usize);
 
         let accounts = self.state.read();
         let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
-        let summaries: Vec<Value> = state
+        // Honor PageSize + NextToken (import-arn cursor). Previously both were
+        // validated then ignored and every import returned in one page.
+        let matched: Vec<(&str, Value)> = state
             .imports
             .values()
             .filter(|i| table_arn.is_none() || table_arn == Some(i.table_arn.as_str()))
+            .filter(|i| match start {
+                Some(s) => i.import_arn.as_str() > s,
+                None => true,
+            })
             .map(|i| {
-                json!({
-                    "ImportArn": i.import_arn,
-                    "ImportStatus": i.import_status,
-                    "TableArn": i.table_arn
-                })
+                (
+                    i.import_arn.as_str(),
+                    json!({
+                        "ImportArn": i.import_arn,
+                        "ImportStatus": i.import_status,
+                        "TableArn": i.table_arn
+                    }),
+                )
             })
             .collect();
+        let truncated = max.is_some_and(|m| matched.len() > m);
+        let take = max.unwrap_or(matched.len());
+        let summaries: Vec<Value> = matched.iter().take(take).map(|(_, v)| v.clone()).collect();
 
-        Self::ok_json(json!({
-            "ImportSummaryList": summaries
-        }))
+        let mut resp = json!({ "ImportSummaryList": summaries });
+        if truncated {
+            resp["NextToken"] = json!(matched[take - 1].0);
+        }
+        Self::ok_json(resp)
     }
 }
 

--- a/crates/fakecloud-e2e/tests/dynamodb.rs
+++ b/crates/fakecloud-e2e/tests/dynamodb.rs
@@ -1837,6 +1837,130 @@ async fn dynamodb_backup_lifecycle() {
         .unwrap();
 }
 
+/// Regression: ListBackups must honor Limit + ExclusiveStartBackupArn and
+/// emit LastEvaluatedBackupArn when truncated. Previously it returned every
+/// backup with no continuation token, so a paginating client silently lost
+/// the remainder.
+#[tokio::test]
+async fn dynamodb_list_backups_paginates() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    client
+        .create_table()
+        .table_name("PagBackupTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+    for i in 0..3 {
+        client
+            .create_backup()
+            .table_name("PagBackupTable")
+            .backup_name(format!("bk-{i}"))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let mut seen = std::collections::BTreeSet::new();
+    let mut token: Option<String> = None;
+    let mut pages = 0;
+    loop {
+        let mut req = client.list_backups().limit(2);
+        if let Some(t) = &token {
+            req = req.exclusive_start_backup_arn(t);
+        }
+        let resp = req.send().await.unwrap();
+        assert!(
+            resp.backup_summaries().len() <= 2,
+            "Limit=2 must cap the page"
+        );
+        for s in resp.backup_summaries() {
+            assert!(
+                seen.insert(s.backup_arn().unwrap().to_string()),
+                "backup returned on more than one page"
+            );
+        }
+        pages += 1;
+        assert!(pages <= 10, "ListBackups pagination did not terminate");
+        match resp.last_evaluated_backup_arn() {
+            Some(t) => token = Some(t.to_string()),
+            None => break,
+        }
+    }
+    assert_eq!(
+        seen.len(),
+        3,
+        "all 3 backups reachable across pages exactly once"
+    );
+}
+
+/// Regression: BatchWriteItem duplicate-key detection must be numeric-aware.
+/// `{"N":"1"}` and `{"N":"1.0"}` are the same DynamoDB key, so a batch with
+/// both must be rejected with ValidationException (a raw JSON compare missed
+/// this and silently applied last-writer-wins).
+#[tokio::test]
+async fn dynamodb_batch_write_numeric_duplicate_key_rejected() {
+    let server = TestServer::start().await;
+    let client = server.dynamodb_client().await;
+    client
+        .create_table()
+        .table_name("NumKeyTable")
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("id")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("id")
+                .attribute_type(ScalarAttributeType::N)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+
+    let put = |n: &str| {
+        WriteRequest::builder()
+            .put_request(
+                PutRequest::builder()
+                    .item("id", AttributeValue::N(n.to_string()))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+    };
+    let err = client
+        .batch_write_item()
+        .request_items("NumKeyTable", vec![put("1"), put("1.0")])
+        .send()
+        .await
+        .expect_err("batch with numerically-equal duplicate keys must be rejected");
+    assert!(
+        format!("{err:?}").contains("ValidationException"),
+        "expected ValidationException for duplicate key, got: {err:?}"
+    );
+}
+
 #[tokio::test]
 async fn dynamodb_continuous_backups() {
     let server = TestServer::start().await;


### PR DESCRIPTION
## Summary
Bug-hunt (2026-07-15), Tier-1. Five silent-wrong-output bugs in DynamoDB:

**Pagination truncation / data-loss** — four list ops validated their page-size/token params then ignored them, so a paginating client either lost the remainder or (with a Limit) got a truncated set with no continuation token:
- `ListGlobalTables` — ignored `ExclusiveStartGlobalTableName`, never emitted `LastEvaluatedGlobalTableName`; `Limit` range-checked to i64::MAX vs AWS 100.
- `ListBackups` — returned every backup, no `.take`, no `LastEvaluatedBackupArn`.
- `ListExports` — validated `MaxResults`/`NextToken`, returned everything.
- `ListImports` — validated `PageSize`/`NextToken`, returned everything.

All four now resume after the inbound arn/name cursor (BTreeMap key order), cap the page, and emit the continuation token only when truncated.

**Numeric-aware duplicate keys** — `BatchWriteItem` / `TransactWriteItems` duplicate-key detection used raw JSON equality, so `{"N":"1"}` and `{"N":"1.0"}` were treated as distinct and the batch silently applied last-writer-wins instead of AWS's `ValidationException`. Both now use `keys_equal` (numeric-normalizing), matching `BatchGetItem`.

## Surface impact
No new API surface — behavioral corrections to existing ops' pagination and validation contracts. No SDK/docs/metadata changes.

## Test plan
- e2e `dynamodb_list_backups_paginates`: 3 backups, Limit=2, every arn reached exactly once, loop terminates.
- e2e `dynamodb_batch_write_numeric_duplicate_key_rejected`: {N:1} + {N:1.0} → ValidationException.
- 372 dynamodb lib tests pass; `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB pagination for list operations, ensures unique backup ARNs, and makes duplicate-key checks numeric-aware in batch/transaction writes. Prevents lost pages and overwritten backups, and returns the correct ValidationException for numerically equal keys.

- Bug Fixes
  - ListGlobalTables: honors `ExclusiveStartGlobalTableName`, emits `LastEvaluatedGlobalTableName`, and enforces `Limit` ≤ 100.
  - ListBackups: respects `Limit` and `ExclusiveStartBackupArn`; emits `LastEvaluatedBackupArn` when truncated.
  - ListExports: honors `MaxResults` and `NextToken`; emits `NextToken` when truncated.
  - ListImports: honors `PageSize` and `NextToken`; emits `NextToken` when truncated.
  - CreateBackup: generates unique backup ARNs (`.../backup/<epoch-millis>-<hex>`); prevents same-second collisions that overwrote earlier backups.
  - BatchWriteItem / TransactWriteItems: duplicate-key detection uses numeric-normalizing `keys_equal`; treats `{"N":"1"}` and `{"N":"1.0"}` as the same key and returns `ValidationException`.

<sup>Written for commit d9a1f83a1a24c3c66e1e975d4fca6a02b7d9b23f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

