### PR TITLE
fix(core,s3): explicit-Deny beats public ACL + strict-mode deny on unmapped action (bug-hunt)

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -710,16 +710,39 @@ pub async fn dispatch(
                             // through to the handler.
                         }
                     } else {
-                        // Service opted in but didn't return an IamAction
-                        // for this specific operation — programming bug,
-                        // surface it loudly in soft/strict mode so it's
-                        // visible during rollout.
+                        // Service opted in via `iam_enforceable()` but its
+                        // `iam_action_for` returned no `IamAction` for this
+                        // specific operation (e.g. S3's `s3_detect_action`
+                        // has `_ => return None` arms for unrecognized
+                        // sub-resources). Under strict enforcement that must
+                        // fail closed: an operation we cannot map to an IAM
+                        // action cannot be authorized, so serving it would be
+                        // a fail-open bypass of `--iam strict`. Deny by
+                        // default. In soft mode we preserve the historical
+                        // warn-and-allow so an incomplete mapping surfaces
+                        // during rollout without blocking traffic.
                         tracing::warn!(
                             target: "fakecloud::iam::audit",
                             service = %detected.service,
                             action = %aws_request.action,
-                            "service is iam_enforceable but has no IamAction mapping for this action; skipping evaluation"
+                            mode = %config.iam_mode,
+                            request_id = %request_id,
+                            "service is iam_enforceable but has no IamAction mapping for this action; denying under strict, allowing under soft"
                         );
+                        if config.iam_mode.is_strict() {
+                            return build_error_response(
+                                StatusCode::FORBIDDEN,
+                                "AccessDeniedException",
+                                &format!(
+                                    "User: {} is not authorized to perform: {}: no IAM action mapping exists for this operation, so it cannot be authorized under strict IAM enforcement",
+                                    principal.arn, aws_request.action,
+                                ),
+                                &request_id,
+                                detected.protocol,
+                            );
+                        }
+                        // Soft mode: audit log emitted; fall through to the
+                        // handler.
                     }
                 }
             } else if aws_request.access_key_id.is_none() {

--- a/crates/fakecloud-e2e/tests/iam_enforcement.rs
+++ b/crates/fakecloud-e2e/tests/iam_enforcement.rs
@@ -907,6 +907,97 @@ async fn bucket_policy_identity_allow_no_bucket_policy_still_works() {
         .unwrap();
 }
 
+/// A hand-crafted signed Authorization header carrying `akid`'s access key in
+/// the S3 credential scope. With SigV4 verification off the dummy signature is
+/// never checked, but dispatch still parses the access key and resolves the
+/// principal — letting a test drive requests that the AWS SDK would never
+/// emit (here, an S3 sub-resource form with no IAM-action mapping).
+fn s3_signed_auth_header(akid: &str) -> String {
+    format!(
+        "AWS4-HMAC-SHA256 Credential={akid}/20240101/us-east-1/s3/aws4_request, \
+         SignedHeaders=host, Signature=deadbeef"
+    )
+}
+
+#[tokio::test]
+async fn strict_mode_denies_unmapped_enforceable_action() {
+    // Fix 5.2: strict enforcement must fail closed when an `iam_enforceable`
+    // service returns no `IamAction` for an operation. `POST /bucket?acl` is
+    // not a valid S3 op (ACL is GET/PUT only), so `s3_detect_action` returns
+    // None — the enforceable-but-unmapped branch. Previously dispatch warned
+    // and fell through to the handler, running the op with no policy check.
+    //
+    // SigV4 verification is left OFF so the hand-crafted request reaches the
+    // IAM layer (a bad signature would otherwise 403 earlier, masking the
+    // behavior under test).
+    let server = TestServer::start_with_env(&[("FAKECLOUD_IAM", "strict")]).await;
+
+    let boot = sdk_config_with(&server, "test", "test").await;
+    aws_sdk_s3::Client::new(&boot)
+        .create_bucket()
+        .bucket("unmapped-probe")
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, _secret) = bootstrap_user(&server, "unmapped_user").await;
+    // Allow-all identity policy: any *mapped* action would be permitted, so a
+    // 403 here can only come from the missing IAM-action mapping, not a policy
+    // deny. This isolates the fail-closed behavior.
+    attach_inline_policy(
+        &server,
+        "unmapped_user",
+        "AllowEverything",
+        r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}"#,
+    )
+    .await;
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!("{}/unmapped-probe?acl", server.endpoint()))
+        .header("authorization", s3_signed_auth_header(&akid))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "strict mode must deny an enforceable action with no IAM-action mapping (fail closed)"
+    );
+}
+
+#[tokio::test]
+async fn soft_mode_allows_unmapped_enforceable_action_through() {
+    // Counterpart guarantee to `strict_mode_denies_unmapped_enforceable_action`:
+    // the new deny is gated on strict mode only. In soft mode the same unmapped
+    // enforceable action is NOT denied by the IAM layer — it warns and falls
+    // through to the handler, preserving historical rollout behavior.
+    let server = TestServer::start_with_env(&[("FAKECLOUD_IAM", "soft")]).await;
+
+    let boot = sdk_config_with(&server, "test", "test").await;
+    aws_sdk_s3::Client::new(&boot)
+        .create_bucket()
+        .bucket("unmapped-soft-probe")
+        .send()
+        .await
+        .unwrap();
+
+    let (akid, _secret) = bootstrap_user(&server, "unmapped_soft_user").await;
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!("{}/unmapped-soft-probe?acl", server.endpoint()))
+        .header("authorization", s3_signed_auth_header(&akid))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.status(),
+        403,
+        "soft mode must not deny an unmapped enforceable action; it falls through to the handler"
+    );
+}
+
 #[tokio::test]
 async fn bucket_policy_principal_wildcard_grants_any_user() {
     // Public bucket idiom: `"Principal": "*"`. Any non-root caller


### PR DESCRIPTION
## Summary

Closes an auth enforcement fail-open in the strict-mode IAM dispatch path (bug-hunt batch 2). Behavior-only; no SDK, docs, or count-surface change. These paths only run when `--iam` is enabled — `off` (the default) is unchanged.

**Fix 5.2 (MED) — strict-mode fail-open on unmapped enforceable action.** When an `iam_enforceable()` service returns `None` from `iam_action_for` for an operation (e.g. S3's `s3_detect_action` has many `_ => return None` arms for unrecognized sub-resource forms), dispatch previously logged a warn and fell through to the handler — the op executed with no policy check even under `--iam strict`. That is fail-open: a signed request to an unmapped S3 sub-resource ran unauthorized. Now, under strict mode, an enforceable service that yields no `IamAction` is denied by default (`AccessDeniedException`, matching the existing signed-path deny code). Soft/off modes are unchanged: soft still warns-and-allows so an incomplete mapping surfaces during rollout without blocking traffic. The audit warn is preserved (now carrying `mode` + `request_id`).

**Fix 5.1 (HIGH) — anonymous explicit-Deny beats public-read ACL** was already landed in #2288; this PR adds no code there. Its regression test (`anonymous_get_explicit_deny_overrides_public_acl`) is confirmed green alongside the new tests.

## Test plan

New e2e tests in `iam_enforcement.rs`:
- `strict_mode_denies_unmapped_enforceable_action` — a signed `POST /bucket?acl` (ACL is GET/PUT only, so `s3_detect_action` returns `None`) with an **allow-all** identity policy is denied `403` under `--iam strict`. The allow-all policy isolates the deny to the unmapped-action path (not policy evaluation).
- `soft_mode_allows_unmapped_enforceable_action_through` — the same request under `--iam soft` is **not** denied by the IAM layer (falls through), pinning the strict-only gating.

Verified locally:
- `cargo clippy -p fakecloud-core -p fakecloud-s3 --all-targets -- -D warnings` clean; `cargo fmt`.
- `cargo build --bin fakecloud`; `cargo nextest run -p fakecloud-e2e -E 'binary(iam_enforcement) | binary(s3_anonymous_access) | binary(sigv4_verification)'` -> **62 passed, 0 failed**.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fail-open in strict IAM mode: when a service is `iam_enforceable` but the operation has no IAM action mapping, we now return 403 AccessDeniedException instead of executing the handler. Soft mode still warns and allows; `--iam off` is unchanged.

- **Bug Fixes**
  - Core (`fakecloud-core`): in `dispatch.rs`, deny unmapped enforceable operations under strict and include `mode` and `request_id` in the audit log.
  - Tests (`fakecloud-e2e`): added e2e tests to verify strict-mode deny and soft-mode allow for unmapped actions.

<sup>Written for commit 5ca71051c66dff74f7314ef05aa852b9a2f2d0d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

