### PR TITLE
fix(s3,lambda): checksum integrity, bucket-name + config validation (bug-hunt)

### DIFF
--- a/crates/fakecloud-conformance/tests/lambda.rs
+++ b/crates/fakecloud-conformance/tests/lambda.rs
@@ -852,9 +852,11 @@ async fn lambda_recursion_config() {
 async fn lambda_scaling_config_via_route() {
     // Function scaling config — the live AWS route is
     // `/2025-11-30/functions/{name}/function-scaling-config?Qualifier=...`.
-    // We just need to exercise the dispatch path; the function
-    // doesn't need to exist for the validation guards to pass.
+    // The function must exist: AWS (and now fakecloud) returns
+    // ResourceNotFoundException for a scaling-config put on a missing function.
     let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+    make_basic_function(&client, "scaling-fn").await;
     let auth = "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/lambda/aws4_request, SignedHeaders=host, Signature=0";
     let resp = reqwest::Client::new()
         .put(format!(

--- a/crates/fakecloud-e2e/tests/lambda.rs
+++ b/crates/fakecloud-e2e/tests/lambda.rs
@@ -68,6 +68,68 @@ async fn lambda_create_get_delete_function() {
 }
 
 #[tokio::test]
+async fn lambda_create_function_validates_timeout_upper_bound() {
+    // Bug-hunt 1.15: CreateFunction never validated MemorySize/Timeout/Runtime,
+    // and UpdateFunctionConfiguration used `i64::MAX` for Timeout instead of the
+    // Smithy max (5400). A Timeout above 5400 must be rejected.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let result = client
+        .create_function()
+        .function_name("bad-timeout")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .timeout(6000)
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await;
+    assert!(result.is_err(), "Timeout=6000 (> 5400) must be rejected");
+
+    // A valid Timeout at the boundary is accepted.
+    client
+        .create_function()
+        .function_name("ok-timeout")
+        .runtime(aws_sdk_lambda::types::Runtime::Python312)
+        .role("arn:aws:iam::123456789012:role/test-role")
+        .handler("index.handler")
+        .timeout(5400)
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(make_python_zip()))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("Timeout=5400 (boundary) must be accepted");
+}
+
+#[tokio::test]
+async fn lambda_put_concurrency_on_missing_function_is_not_found() {
+    // Bug-hunt 1.16: PutFunctionConcurrency against a nonexistent function
+    // stored a ghost config and returned 200. AWS returns
+    // ResourceNotFoundException.
+    let server = TestServer::start().await;
+    let client = server.lambda_client().await;
+
+    let result = client
+        .put_function_concurrency()
+        .function_name("does-not-exist")
+        .reserved_concurrent_executions(5)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "reserved concurrency on a missing function must be an error"
+    );
+}
+
+#[tokio::test]
 async fn lambda_get_function_code_location_is_downloadable() {
     // Regression for #1375: AWS Toolkit + `aws lambda get-function` need
     // Code.Location to resolve to the actual ZIP body.

--- a/crates/fakecloud-e2e/tests/s3_checksum_integrity.rs
+++ b/crates/fakecloud-e2e/tests/s3_checksum_integrity.rs
@@ -1,0 +1,47 @@
+mod helpers;
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::ChecksumAlgorithm;
+use helpers::TestServer;
+
+/// Bug-hunt 1.13: PutObject computed the modern `x-amz-checksum-*` value over
+/// the received body but never compared it against a client-supplied value, so
+/// a corrupt upload with a wrong precomputed checksum stored silently. AWS
+/// rejects the mismatch with `BadDigest`. Supplying an explicit (wrong)
+/// SHA256 must fail; a correct request still succeeds.
+#[tokio::test]
+async fn s3_put_object_rejects_checksum_mismatch() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+
+    s3.create_bucket()
+        .bucket("checksum-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    // A syntactically-valid base64 SHA256 that does NOT match the body.
+    let wrong_sha256 = "3q2+7wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    let result = s3
+        .put_object()
+        .bucket("checksum-bucket")
+        .key("obj")
+        .body(ByteStream::from_static(b"hello world"))
+        .checksum_sha256(wrong_sha256)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "a mismatched x-amz-checksum-sha256 must be rejected"
+    );
+
+    // Letting the SDK compute the checksum for us round-trips fine.
+    s3.put_object()
+        .bucket("checksum-bucket")
+        .key("obj-ok")
+        .body(ByteStream::from_static(b"hello world"))
+        .checksum_algorithm(ChecksumAlgorithm::Sha256)
+        .send()
+        .await
+        .expect("a correct checksum must be accepted");
+}

--- a/crates/fakecloud-lambda/src/extras/account.rs
+++ b/crates/fakecloud-lambda/src/extras/account.rs
@@ -102,10 +102,7 @@ impl LambdaService {
 
             // Scaling
             "PutFunctionScalingConfig" => self.put_scaling_config(res, req),
-            "GetFunctionScalingConfig" => {
-                require_qualifier(req)?;
-                self.get_scaling_config(res, aid)
-            }
+            "GetFunctionScalingConfig" => self.get_scaling_config(res, req),
 
             // Recursion
             "PutFunctionRecursionConfig" => self.put_recursion_config(res, req),

--- a/crates/fakecloud-lambda/src/extras/concurrency.rs
+++ b/crates/fakecloud-lambda/src/extras/concurrency.rs
@@ -24,6 +24,13 @@ impl LambdaService {
         }
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // AWS returns ResourceNotFoundException for a config-put against a
+        // function that doesn't exist; get_or_create only makes the account,
+        // so guard explicitly or we'd store a ghost config the function never
+        // owns.
+        if !state.functions.contains_key(function_name) {
+            return Err(not_found("Function", function_name));
+        }
         state
             .function_concurrency
             .insert(function_name.to_string(), n);
@@ -81,6 +88,9 @@ impl LambdaService {
         }
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        if !state.functions.contains_key(function_name) {
+            return Err(not_found("Function", function_name));
+        }
         let cfg = ProvisionedConcurrencyConfig {
             requested,
             allocated: requested,
@@ -173,7 +183,7 @@ impl LambdaService {
         function_name: &str,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let _qualifier = require_qualifier(req)?;
+        let qualifier = require_qualifier(req)?;
         let body = body(req);
         let inner = body
             .get("FunctionScalingConfig")
@@ -185,7 +195,14 @@ impl LambdaService {
         };
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        state.scaling_configs.insert(function_name.to_string(), cfg);
+        if !state.functions.contains_key(function_name) {
+            return Err(not_found("Function", function_name));
+        }
+        // Scaling config is per-qualifier (version/alias); keying by bare
+        // function name collided distinct versions onto one entry.
+        state
+            .scaling_configs
+            .insert(Self::pc_key(function_name, &qualifier), cfg);
         // `PutFunctionScalingConfigResponse` only carries `FunctionState`
         // (the post-update steady state). Pending → ready is instant in
         // fakecloud since there's no real fleet to scale.
@@ -195,18 +212,14 @@ impl LambdaService {
     pub(super) fn get_scaling_config(
         &self,
         function_name: &str,
-        account_id: &str,
+        req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        // Caller validates `Qualifier` via `require_qualifier` before
-        // delegating here; reads don't need it post-validation since
-        // scaling config is per-function in fakecloud.
+        let qualifier = require_qualifier(req)?;
+        let account_id = &req.account_id;
         let region = self.region_for(account_id);
+        let key = Self::pc_key(function_name, &qualifier);
         self.with_state_read(account_id, &region, |state| {
-            let cfg = state
-                .scaling_configs
-                .get(function_name)
-                .cloned()
-                .unwrap_or_default();
+            let cfg = state.scaling_configs.get(&key).cloned().unwrap_or_default();
             let mut applied = serde_json::Map::new();
             if let Some(v) = cfg.min_execution_environments {
                 applied.insert("MinExecutionEnvironments".into(), json!(v));

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -136,6 +136,13 @@ fn check_optional_enum(
 fn prevalidate_lambda(action: &str, req: &AwsRequest) -> Result<(), AwsServiceError> {
     let body: Value = serde_json::from_slice(&req.body).unwrap_or(Value::Null);
     match action {
+        "CreateFunction" => {
+            check_optional_len("Description", body["Description"].as_str(), 0, 256)?;
+            check_optional_len("Handler", body["Handler"].as_str(), 0, 128)?;
+            check_optional_int_range("MemorySize", body["MemorySize"].as_i64(), 128, 32768)?;
+            check_optional_int_range("Timeout", body["Timeout"].as_i64(), 1, 5400)?;
+            check_optional_enum("Runtime", body["Runtime"].as_str(), LAMBDA_RUNTIMES)?;
+        }
         "PublishVersion" => {
             check_optional_len("Description", body["Description"].as_str(), 0, 256)?;
             check_optional_enum(
@@ -158,7 +165,7 @@ fn prevalidate_lambda(action: &str, req: &AwsRequest) -> Result<(), AwsServiceEr
             check_optional_len("Description", body["Description"].as_str(), 0, 256)?;
             check_optional_len("Handler", body["Handler"].as_str(), 0, 128)?;
             check_optional_int_range("MemorySize", body["MemorySize"].as_i64(), 128, 32768)?;
-            check_optional_int_range("Timeout", body["Timeout"].as_i64(), 1, i64::MAX)?;
+            check_optional_int_range("Timeout", body["Timeout"].as_i64(), 1, 5400)?;
             check_optional_enum("Runtime", body["Runtime"].as_str(), LAMBDA_RUNTIMES)?;
         }
         _ => {}

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2340,17 +2340,56 @@ pub(crate) fn is_valid_storage_class(class: &str) -> bool {
 }
 
 pub(crate) fn is_valid_bucket_name(name: &str) -> bool {
+    // General-purpose bucket naming rules (AWS S3):
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
     if name.len() < 3 || name.len() > 63 {
         return false;
     }
-    // Must start and end with alphanumeric
+    // Only lowercase letters, digits, hyphens, and dots. Underscores are NOT
+    // permitted for general-purpose buckets.
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'.')
+    {
+        return false;
+    }
+    // Must start and end with a letter or number.
     let bytes = name.as_bytes();
     if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
         return false;
     }
-    // Only lowercase letters, digits, hyphens, dots (also allow underscores for compatibility)
-    name.chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.' || c == '_')
+    // Must not contain two adjacent periods.
+    if name.contains("..") {
+        return false;
+    }
+    // Must not be formatted as an IPv4 address (e.g. 192.168.5.4).
+    if is_ipv4_format(name) {
+        return false;
+    }
+    // Reserved prefixes / suffixes.
+    if name.starts_with("xn--")
+        || name.starts_with("sthree-")
+        || name.starts_with("amzn-s3-demo-")
+        || name.ends_with("-s3alias")
+        || name.ends_with("--ol-s3")
+        || name.ends_with(".mrap")
+    {
+        return false;
+    }
+    true
+}
+
+/// True when `name` is four dot-separated decimal octets (0-255), i.e. looks
+/// like an IPv4 address, which S3 forbids as a bucket name.
+fn is_ipv4_format(name: &str) -> bool {
+    let parts: Vec<&str> = name.split('.').collect();
+    parts.len() == 4
+        && parts.iter().all(|p| {
+            !p.is_empty()
+                && p.len() <= 3
+                && p.bytes().all(|b| b.is_ascii_digit())
+                && p.parse::<u8>().is_ok()
+        })
 }
 
 pub(crate) fn is_valid_region(region: &str) -> bool {

--- a/crates/fakecloud-s3/src/service/objects/write.rs
+++ b/crates/fakecloud-s3/src/service/objects/write.rs
@@ -388,6 +388,37 @@ impl S3Service {
             None
         };
 
+        // Integrity check for the modern precomputed checksum headers. When
+        // the client sends a checksum *value* (`x-amz-checksum-<algo>`), S3
+        // compares it against the checksum it computes over the received body
+        // and rejects a mismatch with `BadDigest` — same contract as the
+        // Content-MD5 path above. Validate every supplied value header (a
+        // client/SDK may send more than one), not just the primary detected
+        // algorithm. Both values are base64, so compare exactly. Previously the
+        // supplied value was ignored and a corrupt upload stored silently.
+        for algo in ["CRC32", "CRC32C", "CRC64NVME", "SHA1", "SHA256"] {
+            let header_name = format!("x-amz-checksum-{}", algo.to_lowercase());
+            let Some(supplied) = req
+                .headers
+                .get(header_name.as_str())
+                .and_then(|v| v.to_str().ok())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            else {
+                continue;
+            };
+            let computed = crate::service::compute_checksum_streaming(algo, &spooled.path)
+                .await
+                .map_err(crate::service::io_to_aws)?;
+            if supplied != computed {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "BadDigest",
+                    format!("The {algo} you specified did not match the calculated checksum."),
+                ));
+            }
+        }
+
         // Object lock - explicit headers or bucket default
         let mut lock_mode = req
             .headers

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -46,6 +46,18 @@ fn valid_bucket_names() {
     assert!(!is_valid_bucket_name("-bucket"));
     assert!(!is_valid_bucket_name("Bucket"));
     assert!(!is_valid_bucket_name("bucket-"));
+    // Underscores are not permitted for general-purpose buckets.
+    assert!(!is_valid_bucket_name("my_bucket"));
+    // No two adjacent periods.
+    assert!(!is_valid_bucket_name("my..bucket"));
+    // Must not look like an IPv4 address.
+    assert!(!is_valid_bucket_name("192.168.5.4"));
+    assert!(is_valid_bucket_name("192.168.5.4.example"));
+    // Reserved prefixes / suffixes.
+    assert!(!is_valid_bucket_name("xn--bucket"));
+    assert!(!is_valid_bucket_name("sthree-bucket"));
+    assert!(!is_valid_bucket_name("my-bucket-s3alias"));
+    assert!(!is_valid_bucket_name("my-bucket--ol-s3"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Bug-hunt findings 1.13–1.17.

**S3**
- `PutObject` verifies every supplied `x-amz-checksum-<algo>` header against the checksum computed over the received body; mismatch → `BadDigest`. Previously computed but never compared (silent corrupt upload). (1.13)
- `is_valid_bucket_name` rejects underscores, adjacent `..`, IPv4-format names, and reserved prefixes/suffixes per AWS general-purpose rules. (1.14)

**Lambda**
- `CreateFunction` now validates MemorySize/Timeout/Runtime; Create+UpdateFunctionConfiguration use the Smithy Timeout max (5400) not `i64::MAX`. (1.15)
- `Put{Function,Provisioned}Concurrency` + `PutFunctionScalingConfig` return `ResourceNotFoundException` for a missing function instead of a ghost config. (1.16)
- Scaling config keyed per-qualifier (`function:qualifier`); versions/aliases no longer collide. (1.17)

## Test plan
- s3 unit: `valid_bucket_names` extended (underscore/`..`/IPv4/reserved).
- e2e: `s3_put_object_rejects_checksum_mismatch`, `lambda_create_function_validates_timeout_upper_bound`, `lambda_put_concurrency_on_missing_function_is_not_found`.

## Surface
No new API surface (validation fixes to existing ops) → no SDK/docs/website/metadata change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent S3 upload corruption and tightens bucket-name rules, and aligns Lambda validations and scaling config behavior with AWS to prevent ghost configs and invalid inputs. No API changes.

- **Bug Fixes**
  - S3 `PutObject`: verify all provided `x-amz-checksum-<algo>` headers against the computed checksum; mismatch returns `BadDigest`.
  - S3 bucket names: reject underscores, adjacent `..`, IPv4-like names, and reserved prefixes/suffixes (`xn--`, `sthree-`, `amzn-s3-demo-`, `-s3alias`, `--ol-s3`, `.mrap`).
  - Lambda `CreateFunction`/`UpdateFunctionConfiguration`: validate `MemorySize`, `Timeout` (max 5400), `Runtime`, and field lengths.
  - Lambda `PutFunctionConcurrency`, `PutProvisionedConcurrencyConfig`, `PutFunctionScalingConfig`: return `ResourceNotFoundException` if the function does not exist.
  - Lambda scaling config: key per-qualifier (`function:qualifier`) to avoid version/alias collisions.

<sup>Written for commit a909020c041b771f30c7b1f871dfbdec0a95353b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

