### PR TITLE
feat(core): recover repeated @httpQuery params via query_param_all (bug-hunt 1.45)

### DIFF
--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -837,6 +837,26 @@ fn flatten_json_value(prefix: &str, value: &serde_json::Value, out: &mut HashMap
     }
 }
 
+/// Decode a query / form-urlencoded string into ordered `(key, value)` pairs,
+/// **preserving repeated keys**. The [`HashMap`] form
+/// ([`decode_form_urlencoded`]) collapses `a=1&a=2` to a single entry, which
+/// loses multi-value `@httpQuery` params; this variant keeps every occurrence
+/// in wire order for callers that need them (e.g. list-style query params).
+pub(crate) fn form_urlencoded_pairs(input: &str) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    for pair in input.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (key, value) = match pair.find('=') {
+            Some(pos) => (&pair[..pos], &pair[pos + 1..]),
+            None => (pair, ""),
+        };
+        pairs.push((url_decode(key), url_decode(value)));
+    }
+    pairs
+}
+
 fn decode_form_urlencoded(input: &[u8]) -> HashMap<String, String> {
     let s = std::str::from_utf8(input).unwrap_or("");
     let mut result = HashMap::new();
@@ -892,6 +912,31 @@ fn from_hex(b: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn form_urlencoded_pairs_preserves_repeated_keys() {
+        // The HashMap decoder collapses repeats; the ordered-pairs variant must
+        // keep every occurrence in wire order (1.45 multi-value @httpQuery).
+        let pairs = form_urlencoded_pairs("Id=a&Id=b&Id=c&Other=x");
+        let ids: Vec<&str> = pairs
+            .iter()
+            .filter(|(k, _)| k == "Id")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+        // Sanity: the HashMap form keeps only the last value.
+        assert_eq!(
+            decode_form_urlencoded(b"Id=a&Id=b&Id=c").get("Id").unwrap(),
+            "c"
+        );
+    }
+
+    #[test]
+    fn form_urlencoded_pairs_decodes_percent_and_plus() {
+        let pairs = form_urlencoded_pairs("q=caf%C3%A9+bar&empty=");
+        assert_eq!(pairs[0], ("q".to_string(), "café bar".to_string()));
+        assert_eq!(pairs[1], ("empty".to_string(), String::new()));
+    }
 
     #[test]
     fn parse_amz_target_events() {

--- a/crates/fakecloud-core/src/service.rs
+++ b/crates/fakecloud-core/src/service.rs
@@ -91,6 +91,19 @@ impl AwsRequest {
     pub fn take_body_stream(&self) -> Option<RequestBodyStream> {
         self.body_stream.lock().take()
     }
+
+    /// All values supplied for a repeated `@httpQuery` parameter, in wire
+    /// order. [`AwsRequest::query_params`] is a `HashMap`, so `?a=1&a=2` keeps
+    /// only `2` there; this re-parses [`AwsRequest::raw_query`] to recover every
+    /// occurrence. Use it for list-style query params (filters, ids) where a
+    /// client legitimately repeats the key. Returns an empty vec when the key
+    /// is absent.
+    pub fn query_param_all(&self, key: &str) -> Vec<String> {
+        crate::protocol::form_urlencoded_pairs(&self.raw_query)
+            .into_iter()
+            .filter_map(|(k, v)| (k == key).then_some(v))
+            .collect()
+    }
 }
 
 /// Drain a streaming request body into a single [`Bytes`] buffer with no


### PR DESCRIPTION
## Summary

The axum `Query<HashMap<String,String>>` extraction — and the `query_params` map on `AwsRequest` derived from it — collapses repeated query keys, keeping only the **last** value of `?Id=a&Id=b&Id=c`. That silently drops multi-value `@httpQuery` parameters (list-style filters / ids). This is the known-systemic finding 1.45 (LOW).

`raw_query` already preserves the full query string, so rather than a repo-wide change to the core representation, this adds first-class recovery:

- `AwsRequest::query_param_all(key) -> Vec<String>` — re-parses `raw_query` and returns **every** occurrence of a repeated key, in wire order (empty vec if absent).
- `pub(crate) protocol::form_urlencoded_pairs(&str) -> Vec<(String, String)>` — decodes into ordered pairs, reusing the existing UTF-8-correct `url_decode` (the `HashMap` decoder that collapses repeats is untouched).

Handlers that legitimately accept repeated keys can now recover them without every caller re-implementing query parsing, and without disturbing the `query_params` fast path every other handler relies on.

## Test plan

- `cargo test -p fakecloud-core --lib form_urlencoded_pairs` — repeated keys preserved as `[a, b, c]` (vs the `HashMap` form collapsing to `c`); percent/`+` decoding (`caf%C3%A9+bar` → `café bar`).
- `cargo clippy -p fakecloud-core --tests -- -D warnings` clean.

Additive API only — no existing behavior changes, no SDK/docs surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AwsRequest::query_param_all to return all values of repeated @httpQuery params by re-parsing raw_query, fixing the drop of multi-value filters (bug-hunt 1.45). The existing HashMap-based query_params behavior stays unchanged.

- **New Features**
  - query_param_all(key) -> Vec<String> returns every occurrence in wire order; empty when absent.
  - pub(crate) form_urlencoded_pairs(&str) -> Vec<(String, String)> decodes ordered key/value pairs (handles percent and +) for internal use.

<sup>Written for commit 66ad93277490b0440b6602e31d2389c5af35d1c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

