### PR TITLE
fix(iot): persist security-profile attachments + DeprecateThingType (bug-hunt)

### DIFF
--- a/crates/fakecloud-e2e/tests/iot.rs
+++ b/crates/fakecloud-e2e/tests/iot.rs
@@ -528,8 +528,7 @@ async fn iot_security_profile_attach_detach_reflected() {
         profiles
             .security_profile_target_mappings()
             .iter()
-            .any(|m| m
-                .security_profile_identifier().map(|i| i.name()) == Some("sp-1")),
+            .any(|m| m.security_profile_identifier().map(|i| i.name()) == Some("sp-1")),
         "profile must map to the target"
     );
 

--- a/crates/fakecloud-e2e/tests/iot.rs
+++ b/crates/fakecloud-e2e/tests/iot.rs
@@ -418,3 +418,137 @@ async fn iot_update_thing_groups_for_thing_reflected() {
         "got: {names:?}"
     );
 }
+
+#[tokio::test]
+async fn iot_deprecate_thing_type_reflected() {
+    // Bug-hunt 1.22: DeprecateThingType was an accept-and-discard no-op;
+    // DescribeThingType must reflect the deprecation, and undoDeprecate revert.
+    let server = TestServer::start().await;
+    let client = iot_client(&server).await;
+
+    client
+        .create_thing_type()
+        .thing_type_name("dep-type")
+        .send()
+        .await
+        .expect("create_thing_type");
+
+    client
+        .deprecate_thing_type()
+        .thing_type_name("dep-type")
+        .send()
+        .await
+        .expect("deprecate_thing_type");
+
+    let d = client
+        .describe_thing_type()
+        .thing_type_name("dep-type")
+        .send()
+        .await
+        .expect("describe_thing_type");
+    assert_eq!(
+        d.thing_type_metadata().map(|m| m.deprecated()),
+        Some(true),
+        "thing type must read as deprecated"
+    );
+
+    client
+        .deprecate_thing_type()
+        .thing_type_name("dep-type")
+        .undo_deprecate(true)
+        .send()
+        .await
+        .expect("undo deprecate");
+    let d = client
+        .describe_thing_type()
+        .thing_type_name("dep-type")
+        .send()
+        .await
+        .expect("describe_thing_type");
+    assert_eq!(
+        d.thing_type_metadata().map(|m| m.deprecated()),
+        Some(false),
+        "undoDeprecate must clear the flag"
+    );
+}
+
+#[tokio::test]
+async fn iot_security_profile_attach_detach_reflected() {
+    // Bug-hunt 1.22: Attach/DetachSecurityProfile + their list readers were
+    // no-ops. Attachment must round-trip through both list directions.
+    let server = TestServer::start().await;
+    let client = iot_client(&server).await;
+
+    client
+        .create_security_profile()
+        .security_profile_name("sp-1")
+        .send()
+        .await
+        .expect("create_security_profile");
+    // A thing group to use as the monitored target.
+    let grp = client
+        .create_thing_group()
+        .thing_group_name("sp-target")
+        .send()
+        .await
+        .expect("create_thing_group");
+    let target_arn = grp.thing_group_arn().expect("group arn").to_string();
+
+    client
+        .attach_security_profile()
+        .security_profile_name("sp-1")
+        .security_profile_target_arn(&target_arn)
+        .send()
+        .await
+        .expect("attach_security_profile");
+
+    // Forward: targets for the profile.
+    let targets = client
+        .list_targets_for_security_profile()
+        .security_profile_name("sp-1")
+        .send()
+        .await
+        .expect("list_targets_for_security_profile");
+    assert!(
+        targets
+            .security_profile_targets()
+            .iter()
+            .any(|t| t.arn() == target_arn.as_str()),
+        "attached target must be listed"
+    );
+
+    // Inverse: profiles for the target.
+    let profiles = client
+        .list_security_profiles_for_target()
+        .security_profile_target_arn(&target_arn)
+        .send()
+        .await
+        .expect("list_security_profiles_for_target");
+    assert!(
+        profiles
+            .security_profile_target_mappings()
+            .iter()
+            .any(|m| m
+                .security_profile_identifier().map(|i| i.name()) == Some("sp-1")),
+        "profile must map to the target"
+    );
+
+    // Detach clears both directions.
+    client
+        .detach_security_profile()
+        .security_profile_name("sp-1")
+        .security_profile_target_arn(&target_arn)
+        .send()
+        .await
+        .expect("detach_security_profile");
+    let targets = client
+        .list_targets_for_security_profile()
+        .security_profile_name("sp-1")
+        .send()
+        .await
+        .expect("list after detach");
+    assert!(
+        targets.security_profile_targets().is_empty(),
+        "detach must remove the target"
+    );
+}

--- a/crates/fakecloud-iot/src/service/special.rs
+++ b/crates/fakecloud-iot/src/service/special.rs
@@ -330,6 +330,45 @@ pub(super) fn dispatch(
         // `group-things` relation so ListThingGroupsForThing reflects it.
         "UpdateThingGroupsForThing" => Ok(Some(update_thing_groups_for_thing(svc, ctx, body))),
 
+        // Security-profile <-> target attachment. Target ARN is a query
+        // parameter; stored as a `profile-targets` relation the two list
+        // readers project (forward + inverse).
+        "AttachSecurityProfile" => Ok(Some(relate(
+            svc,
+            ctx,
+            true,
+            &[(
+                "profile-targets",
+                lbl(labels, "securityProfileName"),
+                query_get(query, "securityProfileTargetArn"),
+            )],
+        ))),
+        "DetachSecurityProfile" => Ok(Some(relate(
+            svc,
+            ctx,
+            false,
+            &[(
+                "profile-targets",
+                lbl(labels, "securityProfileName"),
+                query_get(query, "securityProfileTargetArn"),
+            )],
+        ))),
+        "ListTargetsForSecurityProfile" => Ok(Some(list_relation_objs(
+            svc,
+            ctx,
+            "profile-targets",
+            lbl(labels, "securityProfileName"),
+            "securityProfileTargets",
+            "arn",
+        ))),
+        "ListSecurityProfilesForTarget" => {
+            Ok(Some(list_security_profiles_for_target(svc, ctx, query)))
+        }
+
+        // DeprecateThingType flips the stored thing-type's metadata so
+        // DescribeThingType reflects it (previously an accept-and-discard no-op).
+        "DeprecateThingType" => Ok(Some(deprecate_thing_type(svc, ctx, meta, labels, body)?)),
+
         _ => Ok(None),
     }
 }
@@ -967,6 +1006,84 @@ fn list_security_profiles(svc: &IotService, ctx: &Ctx) -> (AwsResponse, bool) {
         ok_json(json!({ "securityProfileIdentifiers": identifiers })),
         false,
     )
+}
+
+/// Inverse of the `profile-targets` relation: every security profile attached
+/// to `securityProfileTargetArn`. Mirrors `list_attached_policies`.
+fn list_security_profiles_for_target(
+    svc: &IotService,
+    ctx: &Ctx,
+    query: &[(String, String)],
+) -> (AwsResponse, bool) {
+    let target = query_get(query, "securityProfileTargetArn");
+    let g = svc.state.read();
+    let data = g.get(&ctx.account);
+    let mut mappings = Vec::new();
+    if let (Some(target), Some(data)) = (target, data) {
+        for (key, targets) in &data.relations {
+            let Some(profile) = key.strip_prefix("profile-targets:") else {
+                continue;
+            };
+            if targets.iter().any(|t| t == target) {
+                // Prefer the stored profile's real ARN; fall back to a minted one.
+                let arn = data
+                    .get_resource("security-profiles", profile)
+                    .and_then(|r| r.get("securityProfileArn"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| mint_arn(ctx, "security-profiles", profile));
+                mappings.push(json!({
+                    "securityProfileIdentifier": { "name": profile, "arn": arn },
+                    "target": { "arn": target },
+                }));
+            }
+        }
+    }
+    (
+        ok_json(json!({ "securityProfileTargetMappings": mappings })),
+        false,
+    )
+}
+
+/// DeprecateThingType / undo: flip `thingTypeMetadata.deprecated` on the
+/// stored thing-type record so DescribeThingType round-trips the state, rather
+/// than accepting the call and discarding it.
+fn deprecate_thing_type(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let name = lbl(labels, "thingTypeName")
+        .ok_or_else(|| super::engine::not_found(meta, ""))?
+        .to_string();
+    let undo = body
+        .get("undoDeprecate")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(mut record) = data.get_resource(meta.rtype, &name).cloned() else {
+        return Err(super::engine::not_found(meta, &name));
+    };
+    if let Some(obj) = record.as_object_mut() {
+        let md = obj
+            .entry("thingTypeMetadata")
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(md) = md.as_object_mut() {
+            if undo {
+                md.insert("deprecated".to_string(), Value::Bool(false));
+                md.remove("deprecationDate");
+            } else {
+                md.insert("deprecated".to_string(), Value::Bool(true));
+                md.insert("deprecationDate".to_string(), super::now_epoch());
+            }
+        }
+    }
+    data.put_resource(meta.rtype, &name, record);
+    Ok((ok_json(Value::Object(Map::new())), true))
 }
 
 // ---------- audit suppressions ----------


### PR DESCRIPTION
## Summary
Continues #2278 on the IoT `Verb::Action` catch-all (finding 1.22), which accepted these ops and discarded them:

- `Attach`/`DetachSecurityProfile` store a `profile-targets` relation; `ListTargetsForSecurityProfile` (forward) and `ListSecurityProfilesForTarget` (inverse mapping) project it, so attachments round-trip.
- `DeprecateThingType` flips `thingTypeMetadata.deprecated` on the stored thing-type (`undoDeprecate` clears it) so `DescribeThingType` reflects it.

## Test plan
- e2e: `iot_deprecate_thing_type_reflected` (deprecate + undo), `iot_security_profile_attach_detach_reflected` (attach → both list directions → detach).

## Surface
No new API surface (implements existing ops) → no SDK/docs/metadata change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist IoT security profile attachments and make deprecating a thing type update stored metadata. Read/list APIs now reflect attachment and deprecation state.

- **Bug Fixes**
  - Attach/DetachSecurityProfile now stores a profile-to-target relation; ListTargetsForSecurityProfile and ListSecurityProfilesForTarget return it; detach removes it.
  - DeprecateThingType toggles thingTypeMetadata.deprecated (and deprecationDate); undoDeprecate resets it; DescribeThingType shows the state.

<sup>Written for commit 6d91e2c0f17794e9295443d212cded206e531042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

