### PR TITLE
fix(kms): key usage/state/spec validation + real ECDH DeriveSharedSecret (bug-hunt)

### DIFF
--- a/crates/fakecloud-e2e/tests/kms.rs
+++ b/crates/fakecloud-e2e/tests/kms.rs
@@ -1151,3 +1151,124 @@ async fn kms_generate_data_key_binds_encryption_context() {
         "decrypt with a different encryption context must fail"
     );
 }
+
+#[tokio::test]
+async fn kms_generate_data_key_rejects_non_encrypt_key() {
+    // Bug-hunt 1.18: GenerateDataKey must reject a key whose usage isn't
+    // ENCRYPT_DECRYPT (InvalidKeyUsageException), not silently succeed.
+    let server = helpers::TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client
+        .create_key()
+        .key_usage(aws_sdk_kms::types::KeyUsageType::SignVerify)
+        .key_spec(aws_sdk_kms::types::KeySpec::Rsa2048)
+        .send()
+        .await
+        .unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let result = client
+        .generate_data_key()
+        .key_id(&key_id)
+        .key_spec(aws_sdk_kms::types::DataKeySpec::Aes256)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "GenerateDataKey on a SIGN_VERIFY key must fail"
+    );
+}
+
+#[tokio::test]
+async fn kms_create_key_rejects_incompatible_spec_usage() {
+    // Bug-hunt 1.20: an HMAC spec with ENCRYPT_DECRYPT usage is unusable and
+    // must be rejected at CreateKey.
+    let server = helpers::TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let result = client
+        .create_key()
+        .key_spec(aws_sdk_kms::types::KeySpec::Hmac256)
+        .key_usage(aws_sdk_kms::types::KeyUsageType::EncryptDecrypt)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "HMAC + ENCRYPT_DECRYPT is incompatible and must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn kms_enable_key_rejects_pending_deletion() {
+    // Bug-hunt 1.19: EnableKey must not resurrect a key scheduled for deletion.
+    let server = helpers::TestServer::start().await;
+    let client = server.kms_client().await;
+
+    let key = client.create_key().send().await.unwrap();
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    client
+        .schedule_key_deletion()
+        .key_id(&key_id)
+        .pending_window_in_days(7)
+        .send()
+        .await
+        .unwrap();
+
+    let result = client.enable_key().key_id(&key_id).send().await;
+    assert!(
+        result.is_err(),
+        "EnableKey on a PendingDeletion key must fail (KMSInvalidStateException)"
+    );
+}
+
+#[tokio::test]
+async fn kms_derive_shared_secret_converges() {
+    // Bug-hunt 1.21: two parties running DeriveSharedSecret with each other's
+    // public key must derive the SAME secret (real ECDH), which the prior
+    // SHA-256(seed || peer) construction did not.
+    let server = helpers::TestServer::start().await;
+    let client = server.kms_client().await;
+
+    async fn make_agreement_key(
+        c: &aws_sdk_kms::Client,
+    ) -> (String, aws_sdk_kms::primitives::Blob) {
+        let k = c
+            .create_key()
+            .key_spec(aws_sdk_kms::types::KeySpec::EccNistP256)
+            .key_usage(aws_sdk_kms::types::KeyUsageType::KeyAgreement)
+            .send()
+            .await
+            .unwrap();
+        let id = k.key_metadata().unwrap().key_id().to_string();
+        let pk = c.get_public_key().key_id(&id).send().await.unwrap();
+        let spki = pk.public_key().unwrap().clone();
+        (id, spki)
+    }
+    let (id_a, pub_a) = make_agreement_key(&client).await;
+    let (id_b, pub_b) = make_agreement_key(&client).await;
+
+    let secret_a = client
+        .derive_shared_secret()
+        .key_id(&id_a)
+        .key_agreement_algorithm(aws_sdk_kms::types::KeyAgreementAlgorithmSpec::Ecdh)
+        .public_key(pub_b)
+        .send()
+        .await
+        .unwrap();
+    let secret_b = client
+        .derive_shared_secret()
+        .key_id(&id_b)
+        .key_agreement_algorithm(aws_sdk_kms::types::KeyAgreementAlgorithmSpec::Ecdh)
+        .public_key(pub_a)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        secret_a.shared_secret().unwrap().as_ref(),
+        secret_b.shared_secret().unwrap().as_ref(),
+        "both parties must derive identical shared secrets"
+    );
+}

--- a/crates/fakecloud-e2e/tests/kms.rs
+++ b/crates/fakecloud-e2e/tests/kms.rs
@@ -390,12 +390,31 @@ async fn kms_derive_shared_secret() {
         .unwrap();
     let key_id = resp.key_metadata().unwrap().key_id().to_string();
 
-    let fake_pub = Blob::new(vec![0x04; 65]); // Fake uncompressed EC point
+    // Real ECDH requires a valid SubjectPublicKeyInfo for the counterparty;
+    // use a second KEY_AGREEMENT key's public key.
+    let peer = client
+        .create_key()
+        .key_usage(aws_sdk_kms::types::KeyUsageType::KeyAgreement)
+        .key_spec(aws_sdk_kms::types::KeySpec::EccNistP256)
+        .send()
+        .await
+        .unwrap();
+    let peer_id = peer.key_metadata().unwrap().key_id().to_string();
+    let peer_pub = client
+        .get_public_key()
+        .key_id(&peer_id)
+        .send()
+        .await
+        .unwrap()
+        .public_key()
+        .unwrap()
+        .clone();
+
     let result = client
         .derive_shared_secret()
         .key_id(&key_id)
         .key_agreement_algorithm(aws_sdk_kms::types::KeyAgreementAlgorithmSpec::Ecdh)
-        .public_key(fake_pub)
+        .public_key(peer_pub)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-kms/Cargo.toml
+++ b/crates/fakecloud-kms/Cargo.toml
@@ -29,7 +29,7 @@ aes-gcm = "0.10"
 rsa = { workspace = true }
 rand = "0.8"
 signature = "2"
-p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
-p384 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
+p256 = { version = "0.13", features = ["ecdsa", "ecdh", "pkcs8"] }
+p384 = { version = "0.13", features = ["ecdsa", "ecdh", "pkcs8"] }
 k256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
 p521 = { version = "0.13", features = ["ecdsa", "pkcs8"] }

--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -540,6 +540,78 @@ pub(crate) fn require_usable_key_state(key: &KmsKey) -> Result<(), AwsServiceErr
     ))
 }
 
+/// The KeyUsage values compatible with a given KeySpec, per AWS KMS. An
+/// empty slice means the spec is unknown (leave validation to later paths).
+fn allowed_usages_for_key_spec(key_spec: &str) -> &'static [&'static str] {
+    match key_spec {
+        "SYMMETRIC_DEFAULT" => &["ENCRYPT_DECRYPT"],
+        s if s.starts_with("HMAC_") => &["GENERATE_VERIFY_MAC"],
+        s if s.starts_with("RSA_") => &["ENCRYPT_DECRYPT", "SIGN_VERIFY"],
+        // NIST curves support signing and key agreement.
+        "ECC_NIST_P256" | "ECC_NIST_P384" | "ECC_NIST_P521" => &["SIGN_VERIFY", "KEY_AGREEMENT"],
+        // secp256k1 supports signing only.
+        "ECC_SECG_P256K1" => &["SIGN_VERIFY"],
+        // SM2 (China regions) supports all three.
+        "SM2" => &["SIGN_VERIFY", "ENCRYPT_DECRYPT", "KEY_AGREEMENT"],
+        _ => &[],
+    }
+}
+
+/// CreateKey must reject a KeyUsage that is incompatible with the KeySpec
+/// (e.g. HMAC_256 + ENCRYPT_DECRYPT), which would otherwise create a key that
+/// no crypto operation can use. AWS returns ValidationException.
+pub(crate) fn validate_key_spec_usage(
+    key_spec: &str,
+    key_usage: &str,
+) -> Result<(), AwsServiceError> {
+    let allowed = allowed_usages_for_key_spec(key_spec);
+    if allowed.is_empty() || allowed.contains(&key_usage) {
+        return Ok(());
+    }
+    Err(AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ValidationException",
+        format!("KeyUsage {key_usage} is not compatible with KeySpec {key_spec}"),
+    ))
+}
+
+/// EnableKey / DisableKey may only transition a key that is currently
+/// `Enabled` or `Disabled`. Any other lifecycle state
+/// (`PendingDeletion`, `PendingImport`, `Unavailable`, ...) is a
+/// `KMSInvalidStateException`; in particular a scheduled-for-deletion key must
+/// not be resurrected without CancelKeyDeletion.
+pub(crate) fn require_enable_disable_transition(key: &KmsKey) -> Result<(), AwsServiceError> {
+    if key.key_state == "Enabled" || key.key_state == "Disabled" {
+        return Ok(());
+    }
+    Err(AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "KMSInvalidStateException",
+        format!(
+            "Key '{}' is not in a state that allows this operation (current state: {})",
+            key.arn, key.key_state
+        ),
+    ))
+}
+
+/// GenerateDataKey / GenerateDataKeyPair (and their `WithoutPlaintext`
+/// variants) require an `ENCRYPT_DECRYPT` key. A SIGN_VERIFY /
+/// GENERATE_VERIFY_MAC / KEY_AGREEMENT key must be rejected with
+/// `InvalidKeyUsageException`, matching the Encrypt/ReEncrypt paths.
+pub(crate) fn require_key_usage_encrypt_decrypt(key: &KmsKey) -> Result<(), AwsServiceError> {
+    if key.key_usage != "ENCRYPT_DECRYPT" {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "InvalidKeyUsageException",
+            format!(
+                "The operation failed because the KMS key {} is not enabled for the requested operation. The key usage must be ENCRYPT_DECRYPT but is {}.",
+                key.arn, key.key_usage
+            ),
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_key_usage_signing(
     key: &KmsKey,
     resolved: &str,
@@ -922,4 +994,29 @@ pub(crate) fn action_matches(policy_action: &str, requested_action: &str) -> boo
         }
     }
     false
+}
+
+#[cfg(test)]
+mod key_spec_usage_tests {
+    use super::validate_key_spec_usage;
+
+    #[test]
+    fn compatible_combos_pass() {
+        assert!(validate_key_spec_usage("SYMMETRIC_DEFAULT", "ENCRYPT_DECRYPT").is_ok());
+        assert!(validate_key_spec_usage("HMAC_256", "GENERATE_VERIFY_MAC").is_ok());
+        assert!(validate_key_spec_usage("RSA_2048", "SIGN_VERIFY").is_ok());
+        assert!(validate_key_spec_usage("RSA_2048", "ENCRYPT_DECRYPT").is_ok());
+        assert!(validate_key_spec_usage("ECC_NIST_P256", "KEY_AGREEMENT").is_ok());
+        assert!(validate_key_spec_usage("ECC_NIST_P256", "SIGN_VERIFY").is_ok());
+    }
+
+    #[test]
+    fn incompatible_combos_rejected() {
+        // HMAC key can't encrypt/decrypt.
+        assert!(validate_key_spec_usage("HMAC_256", "ENCRYPT_DECRYPT").is_err());
+        // Symmetric key can't sign.
+        assert!(validate_key_spec_usage("SYMMETRIC_DEFAULT", "SIGN_VERIFY").is_err());
+        // secp256k1 supports signing only.
+        assert!(validate_key_spec_usage("ECC_SECG_P256K1", "KEY_AGREEMENT").is_err());
+    }
 }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -546,6 +546,9 @@ impl KmsService {
 
     fn create_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let input = CreateKeyInput::from_body(&req.json_body())?;
+        // Reject incompatible KeySpec/KeyUsage combinations (e.g. an HMAC spec
+        // with ENCRYPT_DECRYPT) before minting a key no operation can use.
+        validate_key_spec_usage(&input.key_spec, &input.key_usage)?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -825,6 +828,11 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        // EnableKey is only valid from Enabled/Disabled. A key that is
+        // PendingDeletion / PendingImport / Unavailable must not be silently
+        // resurrected to Enabled — AWS returns KMSInvalidStateException (you
+        // must CancelKeyDeletion / import material first).
+        require_enable_disable_transition(key)?;
         key.enabled = true;
         key.key_state = "Enabled".to_string();
 
@@ -844,6 +852,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        require_enable_disable_transition(key)?;
         key.enabled = false;
         key.key_state = "Disabled".to_string();
 
@@ -1209,6 +1218,9 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        // Rotation cannot be toggled on a key pending deletion / import;
+        // AWS rejects with KMSInvalidStateException (Disabled -> DisabledException).
+        require_usable_key_state(key)?;
         // RotationPeriodInDays is optional; AWS validates 90..=2560 and
         // defaults to 365. Persist it so GetKeyRotationStatus echoes it back
         // instead of dropping it (bug-audit 2026-06-20, 1.24).
@@ -1251,6 +1263,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        require_usable_key_state(key)?;
         key.key_rotation_enabled = false;
 
         Ok(AwsResponse::json(StatusCode::OK, "{}"))
@@ -1269,6 +1282,7 @@ impl KmsService {
                 "Key state became inconsistent",
             )
         })?;
+        require_usable_key_state(key)?;
 
         let rotation = KeyRotation {
             key_id: key.key_id.clone(),

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -425,6 +425,7 @@ impl KmsService {
             )
         })?;
         require_usable_key_state(key)?;
+        require_key_usage_encrypt_decrypt(key)?;
 
         let num_bytes = data_key_size_from_body(&body)?;
 
@@ -485,6 +486,7 @@ impl KmsService {
             )
         })?;
         require_usable_key_state(key)?;
+        require_key_usage_encrypt_decrypt(key)?;
 
         let num_bytes = data_key_size_from_body(&body)?;
         let data_key_bytes: Vec<u8> = rand_bytes(num_bytes);
@@ -1066,6 +1068,7 @@ impl KmsService {
             )
         })?;
         require_usable_key_state(key)?;
+        require_key_usage_encrypt_decrypt(key)?;
 
         let (private_key_bytes, public_key_bytes) = generate_data_keypair_bytes(&key_pair_spec)?;
         let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
@@ -1128,6 +1131,7 @@ impl KmsService {
             )
         })?;
         require_usable_key_state(key)?;
+        require_key_usage_encrypt_decrypt(key)?;
 
         let (private_key_bytes, public_key_bytes) = generate_data_keypair_bytes(&key_pair_spec)?;
         let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(&public_key_bytes);
@@ -1167,7 +1171,7 @@ impl KmsService {
             .as_str()
             .unwrap_or("ECDH")
             .to_string();
-        let _public_key = body["PublicKey"].as_str().ok_or_else(|| {
+        let public_key_b64 = body["PublicKey"].as_str().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -1210,17 +1214,36 @@ impl KmsService {
             ));
         }
 
-        // Deterministic shared secret: SHA-256(private_key_seed || public_key_bytes)
-        // Both parties using the correct keys will derive the same result.
-        let public_key_bytes = base64::engine::general_purpose::STANDARD
-            .decode(_public_key)
-            .unwrap_or_default();
-
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(&key.private_key_seed);
-        hasher.update(&public_key_bytes);
-        let shared_secret_bytes = hasher.finalize();
+        // Real ECDH so both parties converge on the same secret:
+        // ECDH(privA, pubB) == ECDH(privB, pubA). The previous
+        // SHA-256(private_seed || peer_public) was asymmetric in its inputs,
+        // so A and B derived *different* secrets and the agreement was useless.
+        // KEY_AGREEMENT keys can only be ECC_NIST_P256/P384 here (CreateKey
+        // refuses P521/SM2), so those two curves cover every case.
+        let peer_spki_der = base64::engine::general_purpose::STANDARD
+            .decode(public_key_b64)
+            .map_err(|_| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    "PublicKey is not valid base64",
+                )
+            })?;
+        let priv_der = key.asymmetric_private_key_der.as_deref().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidKeyUsageException",
+                format!("Key '{}' has no asymmetric key material", key.arn),
+            )
+        })?;
+        let shared_secret_bytes = ecdh_shared_secret(&key.key_spec, priv_der, &peer_spki_der)
+            .map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("ECDH failed: {e}"),
+                )
+            })?;
         let shared_secret_b64 =
             base64::engine::general_purpose::STANDARD.encode(shared_secret_bytes);
 
@@ -1234,6 +1257,38 @@ impl KmsService {
             }))
             .unwrap(),
         ))
+    }
+}
+
+/// Real ECDH shared-secret derivation for KMS KEY_AGREEMENT keys. `priv_der`
+/// is our key's PKCS#8 private key; `peer_spki_der` is the counterparty's
+/// SubjectPublicKeyInfo. Returns the raw shared secret (the X coordinate),
+/// which is symmetric: `ecdh(a, B) == ecdh(b, A)`.
+fn ecdh_shared_secret(
+    key_spec: &str,
+    priv_der: &[u8],
+    peer_spki_der: &[u8],
+) -> Result<Vec<u8>, String> {
+    match key_spec {
+        "ECC_NIST_P256" => {
+            use p256::pkcs8::{DecodePrivateKey, DecodePublicKey};
+            let sk = p256::SecretKey::from_pkcs8_der(priv_der)
+                .map_err(|e| format!("bad P256 private key: {e}"))?;
+            let pk = p256::PublicKey::from_public_key_der(peer_spki_der)
+                .map_err(|e| format!("bad P256 peer public key: {e}"))?;
+            let shared = p256::ecdh::diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
+            Ok(shared.raw_secret_bytes().to_vec())
+        }
+        "ECC_NIST_P384" => {
+            use p384::pkcs8::{DecodePrivateKey, DecodePublicKey};
+            let sk = p384::SecretKey::from_pkcs8_der(priv_der)
+                .map_err(|e| format!("bad P384 private key: {e}"))?;
+            let pk = p384::PublicKey::from_public_key_der(peer_spki_der)
+                .map_err(|e| format!("bad P384 peer public key: {e}"))?;
+            let shared = p384::ecdh::diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine());
+            Ok(shared.raw_secret_bytes().to_vec())
+        }
+        other => Err(format!("unsupported KEY_AGREEMENT KeySpec: {other}")),
     }
 }
 
@@ -1283,4 +1338,44 @@ fn generate_data_keypair_bytes(key_pair_spec: &str) -> Result<(Vec<u8>, Vec<u8>)
         "ValidationException",
         format!("Unsupported KeyPairSpec: {key_pair_spec}"),
     ))
+}
+
+#[cfg(test)]
+mod ecdh_tests {
+    use super::ecdh_shared_secret;
+
+    /// ECDH must converge: ecdh(privA, pubB) == ecdh(privB, pubA). The prior
+    /// SHA-256(seed || peer) construction did not, making DeriveSharedSecret
+    /// useless for actual key agreement.
+    #[test]
+    fn ecdh_converges_p256() {
+        let (priv_a, pub_a) = super::super::asym_ecdsa::generate_keypair("ECC_NIST_P256")
+            .unwrap()
+            .unwrap();
+        let (priv_b, pub_b) = super::super::asym_ecdsa::generate_keypair("ECC_NIST_P256")
+            .unwrap()
+            .unwrap();
+        let a = ecdh_shared_secret("ECC_NIST_P256", &priv_a, &pub_b).unwrap();
+        let b = ecdh_shared_secret("ECC_NIST_P256", &priv_b, &pub_a).unwrap();
+        assert_eq!(a, b, "both parties must derive the same secret");
+        assert_eq!(
+            a.len(),
+            32,
+            "P256 shared secret is the 32-byte X coordinate"
+        );
+    }
+
+    #[test]
+    fn ecdh_converges_p384() {
+        let (priv_a, pub_a) = super::super::asym_ecdsa::generate_keypair("ECC_NIST_P384")
+            .unwrap()
+            .unwrap();
+        let (priv_b, pub_b) = super::super::asym_ecdsa::generate_keypair("ECC_NIST_P384")
+            .unwrap()
+            .unwrap();
+        let a = ecdh_shared_secret("ECC_NIST_P384", &priv_a, &pub_b).unwrap();
+        let b = ecdh_shared_secret("ECC_NIST_P384", &priv_b, &pub_a).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 48);
+    }
 }

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -320,6 +320,16 @@ fn generate_data_key_pair_ecc_returns_parseable_pkcs8_and_spki() {
     assert_eq!(secret.public_key(), public);
 }
 
+/// A fresh, valid P-256 SubjectPublicKeyInfo (base64), for use as a
+/// DeriveSharedSecret counterparty key. Real ECDH requires a parseable SPKI,
+/// so tests can no longer pass arbitrary bytes.
+fn real_p256_public_key_b64() -> String {
+    let (_priv_der, pub_der) = crate::service::asym_ecdsa::generate_keypair("ECC_NIST_P256")
+        .unwrap()
+        .unwrap();
+    base64::engine::general_purpose::STANDARD.encode(pub_der)
+}
+
 #[test]
 fn derive_shared_secret_success() {
     let svc = make_service();
@@ -331,7 +341,7 @@ fn derive_shared_secret_success() {
         }),
     );
 
-    let fake_pub = base64::engine::general_purpose::STANDARD.encode(b"fake-public-key");
+    let fake_pub = real_p256_public_key_b64();
     let req = make_request(
         "DeriveSharedSecret",
         json!({
@@ -717,7 +727,7 @@ fn derive_shared_secret_is_deterministic() {
         }),
     );
 
-    let pub_key = base64::engine::general_purpose::STANDARD.encode(b"counterparty-public-key");
+    let pub_key = real_p256_public_key_b64();
     let req = make_request(
         "DeriveSharedSecret",
         json!({
@@ -739,7 +749,7 @@ fn derive_shared_secret_is_deterministic() {
     assert_eq!(secret1, secret2, "DeriveSharedSecret must be deterministic");
 
     // Different public key must produce a different shared secret
-    let other_pub = base64::engine::general_purpose::STANDARD.encode(b"different-public-key");
+    let other_pub = real_p256_public_key_b64();
     let req2 = make_request(
         "DeriveSharedSecret",
         json!({


### PR DESCRIPTION
## Summary
Bug-hunt findings 1.18–1.21.

- `GenerateDataKey`/`GenerateDataKeyPair` (+ `WithoutPlaintext`) now require an `ENCRYPT_DECRYPT` key → `InvalidKeyUsageException`, matching Encrypt/ReEncrypt. (1.18)
- `EnableKey`/`DisableKey` reject a `PendingDeletion`/`PendingImport`/etc key (`KMSInvalidStateException`) instead of resurrecting it; `Enable/DisableKeyRotation` + `RotateKeyOnDemand` guard key_state too. (1.19)
- `CreateKey` validates KeySpec/KeyUsage compatibility (e.g. HMAC + ENCRYPT_DECRYPT rejected) before minting an unusable key. (1.20)
- `DeriveSharedSecret` computes a **real ECDH** shared secret (stored EC private key × peer SPKI), so both parties converge: `ecdh(a,B) == ecdh(b,A)`. Prior `SHA-256(seed ‖ peer_public)` never converged. Enables p256/p384 `ecdh` feature. (1.21)

## Test plan
- unit: `ecdh_converges_p256`/`_p384` (convergence + secret length), `key_spec_usage` compat matrix.
- e2e: `kms_generate_data_key_rejects_non_encrypt_key`, `kms_create_key_rejects_incompatible_spec_usage`, `kms_enable_key_rejects_pending_deletion`, `kms_derive_shared_secret_converges`.

## Surface
No new API surface (validation + crypto correctness on existing ops) → no SDK/docs/website/metadata change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns KMS behavior with AWS by enforcing key usage/state validation and using real ECDH for DeriveSharedSecret. Prevents unusable keys, returns correct errors, and ensures both parties derive the same shared secret.

- **Bug Fixes**
  - Require ENCRYPT_DECRYPT for GenerateDataKey/GenerateDataKeyPair (+ WithoutPlaintext); return InvalidKeyUsageException.
  - EnableKey/DisableKey only allowed from Enabled/Disabled; reject PendingDeletion/PendingImport/etc with KMSInvalidStateException. Apply same guard to Enable/DisableKeyRotation and RotateKeyOnDemand.
  - Validate KeySpec vs KeyUsage in CreateKey; reject incompatible combos (e.g., HMAC + ENCRYPT_DECRYPT) with ValidationException.
  - Implement real ECDH for DeriveSharedSecret (EC private key × peer SPKI) on P-256/P-384; validate base64/SPKI input and return ValidationException on bad keys so both sides converge.
  - Update DeriveSharedSecret tests to use real SPKI peer keys.

- **Dependencies**
  - Enable `ecdh` feature in `p256` and `p384`.

<sup>Written for commit 54ecdb258fc60bfb6b7b156dd5151ae5fa99862e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

