### PR TITLE
fix(ssm): JIT access requests, automation signals, resource-data-sync type (bug-hunt)

### DIFF
--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -2497,3 +2497,129 @@ async fn ssm_lookup_tolerates_version_suffix() {
     assert_eq!(tag_list.len(), 1);
     assert_eq!(tag_list[0].key(), "env");
 }
+
+#[tokio::test]
+async fn ssm_get_access_token_requires_real_request() {
+    // Bug-hunt 1.23: GetAccessToken issued approved credentials for ANY id.
+    // A token must only be issued for a request created by StartAccessRequest.
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    // Unknown request id -> error, not fabricated credentials.
+    let bogus = client
+        .get_access_token()
+        .access_request_id("ar-doesnotexist")
+        .send()
+        .await;
+    assert!(
+        bogus.is_err(),
+        "unknown access request must not yield a token"
+    );
+
+    // Real flow: create a request, then exchange it.
+    let target = aws_sdk_ssm::types::Target::builder()
+        .key("InstanceIds")
+        .values("i-1234567890abcdef0")
+        .build();
+    let created = client
+        .start_access_request()
+        .reason("debugging prod incident")
+        .targets(target)
+        .send()
+        .await
+        .expect("start_access_request");
+    let id = created.access_request_id().unwrap().to_string();
+
+    let token = client
+        .get_access_token()
+        .access_request_id(&id)
+        .send()
+        .await
+        .expect("get_access_token");
+    assert_eq!(
+        token.access_request_status().map(|s| s.as_str()),
+        Some("Approved")
+    );
+    assert!(token.credentials().is_some());
+}
+
+#[tokio::test]
+async fn ssm_send_automation_signal_reject_cancels() {
+    // Bug-hunt 1.24: SendAutomationSignal was a no-op. Reject must move the
+    // execution to Cancelled.
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let start = client
+        .start_automation_execution()
+        .document_name("AWS-RunShellScript")
+        .send()
+        .await
+        .unwrap();
+    let exec_id = start.automation_execution_id().unwrap().to_string();
+
+    client
+        .send_automation_signal()
+        .automation_execution_id(&exec_id)
+        .signal_type(aws_sdk_ssm::types::SignalType::Reject)
+        .send()
+        .await
+        .expect("send_automation_signal");
+
+    let got = client
+        .get_automation_execution()
+        .automation_execution_id(&exec_id)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        got.automation_execution()
+            .unwrap()
+            .automation_execution_status()
+            .map(|s| s.as_str()),
+        Some("Cancelled"),
+        "Reject must cancel the execution"
+    );
+}
+
+#[tokio::test]
+async fn ssm_update_resource_data_sync_type_must_match() {
+    // Bug-hunt 1.25: UpdateResourceDataSync dropped SyncType; a mismatched
+    // type must be rejected.
+    let server = TestServer::start().await;
+    let client = server.ssm_client().await;
+
+    let source = aws_sdk_ssm::types::ResourceDataSyncSource::builder()
+        .source_type("SingleAccountMultiRegions")
+        .source_regions("us-east-1")
+        .build()
+        .unwrap();
+    client
+        .create_resource_data_sync()
+        .sync_name("mysync")
+        .sync_type("SyncFromSource")
+        .sync_source(source.clone())
+        .send()
+        .await
+        .expect("create_resource_data_sync");
+
+    // Wrong SyncType -> rejected.
+    let bad = client
+        .update_resource_data_sync()
+        .sync_name("mysync")
+        .sync_type("SyncToDestination")
+        .sync_source(source.clone())
+        .send()
+        .await;
+    assert!(bad.is_err(), "mismatched SyncType must be rejected");
+
+    // Matching SyncType -> ok.
+    client
+        .update_resource_data_sync()
+        .sync_name("mysync")
+        .sync_type("SyncFromSource")
+        .sync_source(source)
+        .send()
+        .await
+        .expect("matching SyncType update must succeed");
+}

--- a/crates/fakecloud-ssm/src/service/automation.rs
+++ b/crates/fakecloud-ssm/src/service/automation.rs
@@ -236,20 +236,67 @@ impl SsmService {
         let body = req.json_body();
         let exec_id = body["AutomationExecutionId"]
             .as_str()
-            .ok_or_else(|| missing("AutomationExecutionId"))?;
-        let _signal_type = body["SignalType"]
+            .ok_or_else(|| missing("AutomationExecutionId"))?
+            .to_string();
+        let signal_type = body["SignalType"]
             .as_str()
-            .ok_or_else(|| missing("SignalType"))?;
+            .ok_or_else(|| missing("SignalType"))?
+            .to_string();
 
-        let accounts = self.state.read();
-        let empty = SsmState::new(&req.account_id, &req.region);
-        let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        if !state.automation_executions.contains_key(exec_id) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "AutomationExecutionNotFoundException",
-                format!("Automation execution {exec_id} not found"),
-            ));
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let exec = state
+            .automation_executions
+            .get_mut(&exec_id)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "AutomationExecutionNotFoundException",
+                    format!("Automation execution {exec_id} not found"),
+                )
+            })?;
+
+        // Apply the signal so approval steps actually advance rather than the
+        // execution sitting in Pending/Waiting forever (previously a no-op).
+        let now = Utc::now();
+        match signal_type.as_str() {
+            "Approve" | "Resume" | "StartStep" => {
+                for s in &mut exec.step_executions {
+                    if s.step_status == "Pending" || s.step_status == "Waiting" {
+                        s.step_status = "Success".to_string();
+                        if s.execution_end_time.is_none() {
+                            s.execution_end_time = Some(now);
+                        }
+                    }
+                }
+                let all_done = exec
+                    .step_executions
+                    .iter()
+                    .all(|s| matches!(s.step_status.as_str(), "Success" | "Skipped"));
+                exec.automation_execution_status = if all_done {
+                    exec.execution_end_time = Some(now);
+                    "Success".to_string()
+                } else {
+                    "InProgress".to_string()
+                };
+            }
+            "Reject" | "StopStep" => {
+                for s in &mut exec.step_executions {
+                    if s.step_status == "Pending" || s.step_status == "Waiting" {
+                        s.step_status = "Cancelled".to_string();
+                        s.execution_end_time = Some(now);
+                    }
+                }
+                exec.automation_execution_status = "Cancelled".to_string();
+                exec.execution_end_time = Some(now);
+            }
+            _ => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidAutomationSignalException",
+                    format!("Unknown SignalType '{signal_type}'"),
+                ));
+            }
         }
 
         Ok(AwsResponse::ok_json(json!({})))

--- a/crates/fakecloud-ssm/src/service/resource_sync.rs
+++ b/crates/fakecloud-ssm/src/service/resource_sync.rs
@@ -124,7 +124,7 @@ impl SsmService {
         let sync_name = body["SyncName"]
             .as_str()
             .ok_or_else(|| missing("SyncName"))?;
-        let _sync_type = body["SyncType"]
+        let sync_type = body["SyncType"]
             .as_str()
             .ok_or_else(|| missing("SyncType"))?;
         let sync_source = body
@@ -144,6 +144,16 @@ impl SsmService {
                     format!("Sync {sync_name} not found"),
                 )
             })?;
+        // UpdateResourceDataSync only updates SyncFromSource syncs, and the
+        // SyncType must match the stored sync — AWS rejects a mismatch rather
+        // than silently ignoring the field.
+        if sync.sync_type.as_deref() != Some(sync_type) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceDataSyncInvalidConfigurationException",
+                format!("SyncType '{sync_type}' does not match the existing sync's type"),
+            ));
+        }
         sync.sync_source = Some(sync_source);
         sync.sync_last_modified_time = Utc::now();
 

--- a/crates/fakecloud-ssm/src/service/sessions.rs
+++ b/crates/fakecloud-ssm/src/service/sessions.rs
@@ -219,8 +219,8 @@ impl SsmService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         validate_optional_string_length("Reason", body["Reason"].as_str(), 1, 256)?;
-        let _reason = body["Reason"].as_str().ok_or_else(|| missing("Reason"))?;
-        let _targets = body["Targets"]
+        let reason = body["Reason"].as_str().ok_or_else(|| missing("Reason"))?;
+        let targets = body["Targets"]
             .as_array()
             .ok_or_else(|| missing("Targets"))?;
 
@@ -228,6 +228,19 @@ impl SsmService {
         let state = accounts.get_or_create(&req.account_id);
         state.session_counter += 1;
         let access_request_id = format!("ar-{:012x}", state.session_counter);
+        // Persist the request (auto-approved, no human approver) so
+        // GetAccessToken reflects its Reason/Targets rather than discarding
+        // them and issuing a token for any arbitrary id.
+        state.access_requests.insert(
+            access_request_id.clone(),
+            crate::state::SsmAccessRequest {
+                access_request_id: access_request_id.clone(),
+                reason: reason.to_string(),
+                targets: json!(targets),
+                status: "Approved".to_string(),
+                created: Utc::now(),
+            },
+        );
 
         Ok(AwsResponse::ok_json(
             json!({ "AccessRequestId": access_request_id }),
@@ -239,16 +252,39 @@ impl SsmService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _access_request_id = body["AccessRequestId"]
+        let access_request_id = body["AccessRequestId"]
             .as_str()
             .ok_or_else(|| missing("AccessRequestId"))?;
 
+        let accounts = self.state.read();
+        // A token can only be issued for a real, previously-created request.
+        // Returning approved credentials for an unknown id (the old behavior)
+        // is a security-relevant fiction.
+        let request = accounts
+            .get(&req.account_id)
+            .and_then(|s| s.access_requests.get(access_request_id))
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Access request {access_request_id} does not exist"),
+                )
+            })?;
+
+        if request.status != "Approved" {
+            return Ok(AwsResponse::ok_json(json!({
+                "AccessRequestStatus": request.status,
+            })));
+        }
+
+        // Deterministic per-request session token so repeated calls are stable.
+        let session_token = format!("FwoGZXIvYXdz{access_request_id}");
         Ok(AwsResponse::ok_json(json!({
-            "AccessRequestStatus": "Approved",
+            "AccessRequestStatus": request.status,
             "Credentials": {
                 "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
                 "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "SessionToken": "FwoGZXIvYXdzEA...",
+                "SessionToken": session_token,
                 "ExpirationTime": Utc::now().timestamp_millis() as f64 / 1000.0 + 3600.0,
             },
         })))

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -396,6 +396,18 @@ pub struct SsmSession {
     pub reason: Option<String>,
 }
 
+/// A just-in-time access request created by StartAccessRequest and consumed
+/// by GetAccessToken. There is no human approver in the emulator, so requests
+/// are auto-approved, but the request must exist for a token to be issued.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SsmAccessRequest {
+    pub access_request_id: String,
+    pub reason: String,
+    pub targets: serde_json::Value,
+    pub status: String,
+    pub created: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SsmActivation {
     pub activation_id: String,
@@ -487,6 +499,10 @@ pub struct SsmState {
     /// Defaults to empty when deserializing pre-existing snapshots.
     #[serde(default)]
     pub cloud_connectors: BTreeMap<String, CloudConnector>,
+    /// Just-in-time access requests keyed by AccessRequestId. Defaults to
+    /// empty when deserializing pre-existing snapshots.
+    #[serde(default)]
+    pub access_requests: BTreeMap<String, SsmAccessRequest>,
 }
 
 /// A cloud connector federating an external cloud provider (Azure) into SSM.
@@ -557,6 +573,7 @@ impl SsmState {
             execution_preview_counter: 0,
             parameter_policy_events: Vec::new(),
             cloud_connectors: BTreeMap::new(),
+            access_requests: BTreeMap::new(),
         };
         state.seed_defaults();
         state
@@ -597,6 +614,7 @@ impl SsmState {
         self.execution_preview_counter = 0;
         self.parameter_policy_events.clear();
         self.cloud_connectors.clear();
+        self.access_requests.clear();
         self.seed_defaults();
     }
 


### PR DESCRIPTION
## Summary
Bug-hunt findings 1.23–1.25.

- **StartAccessRequest / GetAccessToken (1.23)**: requests are now persisted (Reason/Targets); `GetAccessToken` issues a token only for a real, approved request, instead of returning approved credentials for any arbitrary id.
- **SendAutomationSignal (1.24)**: applies the signal — Approve/Resume/StartStep advance Pending/Waiting steps (completing the execution when all are done); Reject/StopStep cancel it. Previously validated then discarded.
- **UpdateResourceDataSync (1.25)**: validates the supplied `SyncType` matches the stored sync instead of silently dropping it.

New state: `SsmState.access_requests` (serde-default; `new()` + `reset()` updated).

## Test plan
- e2e: `ssm_get_access_token_requires_real_request`, `ssm_send_automation_signal_reject_cancels`, `ssm_update_resource_data_sync_type_must_match`.

## Surface
No new API surface (implements/validates existing ops) → no SDK/docs/metadata change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSM JIT access requests, automation signal handling, and resource data sync type validation. Prevents tokens for unknown IDs, applies signals to progress or cancel executions, and rejects mismatched sync types.

- **Bug Fixes**
  - StartAccessRequest/GetAccessToken: persist Reason/Targets; issue a token only for an existing approved request; stable per-request session token.
  - SendAutomationSignal: Approve/Resume/StartStep advance Pending/Waiting steps and finish when all succeed; Reject/StopStep cancel the execution.
  - UpdateResourceDataSync: require `SyncType` to match the stored sync; reject mismatches.

- **Refactors**
  - Added `SsmState.access_requests` (serde-default); updated constructor and reset.

<sup>Written for commit 4625405be08ce264d68e4c27ede30dbb044cfbd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

