### PR TITLE
fix(iot): persist TopicRuleDestination + UpdateThingGroupsForThing

### DIFF
--- a/crates/fakecloud-e2e/tests/iot.rs
+++ b/crates/fakecloud-e2e/tests/iot.rs
@@ -286,3 +286,135 @@ async fn iot_register_thing_returns_resource_arns() {
         .map(|a| a.contains(":thing/"))
         .unwrap_or(false));
 }
+
+/// Regression: CreateTopicRuleDestination is server-minted (no path label), so
+/// it used to hit the generic Action no-op and never persist — Get/List always
+/// 404/empty. Now it stores a real destination the read path reflects.
+#[tokio::test]
+async fn iot_topic_rule_destination_persists() {
+    use aws_sdk_iot::types::{HttpUrlDestinationConfiguration, TopicRuleDestinationConfiguration};
+    let server = TestServer::start().await;
+    let client = iot_client(&server).await;
+
+    let created = client
+        .create_topic_rule_destination()
+        .destination_configuration(
+            TopicRuleDestinationConfiguration::builder()
+                .http_url_configuration(
+                    HttpUrlDestinationConfiguration::builder()
+                        .confirmation_url("https://example.com/confirm")
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create destination");
+    let arn = created
+        .topic_rule_destination()
+        .unwrap()
+        .arn()
+        .unwrap()
+        .to_string();
+    assert!(arn.contains(":ruledestination/"), "arn: {arn}");
+
+    // Get reflects it (previously 404).
+    let got = client
+        .get_topic_rule_destination()
+        .arn(&arn)
+        .send()
+        .await
+        .expect("get destination");
+    assert_eq!(
+        got.topic_rule_destination().unwrap().arn(),
+        Some(arn.as_str())
+    );
+
+    // List reflects it (previously empty).
+    let listed = client
+        .list_topic_rule_destinations()
+        .send()
+        .await
+        .expect("list destinations");
+    assert!(
+        listed
+            .destination_summaries()
+            .iter()
+            .any(|s| s.arn() == Some(arn.as_str())),
+        "created destination must appear in the list"
+    );
+}
+
+/// Regression: UpdateThingGroupsForThing (bulk add/remove) used to be an Action
+/// no-op, so the membership never took effect. Now it mirrors the
+/// group-things relation that ListThingGroupsForThing reads.
+#[tokio::test]
+async fn iot_update_thing_groups_for_thing_reflected() {
+    let server = TestServer::start().await;
+    let client = iot_client(&server).await;
+
+    client
+        .create_thing()
+        .thing_name("bulk-thing")
+        .send()
+        .await
+        .unwrap();
+    for g in ["grp-a", "grp-b"] {
+        client
+            .create_thing_group()
+            .thing_group_name(g)
+            .send()
+            .await
+            .unwrap();
+    }
+
+    client
+        .update_thing_groups_for_thing()
+        .thing_name("bulk-thing")
+        .thing_groups_to_add("grp-a")
+        .thing_groups_to_add("grp-b")
+        .send()
+        .await
+        .expect("bulk add to groups");
+
+    let groups = client
+        .list_thing_groups_for_thing()
+        .thing_name("bulk-thing")
+        .send()
+        .await
+        .expect("list groups for thing");
+    let names: Vec<&str> = groups
+        .thing_groups()
+        .iter()
+        .filter_map(|g| g.group_name())
+        .collect();
+    assert!(
+        names.contains(&"grp-a") && names.contains(&"grp-b"),
+        "got: {names:?}"
+    );
+
+    // Remove one; it must drop out.
+    client
+        .update_thing_groups_for_thing()
+        .thing_name("bulk-thing")
+        .thing_groups_to_remove("grp-a")
+        .send()
+        .await
+        .expect("bulk remove");
+    let groups = client
+        .list_thing_groups_for_thing()
+        .thing_name("bulk-thing")
+        .send()
+        .await
+        .unwrap();
+    let names: Vec<&str> = groups
+        .thing_groups()
+        .iter()
+        .filter_map(|g| g.group_name())
+        .collect();
+    assert!(
+        !names.contains(&"grp-a") && names.contains(&"grp-b"),
+        "got: {names:?}"
+    );
+}

--- a/crates/fakecloud-iot/src/service/special.rs
+++ b/crates/fakecloud-iot/src/service/special.rs
@@ -317,6 +317,19 @@ pub(super) fn dispatch(
         "EnableTopicRule" => Ok(Some(set_topic_rule_disabled(svc, ctx, labels, false))),
         "DisableTopicRule" => Ok(Some(set_topic_rule_disabled(svc, ctx, labels, true))),
 
+        // Topic-rule destinations: the arn is server-minted (nlabels:0 create),
+        // so the generic engine can't key it. Store into the shared
+        // `destinations` resource family that Get/List/Delete read.
+        "CreateTopicRuleDestination" => Ok(Some(create_topic_rule_destination(svc, ctx, body))),
+        "UpdateTopicRuleDestination" => Ok(Some(update_topic_rule_destination(svc, ctx, body))),
+        // No async confirmation channel exists, so destinations are created
+        // ENABLED; Confirm is accepted idempotently (AWS returns an empty body).
+        "ConfirmTopicRuleDestination" => Ok(Some((ok_json(Value::Object(Map::new())), false))),
+
+        // Bulk thing<->group membership; mirrors AddThingToThingGroup's
+        // `group-things` relation so ListThingGroupsForThing reflects it.
+        "UpdateThingGroupsForThing" => Ok(Some(update_thing_groups_for_thing(svc, ctx, body))),
+
         _ => Ok(None),
     }
 }
@@ -658,6 +671,135 @@ fn list_attached_policies(
 }
 
 // ---------- topic rules ----------
+
+fn create_topic_rule_destination(
+    svc: &IotService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let cfg = body.get("destinationConfiguration");
+    let http = cfg.and_then(|c| c.get("httpUrlConfiguration"));
+    let vpc = cfg.and_then(|c| c.get("vpcConfiguration"));
+    let http_props = http
+        .and_then(|h| h.get("confirmationUrl"))
+        .map(|u| json!({ "confirmationUrl": u }));
+
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.seq += 1;
+    let kind = if vpc.is_some() { "vpc" } else { "http" };
+    let uid = super::mint_uuid(&format!("{}:dest:{}", ctx.account, data.seq));
+    let arn = format!(
+        "arn:aws:iot:{}:{}:ruledestination/{kind}/{uid}",
+        ctx.region, ctx.account
+    );
+    let now = super::now_epoch();
+
+    let mut dest = Map::new();
+    dest.insert("arn".into(), Value::String(arn.clone()));
+    dest.insert("status".into(), Value::String("ENABLED".into()));
+    dest.insert("createdAt".into(), now.clone());
+    dest.insert("lastUpdatedAt".into(), now.clone());
+    if let Some(hp) = &http_props {
+        dest.insert("httpUrlProperties".into(), hp.clone());
+    }
+    if let Some(v) = vpc {
+        dest.insert("vpcProperties".into(), v.clone());
+    }
+    let destination = Value::Object(dest);
+
+    // Record: top-level fields feed the List element projection; the nested
+    // `topicRuleDestination` feeds the Get struct projection.
+    let mut record = Map::new();
+    record.insert("arn".into(), Value::String(arn.clone()));
+    record.insert("status".into(), Value::String("ENABLED".into()));
+    record.insert("createdAt".into(), now.clone());
+    record.insert("lastUpdatedAt".into(), now);
+    if let Some(hp) = &http_props {
+        record.insert("httpUrlSummary".into(), hp.clone());
+    }
+    record.insert("topicRuleDestination".into(), destination.clone());
+    data.put_resource("destinations", &arn, Value::Object(record));
+
+    (
+        ok_json(json!({ "topicRuleDestination": destination })),
+        true,
+    )
+}
+
+fn update_topic_rule_destination(
+    svc: &IotService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let Some(arn) = body_str(body, "arn") else {
+        return (ok_json(Value::Object(Map::new())), false);
+    };
+    let status = body_str(body, "status").unwrap_or("ENABLED").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(Value::Object(mut record)) = data.get_resource("destinations", arn).cloned() else {
+        return (ok_json(Value::Object(Map::new())), false);
+    };
+    record.insert("status".into(), Value::String(status.clone()));
+    record.insert("lastUpdatedAt".into(), super::now_epoch());
+    if let Some(Value::Object(dest)) = record.get_mut("topicRuleDestination") {
+        dest.insert("status".into(), Value::String(status));
+    }
+    data.put_resource("destinations", arn, Value::Object(record));
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+fn update_thing_groups_for_thing(
+    svc: &IotService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let Some(thing) = body_str(body, "thingName") else {
+        return (ok_json(Value::Object(Map::new())), false);
+    };
+    let adds: Vec<String> = body
+        .get("thingGroupsToAdd")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let removes: Vec<String> = body
+        .get("thingGroupsToRemove")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let mut mutated = false;
+    for grp in &adds {
+        let entry = data
+            .relations
+            .entry(format!("group-things:{grp}"))
+            .or_default();
+        if !entry.iter().any(|x| x == thing) {
+            entry.push(thing.to_string());
+            mutated = true;
+        }
+    }
+    for grp in &removes {
+        if let Some(entry) = data.relations.get_mut(&format!("group-things:{grp}")) {
+            if let Some(pos) = entry.iter().position(|x| x == thing) {
+                entry.remove(pos);
+                mutated = true;
+            }
+        }
+    }
+    (ok_json(Value::Object(Map::new())), mutated)
+}
 
 fn put_topic_rule(
     svc: &IotService,


### PR DESCRIPTION
## Summary
Bug-hunt (2026-07-15), Tier-1 (the greenfield Action stub-band). The table-driven IoT service accepted any unclaimed `Verb::Action` as a shape-valid no-op that touched no state, silently dropping real writes:

- **CreateTopicRuleDestination / UpdateTopicRuleDestination** — the arn is server-minted (`nlabels:0`), so the generic engine couldn't key it and the create fell through to the no-op. `GetTopicRuleDestination` / `ListTopicRuleDestinations` then always 404'd / returned empty. Now the create stores a real record into the shared `destinations` resource family the read path already uses (top-level fields for the List element projection + a nested `topicRuleDestination` for the Get struct projection); update mutates status. Destinations are created ENABLED (no async confirmation transport exists); `ConfirmTopicRuleDestination` is accepted idempotently.
- **UpdateThingGroupsForThing** (bulk add/remove) dropped the membership; now mirrors `AddThingToThingGroup`'s `group-things` relation so `ListThingGroupsForThing` reflects it.

First of two IoT batches; a follow-up covers AttachSecurityProfile/Detach (+ their list readers), DeprecateThingType, and the iotwireless associations.

## Surface impact
No new API surface — makes existing ops actually persist. No SDK/docs/metadata changes.

## Test plan
- e2e `iot_topic_rule_destination_persists`: create → get → list all reflect the arn.
- e2e `iot_update_thing_groups_for_thing_reflected`: bulk-add two groups, list confirms; remove one, list confirms drop.
- 44 iot lib tests pass; `clippy` (lib + e2e --tests) clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists IoT TopicRuleDestination resources and UpdateThingGroupsForThing memberships so writes are reflected by Get/List instead of being dropped. Fixes prior no-op behavior on these actions.

- Bug Fixes
  - TopicRuleDestination: create now stores a record in `destinations`; update mutates status; resources start as ENABLED; confirm is accepted idempotently; Get/List now return the created destination.
  - UpdateThingGroupsForThing: bulk add/remove updates the `group-things` relation so ListThingGroupsForThing shows correct membership.

<sup>Written for commit 0d61a9e3b10cdbbd278d10520d6a8ca25414a02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

