### PR TITLE
fix(glue,sagemaker,pipes,sns,scheduler): persist versions/status + honor DLQ + FIFO/EB params (bug-hunt)

### DIFF
--- a/crates/fakecloud-core/src/delivery.rs
+++ b/crates/fakecloud-core/src/delivery.rs
@@ -19,6 +19,8 @@ pub struct DeliveryBus {
     kinesis_sender: Option<Arc<dyn KinesisDelivery>>,
     /// Start Step Functions executions.
     stepfunctions_starter: Option<Arc<dyn StepFunctionsDelivery>>,
+    /// Start SageMaker pipeline executions (Scheduler sagemaker target).
+    sagemaker_pipeline_starter: Option<Arc<dyn SageMakerPipelineDelivery>>,
     /// Write objects to S3 buckets.
     s3_writer: Option<Arc<dyn S3Delivery>>,
     /// Put records into Firehose delivery streams.
@@ -194,6 +196,14 @@ pub trait StepFunctionsDelivery: Send + Sync {
     /// Start a state machine execution with the given input.
     /// The state machine is identified by ARN.
     fn start_execution(&self, state_machine_arn: &str, input: &str);
+}
+
+/// Cross-service SageMaker pipeline dispatch used by EventBridge Scheduler's
+/// `sagemaker:pipeline` target. The pipeline is identified by ARN
+/// (`arn:aws:sagemaker:<region>:<account>:pipeline/<name>`); `parameters` is the
+/// target's `PipelineParameterList`.
+pub trait SageMakerPipelineDelivery: Send + Sync {
+    fn start_pipeline_execution(&self, pipeline_arn: &str, parameters: &serde_json::Value);
 }
 
 /// Cross-service Kinesis Data Firehose dispatch used by services
@@ -385,6 +395,7 @@ impl DeliveryBus {
             lambda_invoker: None,
             kinesis_sender: None,
             stepfunctions_starter: None,
+            sagemaker_pipeline_starter: None,
             s3_writer: None,
             firehose_sender: None,
             ses_dispatcher: None,
@@ -676,6 +687,18 @@ impl DeliveryBus {
     pub fn put_record_to_kinesis(&self, stream_arn: &str, data: &str, partition_key: &str) {
         if let Some(ref sender) = self.kinesis_sender {
             sender.put_record(stream_arn, data, partition_key);
+        }
+    }
+
+    pub fn with_sagemaker_pipeline(mut self, starter: Arc<dyn SageMakerPipelineDelivery>) -> Self {
+        self.sagemaker_pipeline_starter = Some(starter);
+        self
+    }
+
+    /// Start a SageMaker pipeline execution if a starter is wired.
+    pub fn start_sagemaker_pipeline(&self, pipeline_arn: &str, parameters: &serde_json::Value) {
+        if let Some(ref starter) = self.sagemaker_pipeline_starter {
+            starter.start_pipeline_execution(pipeline_arn, parameters);
         }
     }
 

--- a/crates/fakecloud-e2e/tests/glue.rs
+++ b/crates/fakecloud-e2e/tests/glue.rs
@@ -191,6 +191,95 @@ async fn table_lifecycle() {
 }
 
 #[tokio::test]
+async fn table_versions_are_archived_on_create_and_update() {
+    let server = TestServer::start().await;
+    let glue = server.glue_client().await;
+
+    glue.create_database()
+        .database_input(DatabaseInput::builder().name("versdb").build().unwrap())
+        .send()
+        .await
+        .expect("create db");
+
+    glue.create_table()
+        .database_name("versdb")
+        .table_input(table_input("t"))
+        .send()
+        .await
+        .expect("create table");
+
+    // A create archives version 1.
+    let v1 = glue
+        .get_table_versions()
+        .database_name("versdb")
+        .table_name("t")
+        .send()
+        .await
+        .expect("get versions after create");
+    assert_eq!(v1.table_versions().len(), 1);
+    assert_eq!(v1.table_versions()[0].version_id(), Some("1"));
+
+    // An update archives a second version with the mutated table.
+    glue.update_table()
+        .database_name("versdb")
+        .table_input(
+            TableInput::builder()
+                .name("t")
+                .description("updated description")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("update table");
+
+    let v2 = glue
+        .get_table_versions()
+        .database_name("versdb")
+        .table_name("t")
+        .send()
+        .await
+        .expect("get versions after update");
+    assert_eq!(
+        v2.table_versions().len(),
+        2,
+        "update must archive a new version"
+    );
+
+    // GetTableVersion with no VersionId returns the latest (2), reflecting the
+    // updated description rather than a synthesized default.
+    let latest = glue
+        .get_table_version()
+        .database_name("versdb")
+        .table_name("t")
+        .send()
+        .await
+        .expect("get latest version");
+    let tv = latest.table_version().expect("table version");
+    assert_eq!(tv.version_id(), Some("2"));
+    assert_eq!(
+        tv.table().and_then(|t| t.description()),
+        Some("updated description")
+    );
+
+    // Deleting the table purges its version archive.
+    glue.delete_table()
+        .database_name("versdb")
+        .name("t")
+        .send()
+        .await
+        .expect("delete");
+    let after = glue
+        .get_table_versions()
+        .database_name("versdb")
+        .table_name("t")
+        .send()
+        .await
+        .expect("get versions after delete");
+    assert!(after.table_versions().is_empty());
+}
+
+#[tokio::test]
 async fn partition_lifecycle() {
     let server = TestServer::start().await;
     let glue = server.glue_client().await;

--- a/crates/fakecloud-e2e/tests/sagemaker.rs
+++ b/crates/fakecloud-e2e/tests/sagemaker.rs
@@ -193,6 +193,59 @@ async fn sagemaker_pipeline_execution_round_trip() {
     );
 }
 
+/// Stop*/Start* lifecycle ops must advance the target resource's status so a
+/// subsequent Describe reflects the transition instead of the default state.
+#[tokio::test]
+async fn sagemaker_notebook_instance_stop_start_transitions_status() {
+    let server = TestServer::start().await;
+    let client = sagemaker_client(&server).await;
+
+    client
+        .create_notebook_instance()
+        .notebook_instance_name("nb-1")
+        .instance_type(aws_sdk_sagemaker::types::InstanceType::MlT2Medium)
+        .role_arn("arn:aws:iam::000000000000:role/SageMakerRole")
+        .send()
+        .await
+        .expect("create_notebook_instance");
+
+    client
+        .stop_notebook_instance()
+        .notebook_instance_name("nb-1")
+        .send()
+        .await
+        .expect("stop_notebook_instance");
+    let stopped = client
+        .describe_notebook_instance()
+        .notebook_instance_name("nb-1")
+        .send()
+        .await
+        .expect("describe after stop");
+    assert_eq!(
+        stopped.notebook_instance_status(),
+        Some(&aws_sdk_sagemaker::types::NotebookInstanceStatus::Stopped),
+        "StopNotebookInstance must move status to Stopped"
+    );
+
+    client
+        .start_notebook_instance()
+        .notebook_instance_name("nb-1")
+        .send()
+        .await
+        .expect("start_notebook_instance");
+    let started = client
+        .describe_notebook_instance()
+        .notebook_instance_name("nb-1")
+        .send()
+        .await
+        .expect("describe after start");
+    assert_eq!(
+        started.notebook_instance_status(),
+        Some(&aws_sdk_sagemaker::types::NotebookInstanceStatus::InService),
+        "StartNotebookInstance must move status to InService"
+    );
+}
+
 /// `AddAssociation` is the only creation path for a lineage edge; the edge must
 /// then be listed and deletable.
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -264,6 +264,114 @@ async fn sns_publish_delivers_to_sqs_subscriber() {
     assert_eq!(envelope["TopicArn"], topic_arn);
 }
 
+/// An SQS subscriber whose target queue is gone must route the notification to
+/// the subscription's RedrivePolicy DLQ instead of silently dropping it — the
+/// DLQ was previously honored for HTTP subscribers only.
+#[tokio::test]
+async fn sns_sqs_subscriber_failure_routes_to_dlq() {
+    let server = TestServer::start().await;
+    let sns = server.sns_client().await;
+    let sqs = server.sqs_client().await;
+
+    async fn queue_arn(sqs: &aws_sdk_sqs::Client, url: &str) -> String {
+        sqs.get_queue_attributes()
+            .queue_url(url)
+            .attribute_names(QueueAttributeName::QueueArn)
+            .send()
+            .await
+            .unwrap()
+            .attributes()
+            .unwrap()
+            .get(&QueueAttributeName::QueueArn)
+            .unwrap()
+            .to_string()
+    }
+
+    // Main queue (will be deleted) + DLQ.
+    let main_url = sqs
+        .create_queue()
+        .queue_name("dlq-main")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let main_arn = queue_arn(&sqs, &main_url).await;
+    let dlq_url = sqs
+        .create_queue()
+        .queue_name("dlq-target")
+        .send()
+        .await
+        .unwrap()
+        .queue_url()
+        .unwrap()
+        .to_string();
+    let dlq_arn = queue_arn(&sqs, &dlq_url).await;
+
+    let topic_arn = sns
+        .create_topic()
+        .name("dlq-topic")
+        .send()
+        .await
+        .unwrap()
+        .topic_arn()
+        .unwrap()
+        .to_string();
+    let sub_arn = sns
+        .subscribe()
+        .topic_arn(&topic_arn)
+        .protocol("sqs")
+        .endpoint(&main_arn)
+        .return_subscription_arn(true)
+        .send()
+        .await
+        .unwrap()
+        .subscription_arn()
+        .unwrap()
+        .to_string();
+    sns.set_subscription_attributes()
+        .subscription_arn(&sub_arn)
+        .attribute_name("RedrivePolicy")
+        .attribute_value(format!(r#"{{"deadLetterTargetArn":"{dlq_arn}"}}"#))
+        .send()
+        .await
+        .unwrap();
+
+    // Delete the subscribed queue so delivery fails.
+    sqs.delete_queue()
+        .queue_url(&main_url)
+        .send()
+        .await
+        .unwrap();
+
+    sns.publish()
+        .topic_arn(&topic_arn)
+        .message("to-dlq")
+        .send()
+        .await
+        .unwrap();
+
+    // The notification must land in the DLQ.
+    let msgs = sqs
+        .receive_message()
+        .queue_url(&dlq_url)
+        .max_number_of_messages(10)
+        .wait_time_seconds(1)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        msgs.messages().len(),
+        1,
+        "failed delivery must route to DLQ"
+    );
+    assert!(
+        msgs.messages()[0].body().unwrap().contains("to-dlq"),
+        "DLQ envelope should wrap the original message"
+    );
+}
+
 /// Subscribing Lambda/email/sms protocols should succeed (stub delivery).
 #[tokio::test]
 async fn sns_subscribe_lambda_email_sms() {

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -1101,26 +1101,27 @@ impl GlueService {
         if db.tables.contains_key(&name) {
             return Err(already_exists(format!("Table {name} already exists")));
         }
-        db.tables.insert(
-            name.clone(),
-            Table {
-                name,
-                database_name: db_name,
-                description: input["Description"].as_str().map(|s| s.to_string()),
-                owner: input["Owner"].as_str().map(|s| s.to_string()),
-                create_time: now,
-                update_time: now,
-                last_access_time: None,
-                retention: input["Retention"].as_i64().unwrap_or(0),
-                storage_descriptor: parse_storage_descriptor(&input["StorageDescriptor"]),
-                partition_keys: parse_columns(&input["PartitionKeys"]),
-                view_original_text: input["ViewOriginalText"].as_str().map(|s| s.to_string()),
-                view_expanded_text: input["ViewExpandedText"].as_str().map(|s| s.to_string()),
-                table_type: input["TableType"].as_str().map(|s| s.to_string()),
-                parameters: parse_string_map(&input["Parameters"]),
-                partitions: BTreeMap::new(),
-            },
-        );
+        let table = Table {
+            name: name.clone(),
+            database_name: db_name.clone(),
+            description: input["Description"].as_str().map(|s| s.to_string()),
+            owner: input["Owner"].as_str().map(|s| s.to_string()),
+            create_time: now,
+            update_time: now,
+            last_access_time: None,
+            retention: input["Retention"].as_i64().unwrap_or(0),
+            storage_descriptor: parse_storage_descriptor(&input["StorageDescriptor"]),
+            partition_keys: parse_columns(&input["PartitionKeys"]),
+            view_original_text: input["ViewOriginalText"].as_str().map(|s| s.to_string()),
+            view_expanded_text: input["ViewExpandedText"].as_str().map(|s| s.to_string()),
+            table_type: input["TableType"].as_str().map(|s| s.to_string()),
+            parameters: parse_string_map(&input["Parameters"]),
+            partitions: BTreeMap::new(),
+        };
+        let tv_json = table_json(&table);
+        db.tables.insert(name.clone(), table);
+        // Archive the initial version so GetTableVersion(s) return real data.
+        state.archive_table_version(&db_name, &name, tv_json);
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -1224,6 +1225,10 @@ impl GlueService {
         if let Some(r) = input["Retention"].as_i64() {
             t.retention = r;
         }
+        // Snapshot the mutated table as a new archived version (Glue bumps the
+        // VersionId on every UpdateTable).
+        let tv_json = table_json(t);
+        state.archive_table_version(db_name, name, tv_json);
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -1242,6 +1247,7 @@ impl GlueService {
         if db.tables.remove(name).is_none() {
             return Err(entity_not_found(format!("Table {name} not found")));
         }
+        state.purge_table_versions(db_name, name);
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-glue/src/state.rs
+++ b/crates/fakecloud-glue/src/state.rs
@@ -221,6 +221,50 @@ impl GlueState {
     pub fn dbs_in_mut(&mut self, region: &str) -> &mut BTreeMap<String, Database> {
         self.databases.entry(region.to_string()).or_default()
     }
+
+    fn tv_prefix(db: &str, table: &str) -> String {
+        format!("{db}\u{1f}{table}\u{1f}")
+    }
+
+    /// Version ids currently archived for a table, sorted ascending.
+    pub fn table_version_ids(&self, db: &str, table: &str) -> Vec<i64> {
+        let prefix = Self::tv_prefix(db, table);
+        let mut ids: Vec<i64> = self
+            .table_versions
+            .keys()
+            .filter_map(|k| k.strip_prefix(&prefix))
+            .filter_map(|v| v.parse::<i64>().ok())
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    /// Archive a new version of a table (`table_json` is the projected Table
+    /// object) and return the assigned VersionId. Glue assigns monotonically
+    /// increasing integer version ids per table starting at 1.
+    pub fn archive_table_version(&mut self, db: &str, table: &str, table_json: Value) -> String {
+        let next = self
+            .table_version_ids(db, table)
+            .last()
+            .copied()
+            .unwrap_or(0)
+            + 1;
+        let key = format!("{}{next}", Self::tv_prefix(db, table));
+        self.table_versions.insert(
+            key,
+            serde_json::json!({
+                "Table": table_json,
+                "VersionId": next.to_string(),
+            }),
+        );
+        next.to_string()
+    }
+
+    /// Drop every archived version of a table (used on DeleteTable).
+    pub fn purge_table_versions(&mut self, db: &str, table: &str) {
+        let prefix = Self::tv_prefix(db, table);
+        self.table_versions.retain(|k, _| !k.starts_with(&prefix));
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -779,15 +779,29 @@ impl GlueService {
         let body = req.json_body();
         let db = req_str(&body, "DatabaseName")?;
         let table = req_str(&body, "TableName")?;
-        let version = body
-            .get("VersionId")
-            .and_then(|v| v.as_str())
-            .unwrap_or("1");
+        let requested = body.get("VersionId").and_then(|v| v.as_str());
         let accounts = self.state.read();
-        // Synthesize a version from the live table when no archived version exists.
-        let tbl = accounts
+        let st = accounts
             .get(&req.account_id)
-            .and_then(|s| s.dbs_in(&req.region))
+            .ok_or_else(|| entity_not_found(format!("Table {table} not found")))?;
+        // Prefer the archived version store; default to the latest version when
+        // no VersionId is supplied.
+        let version = match requested {
+            Some(v) => v.to_string(),
+            None => st
+                .table_version_ids(db, table)
+                .last()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "1".to_string()),
+        };
+        let tv_key = Self::tv_key(db, table, &version);
+        if let Some(tv) = st.table_versions.get(&tv_key) {
+            return Ok(AwsResponse::ok_json(json!({ "TableVersion": tv })));
+        }
+        // Fall back to synthesizing from the live table (tables created before
+        // the archive existed, or restored from an older snapshot).
+        let tbl = st
+            .dbs_in(&req.region)
             .and_then(|dbs| dbs.get(db))
             .and_then(|d| d.tables.get(table))
             .ok_or_else(|| entity_not_found(format!("Table {table} not found")))?;
@@ -807,12 +821,30 @@ impl GlueService {
         let db = req_str(&body, "DatabaseName")?;
         let table = req_str(&body, "TableName")?;
         let accounts = self.state.read();
-        let tbl = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.dbs_in(&req.region))
+        let st = match accounts.get(&req.account_id) {
+            Some(s) => s,
+            None => return Ok(AwsResponse::ok_json(json!({ "TableVersions": [] }))),
+        };
+        // Return the full archive, newest first (Glue orders descending).
+        let ids = st.table_version_ids(db, table);
+        if !ids.is_empty() {
+            let versions: Vec<Value> = ids
+                .iter()
+                .rev()
+                .filter_map(|n| {
+                    st.table_versions
+                        .get(&Self::tv_key(db, table, &n.to_string()))
+                })
+                .cloned()
+                .collect();
+            return Ok(AwsResponse::ok_json(json!({ "TableVersions": versions })));
+        }
+        // Fall back to a synthesized single version for pre-archive tables.
+        let versions = match st
+            .dbs_in(&req.region)
             .and_then(|dbs| dbs.get(db))
-            .and_then(|d| d.tables.get(table));
-        let versions = match tbl {
+            .and_then(|d| d.tables.get(table))
+        {
             Some(t) => vec![json!({
                 "Table": crate::service::table_json(t), "VersionId": "1",
             })],

--- a/crates/fakecloud-sagemaker/src/lib.rs
+++ b/crates/fakecloud-sagemaker/src/lib.rs
@@ -48,3 +48,57 @@ pub use service::{SageMakerService, SAGEMAKER_ACTIONS};
 pub use state::{
     SageMakerData, SageMakerSnapshot, SharedSageMakerState, SAGEMAKER_SNAPSHOT_SCHEMA_VERSION,
 };
+
+/// Start a SageMaker pipeline execution from a cross-service delivery (an
+/// EventBridge Scheduler `sagemaker:pipeline` target). Persists a
+/// `PipelineExecution` record keyed by its minted ARN so
+/// DescribePipelineExecution / ListPipelineExecutions resolve it — the same
+/// shape the `StartPipelineExecution` API produces. `pipeline_arn` is
+/// `arn:aws:sagemaker:<region>:<account>:pipeline/<name>`; `parameters` is the
+/// target's `PipelineParameterList` (a JSON array, echoed onto the record).
+pub fn start_pipeline_execution_from_delivery(
+    state: &SharedSageMakerState,
+    pipeline_arn: &str,
+    parameters: &serde_json::Value,
+) {
+    let parts: Vec<&str> = pipeline_arn.split(':').collect();
+    let region = parts.get(3).copied().unwrap_or("us-east-1");
+    let account = parts.get(4).copied().unwrap_or_default();
+    let pipeline_name = pipeline_arn
+        .rsplit_once("pipeline/")
+        .map(|(_, n)| n)
+        .unwrap_or_default();
+    if account.is_empty() || pipeline_name.is_empty() {
+        tracing::warn!(%pipeline_arn, "scheduler->sagemaker: malformed pipeline ARN, skipping");
+        return;
+    }
+
+    let mut g = state.write();
+    let data = g.get_or_create(account);
+    let exec_id = service::mint_id(account, "PipelineExecution", &data.next_seq().to_string());
+    let exec_arn = format!(
+        "arn:aws:sagemaker:{region}:{account}:pipeline/{pipeline_name}/execution/{exec_id}"
+    );
+    let mut record = serde_json::Map::new();
+    record.insert(
+        "PipelineExecutionArn".to_string(),
+        serde_json::Value::String(exec_arn.clone()),
+    );
+    record.insert(
+        "PipelineArn".to_string(),
+        serde_json::Value::String(pipeline_arn.to_string()),
+    );
+    record.insert(
+        "PipelineExecutionStatus".to_string(),
+        serde_json::Value::String("Executing".to_string()),
+    );
+    record.insert("StartTime".to_string(), service::now_epoch());
+    if parameters.is_array() {
+        record.insert("PipelineParameters".to_string(), parameters.clone());
+    }
+    data.put_resource(
+        "PipelineExecution",
+        &exec_arn,
+        serde_json::Value::Object(record),
+    );
+}

--- a/crates/fakecloud-sagemaker/src/service/engine.rs
+++ b/crates/fakecloud-sagemaker/src/service/engine.rs
@@ -398,7 +398,7 @@ pub(super) fn get(
 /// A best-effort resource identifier from a request body, used to derive ARNs /
 /// names for an action's synthesised output members: the first `*Arn`, else the
 /// first `*Name` / `*Id`, else the first string member.
-fn action_key(body: &Map<String, Value>) -> String {
+pub(super) fn action_key(body: &Map<String, Value>) -> String {
     let str_members: Vec<(&String, &str)> = body
         .iter()
         .filter_map(|(k, v)| v.as_str().map(|s| (k, s)))

--- a/crates/fakecloud-sagemaker/src/service/special.rs
+++ b/crates/fakecloud-sagemaker/src/service/special.rs
@@ -42,8 +42,81 @@ pub(super) fn dispatch(
         "ImportHubContent" => Ok(Some(import_hub_content(svc, ctx, meta, body))),
         "AddAssociation" => Ok(Some(add_association(svc, ctx, meta, body))),
         "DeleteAssociation" => Ok(Some(delete_association(svc, ctx, body))),
+        op if is_lifecycle_transition(op) => Ok(lifecycle_transition(svc, ctx, meta, body)),
         _ => Ok(None),
     }
+}
+
+/// `Start*` / `Stop*` operations that transition a stored resource's status.
+/// `StartPipelineExecution` is handled separately above (it *creates* a record),
+/// and `StartSession` opens a session rather than transitioning a resource, so
+/// both are excluded here.
+fn is_lifecycle_transition(op: &str) -> bool {
+    (op.starts_with("Start") || op.starts_with("Stop"))
+        && op != "StartPipelineExecution"
+        && op != "StartSession"
+}
+
+/// The settled status a resource reports after a `Start*` (`started=true`) or
+/// `Stop*` transition. Values are real members of each family's status enum;
+/// families not listed fall back to the generic job lifecycle
+/// (`InService` / `Stopped`).
+fn transition_status(family: &str, started: bool) -> &'static str {
+    match (family, started) {
+        ("NotebookInstance", true) => "InService",
+        ("NotebookInstance", false) => "Stopped",
+        ("MonitoringSchedule", true) => "Scheduled",
+        ("MonitoringSchedule", false) => "Stopped",
+        ("InferenceExperiment", true) => "Running",
+        ("InferenceExperiment", false) => "Cancelled",
+        ("MlflowTrackingServer", true) => "Created",
+        ("MlflowTrackingServer", false) => "Stopped",
+        // Batch/async jobs and everything else: a Stop settles to Stopped; a
+        // Start (rare for jobs) returns the resource to service.
+        (_, true) => "InService",
+        (_, false) => "Stopped",
+    }
+}
+
+/// Apply a `Start*` / `Stop*` transition to the target resource's `{Family}Status`
+/// member (or the single `*Status` member it carries) so a subsequent Describe
+/// reflects the new state instead of the stale one. Returns the standard action
+/// output. If no matching record exists, returns `None` so the caller falls back
+/// to the generic no-op action response (matching AWS, which 4xx's only when the
+/// resource is absent — but our engine has no such record to reject against).
+fn lifecycle_transition(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> Option<(AwsResponse, bool)> {
+    let started = meta.op.starts_with("Start");
+    let new_status = transition_status(meta.family, started);
+    let ident = super::engine::action_key(body);
+
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let key = data.resolve_key(meta.family, &ident)?;
+    let rec = data.get_resource_mut(meta.family, &key)?;
+    let obj = rec.as_object_mut()?;
+
+    // Prefer an existing `*Status` member; otherwise write the canonical
+    // `{Family}Status`. A freshly-created record often carries no status member
+    // at all (status is server-derived), so we must insert one — otherwise a
+    // Describe would keep synthesising the default "healthy" status and the
+    // Stop/Start would appear to do nothing.
+    let canonical = format!("{}Status", meta.family);
+    let status_key = if obj.contains_key(&canonical) {
+        canonical
+    } else {
+        obj.keys()
+            .find(|k| k.ends_with("Status"))
+            .filter(|_| obj.keys().filter(|k| k.ends_with("Status")).count() == 1)
+            .cloned()
+            .unwrap_or(canonical)
+    };
+    obj.insert(status_key, Value::String(new_status.to_string()));
+    Some((super::engine::action(ctx, meta, body), true))
 }
 
 fn str_member(body: &Map<String, Value>, key: &str) -> String {

--- a/crates/fakecloud-sagemaker/src/state.rs
+++ b/crates/fakecloud-sagemaker/src/state.rs
@@ -48,6 +48,11 @@ impl SageMakerData {
         self.resources.get(family).and_then(|m| m.get(id))
     }
 
+    /// Fetch a mutable resource record by family + id.
+    pub fn get_resource_mut(&mut self, family: &str, id: &str) -> Option<&mut Value> {
+        self.resources.get_mut(family).and_then(|m| m.get_mut(id))
+    }
+
     /// Insert / replace a resource record.
     pub fn put_resource(&mut self, family: &str, id: &str, record: Value) {
         self.resources

--- a/crates/fakecloud-scheduler/src/delivery.rs
+++ b/crates/fakecloud-scheduler/src/delivery.rs
@@ -66,17 +66,29 @@ pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(),
     if arn.contains(":events:") {
         let bus_name = event_bus_name_from_arn(arn);
         let target_account = account_id_from_arn(arn);
+        // EventBridgeParameters.{Source, DetailType} are REQUIRED by AWS for an
+        // EventBridge bus target and populate the emitted event's source /
+        // detail-type; falling back to the scheduler defaults only when absent.
+        let eb_params = schedule.target.eventbridge_parameters.as_ref();
+        let source = eb_params
+            .and_then(|p| p.get("Source"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("aws.scheduler");
+        let detail_type = eb_params
+            .and_then(|p| p.get("DetailType"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("Scheduled Event");
         match target_account {
             Some(account) => bus.put_event_to_eventbridge_for_account(
-                "aws.scheduler",
-                "Scheduled Event",
+                source,
+                detail_type,
                 body,
                 &bus_name,
                 &account,
             ),
-            None => {
-                bus.put_event_to_eventbridge("aws.scheduler", "Scheduled Event", body, &bus_name)
-            }
+            None => bus.put_event_to_eventbridge(source, detail_type, body, &bus_name),
         }
         return Ok(());
     }
@@ -93,6 +105,20 @@ pub fn deliver_target(bus: &Arc<DeliveryBus>, schedule: &Schedule) -> Result<(),
             .unwrap_or(&schedule.name)
             .to_string();
         bus.send_to_kinesis(arn, body, &partition_key);
+        return Ok(());
+    }
+
+    // Templated SageMaker pipeline target: ARN names the pipeline,
+    // SageMakerPipelineParameters carries the PipelineParameterList.
+    if arn.contains(":sagemaker:") && arn.contains(":pipeline/") {
+        let params = schedule
+            .target
+            .sagemaker_pipeline_parameters
+            .as_ref()
+            .and_then(|p| p.get("PipelineParameterList"))
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::Array(vec![]));
+        bus.start_sagemaker_pipeline(arn, &params);
         return Ok(());
     }
 
@@ -580,6 +606,72 @@ mod tests {
         assert_eq!(calls[0].0, "arn:aws:kinesis:us-east-1:1:stream/orders");
         assert_eq!(calls[0].1, r#"{"order":42}"#);
         assert_eq!(calls[0].2, "tenant-7");
+    }
+
+    #[test]
+    fn deliver_target_eventbridge_uses_source_and_detail_type_params() {
+        struct EbRec(Mutex<Vec<(String, String, String, String)>>);
+        impl fakecloud_core::delivery::EventBridgeDelivery for EbRec {
+            fn put_event(&self, source: &str, detail_type: &str, detail: &str, bus_name: &str) {
+                self.0.lock().unwrap().push((
+                    source.to_string(),
+                    detail_type.to_string(),
+                    detail.to_string(),
+                    bus_name.to_string(),
+                ));
+            }
+        }
+        let eb = Arc::new(EbRec(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_eventbridge(eb.clone()));
+        let mut sched = make_schedule(
+            "arn:aws:events:us-east-1:1:event-bus/app-bus",
+            None,
+            Some(r#"{"k":"v"}"#),
+        );
+        sched.target.eventbridge_parameters =
+            Some(serde_json::json!({"Source": "my.app", "DetailType": "OrderPlaced"}));
+        let result = deliver_target(&bus, &sched);
+        assert!(result.is_ok());
+        let calls = eb.0.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "my.app", "Source must come from params");
+        assert_eq!(
+            calls[0].1, "OrderPlaced",
+            "DetailType must come from params"
+        );
+        assert_eq!(calls[0].3, "app-bus");
+    }
+
+    #[test]
+    fn deliver_target_sagemaker_pipeline_starts_execution() {
+        struct SmRec(Mutex<Vec<(String, serde_json::Value)>>);
+        impl fakecloud_core::delivery::SageMakerPipelineDelivery for SmRec {
+            fn start_pipeline_execution(&self, pipeline_arn: &str, parameters: &serde_json::Value) {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push((pipeline_arn.to_string(), parameters.clone()));
+            }
+        }
+        let sm = Arc::new(SmRec(Mutex::new(Vec::new())));
+        let bus = Arc::new(DeliveryBus::new().with_sagemaker_pipeline(sm.clone()));
+        let mut sched = make_schedule(
+            "arn:aws:sagemaker:us-east-1:1:pipeline/my-pipeline",
+            None,
+            Some("{}"),
+        );
+        sched.target.sagemaker_pipeline_parameters = Some(serde_json::json!({
+            "PipelineParameterList": [{"Name": "p1", "Value": "v1"}]
+        }));
+        let result = deliver_target(&bus, &sched);
+        assert!(result.is_ok());
+        let calls = sm.0.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].0,
+            "arn:aws:sagemaker:us-east-1:1:pipeline/my-pipeline"
+        );
+        assert_eq!(calls[0].1[0]["Name"], "p1");
     }
 
     #[test]

--- a/crates/fakecloud-server/src/hooks.rs
+++ b/crates/fakecloud-server/src/hooks.rs
@@ -260,6 +260,23 @@ impl fakecloud_core::delivery::EcsTaskRunner for EcsTaskRunnerImpl {
     }
 }
 
+/// SageMaker pipeline starter used by EventBridge Scheduler's
+/// `sagemaker:pipeline` target: persists a PipelineExecution record so the
+/// Describe/List pipeline-execution ops resolve it.
+pub(crate) struct SageMakerPipelineDeliveryImpl {
+    pub(crate) state: fakecloud_sagemaker::SharedSageMakerState,
+}
+
+impl fakecloud_core::delivery::SageMakerPipelineDelivery for SageMakerPipelineDeliveryImpl {
+    fn start_pipeline_execution(&self, pipeline_arn: &str, parameters: &serde_json::Value) {
+        fakecloud_sagemaker::start_pipeline_execution_from_delivery(
+            &self.state,
+            pipeline_arn,
+            parameters,
+        );
+    }
+}
+
 /// SMS dispatcher used by Cognito's verification flow: append to the SNS
 /// account's `sms_messages` so test code can assert on what landed.
 pub(crate) struct SnsSmsDispatcher {

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -6608,6 +6608,11 @@ async fn main() {
             Arc::new(EcsTaskRunnerImpl {
                 service: ecs_service_for_scheduler.clone(),
             });
+        let sagemaker_pipeline_for_scheduler: Arc<
+            dyn fakecloud_core::delivery::SageMakerPipelineDelivery,
+        > = Arc::new(hooks::SageMakerPipelineDeliveryImpl {
+            state: sagemaker_state.clone(),
+        });
         let mut bus = DeliveryBus::new()
             .with_sqs(sqs_delivery.clone())
             .with_sns(sns_delivery_for_scheduler)
@@ -6615,7 +6620,8 @@ async fn main() {
             .with_stepfunctions(sfn_delivery_for_scheduler)
             .with_kinesis(kinesis_delivery_for_scheduler)
             .with_ses_dispatcher(ses_dispatcher_for_scheduler)
-            .with_ecs_task_runner(ecs_runner_for_scheduler);
+            .with_ecs_task_runner(ecs_runner_for_scheduler)
+            .with_sagemaker_pipeline(sagemaker_pipeline_for_scheduler);
         if let Some(ref ld) = lambda_delivery {
             bus = bus.with_lambda(ld.clone());
         }

--- a/crates/fakecloud-server/src/pipes_runner.rs
+++ b/crates/fakecloud-server/src/pipes_runner.rs
@@ -24,7 +24,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use base64::Engine;
@@ -68,6 +68,14 @@ struct RunningPipe {
     /// AT_TIMESTAMP); ignored for SQS.
     starting_position: Option<String>,
     starting_position_timestamp: Option<f64>,
+    /// `SourceParameters.{Kinesis,DynamoDB}StreamParameters.MaximumRetryAttempts`.
+    /// `None` (or a negative value) means retry forever — AWS's default. A
+    /// non-negative value caps retries before the poison batch is routed to the
+    /// DLQ and the checkpoint advances past it.
+    max_retry_attempts: Option<i64>,
+    /// `...StreamParameters.DeadLetterConfig.Arn` — where an exhausted batch is
+    /// sent so a poison record can't wedge the stream forever.
+    dlq_arn: Option<String>,
 }
 
 pub struct PipesRunner {
@@ -89,6 +97,11 @@ pub struct PipesRunner {
     /// Set by `set_checkpoint`; drained once per poll to flush at most one
     /// snapshot per cycle rather than one per delivered record.
     checkpoints_dirty: Arc<AtomicBool>,
+    /// Per-window delivery-failure counts for stream sources, keyed by
+    /// `{pipe_arn}\u{1f}{window_head_sequence}`. Drives MaximumRetryAttempts:
+    /// once a window's count exceeds the cap it is routed to the DLQ and the
+    /// checkpoint advances past it so a poison record can't wedge the stream.
+    retry_counts: Mutex<HashMap<String, i64>>,
 }
 
 impl PipesRunner {
@@ -106,6 +119,7 @@ impl PipesRunner {
             kms_hook: None,
             persist_hook: None,
             checkpoints_dirty: Arc::new(AtomicBool::new(false)),
+            retry_counts: Mutex::new(HashMap::new()),
         }
     }
 
@@ -218,6 +232,8 @@ impl PipesRunner {
                 let batch_size = source_batch_size(source_params, &source_kind);
                 let (starting_position, starting_position_timestamp) =
                     starting_position(source_params, &source_kind);
+                let (max_retry_attempts, dlq_arn) =
+                    stream_retry_config(source_params, &source_kind);
                 let target_params = pipe.get("TargetParameters").cloned();
                 let input_template = target_params
                     .as_ref()
@@ -254,6 +270,8 @@ impl PipesRunner {
                     batch_size,
                     starting_position,
                     starting_position_timestamp,
+                    max_retry_attempts,
+                    dlq_arn,
                 });
             }
         }
@@ -511,9 +529,8 @@ impl PipesRunner {
                 .map(|r| kinesis_source_event(r, &window.shard_id, &pipe.source_arn, &region))
                 .collect();
             let key = format!("{}#{}", pipe.arn, window.shard_id);
-            if self.process_stream_window(pipe, events).await {
-                self.set_checkpoint(&account, &key, window.last_seq);
-            }
+            self.deliver_stream_window(&account, &key, window.last_seq, pipe, events)
+                .await;
         }
     }
 
@@ -591,8 +608,83 @@ impl PipesRunner {
         let Some(last_seq) = last_seq else {
             return;
         };
+        let arn = pipe.arn.clone();
+        self.deliver_stream_window(&account, &arn, last_seq, pipe, events)
+            .await;
+    }
+
+    /// Deliver one stream window and apply the checkpoint + retry policy:
+    ///
+    /// * On success the checkpoint advances and the window's failure count is
+    ///   cleared.
+    /// * On failure the window's failure count is bumped. Once it exceeds
+    ///   `MaximumRetryAttempts` (a non-negative cap), the batch is routed to the
+    ///   configured DLQ (if any) and the checkpoint advances past it so a poison
+    ///   record can't wedge the stream forever. A negative/absent cap means
+    ///   retry indefinitely (AWS default), so the checkpoint stays put.
+    async fn deliver_stream_window(
+        &self,
+        account: &str,
+        checkpoint_key: &str,
+        window_head_seq: String,
+        pipe: &RunningPipe,
+        events: Vec<Value>,
+    ) {
+        let retry_key = format!("{checkpoint_key}\u{1f}{window_head_seq}");
+        // Retain a copy for the DLQ before delivery consumes the batch.
+        let events_for_dlq = events.clone();
         if self.process_stream_window(pipe, events).await {
-            self.set_checkpoint(&account, &pipe.arn, last_seq);
+            self.set_checkpoint(account, checkpoint_key, window_head_seq);
+            self.retry_counts.lock().unwrap().remove(&retry_key);
+            return;
+        }
+        let attempts = {
+            let mut counts = self.retry_counts.lock().unwrap();
+            let c = counts.entry(retry_key.clone()).or_insert(0);
+            *c += 1;
+            *c
+        };
+        if let Some(max) = pipe.max_retry_attempts {
+            if max >= 0 && attempts > max {
+                tracing::warn!(
+                    pipe = %pipe.arn,
+                    seq = %window_head_seq,
+                    attempts,
+                    "pipes: stream window exceeded MaximumRetryAttempts; routing to DLQ and advancing"
+                );
+                self.route_stream_batch_to_dlq(pipe, &window_head_seq, &events_for_dlq);
+                self.set_checkpoint(account, checkpoint_key, window_head_seq);
+                self.retry_counts.lock().unwrap().remove(&retry_key);
+            }
+        }
+    }
+
+    /// Send an exhausted stream batch to the pipe's DeadLetterConfig target
+    /// (SQS or SNS). The DLQ record carries the failed batch's metadata plus the
+    /// records, mirroring the envelope AWS Pipes writes. A no-op when no DLQ is
+    /// configured — the batch is still dropped so the stream unblocks.
+    fn route_stream_batch_to_dlq(
+        &self,
+        pipe: &RunningPipe,
+        window_head_seq: &str,
+        events: &[Value],
+    ) {
+        let Some(dlq_arn) = pipe.dlq_arn.as_deref() else {
+            return;
+        };
+        let payload = serde_json::json!({
+            "timestamp": Utc::now().to_rfc3339(),
+            "pipeArn": pipe.arn,
+            "sourceArn": pipe.source_arn,
+            "endSequenceNumber": window_head_seq,
+            "recordCount": events.len(),
+            "records": events,
+        });
+        let body = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+        if dlq_arn.contains(":sqs:") {
+            self.delivery.send_to_sqs(dlq_arn, &body, &HashMap::new());
+        } else if dlq_arn.contains(":sns:") {
+            self.delivery.publish_to_sns(dlq_arn, &body, None);
         }
     }
 
@@ -700,10 +792,30 @@ impl PipesRunner {
                 None => false,
             }
         } else if target_arn.contains(":sqs:") {
+            // FIFO queues need MessageGroupId (and optionally
+            // MessageDeduplicationId) from TargetParameters.SqsQueueParameters,
+            // else the SQS send is rejected for a .fifo target.
+            let sqs_params = target_params.and_then(|p| p.get("SqsQueueParameters"));
+            let group_id = sqs_params
+                .and_then(|p| p.get("MessageGroupId"))
+                .and_then(Value::as_str);
+            let dedup_id = sqs_params
+                .and_then(|p| p.get("MessageDeduplicationId"))
+                .and_then(Value::as_str);
             for event in batch {
                 let body = event_to_payload(event);
-                self.delivery
-                    .send_to_sqs(target_arn, &body, &HashMap::new());
+                if group_id.is_some() || dedup_id.is_some() {
+                    self.delivery.send_to_sqs_with_attrs(
+                        target_arn,
+                        &body,
+                        &HashMap::new(),
+                        group_id,
+                        dedup_id,
+                    );
+                } else {
+                    self.delivery
+                        .send_to_sqs(target_arn, &body, &HashMap::new());
+                }
             }
             true
         } else if target_arn.contains(":sns:") {
@@ -818,6 +930,31 @@ fn source_batch_size(source_params: Option<&Value>, kind: &SourceKind) -> usize 
         .filter(|n| *n > 0)
         .unwrap_or(default)
         .min(max) as usize
+}
+
+/// Resolve `MaximumRetryAttempts` + `DeadLetterConfig.Arn` for a stream source.
+/// Returns `(None, None)` for SQS (which has its own redrive) or when the
+/// parameters are absent.
+fn stream_retry_config(
+    source_params: Option<&Value>,
+    kind: &SourceKind,
+) -> (Option<i64>, Option<String>) {
+    let param_key = match kind {
+        SourceKind::Kinesis => "KinesisStreamParameters",
+        SourceKind::DynamoDbStream => "DynamoDBStreamParameters",
+        SourceKind::Sqs => return (None, None),
+    };
+    let params = source_params.and_then(|p| p.get(param_key));
+    let max_retry = params
+        .and_then(|p| p.get("MaximumRetryAttempts"))
+        .and_then(Value::as_i64);
+    let dlq = params
+        .and_then(|p| p.get("DeadLetterConfig"))
+        .and_then(|d| d.get("Arn"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    (max_retry, dlq)
 }
 
 /// Resolve `StartingPosition` (+ timestamp) for a stream source.
@@ -1136,6 +1273,38 @@ mod tests {
         assert_eq!(source_batch_size(Some(&params), &SourceKind::Sqs), 10);
         let params = json!({"KinesisStreamParameters": {"BatchSize": 500}});
         assert_eq!(source_batch_size(Some(&params), &SourceKind::Kinesis), 500);
+    }
+
+    #[test]
+    fn stream_retry_config_reads_max_attempts_and_dlq() {
+        let params = json!({
+            "KinesisStreamParameters": {
+                "MaximumRetryAttempts": 3,
+                "DeadLetterConfig": {"Arn": "arn:aws:sqs:us-east-1:1:pipe-dlq"}
+            }
+        });
+        let (max, dlq) = stream_retry_config(Some(&params), &SourceKind::Kinesis);
+        assert_eq!(max, Some(3));
+        assert_eq!(dlq.as_deref(), Some("arn:aws:sqs:us-east-1:1:pipe-dlq"));
+
+        // DynamoDB stream parameters key.
+        let ddb = json!({
+            "DynamoDBStreamParameters": {"MaximumRetryAttempts": 0}
+        });
+        let (max, dlq) = stream_retry_config(Some(&ddb), &SourceKind::DynamoDbStream);
+        assert_eq!(max, Some(0));
+        assert!(dlq.is_none());
+
+        // SQS sources have their own redrive; no stream retry config.
+        assert_eq!(
+            stream_retry_config(Some(&params), &SourceKind::Sqs),
+            (None, None)
+        );
+        // Absent parameters => defaults (retry forever, no DLQ).
+        assert_eq!(
+            stream_retry_config(None, &SourceKind::Kinesis),
+            (None, None)
+        );
     }
 
     fn rec(seq: &str) -> fakecloud_kinesis::KinesisRecord {

--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -476,7 +476,12 @@ pub(crate) fn collect_topic_subscribers(
                 .get("RawMessageDelivery")
                 .map(|v| v == "true")
                 .unwrap_or(false);
-            (s.endpoint.clone(), raw, s.subscription_arn.clone())
+            (
+                s.endpoint.clone(),
+                raw,
+                s.subscription_arn.clone(),
+                s.attributes.get("RedrivePolicy").cloned(),
+            )
         })
         .collect();
 
@@ -499,7 +504,13 @@ pub(crate) fn collect_topic_subscribers(
         .values()
         .filter(|s| s.protocol == "lambda")
         .filter(confirmed_for_topic)
-        .map(|s| (s.endpoint.clone(), s.subscription_arn.clone()))
+        .map(|s| {
+            (
+                s.endpoint.clone(),
+                s.subscription_arn.clone(),
+                s.attributes.get("RedrivePolicy").cloned(),
+            )
+        })
         .collect();
 
     let email = state

--- a/crates/fakecloud-sns/src/service.rs
+++ b/crates/fakecloud-sns/src/service.rs
@@ -1798,11 +1798,11 @@ pub(crate) struct SnsLambdaEventInput<'a> {
 /// `collect_topic_subscribers` so the fan-out loop doesn't have to
 /// re-filter the subscriptions map five times inline.
 pub(crate) struct TopicSubscribers {
-    /// (queue_arn, raw_message_delivery, subscription_arn)
-    pub(crate) sqs: Vec<(String, bool, String)>,
+    /// (queue_arn, raw_message_delivery, subscription_arn, redrive_policy)
+    pub(crate) sqs: Vec<(String, bool, String, Option<String>)>,
     pub(crate) http: Vec<HttpSubscriber>,
-    /// (function_arn, subscription_arn)
-    pub(crate) lambda: Vec<(String, String)>,
+    /// (function_arn, subscription_arn, redrive_policy)
+    pub(crate) lambda: Vec<(String, String, Option<String>)>,
     /// (email_address, protocol) where protocol is `email` or `email-json`
     pub(crate) email: Vec<(String, String)>,
     pub(crate) sms: Vec<String>,

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -722,12 +722,12 @@ pub(crate) fn fan_out_to_subscribers(
 
 pub(crate) fn deliver_to_sqs_subscribers(
     delivery: &Arc<DeliveryBus>,
-    subs: &[(String, bool, String)],
+    subs: &[(String, bool, String, Option<String>)],
     ctx: &TopicFanoutContext<'_>,
 ) {
     let sqs_message = ctx.body_for_protocol("sqs");
-    for (queue_arn, raw, subscription_arn) in subs {
-        if *raw {
+    for (queue_arn, raw, subscription_arn, redrive_policy) in subs {
+        let (body, attrs) = if *raw {
             let mut sqs_msg_attrs = HashMap::new();
             for (k, v) in ctx.message_attributes {
                 let mut attr = fakecloud_core::delivery::SqsMessageAttribute {
@@ -740,13 +740,7 @@ pub(crate) fn deliver_to_sqs_subscribers(
                 }
                 sqs_msg_attrs.insert(k.clone(), attr);
             }
-            delivery.send_to_sqs_with_attrs(
-                queue_arn,
-                &sqs_message,
-                &sqs_msg_attrs,
-                ctx.message_group_id,
-                ctx.message_dedup_id,
-            );
+            (sqs_message.clone(), sqs_msg_attrs)
         } else {
             let envelope_str = build_sns_envelope(
                 ctx.msg_id,
@@ -757,16 +751,31 @@ pub(crate) fn deliver_to_sqs_subscribers(
                 ctx.envelope_attrs,
                 ctx.endpoint,
             );
-            // Even non-raw delivery forwards FIFO ordering metadata so
-            // the downstream queue can preserve group ordering /
-            // dedup — SNS does this on real AWS.
-            delivery.send_to_sqs_with_attrs(
-                queue_arn,
-                &envelope_str,
-                &HashMap::new(),
-                ctx.message_group_id,
-                ctx.message_dedup_id,
-            );
+            (envelope_str, HashMap::new())
+        };
+        // Even non-raw delivery forwards FIFO ordering metadata so the
+        // downstream queue can preserve group ordering / dedup — SNS does this
+        // on real AWS. A fallible send lets us route to the subscription's DLQ
+        // when the target queue is gone, instead of silently dropping (the DLQ
+        // was previously honored for HTTP subscribers only).
+        let result = delivery.try_send_to_sqs_with_attrs(
+            queue_arn,
+            &body,
+            &attrs,
+            ctx.message_group_id,
+            ctx.message_dedup_id,
+        );
+        if let Err(err) = result {
+            if let Some(dlq_arn) = parse_redrive_dlq(redrive_policy.as_deref()) {
+                let dlq_body = build_dlq_envelope(&body, &err.to_string(), subscription_arn);
+                delivery.send_to_sqs(&dlq_arn, &dlq_body, &HashMap::new());
+            } else {
+                tracing::warn!(
+                    queue = %queue_arn,
+                    error = %err,
+                    "SNS SQS delivery failed and no RedrivePolicy configured; message dropped"
+                );
+            }
         }
     }
 }
@@ -832,7 +841,7 @@ pub(crate) fn deliver_to_http_subscribers(
 pub(crate) fn deliver_to_lambda_subscribers(
     state: &SharedSnsState,
     delivery: &Arc<DeliveryBus>,
-    subs: &[(String, String)],
+    subs: &[(String, String, Option<String>)],
     ctx: &TopicFanoutContext<'_>,
 ) {
     if subs.is_empty() {
@@ -842,9 +851,10 @@ pub(crate) fn deliver_to_lambda_subscribers(
     let subject_owned = ctx.subject.map(|s| s.to_string());
     let lambda_message = ctx.body_for_protocol("lambda");
 
-    let lambda_payloads: Vec<(String, String)> = subs
+    // (function_arn, payload, subscription_arn, redrive_policy)
+    let lambda_payloads: Vec<(String, String, String, Option<String>)> = subs
         .iter()
-        .map(|(function_arn, subscription_arn)| {
+        .map(|(function_arn, subscription_arn, redrive_policy)| {
             let payload = build_sns_lambda_event(&SnsLambdaEventInput {
                 message_id: ctx.msg_id,
                 topic_arn: ctx.topic_arn,
@@ -855,7 +865,12 @@ pub(crate) fn deliver_to_lambda_subscribers(
                 timestamp: &now,
                 endpoint: ctx.endpoint,
             });
-            (function_arn.clone(), payload)
+            (
+                function_arn.clone(),
+                payload,
+                subscription_arn.clone(),
+                redrive_policy.clone(),
+            )
         })
         .collect();
 
@@ -863,7 +878,7 @@ pub(crate) fn deliver_to_lambda_subscribers(
         let acct = ctx.topic_arn.split(':').nth(4).unwrap_or("");
         let mut accounts = state.write();
         let state = accounts.get_or_create(acct);
-        for (function_arn, _) in &lambda_payloads {
+        for (function_arn, ..) in &lambda_payloads {
             state
                 .lambda_invocations
                 .push(crate::state::LambdaInvocation {
@@ -877,7 +892,7 @@ pub(crate) fn deliver_to_lambda_subscribers(
 
     let delivery = delivery.clone();
     tokio::spawn(async move {
-        for (function_arn, payload) in lambda_payloads {
+        for (function_arn, payload, subscription_arn, redrive_policy) in lambda_payloads {
             tracing::info!(function_arn = %function_arn, "SNS invoking Lambda function");
             match delivery.invoke_lambda(&function_arn, &payload).await {
                 Some(Ok(_)) => {
@@ -892,6 +907,13 @@ pub(crate) fn deliver_to_lambda_subscribers(
                         error = %e,
                         "SNS->Lambda invocation failed"
                     );
+                    // Route the failed notification to the subscription's DLQ
+                    // (previously only HTTP subscribers honored RedrivePolicy).
+                    if let Some(dlq_arn) = parse_redrive_dlq(redrive_policy.as_deref()) {
+                        let dlq_body =
+                            build_dlq_envelope(&payload, &e.to_string(), &subscription_arn);
+                        delivery.send_to_sqs(&dlq_arn, &dlq_body, &HashMap::new());
+                    }
                 }
                 None => {
                     tracing::debug!(


### PR DESCRIPTION
## Summary

Stubs cluster B from the 2026-07-15 bug hunt (findings 1.31-1.36) — six
write-succeeds-read-wrong / never-fires stubs across five services.

| # | Service | Bug | Fix |
|---|---------|-----|-----|
| 1.31 | glue | Table versioning faked; version store never written | Archive a real monotonic version on every Create/Update; Get/List read the archive (newest-first); Delete purges it |
| 1.32 | sagemaker | Stop*/Start* never advance status (generic action no-op) | Transition `{Family}Status` per family (Stopped/InService/Scheduled/Cancelled), inserting the member when a create-record lacks one |
| 1.33 | pipes | SQS-target FIFO MessageGroupId/Dedup dropped at delivery | Forward them via `send_to_sqs_with_attrs` |
| 1.34 | pipes | Stream-source DLQ/retry never applied (poison-pill wedge) | Honor `MaximumRetryAttempts` + `DeadLetterConfig`; route exhausted window to DLQ and advance the checkpoint |
| 1.35 | sns | RedrivePolicy DLQ wired for HTTP subscriber only | SQS uses a fallible send + DLQ; Lambda routes invoke failures to the subscription DLQ |
| 1.36 | scheduler | EB target Source/DetailType ignored; SageMaker-Pipeline target never fires | Honor `EventBridgeParameters.{Source,DetailType}`; start a real PipelineExecution via a new cross-service `SageMakerPipelineDelivery` hook |

## Test plan

- E2E: `glue::table_versions_are_archived_on_create_and_update`,
  `sagemaker::sagemaker_notebook_instance_stop_start_transitions_status`,
  `sns::sns_sqs_subscriber_failure_routes_to_dlq`.
- Unit: `scheduler::deliver_target_eventbridge_uses_source_and_detail_type_params`,
  `scheduler::deliver_target_sagemaker_pipeline_starts_execution`,
  `pipes_runner::stream_retry_config_reads_max_attempts_and_dlq`.
- `cargo build`/`clippy --all-targets`/`fmt` clean across all touched crates +
  the server bin + fakecloud-e2e.

No new public API surface (behavior fixes on existing ops + one internal
cross-service delivery hook), so no SDK/docs regeneration needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes read-after-write and never-fires issues across Glue, SageMaker, Pipes, SNS, and Scheduler. Tables and statuses now persist correctly, DLQ/FIFO settings are honored, and Scheduler sets EventBridge fields and starts SageMaker pipelines.

- **Bug Fixes**
  - Glue: Archive a real table version on Create/Update; Get/List read the archive (newest first); Delete purges versions; fallback to synthesize for pre-archive tables.
  - SageMaker: `Start*`/`Stop*` now update `{Family}Status` (e.g., Stopped/InService/Scheduled/Cancelled), inserting the status field when missing; Scheduler’s `sagemaker:pipeline` target starts a real `PipelineExecution` via a new cross-service hook.
  - Pipes: Forward SQS FIFO `MessageGroupId`/`MessageDeduplicationId` to queue targets; honor stream `MaximumRetryAttempts` and `DeadLetterConfig` for Kinesis/DynamoDB sources—on exhaustion, send batch to DLQ and advance the checkpoint.
  - SNS: Honor `RedrivePolicy` for SQS and Lambda subscribers—failed deliveries route to the subscription DLQ instead of being dropped.
  - Scheduler: Use `EventBridgeParameters.Source` and `EventBridgeParameters.DetailType` for EventBridge targets; support `sagemaker:pipeline` targets with parameter pass-through.

<sup>Written for commit b17ca57f647f562a505e5b8cb5ea5b0507b54ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

