### PR TITLE
fix(iotwireless): persist thing/certificate/partner-account associations (bug-hunt)

### DIFF
--- a/crates/fakecloud-e2e/tests/iotwireless.rs
+++ b/crates/fakecloud-e2e/tests/iotwireless.rs
@@ -285,3 +285,106 @@ async fn iotwireless_stub_fixes_round_trip() {
         .expect("send_data_to_wireless_device");
     assert!(sent.message_id().is_some_and(|m| !m.is_empty()));
 }
+
+#[tokio::test]
+async fn iotwireless_gateway_thing_and_certificate_associations() {
+    // Bug-hunt 1.22: Associate*WithThing / *WithCertificate were accept-and-
+    // discard no-ops. Associations must round-trip through the reads.
+    let server = TestServer::start().await;
+    let client = iotwireless_client(&server).await;
+
+    let gw = client
+        .create_wireless_gateway()
+        .lo_ra_wan(
+            aws_sdk_iotwireless::types::LoRaWanGateway::builder()
+                .gateway_eui("0000000000000001")
+                .rf_region("US915")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create_wireless_gateway");
+    let gw_id = gw.id().expect("gateway id").to_string();
+
+    // Associate with an IoT thing.
+    let thing_arn = "arn:aws:iot:us-east-1:000000000000:thing/gw-thing";
+    client
+        .associate_wireless_gateway_with_thing()
+        .id(&gw_id)
+        .thing_arn(thing_arn)
+        .send()
+        .await
+        .expect("associate_wireless_gateway_with_thing");
+    let got = client
+        .get_wireless_gateway()
+        .identifier(&gw_id)
+        .identifier_type(aws_sdk_iotwireless::types::WirelessGatewayIdType::WirelessGatewayId)
+        .send()
+        .await
+        .expect("get_wireless_gateway");
+    assert_eq!(got.thing_arn(), Some(thing_arn));
+    assert_eq!(got.thing_name(), Some("gw-thing"));
+
+    // Associate a certificate.
+    client
+        .associate_wireless_gateway_with_certificate()
+        .id(&gw_id)
+        .iot_certificate_id("cert-abc123")
+        .send()
+        .await
+        .expect("associate_wireless_gateway_with_certificate");
+    let cert = client
+        .get_wireless_gateway_certificate()
+        .id(&gw_id)
+        .send()
+        .await
+        .expect("get_wireless_gateway_certificate");
+    assert_eq!(cert.iot_certificate_id(), Some("cert-abc123"));
+
+    // Disassociate the thing clears it.
+    client
+        .disassociate_wireless_gateway_from_thing()
+        .id(&gw_id)
+        .send()
+        .await
+        .expect("disassociate_wireless_gateway_from_thing");
+    let got = client
+        .get_wireless_gateway()
+        .identifier(&gw_id)
+        .identifier_type(aws_sdk_iotwireless::types::WirelessGatewayIdType::WirelessGatewayId)
+        .send()
+        .await
+        .expect("get after disassociate");
+    assert!(got.thing_arn().is_none() || got.thing_arn() == Some(""));
+}
+
+#[tokio::test]
+async fn iotwireless_partner_account_association() {
+    // Bug-hunt 1.22: AssociateAwsAccountWithPartnerAccount persisted nothing.
+    let server = TestServer::start().await;
+    let client = iotwireless_client(&server).await;
+
+    client
+        .associate_aws_account_with_partner_account()
+        .sidewalk(
+            aws_sdk_iotwireless::types::SidewalkAccountInfo::builder()
+                .amazon_id("amzn-partner-1")
+                .app_server_private_key("0123456789abcdef")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("associate_aws_account_with_partner_account");
+
+    let list = client
+        .list_partner_accounts()
+        .send()
+        .await
+        .expect("list_partner_accounts");
+    assert!(
+        list.sidewalk()
+            .iter()
+            .any(|s| s.amazon_id() == Some("amzn-partner-1")),
+        "partner account must be listed"
+    );
+}

--- a/crates/fakecloud-iotwireless/src/service/special.rs
+++ b/crates/fakecloud-iotwireless/src/service/special.rs
@@ -149,6 +149,63 @@ pub(super) fn dispatch(
             &fuota_multicast_key(labels),
             labels.get("MulticastGroupId").map(String::as_str),
         ))),
+        // Wireless device/gateway <-> IoT thing. Sets ThingArn/ThingName on
+        // the stored record so GetWirelessDevice/GetWirelessGateway reflect it.
+        "AssociateWirelessDeviceWithThing" => Ok(Some(associate_thing(
+            svc,
+            ctx,
+            "wireless-devices",
+            labels.get("Id").map(String::as_str),
+            body,
+        ))),
+        "DisassociateWirelessDeviceFromThing" => Ok(Some(disassociate_thing(
+            svc,
+            ctx,
+            "wireless-devices",
+            labels.get("Id").map(String::as_str),
+        ))),
+        "AssociateWirelessGatewayWithThing" => Ok(Some(associate_thing(
+            svc,
+            ctx,
+            "wireless-gateways",
+            labels.get("Id").map(String::as_str),
+            body,
+        ))),
+        "DisassociateWirelessGatewayFromThing" => Ok(Some(disassociate_thing(
+            svc,
+            ctx,
+            "wireless-gateways",
+            labels.get("Id").map(String::as_str),
+        ))),
+
+        // Wireless gateway <-> IoT certificate.
+        "AssociateWirelessGatewayWithCertificate" => Ok(Some(associate_gateway_certificate(
+            svc,
+            ctx,
+            labels.get("Id").map(String::as_str),
+            body,
+        ))),
+        "DisassociateWirelessGatewayFromCertificate" => Ok(Some(disassociate_thing_field(
+            svc,
+            ctx,
+            "wireless-gateways",
+            labels.get("Id").map(String::as_str),
+            &["IotCertificateId"],
+        ))),
+        "GetWirelessGatewayCertificate" => {
+            Ok(Some(get_wireless_gateway_certificate(svc, ctx, labels)))
+        }
+
+        // AWS-account <-> Sidewalk partner account.
+        "AssociateAwsAccountWithPartnerAccount" => {
+            Ok(Some(associate_partner_account(svc, ctx, body)))
+        }
+        "DisassociateAwsAccountFromPartnerAccount" => Ok(Some(disassociate_partner_account(
+            svc,
+            ctx,
+            labels.get("PartnerAccountId").map(String::as_str),
+        ))),
+
         "ListMulticastGroupsByFuotaTask" => {
             Ok(Some(list_multicast_groups_by_fuota_task(svc, ctx, labels)))
         }
@@ -700,6 +757,148 @@ fn disassociate(
         let mut g = svc.state.write();
         let data = g.get_or_create(&ctx.account);
         data.remove_relation(key, member);
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// Set `ThingArn` (+ derived `ThingName`) on a stored wireless device/gateway
+/// record so the matching Get reflects the association.
+fn associate_thing(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    rtype: &str,
+    id: Option<&str>,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let (Some(id), Some(thing_arn)) = (id, body.get("ThingArn").and_then(Value::as_str)) else {
+        return (ok_json(Value::Object(Map::new())), false);
+    };
+    let thing_name = thing_arn
+        .rsplit_once("thing/")
+        .map(|(_, n)| n)
+        .unwrap_or("");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(record) = data.get_resource(rtype, id).cloned() {
+        let mut record = record;
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("ThingArn".to_string(), json!(thing_arn));
+            obj.insert("ThingName".to_string(), json!(thing_name));
+        }
+        data.put_resource(rtype, id, record);
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// Clear `ThingArn`/`ThingName` on a wireless device/gateway record.
+fn disassociate_thing(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    rtype: &str,
+    id: Option<&str>,
+) -> (AwsResponse, bool) {
+    disassociate_thing_field(svc, ctx, rtype, id, &["ThingArn", "ThingName"])
+}
+
+/// Remove the named fields from a stored record (used by the disassociate ops).
+fn disassociate_thing_field(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    rtype: &str,
+    id: Option<&str>,
+    fields: &[&str],
+) -> (AwsResponse, bool) {
+    if let Some(id) = id {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        if let Some(mut record) = data.get_resource(rtype, id).cloned() {
+            if let Some(obj) = record.as_object_mut() {
+                for f in fields {
+                    obj.remove(*f);
+                }
+            }
+            data.put_resource(rtype, id, record);
+        }
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// Store `IotCertificateId` on the wireless-gateway record.
+fn associate_gateway_certificate(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    id: Option<&str>,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let (Some(id), Some(cert)) = (id, body.get("IotCertificateId").and_then(Value::as_str)) else {
+        return (ok_json(Value::Object(Map::new())), false);
+    };
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(mut record) = data.get_resource("wireless-gateways", id).cloned() {
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("IotCertificateId".to_string(), json!(cert));
+        }
+        data.put_resource("wireless-gateways", id, record);
+    }
+    (ok_json(json!({ "IotCertificateId": cert })), true)
+}
+
+/// GetWirelessGatewayCertificate (a Verb::Action, so not served by the generic
+/// engine): project the cert id stored on the gateway record.
+fn get_wireless_gateway_certificate(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Id").map(String::as_str).unwrap_or("");
+    let g = svc.state.read();
+    let cert = g
+        .get(&ctx.account)
+        .and_then(|d| d.get_resource("wireless-gateways", id))
+        .and_then(|r| r.get("IotCertificateId"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    (ok_json(json!({ "IotCertificateId": cert })), false)
+}
+
+/// Persist a Sidewalk partner-account association keyed by its AmazonId so
+/// GetPartnerAccount / ListPartnerAccounts (generic reads) reflect it.
+fn associate_partner_account(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let sidewalk = body.get("Sidewalk").cloned().unwrap_or(json!({}));
+    let amazon_id = sidewalk
+        .get("AmazonId")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let record = json!({
+        "Sidewalk": sidewalk,
+        "PartnerAccountId": amazon_id,
+        "PartnerType": "Sidewalk",
+    });
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.put_resource("partner-accounts", &amazon_id, record.clone());
+    (ok_json(record), true)
+}
+
+/// Remove a partner-account association.
+fn disassociate_partner_account(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    id: Option<&str>,
+) -> (AwsResponse, bool) {
+    if let Some(id) = id {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        data.resources
+            .get_mut("partner-accounts")
+            .map(|m| m.remove(id));
     }
     (ok_json(Value::Object(Map::new())), true)
 }

--- a/crates/fakecloud-iotwireless/src/service/special.rs
+++ b/crates/fakecloud-iotwireless/src/service/special.rs
@@ -863,6 +863,24 @@ fn get_wireless_gateway_certificate(
     (ok_json(json!({ "IotCertificateId": cert })), false)
 }
 
+/// A deterministic 64-character hex digest of an input, standing in for the
+/// SHA-256 fingerprint AWS reports for a Sidewalk app-server private key. Built
+/// from eight salted FNV-1a folds so the same key always maps to the same
+/// digest without pulling in a crypto dependency.
+fn fingerprint_hex(input: &str) -> String {
+    let mut out = String::with_capacity(64);
+    for salt in 0u8..8 {
+        let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+        hash ^= salt as u64;
+        for b in input.bytes() {
+            hash ^= b as u64;
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        out.push_str(&format!("{hash:016x}"));
+    }
+    out
+}
+
 /// Persist a Sidewalk partner-account association keyed by its AmazonId so
 /// GetPartnerAccount / ListPartnerAccounts (generic reads) reflect it.
 fn associate_partner_account(
@@ -876,8 +894,26 @@ fn associate_partner_account(
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
+    // AWS returns a fingerprint of the app-server private key, never the key
+    // itself. Derive a deterministic 64-hex digest so Get/List round-trip.
+    let private_key = sidewalk
+        .get("AppServerPrivateKey")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let fingerprint = fingerprint_hex(private_key);
+    // The SidewalkAccountInfoWithFingerprint the reads project carries the
+    // AmazonId + Fingerprint (never the private key).
+    let sidewalk_with_fp = json!({
+        "AmazonId": amazon_id,
+        "Fingerprint": fingerprint,
+    });
+    // Store the projected list-element members (AmazonId/Fingerprint/Arn) at the
+    // top level so the generic ListPartnerAccounts projection finds them, and
+    // keep the nested Sidewalk object for GetPartnerAccount.
     let record = json!({
-        "Sidewalk": sidewalk,
+        "AmazonId": amazon_id,
+        "Fingerprint": fingerprint,
+        "Sidewalk": sidewalk_with_fp,
         "PartnerAccountId": amazon_id,
         "PartnerType": "Sidewalk",
     });


### PR DESCRIPTION
## Summary
Completes bug-hunt finding 1.22 (the iot half shipped in #2281). The IoTWireless `Verb::Action` catch-all accepted these association ops and discarded them; now persisted so reads reflect them:

- `Associate`/`DisassociateWirelessDeviceWithThing` + gateway variants set/clear `ThingArn` (+ derived `ThingName`) on the stored record.
- `Associate`/`DisassociateWirelessGatewayWithCertificate` store `IotCertificateId`; `GetWirelessGatewayCertificate` (a Verb::Action) reads it back.
- `Associate`/`DisassociateAwsAccountWithPartnerAccount` persist the Sidewalk partner account so `GetPartnerAccount`/`ListPartnerAccounts` reflect it.

## Test plan
- e2e: `iotwireless_gateway_thing_and_certificate_associations` (thing + cert round-trip + disassociate), `iotwireless_partner_account_association`.

## Surface
No new API surface (implements existing ops) → no SDK/docs/metadata change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist IoT Wireless associations for Things, certificates, and Sidewalk partner accounts so read APIs return them. Fixes bug-hunt finding 1.22; no API changes.

- **Bug Fixes**
  - Device/gateway ↔ Thing: set/clear ThingArn and ThingName on stored records so GetWirelessDevice/GetWirelessGateway show the link.
  - Gateway ↔ certificate: persist IotCertificateId and return it via GetWirelessGatewayCertificate; disassociate clears it.
  - Account ↔ Sidewalk partner: store association keyed by AmazonId and project AmazonId/Fingerprint at the top level so ListPartnerAccounts shows it; derive a deterministic fingerprint from AppServerPrivateKey (never store the key); disassociate removes it.

<sup>Written for commit 4bc5e2442db61ece83c698326bbb4de8af52b004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

