### PR TITLE
fix(rds): persist Copy/Modify/Restore extras + activity-stream + PI fields (bug-hunt)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -614,6 +614,7 @@ impl ResourceProvisioner {
                 .get("DBClusterIdentifier")
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            activity_stream: None,
         };
         let endpoint = inst.endpoint_address.clone();
         let endpoint_port = inst.port;

--- a/crates/fakecloud-e2e/tests/rds_extras_persistence.rs
+++ b/crates/fakecloud-e2e/tests/rds_extras_persistence.rs
@@ -1,0 +1,266 @@
+//! End-to-end coverage for the RDS Copy/Modify/Restore "extras" that
+//! previously returned canned XML without persisting. Each op below now
+//! writes real state; these tests assert the write round-trips through the
+//! matching Describe using the real AWS SDK. All ops here are container-free
+//! (cluster/parameter-group/subnet-group metadata), so they need no Docker.
+
+mod helpers;
+
+use helpers::TestServer;
+
+/// Create an Aurora cluster and return its real ARN (read back from
+/// Describe rather than constructed, so the test doesn't hardcode the
+/// server's default account id).
+async fn create_cluster(client: &aws_sdk_rds::Client, id: &str) -> String {
+    let created = client
+        .create_db_cluster()
+        .db_cluster_identifier(id)
+        .engine("aurora-postgresql")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .send()
+        .await
+        .unwrap();
+    created
+        .db_cluster()
+        .and_then(|c| c.db_cluster_arn())
+        .expect("cluster arn")
+        .to_string()
+}
+
+#[tokio::test]
+async fn enable_disable_http_endpoint_round_trips_describe() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+    let arn = create_cluster(&client, "http-clus").await;
+
+    let enabled = client
+        .enable_http_endpoint()
+        .resource_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(enabled.http_endpoint_enabled(), Some(true));
+
+    let described = client
+        .describe_db_clusters()
+        .db_cluster_identifier("http-clus")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described
+            .db_clusters()
+            .first()
+            .and_then(|c| c.http_endpoint_enabled()),
+        Some(true)
+    );
+
+    client
+        .disable_http_endpoint()
+        .resource_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    let described = client
+        .describe_db_clusters()
+        .db_cluster_identifier("http-clus")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described
+            .db_clusters()
+            .first()
+            .and_then(|c| c.http_endpoint_enabled()),
+        Some(false)
+    );
+}
+
+#[tokio::test]
+async fn modify_current_db_cluster_capacity_echoes_requested_capacity() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+    create_cluster(&client, "cap-clus").await;
+
+    let out = client
+        .modify_current_db_cluster_capacity()
+        .db_cluster_identifier("cap-clus")
+        .capacity(8)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(out.db_cluster_identifier(), Some("cap-clus"));
+    assert_eq!(out.current_capacity(), Some(8));
+}
+
+#[tokio::test]
+async fn copy_db_parameter_group_persists_and_is_describable() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_parameter_group()
+        .db_parameter_group_name("src-pg")
+        .db_parameter_group_family("postgres16")
+        .description("source")
+        .send()
+        .await
+        .unwrap();
+
+    let copied = client
+        .copy_db_parameter_group()
+        .source_db_parameter_group_identifier("src-pg")
+        .target_db_parameter_group_identifier("copy-pg")
+        .target_db_parameter_group_description("the copy")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        copied
+            .db_parameter_group()
+            .and_then(|g| g.db_parameter_group_name()),
+        Some("copy-pg")
+    );
+
+    let described = client
+        .describe_db_parameter_groups()
+        .db_parameter_group_name("copy-pg")
+        .send()
+        .await
+        .unwrap();
+    let group = described
+        .db_parameter_groups()
+        .first()
+        .expect("copy persisted");
+    assert_eq!(group.db_parameter_group_name(), Some("copy-pg"));
+    assert_eq!(group.description(), Some("the copy"));
+    assert_eq!(group.db_parameter_group_family(), Some("postgres16"));
+}
+
+#[tokio::test]
+async fn restore_db_cluster_from_s3_creates_describable_cluster() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .restore_db_cluster_from_s3()
+        .db_cluster_identifier("s3-clus")
+        .engine("aurora-mysql")
+        .master_username("admin")
+        .master_user_password("secret123")
+        .source_engine("mysql")
+        .source_engine_version("8.0.28")
+        .s3_bucket_name("my-backups")
+        .s3_ingestion_role_arn("arn:aws:iam::123456789012:role/rds-s3-import")
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_db_clusters()
+        .db_cluster_identifier("s3-clus")
+        .send()
+        .await
+        .unwrap();
+    let cluster = described
+        .db_clusters()
+        .first()
+        .expect("restored cluster present");
+    assert_eq!(cluster.db_cluster_identifier(), Some("s3-clus"));
+    assert_eq!(cluster.status(), Some("available"));
+}
+
+#[tokio::test]
+async fn start_stop_activity_stream_round_trips_on_cluster() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+    let arn = create_cluster(&client, "das-clus").await;
+
+    let started = client
+        .start_activity_stream()
+        .resource_arn(&arn)
+        .mode(aws_sdk_rds::types::ActivityStreamMode::Async)
+        .kms_key_id("1234abcd-12ab-34cd-56ef-1234567890ab")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        started.status(),
+        Some(&aws_sdk_rds::types::ActivityStreamStatus::Started)
+    );
+
+    let described = client
+        .describe_db_clusters()
+        .db_cluster_identifier("das-clus")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described
+            .db_clusters()
+            .first()
+            .and_then(|c| c.activity_stream_status()),
+        Some(&aws_sdk_rds::types::ActivityStreamStatus::Started)
+    );
+
+    client
+        .stop_activity_stream()
+        .resource_arn(&arn)
+        .send()
+        .await
+        .unwrap();
+    let described = client
+        .describe_db_clusters()
+        .db_cluster_identifier("das-clus")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described
+            .db_clusters()
+            .first()
+            .and_then(|c| c.activity_stream_status()),
+        Some(&aws_sdk_rds::types::ActivityStreamStatus::Stopped)
+    );
+}
+
+#[tokio::test]
+async fn modify_db_subnet_group_applies_description() {
+    let server = TestServer::start().await;
+    let client = server.rds_client().await;
+
+    client
+        .create_db_subnet_group()
+        .db_subnet_group_name("sng-desc")
+        .db_subnet_group_description("original")
+        .subnet_ids("subnet-aaaa1111")
+        .subnet_ids("subnet-bbbb2222")
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .modify_db_subnet_group()
+        .db_subnet_group_name("sng-desc")
+        .db_subnet_group_description("updated description")
+        .subnet_ids("subnet-aaaa1111")
+        .subnet_ids("subnet-bbbb2222")
+        .send()
+        .await
+        .unwrap();
+
+    let described = client
+        .describe_db_subnet_groups()
+        .db_subnet_group_name("sng-desc")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        described
+            .db_subnet_groups()
+            .first()
+            .and_then(|g| g.db_subnet_group_description()),
+        Some("updated description")
+    );
+}

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -98,6 +98,19 @@ fn missing(name: &str) -> AwsServiceError {
     )
 }
 
+/// `ResourceNotFoundFault` — the generic "no such RDS resource" error
+/// declared on `EnableHttpEndpoint` / `DisableHttpEndpoint` /
+/// `ModifyActivityStream` (which take a `ResourceArn` rather than a typed
+/// cluster/instance id, so the typed `DBClusterNotFoundFault` isn't in their
+/// Smithy error set).
+fn resource_not_found(arn: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::NOT_FOUND,
+        "ResourceNotFoundFault",
+        format!("The specified resource ARN {arn} could not be found."),
+    )
+}
+
 impl RdsService {
     pub(crate) fn handle_extra_action(
         &self,
@@ -1455,13 +1468,53 @@ impl RdsService {
             // ── Shard groups ──
             "CreateDBShardGroup" => {
                 let id = get_param(req, "DBShardGroupIdentifier").ok_or_else(|| missing("DBShardGroupIdentifier"))?;
-                let entry = json!({"DBShardGroupIdentifier": id, "Status": "available"});
+                let mut entry = json!({"DBShardGroupIdentifier": id, "Status": "available"});
+                if let Some(obj) = entry.as_object_mut() {
+                    if let Some(cluster) = get_param(req, "DBClusterIdentifier") {
+                        obj.insert("DBClusterIdentifier".to_string(), json!(cluster));
+                    }
+                    apply_shard_group_capacity(obj, req);
+                }
                 let mut accounts = write_state!();
                 let state = accounts.get_or_create(&aid);
                 store(&mut state.extras, "shard_groups").insert(id.clone(), entry.clone());
                 Ok(xml_response("CreateDBShardGroup", shard_group_xml(&entry), &rid))
             }
-            "ModifyDBShardGroup" | "RebootDBShardGroup" => Ok(xml_response(action.as_str(), "    <DBShardGroup/>".to_string(), &rid)),
+            "ModifyDBShardGroup" => {
+                let id = get_param(req, "DBShardGroupIdentifier").ok_or_else(|| missing("DBShardGroupIdentifier"))?;
+                let entry = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let entry = state
+                        .extras
+                        .get_mut("shard_groups")
+                        .and_then(|m| m.get_mut(&id))
+                        .ok_or_else(|| {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "DBShardGroupNotFound",
+                                format!("DBShardGroup {id} not found."),
+                            )
+                        })?;
+                    if let Some(obj) = entry.as_object_mut() {
+                        apply_shard_group_capacity(obj, req);
+                    }
+                    entry.clone()
+                };
+                Ok(xml_response("ModifyDBShardGroup", shard_group_xml(&entry), &rid))
+            }
+            "RebootDBShardGroup" => {
+                let id = get_param(req, "DBShardGroupIdentifier").ok_or_else(|| missing("DBShardGroupIdentifier"))?;
+                let entry = self
+                    .state_handle()
+                    .read()
+                    .get(&aid)
+                    .and_then(|s| s.extras.get("shard_groups"))
+                    .and_then(|m| m.get(&id))
+                    .cloned()
+                    .unwrap_or_else(|| json!({"DBShardGroupIdentifier": id, "Status": "available"}));
+                Ok(xml_response("RebootDBShardGroup", shard_group_xml(&entry), &rid))
+            }
             "DeleteDBShardGroup" => {
                 let id = get_param(req, "DBShardGroupIdentifier").ok_or_else(|| missing("DBShardGroupIdentifier"))?;
                 let mut accounts = write_state!();
@@ -1544,21 +1597,95 @@ impl RdsService {
             "DescribeExportTasks" => list_extras_xml(self, &aid, "export_tasks", "ExportTasks", "DescribeExportTasks", export_task_xml, &rid),
 
             // ── Activity stream ──
+            // ResourceArn names either an Aurora DB cluster or an RDS DB
+            // instance; the stream state is persisted on whichever exists so
+            // DescribeDBClusters / DescribeDBInstances round-trips it.
             "StartActivityStream" => {
+                let resource_arn =
+                    get_param(req, "ResourceArn").ok_or_else(|| missing("ResourceArn"))?;
                 let kms_input = get_param(req, "KmsKeyId").unwrap_or_default();
                 let kms_arn = format_kms_arn(&kms_input, region, &aid);
                 let mode = get_param(req, "Mode").unwrap_or_else(|| "async".to_string());
-                let resource_arn = get_param(req, "ResourceArn").unwrap_or_default();
-                let stream = if resource_arn.is_empty() {
-                    "aws-rds-das".to_string()
-                } else {
-                    let id = resource_arn.rsplit(':').next().unwrap_or("default");
-                    format!("aws-rds-das-{id}")
-                };
+                let (_, id) = parse_rds_resource_arn(&resource_arn);
+                let stream = format!("aws-rds-das-{id}");
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let cfg = crate::state::ActivityStreamConfig {
+                        status: "started".to_string(),
+                        mode: Some(mode.clone()),
+                        kms_key_id: if kms_arn.is_empty() {
+                            None
+                        } else {
+                            Some(kms_arn.clone())
+                        },
+                        kinesis_stream_name: Some(stream.clone()),
+                    };
+                    if !apply_activity_stream(state, &id, Some(cfg)) {
+                        return Err(
+                            crate::service::service_helpers::db_instance_not_found(&id),
+                        );
+                    }
+                }
                 Ok(xml_response("StartActivityStream", format!("    <Status>started</Status>\n    <KmsKeyId>{}</KmsKeyId>\n    <KinesisStreamName>{}</KinesisStreamName>\n    <Mode>{}</Mode>\n    <ApplyImmediately>true</ApplyImmediately>", xml_escape(&kms_arn), xml_escape(&stream), xml_escape(&mode)), &rid))
             }
-            "StopActivityStream" => Ok(xml_response("StopActivityStream", "    <Status>stopped</Status>".to_string(), &rid)),
-            "ModifyActivityStream" => Ok(xml_response("ModifyActivityStream", "    <Status>started</Status>".to_string(), &rid)),
+            "StopActivityStream" => {
+                let resource_arn =
+                    get_param(req, "ResourceArn").ok_or_else(|| missing("ResourceArn"))?;
+                let (_, id) = parse_rds_resource_arn(&resource_arn);
+                let (kms, kinesis) = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    // Echo the pre-stop kms/kinesis as AWS does, then clear.
+                    let prev = read_activity_stream(state, &id);
+                    if !apply_activity_stream(state, &id, None) {
+                        return Err(
+                            crate::service::service_helpers::db_instance_not_found(&id),
+                        );
+                    }
+                    (
+                        prev.as_ref()
+                            .and_then(|c| c.kms_key_id.clone())
+                            .unwrap_or_default(),
+                        prev.and_then(|c| c.kinesis_stream_name).unwrap_or_default(),
+                    )
+                };
+                Ok(xml_response("StopActivityStream", format!("    <Status>stopped</Status>\n    <KmsKeyId>{}</KmsKeyId>\n    <KinesisStreamName>{}</KinesisStreamName>", xml_escape(&kms), xml_escape(&kinesis)), &rid))
+            }
+            "ModifyActivityStream" => {
+                // ResourceArn is optional in the Smithy model, so an absent or
+                // unknown value must surface the declared ResourceNotFoundFault
+                // rather than an undeclared InvalidParameterValue.
+                let resource_arn = get_param(req, "ResourceArn").unwrap_or_default();
+                let (_, id) = parse_rds_resource_arn(&resource_arn);
+                let (status, kms, kinesis, mode) = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let mut cfg = read_activity_stream(state, &id).unwrap_or_else(|| {
+                        crate::state::ActivityStreamConfig {
+                            status: "started".to_string(),
+                            ..Default::default()
+                        }
+                    });
+                    if cfg.status.is_empty() {
+                        cfg.status = "started".to_string();
+                    }
+                    if let Some(m) = get_param(req, "Mode") {
+                        cfg.mode = Some(m);
+                    }
+                    let echo = (
+                        cfg.status.clone(),
+                        cfg.kms_key_id.clone().unwrap_or_default(),
+                        cfg.kinesis_stream_name.clone().unwrap_or_default(),
+                        cfg.mode.clone().unwrap_or_default(),
+                    );
+                    if !apply_activity_stream(state, &id, Some(cfg)) {
+                        return Err(resource_not_found(&resource_arn));
+                    }
+                    echo
+                };
+                Ok(xml_response("ModifyActivityStream", format!("    <Status>{}</Status>\n    <KmsKeyId>{}</KmsKeyId>\n    <KinesisStreamName>{}</KinesisStreamName>\n    <Mode>{}</Mode>", xml_escape(&status), xml_escape(&kms), xml_escape(&kinesis), xml_escape(&mode)), &rid))
+            }
 
             // ── Database read replicas ──
             "PromoteReadReplica" => promote_read_replica_action(self, &aid, req, &rid),
@@ -1608,12 +1735,112 @@ impl RdsService {
 
             // ── Snapshots / restores / copy ──
             "CopyDBSnapshot" => {
-                let id = get_param(req, "TargetDBSnapshotIdentifier").ok_or_else(|| missing("TargetDBSnapshotIdentifier"))?;
-                Ok(xml_response("CopyDBSnapshot", format!("    <DBSnapshot>\n      <DBSnapshotIdentifier>{}</DBSnapshotIdentifier>\n      <Status>available</Status>\n    </DBSnapshot>", xml_escape(&id)), &rid))
+                let target_id = get_param(req, "TargetDBSnapshotIdentifier")
+                    .ok_or_else(|| missing("TargetDBSnapshotIdentifier"))?;
+                let source_id = get_param(req, "SourceDBSnapshotIdentifier")
+                    .ok_or_else(|| missing("SourceDBSnapshotIdentifier"))?;
+                // Source may be passed as a bare id or a full ARN; key state
+                // by the trailing identifier segment either way.
+                let source_key = source_id.rsplit(':').next().unwrap_or(&source_id).to_string();
+                let option_group_name = get_param(req, "OptionGroupName");
+                let kms_key_id = get_param(req, "KmsKeyId");
+                let (snapshot, arn) = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if state.snapshots.contains_key(&target_id) {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::CONFLICT,
+                            "DBSnapshotAlreadyExists",
+                            format!("DBSnapshot {target_id} already exists."),
+                        ));
+                    }
+                    let mut snapshot = state
+                        .snapshots
+                        .get(&source_key)
+                        .cloned()
+                        .ok_or_else(|| crate::service::service_helpers::db_snapshot_not_found(&source_id))?;
+                    let arn = state.db_snapshot_arn(&target_id);
+                    snapshot.db_snapshot_identifier = target_id.clone();
+                    snapshot.db_snapshot_arn = arn.clone();
+                    snapshot.snapshot_create_time = chrono::Utc::now();
+                    snapshot.snapshot_type = "manual".to_string();
+                    snapshot.status = "available".to_string();
+                    snapshot.percent_progress = Some(100);
+                    if let Some(og) = option_group_name {
+                        snapshot.option_group_name = Some(og);
+                    }
+                    if let Some(kms) = kms_key_id {
+                        snapshot.encrypted = true;
+                        snapshot.kms_key_id = Some(format_kms_arn(&kms, region, &aid));
+                    }
+                    // A copy is a fresh sharing surface; it does not inherit
+                    // the source snapshot's restore attributes.
+                    snapshot.snapshot_attributes = BTreeMap::new();
+                    state.snapshots.insert(target_id.clone(), snapshot.clone());
+                    (snapshot, arn)
+                };
+                self.emit_event(
+                    RdsSourceType::DbSnapshot,
+                    &target_id,
+                    &arn,
+                    "RDS-EVENT-0042",
+                    &["creation"],
+                    "Manual snapshot created",
+                );
+                Ok(xml_response(
+                    "CopyDBSnapshot",
+                    format!(
+                        "    <DBSnapshot>{}</DBSnapshot>",
+                        crate::service::service_helpers::db_snapshot_xml(&snapshot)
+                    ),
+                    &rid,
+                ))
             }
             "CopyDBParameterGroup" => {
-                let name = get_param(req, "TargetDBParameterGroupIdentifier").ok_or_else(|| missing("TargetDBParameterGroupIdentifier"))?;
-                Ok(xml_response("CopyDBParameterGroup", format!("    <DBParameterGroup>\n      <DBParameterGroupName>{}</DBParameterGroupName>\n    </DBParameterGroup>", xml_escape(&name)), &rid))
+                let target = get_param(req, "TargetDBParameterGroupIdentifier")
+                    .ok_or_else(|| missing("TargetDBParameterGroupIdentifier"))?;
+                let source = get_param(req, "SourceDBParameterGroupIdentifier")
+                    .ok_or_else(|| missing("SourceDBParameterGroupIdentifier"))?;
+                let source_key = source.rsplit(':').next().unwrap_or(&source).to_string();
+                let description = get_param(req, "TargetDBParameterGroupDescription");
+                let group = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if state.parameter_groups.contains_key(&target) {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::CONFLICT,
+                            "DBParameterGroupAlreadyExists",
+                            format!("DBParameterGroup {target} already exists."),
+                        ));
+                    }
+                    let mut group = state
+                        .parameter_groups
+                        .get(&source_key)
+                        .cloned()
+                        .ok_or_else(|| {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "DBParameterGroupNotFound",
+                                format!("DBParameterGroup {source} not found."),
+                            )
+                        })?;
+                    group.db_parameter_group_name = target.clone();
+                    group.db_parameter_group_arn = state.db_parameter_group_arn(&target);
+                    if let Some(desc) = description {
+                        group.description = desc;
+                    }
+                    group.tags = Vec::new();
+                    state.parameter_groups.insert(target.clone(), group.clone());
+                    group
+                };
+                Ok(xml_response(
+                    "CopyDBParameterGroup",
+                    format!(
+                        "    <DBParameterGroup>{}</DBParameterGroup>",
+                        crate::service::service_helpers::db_parameter_group_xml(&group)
+                    ),
+                    &rid,
+                ))
             }
             "DescribeDBParameters" => Ok(xml_response("DescribeDBParameters", "    <Parameters/>".to_string(), &rid)),
             "ResetDBParameterGroup" => {
@@ -1659,8 +1886,98 @@ impl RdsService {
                 );
                 Ok(xml_response("DescribeEngineDefaultParameters", body, &rid))
             }
-            "DescribeDBSnapshotAttributes" => Ok(xml_response("DescribeDBSnapshotAttributes", "    <DBSnapshotAttributesResult>\n      <DBSnapshotAttributes/>\n    </DBSnapshotAttributesResult>".to_string(), &rid)),
-            "ModifyDBSnapshot" | "ModifyDBSnapshotAttribute" => Ok(xml_response(action.as_str(), "    <DBSnapshot/>".to_string(), &rid)),
+            "DescribeDBSnapshotAttributes" => {
+                let id = get_param(req, "DBSnapshotIdentifier")
+                    .ok_or_else(|| missing("DBSnapshotIdentifier"))?;
+                let attrs = {
+                    let accounts = self.state_handle().read();
+                    let snapshot = accounts
+                        .get(&aid)
+                        .and_then(|s| s.snapshots.get(&id))
+                        .ok_or_else(|| crate::service::service_helpers::db_snapshot_not_found(&id))?;
+                    snapshot.snapshot_attributes.clone()
+                };
+                Ok(xml_response(
+                    "DescribeDBSnapshotAttributes",
+                    snapshot_attributes_result_xml(&id, &attrs),
+                    &rid,
+                ))
+            }
+            "ModifyDBSnapshotAttribute" => {
+                let id = get_param(req, "DBSnapshotIdentifier")
+                    .ok_or_else(|| missing("DBSnapshotIdentifier"))?;
+                let attribute_name = get_param(req, "AttributeName")
+                    .ok_or_else(|| missing("AttributeName"))?;
+                let to_add = parse_attribute_values(req, "ValuesToAdd");
+                let to_remove = parse_attribute_values(req, "ValuesToRemove");
+                // AWS rejects a value that appears in both add and remove lists.
+                if let Some(dup) = to_add.iter().find(|v| to_remove.contains(v)) {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterCombination",
+                        format!("The value {dup} is present in both ValuesToAdd and ValuesToRemove."),
+                    ));
+                }
+                let attrs = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let snapshot = state
+                        .snapshots
+                        .get_mut(&id)
+                        .ok_or_else(|| crate::service::service_helpers::db_snapshot_not_found(&id))?;
+                    let values = snapshot
+                        .snapshot_attributes
+                        .entry(attribute_name.clone())
+                        .or_default();
+                    values.retain(|v| !to_remove.contains(v));
+                    for v in to_add {
+                        if !values.contains(&v) {
+                            values.push(v);
+                        }
+                    }
+                    // Drop the attribute entirely once it has no values so
+                    // Describe reports an empty (unshared) snapshot rather
+                    // than an empty `restore` list, matching AWS.
+                    if values.is_empty() {
+                        snapshot.snapshot_attributes.remove(&attribute_name);
+                    }
+                    snapshot.snapshot_attributes.clone()
+                };
+                Ok(xml_response(
+                    "ModifyDBSnapshotAttribute",
+                    snapshot_attributes_result_xml(&id, &attrs),
+                    &rid,
+                ))
+            }
+            "ModifyDBSnapshot" => {
+                let id = get_param(req, "DBSnapshotIdentifier")
+                    .ok_or_else(|| missing("DBSnapshotIdentifier"))?;
+                let engine_version = get_param(req, "EngineVersion");
+                let option_group_name = get_param(req, "OptionGroupName");
+                let snapshot = {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let snapshot = state
+                        .snapshots
+                        .get_mut(&id)
+                        .ok_or_else(|| crate::service::service_helpers::db_snapshot_not_found(&id))?;
+                    if let Some(v) = engine_version {
+                        snapshot.engine_version = v;
+                    }
+                    if let Some(og) = option_group_name {
+                        snapshot.option_group_name = Some(og);
+                    }
+                    snapshot.clone()
+                };
+                Ok(xml_response(
+                    "ModifyDBSnapshot",
+                    format!(
+                        "    <DBSnapshot>{}</DBSnapshot>",
+                        crate::service::service_helpers::db_snapshot_xml(&snapshot)
+                    ),
+                    &rid,
+                ))
+            }
             "RestoreDBClusterFromSnapshot" => {
                 let target = get_param(req, "DBClusterIdentifier")
                     .ok_or_else(|| missing("DBClusterIdentifier"))?;
@@ -1834,11 +2151,50 @@ impl RdsService {
                     &rid,
                 ))
             }
-            "RestoreDBClusterFromS3" => Ok(xml_response(
-                action.as_str(),
-                "    <DBCluster/>".to_string(),
-                &rid,
-            )),
+            "RestoreDBClusterFromS3" => {
+                let id = get_param(req, "DBClusterIdentifier")
+                    .ok_or_else(|| missing("DBClusterIdentifier"))?;
+                let arn = Arn::new("rds", region, &aid, &format!("cluster:{id}")).to_string();
+                let engine =
+                    get_param(req, "Engine").unwrap_or_else(|| "aurora-mysql".to_string());
+                let port = get_param(req, "Port")
+                    .and_then(|p| p.parse::<i64>().ok())
+                    .unwrap_or(if engine.contains("postgresql") { 5432 } else { 3306 });
+                let entry = json!({
+                    "DBClusterIdentifier": id, "DBClusterArn": arn,
+                    "DbClusterResourceId": new_cluster_resource_id(),
+                    "Status": "available", "Engine": engine,
+                    "EngineVersion": get_param(req, "EngineVersion").unwrap_or_else(|| "8.0.mysql_aurora.3.04.0".to_string()),
+                    "Endpoint": format!("{id}.cluster-xxx.{region}.rds.amazonaws.com"),
+                    "ReaderEndpoint": format!("{id}.cluster-ro-xxx.{region}.rds.amazonaws.com"),
+                    "Port": port,
+                    "MasterUsername": get_param(req, "MasterUsername").unwrap_or_else(|| "admin".to_string()),
+                });
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    if state.extras.get("clusters").is_some_and(|m| m.contains_key(&id)) {
+                        return Err(cluster_already_exists(&id));
+                    }
+                    store(&mut state.extras, "clusters").insert(id.clone(), entry.clone());
+                }
+                self.emit_event(
+                    RdsSourceType::DbCluster,
+                    &id,
+                    &arn,
+                    "RDS-EVENT-0170",
+                    &["creation"],
+                    "DB cluster created",
+                );
+                Ok(xml_response(
+                    "RestoreDBClusterFromS3",
+                    format!(
+                        "    <DBCluster>\n{}\n    </DBCluster>",
+                        db_cluster_member_xml(&entry)
+                    ),
+                    &rid,
+                ))
+            }
 
             // ── Recommendations ──
             "DescribeDBRecommendations" => Ok(xml_response("DescribeDBRecommendations", "    <DBRecommendations/>".to_string(), &rid)),
@@ -1902,9 +2258,73 @@ impl RdsService {
                 ))
             }
             "DescribeValidDBInstanceModifications" => Ok(xml_response("DescribeValidDBInstanceModifications", "    <ValidDBInstanceModificationsMessage>\n      <ValidProcessorFeatures/>\n      <Storage/>\n    </ValidDBInstanceModificationsMessage>".to_string(), &rid)),
-            "ModifyCurrentDBClusterCapacity" => Ok(xml_response("ModifyCurrentDBClusterCapacity", "    <DBClusterIdentifier>x</DBClusterIdentifier>\n    <CurrentCapacity>4</CurrentCapacity>".to_string(), &rid)),
-            "DisableHttpEndpoint" => Ok(xml_response("DisableHttpEndpoint", "    <HttpEndpointEnabled>false</HttpEndpointEnabled>".to_string(), &rid)),
-            "EnableHttpEndpoint" => Ok(xml_response("EnableHttpEndpoint", "    <HttpEndpointEnabled>true</HttpEndpointEnabled>".to_string(), &rid)),
+            "ModifyCurrentDBClusterCapacity" => {
+                let id = get_param(req, "DBClusterIdentifier")
+                    .ok_or_else(|| missing("DBClusterIdentifier"))?;
+                let capacity = get_param(req, "Capacity")
+                    .and_then(|c| c.parse::<i64>().ok())
+                    .unwrap_or(0);
+                let seconds_before_timeout = get_param(req, "SecondsBeforeTimeout")
+                    .and_then(|c| c.parse::<i64>().ok())
+                    .unwrap_or(300);
+                let timeout_action = get_param(req, "TimeoutAction")
+                    .unwrap_or_else(|| "ForceApplyCapacityChange".to_string());
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let entry = state
+                        .extras
+                        .get_mut("clusters")
+                        .and_then(|m| m.get_mut(&id))
+                        .ok_or_else(|| cluster_not_found(&id))?;
+                    if let Some(obj) = entry.as_object_mut() {
+                        obj.insert("Capacity".to_string(), json!(capacity));
+                    }
+                }
+                Ok(xml_response(
+                    "ModifyCurrentDBClusterCapacity",
+                    format!(
+                        "    <DBClusterIdentifier>{}</DBClusterIdentifier>\n    <PendingCapacity>{}</PendingCapacity>\n    <CurrentCapacity>{}</CurrentCapacity>\n    <SecondsBeforeTimeout>{}</SecondsBeforeTimeout>\n    <TimeoutAction>{}</TimeoutAction>",
+                        xml_escape(&id),
+                        capacity,
+                        capacity,
+                        seconds_before_timeout,
+                        xml_escape(&timeout_action),
+                    ),
+                    &rid,
+                ))
+            }
+            "EnableHttpEndpoint" | "DisableHttpEndpoint" => {
+                let resource_arn =
+                    get_param(req, "ResourceArn").ok_or_else(|| missing("ResourceArn"))?;
+                let enabled = action == "EnableHttpEndpoint";
+                // ResourceArn is the cluster ARN; recover the cluster id from
+                // its trailing segment (bare ids are tolerated too).
+                let (_, cluster_id) = parse_rds_resource_arn(&resource_arn);
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let entry = state
+                        .extras
+                        .get_mut("clusters")
+                        .and_then(|m| m.get_mut(&cluster_id))
+                        // These ops declare ResourceNotFoundFault (not the typed
+                        // DBClusterNotFoundFault) for an unknown ResourceArn.
+                        .ok_or_else(|| resource_not_found(&resource_arn))?;
+                    if let Some(obj) = entry.as_object_mut() {
+                        obj.insert("HttpEndpointEnabled".to_string(), json!(enabled));
+                    }
+                }
+                Ok(xml_response(
+                    action.as_str(),
+                    format!(
+                        "    <ResourceArn>{}</ResourceArn>\n    <HttpEndpointEnabled>{}</HttpEndpointEnabled>",
+                        xml_escape(&resource_arn),
+                        enabled,
+                    ),
+                    &rid,
+                ))
+            }
 
             _ => Err(AwsServiceError::action_not_implemented("rds", &action)),
         }
@@ -1912,6 +2332,161 @@ impl RdsService {
 }
 
 // ── XML helpers per resource ──
+
+/// Parse a repeated attribute-value list (`ValuesToAdd` / `ValuesToRemove`)
+/// from the query body. AWS serializes these as
+/// `ValuesToAdd.AttributeValue.N`; some SDKs and the conformance probe emit
+/// the generic `.member.N` form. Accept both.
+fn parse_attribute_values(req: &AwsRequest, prefix: &str) -> Vec<String> {
+    for member in ["AttributeValue", "member"] {
+        let mut out = Vec::new();
+        for index in 1.. {
+            match get_param(req, &format!("{prefix}.{member}.{index}")) {
+                Some(v) => out.push(v),
+                None => break,
+            }
+        }
+        if !out.is_empty() {
+            return out;
+        }
+    }
+    Vec::new()
+}
+
+/// Persist a Database Activity Stream state onto whichever resource the
+/// `ResourceArn` names — an Aurora DB cluster (stored as JSON keys on the
+/// cluster entry) or an RDS DB instance (stored in `DbInstance::activity_stream`).
+/// `stream` of `None` clears the stream to `stopped`. Returns `false` when
+/// neither a matching instance nor cluster exists.
+fn apply_activity_stream(
+    state: &mut crate::state::RdsState,
+    id: &str,
+    stream: Option<crate::state::ActivityStreamConfig>,
+) -> bool {
+    if let Some(inst) = state.instances.get_mut(id) {
+        inst.activity_stream = stream;
+        return true;
+    }
+    if let Some(entry) = state.extras.get_mut("clusters").and_then(|m| m.get_mut(id)) {
+        if let Some(obj) = entry.as_object_mut() {
+            match stream {
+                Some(cfg) => {
+                    let status = if cfg.status.is_empty() {
+                        "started".to_string()
+                    } else {
+                        cfg.status
+                    };
+                    obj.insert("ActivityStreamStatus".to_string(), json!(status));
+                    set_or_remove(obj, "ActivityStreamKmsKeyId", cfg.kms_key_id);
+                    set_or_remove(
+                        obj,
+                        "ActivityStreamKinesisStreamName",
+                        cfg.kinesis_stream_name,
+                    );
+                    set_or_remove(obj, "ActivityStreamMode", cfg.mode);
+                }
+                None => {
+                    obj.insert("ActivityStreamStatus".to_string(), json!("stopped"));
+                    obj.remove("ActivityStreamKmsKeyId");
+                    obj.remove("ActivityStreamKinesisStreamName");
+                    obj.remove("ActivityStreamMode");
+                }
+            }
+        }
+        return true;
+    }
+    false
+}
+
+/// Read the current activity-stream config from an instance or cluster entry.
+fn read_activity_stream(
+    state: &crate::state::RdsState,
+    id: &str,
+) -> Option<crate::state::ActivityStreamConfig> {
+    if let Some(inst) = state.instances.get(id) {
+        return inst.activity_stream.clone();
+    }
+    let entry = state.extras.get("clusters").and_then(|m| m.get(id))?;
+    let status = entry["ActivityStreamStatus"].as_str()?;
+    if status == "stopped" {
+        return None;
+    }
+    Some(crate::state::ActivityStreamConfig {
+        status: status.to_string(),
+        mode: entry["ActivityStreamMode"].as_str().map(str::to_string),
+        kms_key_id: entry["ActivityStreamKmsKeyId"].as_str().map(str::to_string),
+        kinesis_stream_name: entry["ActivityStreamKinesisStreamName"]
+            .as_str()
+            .map(str::to_string),
+    })
+}
+
+fn set_or_remove(obj: &mut serde_json::Map<String, Value>, key: &str, value: Option<String>) {
+    match value {
+        Some(v) => {
+            obj.insert(key.to_string(), json!(v));
+        }
+        None => {
+            obj.remove(key);
+        }
+    }
+}
+
+/// Apply the serverless capacity knobs (`MaxACU`/`MinACU` as doubles,
+/// `ComputeRedundancy` as an integer) from a Create/Modify DBShardGroup
+/// request onto the stored shard-group JSON object. Absent params are left
+/// untouched so a Modify only overwrites what the caller sent.
+fn apply_shard_group_capacity(obj: &mut serde_json::Map<String, Value>, req: &AwsRequest) {
+    for key in ["MaxACU", "MinACU"] {
+        if let Some(n) = get_param(req, key).and_then(|v| v.parse::<f64>().ok()) {
+            obj.insert(key.to_string(), json!(n));
+        }
+    }
+    if let Some(n) = get_param(req, "ComputeRedundancy").and_then(|v| v.parse::<i64>().ok()) {
+        obj.insert("ComputeRedundancy".to_string(), json!(n));
+    }
+}
+
+/// Render the `DBSnapshotAttributesResult` block shared by
+/// `DescribeDBSnapshotAttributes` and `ModifyDBSnapshotAttribute`.
+fn snapshot_attributes_result_xml(id: &str, attrs: &BTreeMap<String, Vec<String>>) -> String {
+    let attributes = if attrs.is_empty() {
+        "      <DBSnapshotAttributes/>".to_string()
+    } else {
+        let members = attrs
+            .iter()
+            .map(|(name, values)| {
+                let value_members = if values.is_empty() {
+                    "            <AttributeValues/>".to_string()
+                } else {
+                    let inner = values
+                        .iter()
+                        .map(|v| {
+                            format!(
+                                "              <AttributeValue>{}</AttributeValue>",
+                                xml_escape(v)
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    format!("            <AttributeValues>\n{inner}\n            </AttributeValues>")
+                };
+                format!(
+                    "        <DBSnapshotAttribute>\n          <AttributeName>{}</AttributeName>\n{}\n        </DBSnapshotAttribute>",
+                    xml_escape(name),
+                    value_members,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("      <DBSnapshotAttributes>\n{members}\n      </DBSnapshotAttributes>")
+    };
+    format!(
+        "    <DBSnapshotAttributesResult>\n      <DBSnapshotIdentifier>{}</DBSnapshotIdentifier>\n{}\n    </DBSnapshotAttributesResult>",
+        xml_escape(id),
+        attributes,
+    )
+}
 
 /// Generate a `DbClusterResourceId` in AWS's `cluster-XXXX` form. The suffix
 /// is immutable and survives rename, so IAM auth / CloudWatch dimensions key

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -453,8 +453,16 @@ fn integrations_blue_green_shard_groups_tenant_dbs() {
         "CreateDBShardGroup",
         &[("DBShardGroupIdentifier", "sg1")],
     );
-    ok_on(&svc, "ModifyDBShardGroup", &[]);
-    ok_on(&svc, "RebootDBShardGroup", &[]);
+    ok_on(
+        &svc,
+        "ModifyDBShardGroup",
+        &[("DBShardGroupIdentifier", "sg1"), ("MaxACU", "16")],
+    );
+    ok_on(
+        &svc,
+        "RebootDBShardGroup",
+        &[("DBShardGroupIdentifier", "sg1")],
+    );
     ok_on(&svc, "DescribeDBShardGroups", &[]);
     ok_on(
         &svc,
@@ -480,9 +488,8 @@ fn export_activity_replicas_recommendations_certs_pending() {
     ok("StartExportTask", &[("ExportTaskIdentifier", "ex1")]);
     ok("CancelExportTask", &[]);
     ok("DescribeExportTasks", &[]);
-    ok("StartActivityStream", &[]);
-    ok("ModifyActivityStream", &[]);
-    ok("StopActivityStream", &[]);
+    // StartActivityStream / ModifyActivityStream / StopActivityStream now
+    // persist onto a real instance; see activity_stream_persists_on_instance.
     ok("AddRoleToDBCluster", &[]);
     ok("RemoveRoleFromDBCluster", &[]);
     ok("AddRoleToDBInstance", &[]);
@@ -519,27 +526,71 @@ fn export_activity_replicas_recommendations_certs_pending() {
 
 #[test]
 fn snapshots_restores_account_events() {
-    ok("CopyDBSnapshot", &[("TargetDBSnapshotIdentifier", "s2")]);
-    ok(
-        "CopyDBParameterGroup",
-        &[("TargetDBParameterGroupIdentifier", "p2")],
-    );
+    // Copy/Modify snapshot + parameter-group + cluster-capacity + http-endpoint
+    // ops now persist real state and validate required params; they have
+    // dedicated round-trip coverage in service_tests.rs. This smoke test keeps
+    // the stateless describe-style ops.
     ok("DescribeDBParameters", &[]);
     ok("ResetDBParameterGroup", &[("DBParameterGroupName", "p1")]);
     ok("DescribeEngineDefaultParameters", &[]);
-    ok("DescribeDBSnapshotAttributes", &[]);
-    ok("ModifyDBSnapshot", &[]);
-    ok("ModifyDBSnapshotAttribute", &[]);
-    ok("RestoreDBClusterFromS3", &[]);
+    ok(
+        "RestoreDBClusterFromS3",
+        &[("DBClusterIdentifier", "s3clus")],
+    );
     ok("DescribeAccountAttributes", &[]);
     ok("DescribeEventCategories", &[]);
     ok("DescribeEvents", &[]);
     ok("DescribeSourceRegions", &[]);
     ok("DescribeDBMajorEngineVersions", &[]);
     ok("DescribeValidDBInstanceModifications", &[]);
-    ok("ModifyCurrentDBClusterCapacity", &[]);
-    ok("DisableHttpEndpoint", &[]);
-    ok("EnableHttpEndpoint", &[]);
+}
+
+#[test]
+fn activity_stream_persists_on_instance() {
+    let svc = svc();
+    // seed_replica inserts both instances; exercise the stream on the source.
+    seed_replica(&svc, "rep-a", "src-a");
+    let arn = "arn:aws:rds:us-east-1:000000000000:db:src-a";
+    ok_on(
+        &svc,
+        "StartActivityStream",
+        &[("ResourceArn", arn), ("Mode", "sync"), ("KmsKeyId", "k1")],
+    );
+    {
+        let accounts = svc.state_handle().read();
+        let stream = accounts
+            .get("000000000000")
+            .and_then(|s| s.instances.get("src-a"))
+            .and_then(|i| i.activity_stream.clone())
+            .expect("activity stream persisted");
+        assert_eq!(stream.status, "started");
+        assert_eq!(stream.mode.as_deref(), Some("sync"));
+        assert_eq!(
+            stream.kinesis_stream_name.as_deref(),
+            Some("aws-rds-das-src-a")
+        );
+    }
+    ok_on(&svc, "StopActivityStream", &[("ResourceArn", arn)]);
+    assert!(svc
+        .state_handle()
+        .read()
+        .get("000000000000")
+        .and_then(|s| s.instances.get("src-a"))
+        .and_then(|i| i.activity_stream.clone())
+        .is_none());
+}
+
+#[test]
+fn start_activity_stream_requires_existing_instance() {
+    let svc = svc();
+    let r = svc.handle_extra_action(&req(
+        "StartActivityStream",
+        &[("ResourceArn", "arn:aws:rds:us-east-1:000000000000:db:ghost")],
+    ));
+    match r {
+        Err(e) => assert_eq!(e.code(), "DBInstanceNotFound"),
+        Ok(_) => panic!("expected DBInstanceNotFound"),
+    }
 }
 
 fn seed_replica(svc: &RdsService, replica_id: &str, source_id: &str) {
@@ -617,6 +668,7 @@ fn seed_replica(svc: &RdsService, replica_id: &str, source_id: &str) {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         },
     );
     // Replica points at source.
@@ -686,6 +738,7 @@ fn seed_replica(svc: &RdsService, replica_id: &str, source_id: &str) {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         },
     );
 }
@@ -1494,6 +1547,7 @@ fn seed_blue_instance(svc: &RdsService, id: &str, addr: &str, port: i32) {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         },
     );
 }
@@ -2136,6 +2190,7 @@ fn copy_db_cluster_snapshot_unknown_source_errors() {
 #[test]
 fn start_activity_stream_returns_full_kms_arn() {
     let svc = svc();
+    ok_on(&svc, "CreateDBCluster", &[("DBClusterIdentifier", "c1")]);
     let resp = svc
         .handle_extra_action(&req(
             "StartActivityStream",
@@ -2156,15 +2211,36 @@ fn start_activity_stream_returns_full_kms_arn() {
     );
     assert!(body.contains("<KinesisStreamName>aws-rds-das-c1</KinesisStreamName>"));
     assert!(body.contains("<Mode>sync</Mode>"));
+    // Persisted on the cluster: DescribeDBClusters round-trips the stream.
+    let describe = String::from_utf8(
+        svc.handle_extra_action(&req("DescribeDBClusters", &[("DBClusterIdentifier", "c1")]))
+            .expect("DescribeDBClusters")
+            .body
+            .expect_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    assert!(
+        describe.contains("<ActivityStreamStatus>started</ActivityStreamStatus>"),
+        "{describe}"
+    );
+    assert!(describe.contains("<ActivityStreamMode>sync</ActivityStreamMode>"));
 }
 
 #[test]
 fn start_activity_stream_passes_through_existing_arn() {
     let svc = svc();
+    ok_on(&svc, "CreateDBCluster", &[("DBClusterIdentifier", "c1")]);
     let resp = svc
         .handle_extra_action(&req(
             "StartActivityStream",
-            &[("KmsKeyId", "arn:aws:kms:eu-west-1:222:key/abcd")],
+            &[
+                (
+                    "ResourceArn",
+                    "arn:aws:rds:us-east-1:000000000000:cluster:c1",
+                ),
+                ("KmsKeyId", "arn:aws:kms:eu-west-1:222:key/abcd"),
+            ],
         ))
         .expect("StartActivityStream");
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
@@ -2174,10 +2250,17 @@ fn start_activity_stream_passes_through_existing_arn() {
 #[test]
 fn start_activity_stream_accepts_alias() {
     let svc = svc();
+    ok_on(&svc, "CreateDBCluster", &[("DBClusterIdentifier", "c1")]);
     let resp = svc
         .handle_extra_action(&req(
             "StartActivityStream",
-            &[("KmsKeyId", "alias/aws/rds")],
+            &[
+                (
+                    "ResourceArn",
+                    "arn:aws:rds:us-east-1:000000000000:cluster:c1",
+                ),
+                ("KmsKeyId", "alias/aws/rds"),
+            ],
         ))
         .expect("StartActivityStream");
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -230,6 +230,10 @@ pub(super) fn db_cluster_member_xml(v: &Value) -> String {
         "AwsBackupRecoveryPointArn",
         "GlobalWriteForwardingStatus",
         "LocalWriteForwardingStatus",
+        "ActivityStreamStatus",
+        "ActivityStreamKmsKeyId",
+        "ActivityStreamKinesisStreamName",
+        "ActivityStreamMode",
     ] {
         if let Some(s) = v[key].as_str() {
             out.push_str(&format!("          <{key}>{}</{key}>\n", xml_escape(s)));
@@ -240,6 +244,9 @@ pub(super) fn db_cluster_member_xml(v: &Value) -> String {
         "BacktrackWindow",
         "MonitoringInterval",
         "PerformanceInsightsRetentionPeriod",
+        // Aurora Serverless v1 current capacity, set by
+        // ModifyCurrentDBClusterCapacity.
+        "Capacity",
     ] {
         if let Some(n) = v[key].as_i64() {
             out.push_str(&format!("          <{key}>{n}</{key}>\n"));
@@ -443,11 +450,30 @@ pub(super) fn blue_green_xml(v: &Value) -> String {
 }
 
 pub(super) fn shard_group_xml(v: &Value) -> String {
-    format!(
+    let mut out = format!(
         "          <DBShardGroupIdentifier>{}</DBShardGroupIdentifier>\n          <Status>{}</Status>",
         xml_escape(v["DBShardGroupIdentifier"].as_str().unwrap_or("")),
         xml_escape(v["Status"].as_str().unwrap_or("available")),
-    )
+    );
+    if let Some(s) = v["DBClusterIdentifier"].as_str() {
+        out.push_str(&format!(
+            "\n          <DBClusterIdentifier>{}</DBClusterIdentifier>",
+            xml_escape(s)
+        ));
+    }
+    // MaxACU / MinACU are serverless capacity units (doubles); ComputeRedundancy
+    // is an integer. Render whichever the caller set on Create/Modify.
+    for key in ["MaxACU", "MinACU"] {
+        if let Some(n) = v[key].as_f64() {
+            out.push_str(&format!("\n          <{key}>{n}</{key}>"));
+        }
+    }
+    if let Some(n) = v["ComputeRedundancy"].as_i64() {
+        out.push_str(&format!(
+            "\n          <ComputeRedundancy>{n}</ComputeRedundancy>"
+        ));
+    }
+    out
 }
 
 pub(super) fn engine_version_xml(v: &Value) -> String {

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -206,6 +206,7 @@ impl RdsService {
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
                 db_cluster_identifier: db_cluster_identifier.clone(),
+                activity_stream: None,
             };
             state.finish_instance_creation(placeholder.clone());
             placeholder
@@ -526,6 +527,12 @@ impl RdsService {
         let ca_certificate_identifier = optional_query_param(request, "CACertificateIdentifier");
         let monitoring_interval =
             parse_optional_i32(optional_query_param(request, "MonitoringInterval").as_deref())?;
+        let monitoring_role_arn = optional_query_param(request, "MonitoringRoleArn");
+        let performance_insights_kms_key_id =
+            optional_query_param(request, "PerformanceInsightsKMSKeyId");
+        let performance_insights_retention_period = parse_optional_i32(
+            optional_query_param(request, "PerformanceInsightsRetentionPeriod").as_deref(),
+        )?;
         let option_group_name = optional_query_param(request, "OptionGroupName");
         let auto_minor_version_upgrade = parse_optional_bool(
             optional_query_param(request, "AutoMinorVersionUpgrade").as_deref(),
@@ -751,6 +758,18 @@ impl RdsService {
         }
         if let Some(n) = max_allocated_storage {
             instance.max_allocated_storage = Some(n);
+        }
+        // Enhanced Monitoring role and Performance Insights settings apply
+        // immediately in AWS (no reboot), mirroring their already-applied
+        // companions MonitoringInterval / EnablePerformanceInsights.
+        if let Some(arn) = monitoring_role_arn {
+            instance.monitoring_role_arn = Some(arn);
+        }
+        if let Some(kms) = performance_insights_kms_key_id {
+            instance.performance_insights_kms_key_id = Some(kms);
+        }
+        if let Some(days) = performance_insights_retention_period {
+            instance.performance_insights_retention_period = Some(days);
         }
         if let Some(nt) = network_type {
             instance.network_type = Some(nt);

--- a/crates/fakecloud-rds/src/service/snapshots.rs
+++ b/crates/fakecloud-rds/src/service/snapshots.rs
@@ -113,6 +113,7 @@ impl RdsService {
                 .iam_database_authentication_enabled,
             timezone: None,
             storage_throughput: None,
+            snapshot_attributes: std::collections::BTreeMap::new(),
         };
 
         state.snapshots.insert(snapshot_id.to_string(), snapshot);
@@ -223,6 +224,7 @@ impl RdsService {
             iam_database_authentication_enabled: instance.iam_database_authentication_enabled,
             timezone: None,
             storage_throughput: None,
+            snapshot_attributes: std::collections::BTreeMap::new(),
         };
 
         state

--- a/crates/fakecloud-rds/src/service/subnet_groups.rs
+++ b/crates/fakecloud-rds/src/service/subnet_groups.rs
@@ -236,6 +236,9 @@ impl RdsService {
 
         subnet_group.subnet_ids = subnet_ids;
         subnet_group.subnet_availability_zones = subnet_availability_zones;
+        if let Some(description) = optional_query_param(request, "DBSubnetGroupDescription") {
+            subnet_group.db_subnet_group_description = description;
+        }
 
         let subnet_group_clone = subnet_group.clone();
 

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -581,6 +581,7 @@ pub(crate) fn build_restored_instance(
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
         db_cluster_identifier: None,
+        activity_stream: None,
     }
 }
 
@@ -665,6 +666,7 @@ pub(crate) fn build_s3_restored_instance(
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
         db_cluster_identifier: None,
+        activity_stream: None,
     }
 }
 
@@ -756,6 +758,7 @@ pub(crate) fn build_pit_restored_instance(
         domain_auth_secret_arn: source.domain_auth_secret_arn.clone(),
         domain_dns_ips: source.domain_dns_ips.clone(),
         db_cluster_identifier: source.db_cluster_identifier.clone(),
+        activity_stream: source.activity_stream.clone(),
     }
 }
 
@@ -836,6 +839,7 @@ pub(crate) fn build_read_replica_instance(
         domain_auth_secret_arn: source.domain_auth_secret_arn.clone(),
         domain_dns_ips: source.domain_dns_ips.clone(),
         db_cluster_identifier: source.db_cluster_identifier.clone(),
+        activity_stream: source.activity_stream.clone(),
     }
 }
 
@@ -1395,6 +1399,48 @@ pub(crate) fn db_instance_xml(instance: &DbInstance, status_override: Option<&st
     } else {
         "<DomainMemberships/>".to_string()
     };
+    // Database Activity Stream: reflect the persisted stream state so
+    // Start/Stop/Modify ActivityStream round-trips through describe. A
+    // `None` config reads back as a stopped stream (no kms/kinesis/mode).
+    let activity_stream_xml = match instance.activity_stream.as_ref() {
+        Some(stream) => {
+            let status = if stream.status.is_empty() {
+                "stopped"
+            } else {
+                stream.status.as_str()
+            };
+            let kms = stream
+                .kms_key_id
+                .as_ref()
+                .map(|k| {
+                    format!(
+                        "<ActivityStreamKmsKeyId>{}</ActivityStreamKmsKeyId>",
+                        xml_escape(k)
+                    )
+                })
+                .unwrap_or_default();
+            let kinesis = stream
+                .kinesis_stream_name
+                .as_ref()
+                .map(|s| {
+                    format!(
+                        "<ActivityStreamKinesisStreamName>{}</ActivityStreamKinesisStreamName>",
+                        xml_escape(s)
+                    )
+                })
+                .unwrap_or_default();
+            let mode = stream
+                .mode
+                .as_ref()
+                .map(|m| format!("<ActivityStreamMode>{}</ActivityStreamMode>", xml_escape(m)))
+                .unwrap_or_default();
+            format!(
+                "<ActivityStreamStatus>{}</ActivityStreamStatus>{kms}{kinesis}{mode}",
+                xml_escape(status)
+            )
+        }
+        None => "<ActivityStreamStatus>stopped</ActivityStreamStatus>".to_string(),
+    };
 
     format!(
         "<DBInstanceIdentifier>{identifier}</DBInstanceIdentifier>\
@@ -1445,7 +1491,7 @@ pub(crate) fn db_instance_xml(instance: &DbInstance, status_override: Option<&st
          {copy_tags_xml}\
          {master_user_secret_xml}\
          <ProcessorFeatures/>\
-         <ActivityStreamStatus>stopped</ActivityStreamStatus>\
+         {activity_stream_xml}\
          <DbiResourceId>{dbi_resource_id}</DbiResourceId>\
          <DeletionProtection>{deletion_protection}</DeletionProtection>\
          {pending_modified_values_xml}\

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -208,6 +208,7 @@ fn db_instance_xml_renders_endpoint_and_status() {
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
         db_cluster_identifier: None,
+        activity_stream: None,
     };
 
     let xml = db_instance_xml(&instance, Some("creating"));
@@ -303,6 +304,7 @@ fn db_snapshot_xml_emits_extended_fields() {
         iam_database_authentication_enabled: true,
         timezone: None,
         storage_throughput: Some(125),
+        snapshot_attributes: std::collections::BTreeMap::new(),
     };
 
     let xml = db_snapshot_xml(&snapshot);
@@ -390,6 +392,7 @@ fn make_instance_with_defaults(id: &str) -> DbInstance {
         domain_auth_secret_arn: None,
         domain_dns_ips: Vec::new(),
         db_cluster_identifier: None,
+        activity_stream: None,
     }
 }
 
@@ -668,6 +671,7 @@ fn seed_instance(svc: &RdsService, identifier: &str) -> String {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         },
     );
     arn
@@ -1817,6 +1821,7 @@ fn seed_snapshot(svc: &RdsService, snapshot_id: &str, instance_id: &str) {
             iam_database_authentication_enabled: false,
             timezone: None,
             storage_throughput: None,
+            snapshot_attributes: std::collections::BTreeMap::new(),
         },
     );
 }
@@ -2527,6 +2532,7 @@ async fn restore_db_instance_from_db_snapshot_persists_tags() {
         iam_database_authentication_enabled: false,
         timezone: None,
         storage_throughput: None,
+        snapshot_attributes: std::collections::BTreeMap::new(),
     };
     let running = crate::runtime::RunningDbContainer {
         container_id: "c-restored".to_string(),
@@ -2922,6 +2928,7 @@ async fn save_snapshot_static_persists_status_flip_from_bg_task() {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         }
     }
 
@@ -3166,5 +3173,476 @@ async fn create_without_engine_version_uses_engine_default() {
         "InsufficientDBInstanceCapacity",
         "version-less mysql create must pass validation via the engine default, \
          not fail on a hardcoded postgres version"
+    );
+}
+
+// ── bug-hunt: Copy/Modify/Restore extras + activity-stream + PI fields ──
+// Each op below previously returned canned XML without persisting; these
+// tests assert the write now round-trips through the matching Describe.
+
+fn create_cluster(svc: &RdsService, id: &str) {
+    svc.handle_extra_action(&request(
+        "CreateDBCluster",
+        &[("DBClusterIdentifier", id), ("Engine", "aurora-postgresql")],
+    ))
+    .expect("CreateDBCluster");
+}
+
+#[test]
+fn copy_db_snapshot_persists_and_describe_finds_target() {
+    let svc = make_service();
+    seed_snapshot(&svc, "src-snap", "db1");
+    let body = body_of(
+        svc.handle_extra_action(&request(
+            "CopyDBSnapshot",
+            &[
+                ("SourceDBSnapshotIdentifier", "src-snap"),
+                ("TargetDBSnapshotIdentifier", "copy-snap"),
+            ],
+        ))
+        .expect("CopyDBSnapshot"),
+    );
+    assert!(
+        body.contains("<DBSnapshotIdentifier>copy-snap</DBSnapshotIdentifier>"),
+        "{body}"
+    );
+    assert!(body.contains("<Status>available</Status>"));
+    // The copy is now describable instead of DBSnapshotNotFoundFault.
+    let d = body_of(
+        svc.describe_db_snapshots(&request(
+            "DescribeDBSnapshots",
+            &[("DBSnapshotIdentifier", "copy-snap")],
+        ))
+        .expect("DescribeDBSnapshots"),
+    );
+    assert!(d.contains("copy-snap"));
+    assert!(d.contains("<Engine>postgres</Engine>"));
+}
+
+#[test]
+fn copy_db_snapshot_unknown_source_errors() {
+    let svc = make_service();
+    assert_code(
+        svc.handle_extra_action(&request(
+            "CopyDBSnapshot",
+            &[
+                ("SourceDBSnapshotIdentifier", "ghost"),
+                ("TargetDBSnapshotIdentifier", "t"),
+            ],
+        )),
+        "DBSnapshotNotFound",
+    );
+}
+
+#[test]
+fn copy_db_parameter_group_persists_and_describe_finds_target() {
+    let svc = make_service();
+    svc.create_db_parameter_group(&request(
+        "CreateDBParameterGroup",
+        &[
+            ("DBParameterGroupName", "src-pg"),
+            ("DBParameterGroupFamily", "postgres16"),
+            ("Description", "source"),
+        ],
+    ))
+    .expect("CreateDBParameterGroup");
+    let body = body_of(
+        svc.handle_extra_action(&request(
+            "CopyDBParameterGroup",
+            &[
+                ("SourceDBParameterGroupIdentifier", "src-pg"),
+                ("TargetDBParameterGroupIdentifier", "copy-pg"),
+                ("TargetDBParameterGroupDescription", "the copy"),
+            ],
+        ))
+        .expect("CopyDBParameterGroup"),
+    );
+    assert!(body.contains("copy-pg"), "{body}");
+    let d = body_of(
+        svc.describe_db_parameter_groups(&request(
+            "DescribeDBParameterGroups",
+            &[("DBParameterGroupName", "copy-pg")],
+        ))
+        .expect("DescribeDBParameterGroups"),
+    );
+    assert!(d.contains("copy-pg"));
+    assert!(d.contains("the copy"));
+    assert!(d.contains("postgres16"));
+}
+
+#[test]
+fn modify_db_snapshot_attribute_round_trips_describe() {
+    let svc = make_service();
+    seed_snapshot(&svc, "snap-attr", "db1");
+    svc.handle_extra_action(&request(
+        "ModifyDBSnapshotAttribute",
+        &[
+            ("DBSnapshotIdentifier", "snap-attr"),
+            ("AttributeName", "restore"),
+            ("ValuesToAdd.AttributeValue.1", "111111111111"),
+            ("ValuesToAdd.AttributeValue.2", "222222222222"),
+        ],
+    ))
+    .expect("ModifyDBSnapshotAttribute add");
+    let body = body_of(
+        svc.handle_extra_action(&request(
+            "DescribeDBSnapshotAttributes",
+            &[("DBSnapshotIdentifier", "snap-attr")],
+        ))
+        .expect("DescribeDBSnapshotAttributes"),
+    );
+    assert!(
+        body.contains("<AttributeName>restore</AttributeName>"),
+        "{body}"
+    );
+    assert!(body.contains("<AttributeValue>111111111111</AttributeValue>"));
+    assert!(body.contains("<AttributeValue>222222222222</AttributeValue>"));
+    // Removing a value drops it; removing the last empties the attribute.
+    svc.handle_extra_action(&request(
+        "ModifyDBSnapshotAttribute",
+        &[
+            ("DBSnapshotIdentifier", "snap-attr"),
+            ("AttributeName", "restore"),
+            ("ValuesToRemove.AttributeValue.1", "111111111111"),
+        ],
+    ))
+    .expect("ModifyDBSnapshotAttribute remove");
+    let body2 = body_of(
+        svc.handle_extra_action(&request(
+            "DescribeDBSnapshotAttributes",
+            &[("DBSnapshotIdentifier", "snap-attr")],
+        ))
+        .expect("DescribeDBSnapshotAttributes 2"),
+    );
+    assert!(!body2.contains("111111111111"), "{body2}");
+    assert!(body2.contains("222222222222"));
+}
+
+#[test]
+fn describe_db_snapshot_attributes_unknown_errors() {
+    let svc = make_service();
+    assert_code(
+        svc.handle_extra_action(&request(
+            "DescribeDBSnapshotAttributes",
+            &[("DBSnapshotIdentifier", "ghost")],
+        )),
+        "DBSnapshotNotFound",
+    );
+}
+
+#[test]
+fn modify_db_snapshot_applies_engine_version_and_option_group() {
+    let svc = make_service();
+    seed_snapshot(&svc, "snap-mod", "db1");
+    svc.handle_extra_action(&request(
+        "ModifyDBSnapshot",
+        &[
+            ("DBSnapshotIdentifier", "snap-mod"),
+            ("EngineVersion", "16.4"),
+            ("OptionGroupName", "custom-og"),
+        ],
+    ))
+    .expect("ModifyDBSnapshot");
+    let d = body_of(
+        svc.describe_db_snapshots(&request(
+            "DescribeDBSnapshots",
+            &[("DBSnapshotIdentifier", "snap-mod")],
+        ))
+        .expect("DescribeDBSnapshots"),
+    );
+    assert!(d.contains("<EngineVersion>16.4</EngineVersion>"), "{d}");
+    assert!(d.contains("<OptionGroupName>custom-og</OptionGroupName>"));
+}
+
+#[test]
+fn enable_disable_http_endpoint_round_trips_describe() {
+    let svc = make_service();
+    create_cluster(&svc, "aur1");
+    let arn = "arn:aws:rds:us-east-1:123456789012:cluster:aur1";
+    svc.handle_extra_action(&request("EnableHttpEndpoint", &[("ResourceArn", arn)]))
+        .expect("EnableHttpEndpoint");
+    let d = body_of(
+        svc.handle_extra_action(&request(
+            "DescribeDBClusters",
+            &[("DBClusterIdentifier", "aur1")],
+        ))
+        .expect("DescribeDBClusters"),
+    );
+    assert!(
+        d.contains("<HttpEndpointEnabled>true</HttpEndpointEnabled>"),
+        "{d}"
+    );
+    svc.handle_extra_action(&request("DisableHttpEndpoint", &[("ResourceArn", arn)]))
+        .expect("DisableHttpEndpoint");
+    let d2 = body_of(
+        svc.handle_extra_action(&request(
+            "DescribeDBClusters",
+            &[("DBClusterIdentifier", "aur1")],
+        ))
+        .expect("DescribeDBClusters 2"),
+    );
+    assert!(
+        d2.contains("<HttpEndpointEnabled>false</HttpEndpointEnabled>"),
+        "{d2}"
+    );
+}
+
+#[test]
+fn enable_http_endpoint_unknown_cluster_errors() {
+    let svc = make_service();
+    assert_code(
+        svc.handle_extra_action(&request(
+            "EnableHttpEndpoint",
+            &[(
+                "ResourceArn",
+                "arn:aws:rds:us-east-1:123456789012:cluster:ghost",
+            )],
+        )),
+        // EnableHttpEndpoint declares ResourceNotFoundFault (not the typed
+        // DBClusterNotFoundFault) in its Smithy error set.
+        "ResourceNotFoundFault",
+    );
+}
+
+#[test]
+fn modify_current_db_cluster_capacity_echoes_requested_capacity() {
+    let svc = make_service();
+    create_cluster(&svc, "aur-cap");
+    let body = body_of(
+        svc.handle_extra_action(&request(
+            "ModifyCurrentDBClusterCapacity",
+            &[("DBClusterIdentifier", "aur-cap"), ("Capacity", "8")],
+        ))
+        .expect("ModifyCurrentDBClusterCapacity"),
+    );
+    assert!(
+        body.contains("<DBClusterIdentifier>aur-cap</DBClusterIdentifier>"),
+        "{body}"
+    );
+    assert!(
+        body.contains("<CurrentCapacity>8</CurrentCapacity>"),
+        "{body}"
+    );
+    // No longer the hardcoded id/capacity.
+    assert!(!body.contains("<DBClusterIdentifier>x</DBClusterIdentifier>"));
+    assert!(!body.contains("<CurrentCapacity>4</CurrentCapacity>"));
+    // The applied capacity round-trips through DescribeDBClusters.
+    let described = body_of(
+        svc.handle_extra_action(&request(
+            "DescribeDBClusters",
+            &[("DBClusterIdentifier", "aur-cap")],
+        ))
+        .expect("DescribeDBClusters"),
+    );
+    assert!(described.contains("<Capacity>8</Capacity>"), "{described}");
+}
+
+#[test]
+fn modify_db_snapshot_attribute_rejects_value_in_add_and_remove() {
+    let svc = make_service();
+    seed_snapshot(&svc, "snap-dup", "db1");
+    assert_code(
+        svc.handle_extra_action(&request(
+            "ModifyDBSnapshotAttribute",
+            &[
+                ("DBSnapshotIdentifier", "snap-dup"),
+                ("AttributeName", "restore"),
+                ("ValuesToAdd.AttributeValue.1", "111111111111"),
+                ("ValuesToRemove.AttributeValue.1", "111111111111"),
+            ],
+        )),
+        "InvalidParameterCombination",
+    );
+}
+
+#[test]
+fn restore_db_cluster_from_s3_creates_persisted_cluster() {
+    let svc = make_service();
+    svc.handle_extra_action(&request(
+        "RestoreDBClusterFromS3",
+        &[
+            ("DBClusterIdentifier", "s3clus"),
+            ("Engine", "aurora-mysql"),
+        ],
+    ))
+    .expect("RestoreDBClusterFromS3");
+    let d = body_of(
+        svc.handle_extra_action(&request(
+            "DescribeDBClusters",
+            &[("DBClusterIdentifier", "s3clus")],
+        ))
+        .expect("DescribeDBClusters"),
+    );
+    assert!(
+        d.contains("<DBClusterIdentifier>s3clus</DBClusterIdentifier>"),
+        "{d}"
+    );
+    assert!(d.contains("<Status>available</Status>"));
+}
+
+#[test]
+fn modify_db_shard_group_persists_capacity() {
+    let svc = make_service();
+    svc.handle_extra_action(&request(
+        "CreateDBShardGroup",
+        &[
+            ("DBShardGroupIdentifier", "sg1"),
+            ("DBClusterIdentifier", "c1"),
+            ("MaxACU", "16"),
+            ("MinACU", "2"),
+        ],
+    ))
+    .expect("CreateDBShardGroup");
+    let d = body_of(
+        svc.handle_extra_action(&request("DescribeDBShardGroups", &[]))
+            .expect("DescribeDBShardGroups"),
+    );
+    assert!(d.contains("<MaxACU>16</MaxACU>"), "{d}");
+    assert!(d.contains("<MinACU>2</MinACU>"));
+    svc.handle_extra_action(&request(
+        "ModifyDBShardGroup",
+        &[
+            ("DBShardGroupIdentifier", "sg1"),
+            ("MaxACU", "32"),
+            ("ComputeRedundancy", "1"),
+        ],
+    ))
+    .expect("ModifyDBShardGroup");
+    let d2 = body_of(
+        svc.handle_extra_action(&request("DescribeDBShardGroups", &[]))
+            .expect("DescribeDBShardGroups 2"),
+    );
+    assert!(d2.contains("<MaxACU>32</MaxACU>"), "{d2}");
+    assert!(d2.contains("<ComputeRedundancy>1</ComputeRedundancy>"));
+    // MinACU from create is retained through the modify.
+    assert!(d2.contains("<MinACU>2</MinACU>"));
+}
+
+#[test]
+fn activity_stream_start_stop_round_trips_instance_xml() {
+    let svc = make_service();
+    seed_instance(&svc, "das-db");
+    let arn = "arn:aws:rds:us-east-1:123456789012:db:das-db";
+    svc.handle_extra_action(&request(
+        "StartActivityStream",
+        &[
+            ("ResourceArn", arn),
+            ("Mode", "async"),
+            ("KmsKeyId", "key-123"),
+        ],
+    ))
+    .expect("StartActivityStream");
+    {
+        let accounts = svc.state.read();
+        let inst = accounts
+            .default_ref()
+            .instances
+            .get("das-db")
+            .expect("instance");
+        let xml = db_instance_xml(inst, None);
+        assert!(
+            xml.contains("<ActivityStreamStatus>started</ActivityStreamStatus>"),
+            "{xml}"
+        );
+        assert!(xml.contains(
+            "<ActivityStreamKinesisStreamName>aws-rds-das-das-db</ActivityStreamKinesisStreamName>"
+        ));
+        assert!(xml.contains("<ActivityStreamMode>async</ActivityStreamMode>"));
+    }
+    svc.handle_extra_action(&request("StopActivityStream", &[("ResourceArn", arn)]))
+        .expect("StopActivityStream");
+    {
+        let accounts = svc.state.read();
+        let inst = accounts
+            .default_ref()
+            .instances
+            .get("das-db")
+            .expect("instance");
+        assert!(inst.activity_stream.is_none());
+        let xml = db_instance_xml(inst, None);
+        assert!(
+            xml.contains("<ActivityStreamStatus>stopped</ActivityStreamStatus>"),
+            "{xml}"
+        );
+    }
+}
+
+#[test]
+fn start_activity_stream_unknown_instance_errors() {
+    let svc = make_service();
+    assert_code(
+        svc.handle_extra_action(&request(
+            "StartActivityStream",
+            &[("ResourceArn", "arn:aws:rds:us-east-1:123456789012:db:ghost")],
+        )),
+        "DBInstanceNotFound",
+    );
+}
+
+#[test]
+fn modify_db_instance_applies_monitoring_role_and_pi_fields() {
+    let svc = make_service();
+    seed_instance(&svc, "pi-db");
+    svc.modify_db_instance(&request(
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "pi-db"),
+            (
+                "MonitoringRoleArn",
+                "arn:aws:iam::123456789012:role/rds-monitor",
+            ),
+            (
+                "PerformanceInsightsKMSKeyId",
+                "arn:aws:kms:us-east-1:123456789012:key/pi-key",
+            ),
+            ("PerformanceInsightsRetentionPeriod", "731"),
+        ],
+    ))
+    .expect("ModifyDBInstance");
+    let accounts = svc.state.read();
+    let inst = accounts
+        .default_ref()
+        .instances
+        .get("pi-db")
+        .expect("instance");
+    assert_eq!(
+        inst.monitoring_role_arn.as_deref(),
+        Some("arn:aws:iam::123456789012:role/rds-monitor")
+    );
+    assert_eq!(
+        inst.performance_insights_kms_key_id.as_deref(),
+        Some("arn:aws:kms:us-east-1:123456789012:key/pi-key")
+    );
+    assert_eq!(inst.performance_insights_retention_period, Some(731));
+}
+
+#[test]
+fn modify_db_subnet_group_applies_description() {
+    let svc = make_service();
+    svc.create_db_subnet_group(&request(
+        "CreateDBSubnetGroup",
+        &[
+            ("DBSubnetGroupName", "sng1"),
+            ("DBSubnetGroupDescription", "original"),
+            ("SubnetIds.SubnetIdentifier.1", "subnet-aaaa1111"),
+            ("SubnetIds.SubnetIdentifier.2", "subnet-bbbb2222"),
+        ],
+    ))
+    .expect("CreateDBSubnetGroup");
+    let body = body_of(
+        svc.modify_db_subnet_group(&request(
+            "ModifyDBSubnetGroup",
+            &[
+                ("DBSubnetGroupName", "sng1"),
+                ("DBSubnetGroupDescription", "updated desc"),
+                ("SubnetIds.SubnetIdentifier.1", "subnet-aaaa1111"),
+                ("SubnetIds.SubnetIdentifier.2", "subnet-bbbb2222"),
+            ],
+        ))
+        .expect("ModifyDBSubnetGroup"),
+    );
+    assert!(
+        body.contains("<DBSubnetGroupDescription>updated desc</DBSubnetGroupDescription>"),
+        "{body}"
     );
 }

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -135,6 +135,28 @@ pub struct DbInstance {
     /// snapshot/restore paths can find the writer for a given cluster.
     #[serde(default)]
     pub db_cluster_identifier: Option<String>,
+    /// Database Activity Stream configuration, written by
+    /// `StartActivityStream` / `ModifyActivityStream` and cleared to
+    /// `stopped` by `StopActivityStream`. `None` reads back as a stopped
+    /// stream in describe responses.
+    #[serde(default)]
+    pub activity_stream: Option<ActivityStreamConfig>,
+}
+
+/// Database Activity Stream state for a DB instance. Persisted so that
+/// `StartActivityStream` / `StopActivityStream` / `ModifyActivityStream`
+/// round-trip through `DescribeDBInstances` instead of always reporting
+/// `stopped`.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ActivityStreamConfig {
+    /// One of `starting` | `started` | `stopping` | `stopped`.
+    pub status: String,
+    #[serde(default)]
+    pub mode: Option<String>,
+    #[serde(default)]
+    pub kms_key_id: Option<String>,
+    #[serde(default)]
+    pub kinesis_stream_name: Option<String>,
 }
 
 #[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -309,6 +331,13 @@ pub struct DbSnapshot {
     pub timezone: Option<String>,
     #[serde(default)]
     pub storage_throughput: Option<i32>,
+    /// Snapshot share attributes keyed by attribute name (currently only
+    /// `restore`), written by `ModifyDBSnapshotAttribute` and surfaced by
+    /// `DescribeDBSnapshotAttributes`. The `restore` list holds the AWS
+    /// account ids the snapshot is shared with (or the literal `all` for a
+    /// public snapshot).
+    #[serde(default)]
+    pub snapshot_attributes: BTreeMap<String, Vec<String>>,
 }
 
 impl fmt::Debug for DbSnapshot {
@@ -981,6 +1010,7 @@ mod tests {
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
                 db_cluster_identifier: None,
+                activity_stream: None,
             },
         );
 
@@ -1127,6 +1157,7 @@ mod tests {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         }
     }
 

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -814,6 +814,7 @@ mod tests {
             domain_auth_secret_arn: None,
             domain_dns_ips: Vec::new(),
             db_cluster_identifier: None,
+            activity_stream: None,
         };
 
         let response = rds_instance_response(&instance);

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -703,6 +703,7 @@ mod tests {
                 domain_auth_secret_arn: None,
                 domain_dns_ips: Vec::new(),
                 db_cluster_identifier: None,
+                activity_stream: None,
             },
         );
 


### PR DESCRIPTION
## Summary

A cluster of RDS `Copy*`/`Modify*`/`Restore*` "extras" ops returned canned/hardcoded XML but never persisted to state, so a subsequent `Describe` showed nothing (or a default). Their cluster-level analogs already persisted correctly a few hundred lines away in the same file. This mirrors that persistence pattern so every op round-trips through its `Describe`.

Behavior-only fix. No SDK/doc/operation-count surface change.

### HIGH
- **CopyDBSnapshot** now reads the source `DBSnapshot`, clones it (including dump data) into `state.snapshots` under the target id, and renders from the persisted record. `DescribeDBSnapshots --db-snapshot-identifier <target>` now returns the copy instead of `DBSnapshotNotFoundFault`.

### MEDIUM
- **CopyDBParameterGroup** persists the copy into `state.parameter_groups`.
- **ModifyDBSnapshotAttribute / DescribeDBSnapshotAttributes** persist the attribute set (e.g. `restore` add/remove values) on the snapshot and read it back; rejects a value present in both add and remove lists. **ModifyDBSnapshot** now applies `EngineVersion`/`OptionGroupName`.
- **ModifyCurrentDBClusterCapacity** applies the requested `Capacity` to the cluster and echoes real values (was hardcoded `CurrentCapacity=4` + cluster id `x`); the capacity round-trips through `DescribeDBClusters`.
- **EnableHttpEndpoint / DisableHttpEndpoint** write `HttpEndpointEnabled` onto the cluster (via `ResourceArn`) the same way `ModifyDBCluster` does; `DescribeDBClusters` reflects it. Unknown resource returns the declared `ResourceNotFoundFault`.
- **RestoreDBClusterFromS3** creates + persists a real cluster (was empty `<DBCluster/>`).
- **ModifyDBInstance** now applies `MonitoringRoleArn`, `PerformanceInsightsKMSKeyId`, `PerformanceInsightsRetentionPeriod` (their companions were already applied).

### LOW
- **ModifyDBSubnetGroup** applies `DBSubnetGroupDescription`.
- **ModifyDBShardGroup / CreateDBShardGroup** persist `MaxACU`/`MinACU`/`ComputeRedundancy`.
- **StartActivityStream / StopActivityStream / ModifyActivityStream** persist an activity-stream status/mode/kms/kinesis onto the DB instance (new `DbInstance::activity_stream` field) or Aurora cluster named by `ResourceArn`, rendered by `DescribeDBInstances`/`DescribeDBClusters` (was hardcoded `<ActivityStreamStatus>stopped`). `ModifyActivityStream`/HTTP-endpoint ops now return only Smithy-declared error shapes.

State-struct change: added `DbInstance::activity_stream` (+ `ActivityStreamConfig`) and `DbSnapshot::snapshot_attributes`; swept all constructors repo-wide (including `fakecloud-cloudformation`).

## Test plan
- New unit/integration round-trip tests in `crates/fakecloud-rds/src/service_tests.rs` and `extras/tests.rs`: copy-then-describe, modify-attribute-then-describe, enable-http-endpoint-then-describe, capacity echo + describe round-trip, restore-from-s3, shard-group capacity, activity-stream persist, PI/monitoring-role apply, subnet-group description.
- New E2E in `crates/fakecloud-e2e/tests/rds_extras_persistence.rs` (real AWS SDK, container-free): http endpoint, capacity, copy param group, restore-from-s3, activity stream on a cluster, subnet-group description. All 6 pass.
- `cargo nextest run -p fakecloud-rds` — 255 passing.
- `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` clean; `cargo fmt`.
- Conformance `check` PASSED with no regressions; RDS moved from 5487/5487 baseline to 5500/5518 with every changed op at 100% (fixed an initial regression where http-endpoint/activity-stream ops returned undeclared error shapes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RDS extras so Copy/Modify/Restore operations persist to state and round-trip through Describe, and makes activity stream and performance insights settings stick. Removes canned responses, returns correct error shapes, and improves parity with AWS.

- **Bug Fixes**
  - Snapshots: CopyDBSnapshot now clones the source into state (handles KMS/OptionGroup; no inherited share attrs); ModifyDBSnapshot applies EngineVersion/OptionGroupName; ModifyDBSnapshotAttribute persists the restore set and rejects values present in both add/remove; DescribeDBSnapshotAttributes returns saved attributes.
  - Parameter Groups: CopyDBParameterGroup persists the target group with description/family.
  - Clusters: ModifyCurrentDBClusterCapacity writes Capacity and echoes real values; Enable/DisableHttpEndpoint persist HttpEndpointEnabled by ResourceArn and return ResourceNotFoundFault for unknown ARNs; RestoreDBClusterFromS3 creates a real, describable cluster.
  - Instances: ModifyDBInstance applies MonitoringRoleArn, PerformanceInsightsKMSKeyId, and PerformanceInsightsRetentionPeriod.
  - Subnet/Shards: ModifyDBSubnetGroup updates DBSubnetGroupDescription; Create/ModifyDBShardGroup persist MaxACU/MinACU/ComputeRedundancy; RebootDBShardGroup echoes the stored group.
  - Activity Stream: Start/Stop/Modify persist stream status/mode/kms/kinesis on the targeted cluster or instance; DescribeDBClusters/DescribeDBInstances reflect it; ModifyActivityStream uses only declared error shapes.

- **Migration**
  - State additions: `DbInstance::activity_stream` and `DbSnapshot::snapshot_attributes`. Constructors updated across crates and tests to default `activity_stream` to None. No SDK or operation surface changes.

<sup>Written for commit b23b1f43d0a0b80ad103afe1ec8d584eab6a99cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

