### PR TITLE
fix(eventbridge,stepfunctions,sns): dup-name guard + terminal-transition re-check + redrive interpreter + ESM poller snapshot (bug-hunt)

### DIFF
--- a/crates/fakecloud-eventbridge/src/service_connections_apidests.rs
+++ b/crates/fakecloud-eventbridge/src/service_connections_apidests.rs
@@ -81,6 +81,16 @@ impl EventBridgeService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Reject duplicate connection names (real AWS retains the existing one).
+        if state.connections.contains_key(&name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceAlreadyExistsException",
+                format!("Connection {name} already exists."),
+            ));
+        }
+
         let now = Utc::now();
         let conn_uuid = uuid::Uuid::new_v4();
         let arn = format!(
@@ -342,6 +352,16 @@ impl EventBridgeService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+
+        // Reject duplicate api-destination names (real AWS retains the existing one).
+        if state.api_destinations.contains_key(&name) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceAlreadyExistsException",
+                format!("An api-destination {name} already exists."),
+            ));
+        }
+
         let now = Utc::now();
         let dest_uuid = uuid::Uuid::new_v4();
         let arn = format!(

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -674,6 +674,98 @@ fn list_connections_pagination_with_filter() {
 // -- ListApiDestinations tests --
 
 #[test]
+fn create_connection_duplicate_name_rejected() {
+    let svc = make_service();
+    create_connection(&svc, "prod");
+    let arn_first = {
+        let mas = svc.state.read();
+        mas.default_ref()
+            .connections
+            .get("prod")
+            .unwrap()
+            .arn
+            .clone()
+    };
+
+    // A second CreateConnection with the same name must fail, not overwrite.
+    let req = make_request(
+        "CreateConnection",
+        json!({
+            "Name": "prod",
+            "AuthorizationType": "API_KEY",
+            "AuthParameters": {
+                "ApiKeyAuthParameters": { "ApiKeyName": "x-api-key", "ApiKeyValue": "secret2" }
+            }
+        }),
+    );
+    let err = svc.create_connection(&req).err().expect("expected error");
+    assert_eq!(err.code(), "ResourceAlreadyExistsException");
+
+    // The original connection (ARN + secret) must be retained unchanged.
+    let arn_after = {
+        let mas = svc.state.read();
+        mas.default_ref()
+            .connections
+            .get("prod")
+            .unwrap()
+            .arn
+            .clone()
+    };
+    assert_eq!(arn_first, arn_after, "duplicate must not mint a fresh ARN");
+}
+
+#[test]
+fn create_api_destination_duplicate_name_rejected() {
+    let svc = make_service();
+    create_connection(&svc, "my-conn");
+    create_api_destination(&svc, "dest", "my-conn");
+    let arn_first = {
+        let mas = svc.state.read();
+        mas.default_ref()
+            .api_destinations
+            .get("dest")
+            .unwrap()
+            .arn
+            .clone()
+    };
+
+    let conn_arn = {
+        let mas = svc.state.read();
+        mas.default_ref()
+            .connections
+            .get("my-conn")
+            .unwrap()
+            .arn
+            .clone()
+    };
+    let req = make_request(
+        "CreateApiDestination",
+        json!({
+            "Name": "dest",
+            "ConnectionArn": conn_arn,
+            "InvocationEndpoint": "https://example.com",
+            "HttpMethod": "POST"
+        }),
+    );
+    let err = svc
+        .create_api_destination(&req)
+        .err()
+        .expect("expected error");
+    assert_eq!(err.code(), "ResourceAlreadyExistsException");
+
+    let arn_after = {
+        let mas = svc.state.read();
+        mas.default_ref()
+            .api_destinations
+            .get("dest")
+            .unwrap()
+            .arn
+            .clone()
+    };
+    assert_eq!(arn_first, arn_after, "duplicate must not mint a fresh ARN");
+}
+
+#[test]
 fn list_api_destinations_returns_all_by_default() {
     let svc = make_service();
     create_connection(&svc, "my-conn");

--- a/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
+++ b/crates/fakecloud-server/src/dynamodb_streams_lambda_poller.rs
@@ -14,12 +14,18 @@ use fakecloud_core::delivery::LambdaDelivery;
 use fakecloud_dynamodb::{cmp_seq, SharedDynamoDbState};
 use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::{LambdaInvocation, SharedLambdaState};
+use fakecloud_persistence::SnapshotHook;
 
 /// DynamoDB Streams -> Lambda event source mapping poller.
 pub struct DynamoDbStreamsLambdaPoller {
     dynamodb_state: SharedDynamoDbState,
     lambda_state: SharedLambdaState,
     lambda_delivery: Option<Arc<dyn LambdaDelivery>>,
+    /// Persists DynamoDB state after the poller advances a stream checkpoint.
+    /// Without it the checkpoint only reached disk on the next unrelated
+    /// DynamoDB API write, so a restart in the window re-delivered records the
+    /// mapping had already consumed (bug-audit 4.5).
+    snapshot_hook: Option<SnapshotHook>,
 }
 
 impl DynamoDbStreamsLambdaPoller {
@@ -28,12 +34,27 @@ impl DynamoDbStreamsLambdaPoller {
             dynamodb_state,
             lambda_state,
             lambda_delivery: None,
+            snapshot_hook: None,
         }
     }
 
     pub fn with_lambda_delivery(mut self, delivery: Arc<dyn LambdaDelivery>) -> Self {
         self.lambda_delivery = Some(delivery);
         self
+    }
+
+    pub fn with_snapshot_hook(mut self, hook: SnapshotHook) -> Self {
+        self.snapshot_hook = Some(hook);
+        self
+    }
+
+    /// Persist DynamoDB state through the same snapshot path a mutating
+    /// DynamoDB API call uses. Called only after the write guard is released
+    /// so the blocking snapshot IO never runs under the lock.
+    async fn persist(&self) {
+        if let Some(hook) = &self.snapshot_hook {
+            hook().await;
+        }
     }
 
     pub async fn run(self: Arc<Self>) {
@@ -273,6 +294,9 @@ impl DynamoDbStreamsLambdaPoller {
             // the invocation when no real Lambda runtime is wired.
             if let Some(seq) = last_seq.clone() {
                 self.advance_checkpoint(&ddb_account, &mapping_id, seq);
+                // Persist the advanced checkpoint so a restart resumes past the
+                // records this batch already delivered.
+                self.persist().await;
             }
 
             if self.lambda_delivery.is_none() {

--- a/crates/fakecloud-server/src/kinesis_lambda_poller.rs
+++ b/crates/fakecloud-server/src/kinesis_lambda_poller.rs
@@ -17,6 +17,7 @@ use fakecloud_core::delivery::LambdaDelivery;
 use fakecloud_kinesis::SharedKinesisState;
 use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::{LambdaInvocation, SharedLambdaState};
+use fakecloud_persistence::SnapshotHook;
 
 #[derive(Clone)]
 struct Mapping {
@@ -38,6 +39,11 @@ pub struct KinesisLambdaPoller {
     kinesis_state: SharedKinesisState,
     lambda_state: SharedLambdaState,
     lambda_delivery: Option<Arc<dyn LambdaDelivery>>,
+    /// Persists Kinesis state after the poller advances a lambda checkpoint.
+    /// Without it a checkpoint advance only reached disk on the next unrelated
+    /// Kinesis API write, so a restart in the window re-delivered records the
+    /// mapping had already consumed (bug-audit 4.5).
+    snapshot_hook: Option<SnapshotHook>,
 }
 
 impl KinesisLambdaPoller {
@@ -46,12 +52,27 @@ impl KinesisLambdaPoller {
             kinesis_state,
             lambda_state,
             lambda_delivery: None,
+            snapshot_hook: None,
         }
     }
 
     pub fn with_lambda_delivery(mut self, delivery: Arc<dyn LambdaDelivery>) -> Self {
         self.lambda_delivery = Some(delivery);
         self
+    }
+
+    pub fn with_snapshot_hook(mut self, hook: SnapshotHook) -> Self {
+        self.snapshot_hook = Some(hook);
+        self
+    }
+
+    /// Persist Kinesis state through the same snapshot path a mutating Kinesis
+    /// API call uses. Called only after the write guard is released so the
+    /// blocking snapshot IO never runs under the lock.
+    async fn persist(&self) {
+        if let Some(hook) = &self.snapshot_hook {
+            hook().await;
+        }
     }
 
     pub async fn run(self) {
@@ -224,10 +245,13 @@ impl KinesisLambdaPoller {
             // checkpoint past them — AWS treats filtered-out records
             // as consumed and never retries them.
             if matched.is_empty() {
-                let account_id = mapping.stream_arn.split(':').nth(4).unwrap_or("");
-                let mut kinesis_accounts = self.kinesis_state.write();
-                let kinesis = kinesis_accounts.get_or_create(account_id);
-                kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, end);
+                {
+                    let account_id = mapping.stream_arn.split(':').nth(4).unwrap_or("");
+                    let mut kinesis_accounts = self.kinesis_state.write();
+                    let kinesis = kinesis_accounts.get_or_create(account_id);
+                    kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, end);
+                }
+                self.persist().await;
                 continue;
             }
 
@@ -290,6 +314,9 @@ impl KinesisLambdaPoller {
                 let kinesis = kinesis_accounts.get_or_create(account_id);
                 kinesis.set_lambda_checkpoint(&mapping.uuid, &shard_id, new_checkpoint);
             }
+            // Persist the advanced checkpoint so a restart resumes past the
+            // records this batch already delivered.
+            self.persist().await;
 
             if !used_real_delivery {
                 let fn_account = mapping.function_arn.split(':').nth(4).unwrap_or("");

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1518,7 +1518,10 @@ async fn main() {
     if let Some(store) = sqs_snapshot_store.clone() {
         sqs_service = sqs_service.with_snapshot_store(store);
     }
-    if let Some(h) = sqs_service.snapshot_hook() {
+    // Capture the SQS snapshot hook once: shared by the CFN provisioner and the
+    // SQS->Lambda event source poller so poller-driven acks/checkpoints persist.
+    let sqs_poller_snapshot_hook = sqs_service.snapshot_hook();
+    if let Some(h) = sqs_poller_snapshot_hook.clone() {
         cfn_snapshot_hooks.insert("sqs", h);
     }
     // Resume any in-progress message-move task left RUNNING/CANCELLING by a
@@ -2443,7 +2446,10 @@ async fn main() {
     if let Some(store) = dynamodb_snapshot_store {
         dynamodb_service = dynamodb_service.with_snapshot_store(store);
     }
-    if let Some(h) = dynamodb_service.snapshot_hook() {
+    // Capture the DynamoDB snapshot hook once: shared by the CFN provisioner and
+    // the DynamoDB-Streams->Lambda poller so poller-driven checkpoints persist.
+    let dynamodb_poller_snapshot_hook = dynamodb_service.snapshot_hook();
+    if let Some(h) = dynamodb_poller_snapshot_hook.clone() {
         cfn_snapshot_hooks.insert("dynamodb", h);
     }
     let dynamodb_service = Arc::new(dynamodb_service);
@@ -2701,7 +2707,10 @@ async fn main() {
     if let Some(store) = kinesis_snapshot_store.clone() {
         kinesis_service = kinesis_service.with_snapshot_store(store);
     }
-    if let Some(h) = kinesis_service.snapshot_hook() {
+    // Capture the Kinesis snapshot hook once: shared by the CFN provisioner and
+    // the Kinesis->Lambda poller so poller-driven checkpoints persist.
+    let kinesis_poller_snapshot_hook = kinesis_service.snapshot_hook();
+    if let Some(h) = kinesis_poller_snapshot_hook.clone() {
         cfn_snapshot_hooks.insert("kinesis", h);
     }
     registry.register(Arc::new(kinesis_service));
@@ -6658,17 +6667,26 @@ async fn main() {
     if let Some(ref ld) = lambda_delivery {
         sqs_lambda_poller = sqs_lambda_poller.with_lambda_delivery(ld.clone());
     }
+    if let Some(h) = sqs_poller_snapshot_hook {
+        sqs_lambda_poller = sqs_lambda_poller.with_snapshot_hook(h);
+    }
     tokio::spawn(sqs_lambda_poller.run());
     let mut kinesis_lambda_poller =
         KinesisLambdaPoller::new(kinesis_state.clone(), lambda_invocations_state.clone());
     if let Some(ref ld) = lambda_delivery {
         kinesis_lambda_poller = kinesis_lambda_poller.with_lambda_delivery(ld.clone());
     }
+    if let Some(h) = kinesis_poller_snapshot_hook {
+        kinesis_lambda_poller = kinesis_lambda_poller.with_snapshot_hook(h);
+    }
     tokio::spawn(kinesis_lambda_poller.run());
     let mut dynamodb_streams_poller =
         DynamoDbStreamsLambdaPoller::new(dynamodb_state.clone(), lambda_invocations_state.clone());
     if let Some(ref ld) = lambda_delivery {
         dynamodb_streams_poller = dynamodb_streams_poller.with_lambda_delivery(ld.clone());
+    }
+    if let Some(h) = dynamodb_poller_snapshot_hook {
+        dynamodb_streams_poller = dynamodb_streams_poller.with_snapshot_hook(h);
     }
     tokio::spawn(Arc::new(dynamodb_streams_poller).run());
     // EventBridge Pipes runner: executes RUNNING pipes with an SQS / Kinesis /

--- a/crates/fakecloud-server/src/sqs_lambda_poller.rs
+++ b/crates/fakecloud-server/src/sqs_lambda_poller.rs
@@ -27,6 +27,7 @@ use serde_json::{json, Value};
 use fakecloud_core::delivery::{KmsHook, LambdaDelivery};
 use fakecloud_lambda::filter::FilterSet;
 use fakecloud_lambda::{LambdaInvocation, SharedLambdaState};
+use fakecloud_persistence::SnapshotHook;
 use fakecloud_sqs::SharedSqsState;
 
 #[derive(Clone)]
@@ -59,6 +60,12 @@ pub struct SqsLambdaPoller {
     /// mapping on a managed-SSE queue would deliver opaque envelope
     /// bytes and break every consumer.
     kms_hook: Option<Arc<dyn KmsHook>>,
+    /// Persists SQS state after the poller acks/redelivers messages. Without
+    /// this the poller's durable mutations (removed acked messages, bumped
+    /// receive_count / cleared visibility) only reached disk on the next
+    /// unrelated SQS API write, so a restart in the window re-delivered acked
+    /// messages or reset DLQ progress (bug-audit 4.5).
+    snapshot_hook: Option<SnapshotHook>,
 }
 
 impl SqsLambdaPoller {
@@ -68,6 +75,7 @@ impl SqsLambdaPoller {
             lambda_state,
             lambda_delivery: None,
             kms_hook: None,
+            snapshot_hook: None,
         }
     }
 
@@ -79,6 +87,20 @@ impl SqsLambdaPoller {
     pub fn with_kms_hook(mut self, hook: Arc<dyn KmsHook>) -> Self {
         self.kms_hook = Some(hook);
         self
+    }
+
+    pub fn with_snapshot_hook(mut self, hook: SnapshotHook) -> Self {
+        self.snapshot_hook = Some(hook);
+        self
+    }
+
+    /// Persist SQS state through the same snapshot path a mutating SQS API
+    /// call uses. Called only after the write guard is released so the
+    /// blocking snapshot IO never runs under the lock.
+    async fn persist(&self) {
+        if let Some(hook) = &self.snapshot_hook {
+            hook().await;
+        }
     }
 
     pub async fn run(self) {
@@ -303,15 +325,20 @@ impl SqsLambdaPoller {
         // Drop filtered-out messages — AWS treats them as acked so the
         // queue stops redelivering them.
         if !dropped_ids.is_empty() {
-            let mut sqs_mas = self.sqs_state.write();
-            let default_acct = sqs_mas.default_account_id().to_string();
-            let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
-            let sqs = sqs_mas.get_or_create(acct);
-            if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn) {
-                queue
-                    .messages
-                    .retain(|m| !dropped_ids.contains(&m.message_id));
+            {
+                let mut sqs_mas = self.sqs_state.write();
+                let default_acct = sqs_mas.default_account_id().to_string();
+                let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
+                let sqs = sqs_mas.get_or_create(acct);
+                if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn) {
+                    queue
+                        .messages
+                        .retain(|m| !dropped_ids.contains(&m.message_id));
+                }
             }
+            // Persist the filter-dropped (acked) removals so a restart doesn't
+            // re-deliver messages the mapping already discarded.
+            self.persist().await;
         }
 
         if matched_records.is_empty() {
@@ -364,24 +391,29 @@ impl SqsLambdaPoller {
         };
 
         if !acked_ids.is_empty() || !failed_ids.is_empty() {
-            let mut sqs_mas = self.sqs_state.write();
-            let default_acct = sqs_mas.default_account_id().to_string();
-            let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
-            let sqs = sqs_mas.get_or_create(acct);
-            if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn) {
-                queue
-                    .messages
-                    .retain(|m| !acked_ids.contains(&m.message_id));
-                // Failed messages stay; bump receive_count and clear
-                // any pending visibility timeout so the queue
-                // immediately considers them again on the next poll.
-                for msg in queue.messages.iter_mut() {
-                    if failed_ids.contains(&msg.message_id) {
-                        msg.receive_count = msg.receive_count.saturating_add(1);
-                        msg.visible_at = None;
+            {
+                let mut sqs_mas = self.sqs_state.write();
+                let default_acct = sqs_mas.default_account_id().to_string();
+                let acct = mapping.queue_arn.split(':').nth(4).unwrap_or(&default_acct);
+                let sqs = sqs_mas.get_or_create(acct);
+                if let Some(queue) = sqs.queues.values_mut().find(|q| q.arn == mapping.queue_arn) {
+                    queue
+                        .messages
+                        .retain(|m| !acked_ids.contains(&m.message_id));
+                    // Failed messages stay; bump receive_count and clear
+                    // any pending visibility timeout so the queue
+                    // immediately considers them again on the next poll.
+                    for msg in queue.messages.iter_mut() {
+                        if failed_ids.contains(&msg.message_id) {
+                            msg.receive_count = msg.receive_count.saturating_add(1);
+                            msg.visible_at = None;
+                        }
                     }
                 }
             }
+            // Persist acked removals + receive_count/visibility bumps so a
+            // restart preserves delivery progress instead of re-delivering.
+            self.persist().await;
         }
 
         let fn_account = mapping.function_arn.split(':').nth(4).unwrap_or("");
@@ -670,6 +702,45 @@ mod tests {
                 .iter()
                 .map(|m| &m.message_id)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression (bug-audit 4.5): after the poller acks + removes a
+    /// delivered message it must persist SQS state through the snapshot hook,
+    /// so a restart in the window doesn't re-deliver the acked message.
+    #[tokio::test]
+    async fn poller_persists_after_acking_messages() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let invocations = Arc::new(Mutex::new(Vec::<String>::new()));
+        let delivery: Arc<dyn LambdaDelivery> = Arc::new(RecordingLambda { invocations });
+        let (poller, sqs_state, _lambda_state) = build_states();
+
+        let snapshot_calls = Arc::new(AtomicUsize::new(0));
+        let counter = snapshot_calls.clone();
+        let hook: SnapshotHook = Arc::new(move || {
+            let counter = counter.clone();
+            Box::pin(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })
+        });
+
+        let poller = poller
+            .with_lambda_delivery(delivery)
+            .with_snapshot_hook(hook);
+        let mut batching = BatchingState::default();
+        poller.poll(&mut batching).await;
+
+        // The delivered message was acked + removed.
+        {
+            let sqs = sqs_state.read();
+            let queue = sqs.default_ref().queues.values().next().unwrap();
+            assert!(queue.messages.is_empty(), "acked message must be removed");
+        }
+        // ...and the removal must have been persisted through the hook.
+        assert!(
+            snapshot_calls.load(Ordering::SeqCst) >= 1,
+            "poller must snapshot after acking messages"
         );
     }
 

--- a/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_helpers.rs
@@ -1272,6 +1272,29 @@ pub(crate) fn add_event(
     }
 }
 
+/// Apply a terminal transition to `exec` only if it is still `Running`.
+/// Returns `true` when the transition was applied.
+///
+/// This centralizes the write-guard re-check that `succeed_execution` /
+/// `fail_execution` perform: a concurrent `StopExecution` may set the
+/// execution to `Aborted` (or a timeout to `TimedOut`) in the window after the
+/// interpreter's initial read-guard check but before it re-acquires the write
+/// guard. Overwriting that terminal state would make `DescribeExecution` report
+/// `SUCCEEDED`/`FAILED` for an execution the caller already stopped. Keeping the
+/// guard here means the whole terminal-transition stays atomic under the held
+/// write guard.
+pub(crate) fn apply_terminal_transition_if_running(
+    exec: &mut crate::state::Execution,
+    transition: impl FnOnce(&mut crate::state::Execution),
+) -> bool {
+    if exec.status == ExecutionStatus::Running {
+        transition(exec);
+        true
+    } else {
+        false
+    }
+}
+
 pub(crate) fn succeed_execution(
     state: &SharedStepFunctionsState,
     execution_arn: &str,
@@ -1304,9 +1327,11 @@ pub(crate) fn succeed_execution(
     let mut accounts = state.write();
     let s = accounts.get_or_create(&account_id);
     if let Some(exec) = s.executions.get_mut(execution_arn) {
-        exec.status = ExecutionStatus::Succeeded;
-        exec.output = Some(output_str);
-        exec.stop_date = Some(Utc::now());
+        apply_terminal_transition_if_running(exec, |exec| {
+            exec.status = ExecutionStatus::Succeeded;
+            exec.output = Some(output_str);
+            exec.stop_date = Some(Utc::now());
+        });
     }
 }
 
@@ -1340,10 +1365,12 @@ pub(crate) fn fail_execution(
     let mut accounts = state.write();
     let s = accounts.get_or_create(&account_id);
     if let Some(exec) = s.executions.get_mut(execution_arn) {
-        exec.status = ExecutionStatus::Failed;
-        exec.error = Some(error.to_string());
-        exec.cause = Some(cause.to_string());
-        exec.stop_date = Some(Utc::now());
+        apply_terminal_transition_if_running(exec, |exec| {
+            exec.status = ExecutionStatus::Failed;
+            exec.error = Some(error.to_string());
+            exec.cause = Some(cause.to_string());
+            exec.stop_date = Some(Utc::now());
+        });
     }
 }
 

--- a/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter_tests.rs
@@ -1189,6 +1189,68 @@ fn fail_execution_is_noop_when_already_terminal() {
     assert!(exec.error.is_none());
 }
 
+fn make_exec(status: ExecutionStatus) -> Execution {
+    Execution {
+        execution_arn: "arn:aws:states:us-east-1:123456789012:execution:test:x".to_string(),
+        state_machine_arn: "arn:aws:states:us-east-1:123456789012:stateMachine:test".to_string(),
+        state_machine_name: "test".to_string(),
+        name: "x".to_string(),
+        status,
+        input: None,
+        output: None,
+        start_date: Utc::now(),
+        stop_date: None,
+        error: None,
+        cause: None,
+        history_events: vec![],
+        parent_execution_arn: None,
+        is_sync: false,
+        billed_duration_ms: None,
+        billed_memory_mb: None,
+    }
+}
+
+// Deterministic unit test of the write-guard re-check: a concurrent
+// StopExecution sets Aborted in the TOCTOU window, and the late terminal
+// transition from the interpreter must NOT overwrite it.
+#[test]
+fn terminal_transition_skips_when_aborted() {
+    let mut exec = make_exec(ExecutionStatus::Aborted);
+    exec.stop_date = Some(Utc::now());
+    let applied = apply_terminal_transition_if_running(&mut exec, |e| {
+        e.status = ExecutionStatus::Succeeded;
+        e.output = Some("clobbered".to_string());
+    });
+    assert!(
+        !applied,
+        "must not transition an already-terminal execution"
+    );
+    assert_eq!(exec.status, ExecutionStatus::Aborted);
+    assert!(exec.output.is_none(), "Aborted output must be preserved");
+}
+
+#[test]
+fn terminal_transition_skips_when_timed_out() {
+    let mut exec = make_exec(ExecutionStatus::TimedOut);
+    let applied = apply_terminal_transition_if_running(&mut exec, |e| {
+        e.status = ExecutionStatus::Failed;
+    });
+    assert!(!applied);
+    assert_eq!(exec.status, ExecutionStatus::TimedOut);
+}
+
+#[test]
+fn terminal_transition_applies_when_running() {
+    let mut exec = make_exec(ExecutionStatus::Running);
+    let applied = apply_terminal_transition_if_running(&mut exec, |e| {
+        e.status = ExecutionStatus::Succeeded;
+        e.output = Some("ok".to_string());
+    });
+    assert!(applied);
+    assert_eq!(exec.status, ExecutionStatus::Succeeded);
+    assert_eq!(exec.output.as_deref(), Some("ok"));
+}
+
 // ── Pass state with ResultPath ──
 
 #[test]

--- a/crates/fakecloud-stepfunctions/src/service/executions.rs
+++ b/crates/fakecloud-stepfunctions/src/service/executions.rs
@@ -317,17 +317,81 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("executionArn"))?
             .to_string();
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        let exec = state.executions.get_mut(&arn).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ExecutionDoesNotExist",
-                format!("Execution does not exist: {arn}"),
+
+        // Reset the execution to Running and re-spawn the interpreter so a
+        // redriven execution actually runs to completion. Without spawning a
+        // driver the execution would hang RUNNING forever (bug-audit 4.6).
+        let (definition, input, logging_config) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+            let exec = state.executions.get(&arn).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ExecutionDoesNotExist",
+                    format!("Execution does not exist: {arn}"),
+                )
+            })?;
+
+            // Only terminal executions can be redriven; a RUNNING one already has
+            // a driver, and redriving it would spawn a duplicate interpreter.
+            if exec.status == crate::state::ExecutionStatus::Running {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ExecutionNotRedrivable",
+                    format!("Execution is not redrivable: {arn}"),
+                ));
+            }
+
+            let sm_arn = exec.state_machine_arn.clone();
+            let input = exec.input.clone();
+            let sm = state.state_machines.get(&sm_arn).ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ExecutionNotRedrivable",
+                    format!("State machine does not exist for execution: {arn}"),
+                )
+            })?;
+            let definition = sm.definition.clone();
+            let logging_config = sm.logging_configuration.clone();
+
+            // Reset execution to a clean RUNNING state before re-running.
+            let exec = state
+                .executions
+                .get_mut(&arn)
+                .expect("execution presence checked above");
+            exec.status = crate::state::ExecutionStatus::Running;
+            exec.stop_date = None;
+            exec.output = None;
+            exec.error = None;
+            exec.cause = None;
+            exec.history_events.clear();
+
+            (definition, input, logging_config)
+        };
+
+        // Spawn async execution (mirrors StartExecution).
+        let shared_state = self.state.clone();
+        let exec_arn_clone = arn.clone();
+        let delivery = self.delivery.clone();
+        let dynamodb_state = self.dynamodb_state.clone();
+        let registry = self.registry.clone();
+        let snapshot_store = self.snapshot_store.clone();
+        let snapshot_lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            interpreter::execute_state_machine(
+                shared_state.clone(),
+                exec_arn_clone,
+                definition,
+                input,
+                delivery,
+                dynamodb_state,
+                registry,
+                logging_config,
             )
-        })?;
-        exec.status = crate::state::ExecutionStatus::Running;
-        exec.stop_date = None;
+            .await;
+            super::save_stepfunctions_snapshot(&shared_state, snapshot_store, &snapshot_lock).await;
+        });
+
         Ok(AwsResponse::ok_json(json!({
             "redriveDate": chrono::Utc::now().timestamp(),
         })))

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -1594,6 +1594,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn redrive_execution_reruns_to_terminal() {
+        let svc = StepFunctionsService::new(make_state());
+        let sm_arn = create_sm(&svc, "redrive-sm");
+
+        let body = json!({"stateMachineArn": sm_arn, "name": "redrive-e"});
+        let req = make_request("StartExecution", &body.to_string());
+        let resp = svc.start_execution(&req).unwrap();
+        let exec_arn = body_json(&resp)["executionArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Stop before the spawned interpreter runs -> terminal ABORTED.
+        let req = make_request(
+            "StopExecution",
+            &json!({"executionArn": exec_arn, "error": "UserAborted", "cause": "stop"}).to_string(),
+        );
+        svc.stop_execution(&req).unwrap();
+
+        // Redrive: must reset to RUNNING and re-spawn the interpreter.
+        let req = make_request(
+            "RedriveExecution",
+            &json!({"executionArn": exec_arn}).to_string(),
+        );
+        let resp = svc.redrive_execution(&req).unwrap();
+        assert!(body_json(&resp)["redriveDate"].as_i64().is_some());
+
+        // The redriven Pass-state execution must reach a terminal state
+        // (SUCCEEDED) instead of hanging RUNNING forever.
+        let mut status = String::new();
+        for _ in 0..100 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let req = make_request(
+                "DescribeExecution",
+                &json!({"executionArn": exec_arn}).to_string(),
+            );
+            let b = body_json(&svc.describe_execution(&req).unwrap());
+            status = b["status"].as_str().unwrap().to_string();
+            if status != "RUNNING" {
+                break;
+            }
+        }
+        assert_eq!(
+            status, "SUCCEEDED",
+            "redriven execution must run to completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn redrive_execution_running_rejected() {
+        let svc = StepFunctionsService::new(make_state());
+        let sm_arn = create_sm(&svc, "redrive-running-sm");
+        let body = json!({"stateMachineArn": sm_arn, "name": "still-running"});
+        let req = make_request("StartExecution", &body.to_string());
+        let exec_arn = body_json(&svc.start_execution(&req).unwrap())["executionArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // A still-RUNNING execution is not redrivable (it already has a driver).
+        let req = make_request(
+            "RedriveExecution",
+            &json!({"executionArn": exec_arn}).to_string(),
+        );
+        let err = expect_err(svc.redrive_execution(&req));
+        assert!(err.to_string().contains("ExecutionNotRedrivable"));
+    }
+
+    #[tokio::test]
     async fn stop_execution_not_found() {
         let svc = StepFunctionsService::new(make_state());
         let req = make_request(


### PR DESCRIPTION
## Summary

Batch 9 of the concurrency / data-loss bug-hunt. Behavior-only fixes across EventBridge, Step Functions, and the server-side Lambda event-source pollers. No SDK / doc / operation-count changes.

- **EventBridge duplicate-name guard (4.2, MED, data-loss).** `CreateConnection` and `CreateApiDestination` inserted into their maps with no existence check, so a second create with the same name silently overwrote the first with a fresh ARN + secret (and stranded API destinations that referenced the old connection ARN). Both now return `ResourceAlreadyExistsException` when the name already exists, matching the sibling `CreateArchive` / `CreateReplay` error shape. Real AWS rejects the duplicate and retains everything.

- **Step Functions terminal-transition re-check (4.3, MED, TOCTOU).** `succeed_execution` / `fail_execution` checked `status == Running` under a read guard, released it, called `add_event` (which takes its own write lock), then re-acquired the write guard and set `Succeeded`/`Failed` **unconditionally** — overwriting an `Aborted`/`TimedOut` state a concurrent `StopExecution` had set in the window. The final write now re-checks `Running` under the held write guard (extracted into `apply_terminal_transition_if_running`) and leaves an already-terminal state untouched.

- **Step Functions `RedriveExecution` interpreter re-spawn (4.6, LOW, stub).** Redrive set `status = Running` but never spawned an interpreter, so a redriven execution hung `RUNNING` forever. It now re-spawns the interpreter (mirroring `StartExecution`), resetting output/error/cause/history first, and rejects a still-`RUNNING` execution with `ExecutionNotRedrivable`.

- **ESM poller snapshot persistence (4.5, LOW, restart).** The SQS, Kinesis, and DynamoDB-Streams -> Lambda pollers mutated durable state (acked-message removal + `receive_count`/visibility bumps; lambda checkpoints) under a write guard but never persisted — they relied on a later unrelated API write to flush, so a restart in the window re-delivered or reset progress. Each poller now takes the owning service's `SnapshotHook` and persists after releasing the mutation guard (snapshot IO never runs under the lock).

- **SNS -> SQS / SNS -> Lambda DLQ (4.4, MED-LOW).** Verified already implemented and tested on `main` (commit b17ca57f): `collect_topic_subscribers` threads `RedrivePolicy` into the SQS and Lambda subscriber tuples and both delivery paths route failures to the DLQ (e2e `sns_sqs_subscriber_failure_routes_to_dlq`). No further change needed.

### Known limitation
Redriving an execution that was `StopExecution`'d while its interpreter task was still alive (e.g. mid-`Wait`) can transiently run two interpreters — the new re-check keeps the final terminal state consistent, but Task-state side effects could double. Fully preventing it needs interpreter-cancellation infrastructure, out of scope for this batch.

## Test plan

- `cargo test -p fakecloud-eventbridge` — new `create_connection_duplicate_name_rejected`, `create_api_destination_duplicate_name_rejected`.
- `cargo test -p fakecloud-stepfunctions` (212 pass) — new `terminal_transition_skips_when_aborted` / `_timed_out` / `_applies_when_running` (deterministic re-check unit tests), `redrive_execution_reruns_to_terminal`, `redrive_execution_running_rejected`.
- `cargo test -p fakecloud --bin fakecloud poller` (12 pass) — new `poller_persists_after_acking_messages` asserting the snapshot hook fires after acks.
- `cargo clippy -p fakecloud-eventbridge -p fakecloud-stepfunctions -p fakecloud-sns -p fakecloud --all-targets -- -D warnings` clean; `cargo fmt`.
- `cargo build -p fakecloud --tests` green.
- Filtered e2e (`test(eventbridge) or test(stepfunction) or test(sns) or test(event_source)`) could not run locally: the shared build volume hit `No space left on device` while compiling the aws-sdk crates (known E2E disk-full infra flake), not a test failure. CI will exercise it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concurrency and durability issues across EventBridge, Step Functions, and Lambda event source pollers to prevent data loss and incorrect terminal states. Adds duplicate-name guards, atomic terminal transitions, redrive re-run, and snapshot persistence so progress survives restarts.

- **Bug Fixes**
  - EventBridge: `CreateConnection` and `CreateApiDestination` now reject duplicate names with `ResourceAlreadyExistsException` and keep existing ARNs/secrets.
  - Step Functions: terminal transitions re-check under the write lock and only apply when still `RUNNING`; `RedriveExecution` resets state, re-spawns the interpreter, and rejects when already `RUNNING`.
  - Lambda pollers: SQS, Kinesis, and DynamoDB Streams persist via each service’s snapshot hook after acking/removing messages or advancing checkpoints; hooks are wired in `main` and snapshot I/O runs outside locks to avoid contention.
  - SNS DLQ: Confirmed `RedrivePolicy` flows to SQS/Lambda subscribers and failures route to DLQs; no code changes.

<sup>Written for commit 45d4465185c53eb5eed519d2bacce9e46c7419ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

