### PR TITLE
fix(iot,iotwireless): persist remaining Verb::Action mutators + fail loud on unhandled ones (bug-hunt)

### DIFF
--- a/crates/fakecloud-iot/src/service.rs
+++ b/crates/fakecloud-iot/src/service.rs
@@ -188,9 +188,15 @@ impl IotService {
                 Ok((engine::list(data, meta, &query), false))
             }
             Verb::Action => {
-                // Any action not claimed by `special` is accepted as a
-                // control-plane no-op returning an empty (shape-valid) body.
-                Ok((ok_json(Value::Object(Map::new())), false))
+                // Read-only actions not claimed by `special` return an empty
+                // (shape-valid) body. An unclaimed *mutating* action must fail
+                // loud rather than silently accept-and-discard, so future model
+                // gaps surface instead of appearing to persist.
+                if is_read_only_action(meta) {
+                    Ok((ok_json(Value::Object(Map::new())), false))
+                } else {
+                    Err(AwsServiceError::action_not_implemented("iot", meta.op))
+                }
             }
         }
     }
@@ -279,6 +285,18 @@ fn match_segs(pattern: &[Seg], segs: &[String]) -> Option<(HashMap<String, Strin
 
 pub(crate) fn ok_json(v: Value) -> AwsResponse {
     AwsResponse::json_value(StatusCode::OK, v)
+}
+
+/// Whether an unclaimed `Verb::Action` operation is safe to accept as an empty
+/// no-op. Read operations (HTTP GET, or a `Get`/`List`/`Describe`/`Test`/
+/// `Validate` name — e.g. the index-analytics and authorizer-test actions) have
+/// no persisted side effect, so an empty body is shape-valid; anything else
+/// mutates and must fail loud instead of silently discarding the request.
+pub(crate) fn is_read_only_action(meta: &OpMeta) -> bool {
+    meta.method == "GET"
+        || ["Get", "List", "Describe", "Search", "Test", "Validate"]
+            .iter()
+            .any(|p| meta.op.starts_with(p))
 }
 
 pub(crate) fn parse_query(raw: &str) -> Vec<(String, String)> {

--- a/crates/fakecloud-iot/src/service/special.rs
+++ b/crates/fakecloud-iot/src/service/special.rs
@@ -369,6 +369,79 @@ pub(super) fn dispatch(
         // DescribeThingType reflects it (previously an accept-and-discard no-op).
         "DeprecateThingType" => Ok(Some(deprecate_thing_type(svc, ctx, meta, labels, body)?)),
 
+        // Certificate transfer resolutions. `TransferCertificate` parks the cert
+        // in PENDING_TRANSFER; these transitions unpark it (accept -> ACTIVE in
+        // the target account, reject/cancel -> INACTIVE) so DescribeCertificate
+        // reflects the outcome instead of the cert being stuck forever.
+        "AcceptCertificateTransfer" => Ok(Some(resolve_cert_transfer(
+            svc,
+            ctx,
+            meta,
+            labels,
+            CertTransfer::Accept,
+        )?)),
+        "RejectCertificateTransfer" => Ok(Some(resolve_cert_transfer(
+            svc,
+            ctx,
+            meta,
+            labels,
+            CertTransfer::Reject,
+        )?)),
+        "CancelCertificateTransfer" => Ok(Some(resolve_cert_transfer(
+            svc,
+            ctx,
+            meta,
+            labels,
+            CertTransfer::Cancel,
+        )?)),
+
+        // Package-version SBOM: persist the sbom + validation status on the
+        // stored package version so GetPackageVersion reflects it.
+        "AssociateSbomWithPackageVersion" => {
+            Ok(Some(associate_sbom(svc, ctx, meta, labels, body, true)?))
+        }
+        "DisassociateSbomFromPackageVersion" => {
+            Ok(Some(associate_sbom(svc, ctx, meta, labels, body, false)?))
+        }
+
+        // Per-target V2 logging level: persist so ListV2LoggingLevels reflects it
+        // (the account-wide singleton pair is handled by `singleton_spec`).
+        "SetV2LoggingLevel" => Ok(Some(set_v2_logging_level(svc, ctx, body))),
+        "DeleteV2LoggingLevel" => Ok(Some(delete_v2_logging_level(svc, ctx, query))),
+
+        // Per-thing job execution cancel: record a CANCELED execution so
+        // DescribeJobExecution reflects it (whole-job CancelJob is separate).
+        "CancelJobExecution" => Ok(Some(cancel_job_execution(svc, ctx, labels))),
+
+        // Long-running task cancels: transition the task record persisted by the
+        // matching Start* op so the Describe read reflects CANCELED.
+        "CancelAuditTask" => Ok(Some(cancel_task(svc, ctx, "audit/tasks", labels))),
+        "CancelAuditMitigationActionsTask" => Ok(Some(cancel_task(
+            svc,
+            ctx,
+            "audit/mitigationactions/tasks",
+            labels,
+        ))),
+        "CancelDetectMitigationActionsTask" => Ok(Some(cancel_task(
+            svc,
+            ctx,
+            "detect/mitigationactions/tasks",
+            labels,
+        ))),
+        "StopThingRegistrationTask" => Ok(Some(stop_thing_registration_task(svc, ctx, labels))),
+
+        // Violation verification state: persist so ListViolationEvents reflects
+        // it (there is no live detect plane generating violations otherwise).
+        "PutVerificationStateOnViolation" => {
+            Ok(Some(put_verification_state(svc, ctx, labels, body)))
+        }
+        "ListViolationEvents" => Ok(Some(list_violation_events(svc, ctx))),
+
+        // The CA registration code is derived deterministically per account (see
+        // `get_registration_code`), so there is no stored value to delete; accept
+        // the reset explicitly rather than letting it fall through.
+        "DeleteRegistrationCode" => Ok(Some((ok_json(Value::Object(Map::new())), false))),
+
         _ => Ok(None),
     }
 }
@@ -1967,4 +2040,279 @@ fn list_thing_groups_for_thing(
         })
         .collect();
     (ok_json(json!({ "thingGroups": objs })), false)
+}
+
+// ---------- certificate transfer resolution ----------
+
+enum CertTransfer {
+    Accept,
+    Reject,
+    Cancel,
+}
+
+/// Resolve a pending certificate transfer parked by `TransferCertificate`.
+/// Accept moves the cert to the target account and reactivates it; reject /
+/// cancel return it to an INACTIVE state and clear the pending-transfer fields.
+fn resolve_cert_transfer(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    kind: CertTransfer,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let cert_id = lbl(labels, "certificateId").unwrap_or("").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(mut record) = data.get_resource("certificates", &cert_id).cloned() else {
+        return Err(super::engine::not_found(meta, &cert_id));
+    };
+    // Only a certificate parked by TransferCertificate can be resolved; a cert
+    // that is not PENDING_TRANSFER yields the declared TransferAlreadyCompleted
+    // error rather than silently flipping status.
+    if record.get("status").and_then(Value::as_str) != Some("PENDING_TRANSFER") {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "TransferAlreadyCompletedException",
+            format!("The certificate transfer for '{cert_id}' is not pending."),
+        ));
+    }
+    if let Some(obj) = record.as_object_mut() {
+        match kind {
+            CertTransfer::Accept => {
+                let target = obj
+                    .remove("transferredTo")
+                    .and_then(|v| v.as_str().map(String::from));
+                obj.insert("status".to_string(), Value::String("ACTIVE".to_string()));
+                if let Some(target) = target {
+                    obj.insert(
+                        "certificateArn".to_string(),
+                        Value::String(format!(
+                            "arn:aws:iot:{}:{}:cert/{}",
+                            ctx.region, target, cert_id
+                        )),
+                    );
+                    obj.insert("ownedBy".to_string(), Value::String(target));
+                }
+                obj.remove("transferMessage");
+            }
+            CertTransfer::Reject | CertTransfer::Cancel => {
+                obj.insert("status".to_string(), Value::String("INACTIVE".to_string()));
+                obj.remove("transferredTo");
+                obj.remove("transferMessage");
+            }
+        }
+    }
+    data.put_resource("certificates", &cert_id, record);
+    Ok((ok_json(Value::Object(Map::new())), true))
+}
+
+// ---------- package-version SBOM ----------
+
+/// Persist (or clear) the SBOM + validation status on a stored package version
+/// so GetPackageVersion round-trips it. The package version is keyed
+/// `packageName/versionName` under the shared `packages/versions` store.
+fn associate_sbom(
+    svc: &IotService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+    associate: bool,
+) -> Result<(AwsResponse, bool), AwsServiceError> {
+    let pkg = lbl(labels, "packageName").unwrap_or("");
+    let ver = lbl(labels, "versionName").unwrap_or("");
+    let key = format!("{pkg}/{ver}");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let Some(mut record) = data.get_resource("packages/versions", &key).cloned() else {
+        return Err(super::engine::not_found(meta, &key));
+    };
+    if let Some(obj) = record.as_object_mut() {
+        if associate {
+            if let Some(sbom) = body.get("sbom") {
+                obj.insert("sbom".to_string(), sbom.clone());
+            }
+            // AWS validates the SBOM asynchronously; with no scanner the emulated
+            // outcome is a successful validation.
+            obj.insert(
+                "sbomValidationStatus".to_string(),
+                Value::String("SUCCEEDED".to_string()),
+            );
+        } else {
+            obj.remove("sbom");
+            obj.remove("sbomValidationStatus");
+        }
+    }
+    let out = super::build_output(meta, &record);
+    data.put_resource("packages/versions", &key, record);
+    Ok((ok_json(out), true))
+}
+
+// ---------- per-target V2 logging levels ----------
+
+/// `SetV2LoggingLevel`: persist one `(logTarget, logLevel)` pair keyed by the
+/// target identity so the generic `ListV2LoggingLevels` projection reflects it.
+fn set_v2_logging_level(
+    svc: &IotService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let target = body.get("logTarget").cloned().unwrap_or(json!({}));
+    let ttype = target
+        .get("targetType")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let tname = target
+        .get("targetName")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let key = format!("{ttype}:{tname}");
+    let level = body
+        .get("logLevel")
+        .cloned()
+        .unwrap_or_else(|| Value::String("INFO".to_string()));
+    let record = json!({ "logTarget": target, "logLevel": level });
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.put_resource("v2LoggingLevel", &key, record);
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `DeleteV2LoggingLevel`: clear the per-target level (target identity is a
+/// query parameter pair).
+fn delete_v2_logging_level(
+    svc: &IotService,
+    ctx: &Ctx,
+    query: &[(String, String)],
+) -> (AwsResponse, bool) {
+    let ttype = query_get(query, "targetType").unwrap_or("");
+    let tname = query_get(query, "targetName").unwrap_or("");
+    let key = format!("{ttype}:{tname}");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.remove_resource("v2LoggingLevel", &key);
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+// ---------- job execution / task cancels ----------
+
+/// `CancelJobExecution`: record a CANCELED execution for `thingName/jobId` so
+/// DescribeJobExecution (which projects the `execution` struct) reflects it.
+fn cancel_job_execution(
+    svc: &IotService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let thing = lbl(labels, "thingName").unwrap_or("");
+    let job = lbl(labels, "jobId").unwrap_or("");
+    let key = format!("{thing}/{job}");
+    let execution = json!({
+        "jobId": job,
+        "thingArn": mint_arn(ctx, "things", thing),
+        "status": "CANCELED",
+        "lastUpdatedAt": super::now_epoch(),
+    });
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.put_resource("things/jobs", &key, json!({ "execution": execution }));
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// Transition a long-running task record (persisted by its Start* op) to a
+/// CANCELED status. `store` is the task's resource type. Updates the top-level
+/// status members and, for the detect-mitigation variant, the nested
+/// `taskSummary.taskStatus` the Describe read projects.
+fn cancel_task(
+    svc: &IotService,
+    ctx: &Ctx,
+    store: &str,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let task_id = lbl(labels, "taskId").unwrap_or("").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(mut record) = data.get_resource(store, &task_id).cloned() {
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("status".to_string(), Value::String("CANCELED".to_string()));
+            obj.insert(
+                "taskStatus".to_string(),
+                Value::String("CANCELED".to_string()),
+            );
+            match obj.get_mut("taskSummary") {
+                Some(Value::Object(summary)) => {
+                    summary.insert(
+                        "taskStatus".to_string(),
+                        Value::String("CANCELED".to_string()),
+                    );
+                }
+                _ => {
+                    obj.insert(
+                        "taskSummary".to_string(),
+                        json!({ "taskId": task_id, "taskStatus": "CANCELED" }),
+                    );
+                }
+            }
+        }
+        data.put_resource(store, &task_id, record);
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `StopThingRegistrationTask`: transition the task record to Cancelled so
+/// DescribeThingRegistrationTask reflects it.
+fn stop_thing_registration_task(
+    svc: &IotService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let task_id = lbl(labels, "taskId").unwrap_or("").to_string();
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(mut record) = data
+        .get_resource("thing-registration-tasks", &task_id)
+        .cloned()
+    {
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("status".to_string(), Value::String("Cancelled".to_string()));
+        }
+        data.put_resource("thing-registration-tasks", &task_id, record);
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+// ---------- violation verification state ----------
+
+/// `PutVerificationStateOnViolation`: persist the verification state keyed by
+/// violation id so `ListViolationEvents` reflects it.
+fn put_verification_state(
+    svc: &IotService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let vid = lbl(labels, "violationId").unwrap_or("").to_string();
+    let mut record = Map::new();
+    record.insert("violationId".to_string(), Value::String(vid.clone()));
+    if let Some(state) = body.get("verificationState") {
+        record.insert("verificationState".to_string(), state.clone());
+    }
+    if let Some(desc) = body.get("verificationStateDescription") {
+        record.insert("verificationStateDescription".to_string(), desc.clone());
+    }
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.put_resource("violation-events", &vid, Value::Object(record));
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `ListViolationEvents`: return the stored violation records verbatim. The
+/// model gives the list element no projected members, so the generic engine
+/// would drop every field — this projects the full record instead.
+fn list_violation_events(svc: &IotService, ctx: &Ctx) -> (AwsResponse, bool) {
+    let g = svc.state.read();
+    let events = g
+        .get(&ctx.account)
+        .map(|d| d.list_resources("violation-events"))
+        .unwrap_or_default();
+    (ok_json(json!({ "violationEvents": events })), false)
 }

--- a/crates/fakecloud-iot/src/service/tests.rs
+++ b/crates/fakecloud-iot/src/service/tests.rs
@@ -1003,6 +1003,267 @@ fn list_thing_groups_for_thing_inverts_membership() {
         .contains(":thinggroup/g1"));
 }
 
+// ---------- certificate transfer resolution ----------
+
+fn cert_status(s: &IotService, cert_id: &str) -> String {
+    let desc = body_of(
+        &run(
+            s,
+            "GET",
+            &format!("/certificates/{cert_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    desc["certificateDescription"]["status"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn accept_certificate_transfer_reactivates_cert() {
+    let s = svc();
+    let cert = body_of(&run(&s, "POST", "/keys-and-certificate", &[], Value::Null).unwrap());
+    let cert_id = cert["certificateId"].as_str().unwrap().to_string();
+    run(
+        &s,
+        "PATCH",
+        &format!("/transfer-certificate/{cert_id}?targetAwsAccount=111122223333"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    assert_eq!(cert_status(&s, &cert_id), "PENDING_TRANSFER");
+
+    run(
+        &s,
+        "PATCH",
+        &format!("/accept-certificate-transfer/{cert_id}"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    assert_eq!(cert_status(&s, &cert_id), "ACTIVE");
+}
+
+#[test]
+fn reject_certificate_transfer_deactivates_cert() {
+    let s = svc();
+    let cert = body_of(&run(&s, "POST", "/keys-and-certificate", &[], Value::Null).unwrap());
+    let cert_id = cert["certificateId"].as_str().unwrap().to_string();
+    run(
+        &s,
+        "PATCH",
+        &format!("/transfer-certificate/{cert_id}?targetAwsAccount=111122223333"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    run(
+        &s,
+        "PATCH",
+        &format!("/reject-certificate-transfer/{cert_id}"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    assert_eq!(cert_status(&s, &cert_id), "INACTIVE");
+}
+
+#[test]
+fn accept_certificate_transfer_unknown_cert_is_not_found() {
+    let s = svc();
+    // certificateId is @length(min: 64); use a 64-char hex id that was never
+    // created so the handler (not validation) produces the not-found.
+    let unknown = "a".repeat(64);
+    let err = expect_err(run(
+        &s,
+        "PATCH",
+        &format!("/accept-certificate-transfer/{unknown}"),
+        &[],
+        Value::Null,
+    ));
+    assert!(is_code(&err, "ResourceNotFoundException"));
+}
+
+// ---------- package-version SBOM ----------
+
+#[test]
+fn associate_sbom_round_trips_through_get_package_version() {
+    let s = svc();
+    run(&s, "PUT", "/packages/pkg1", &[], json!({})).unwrap();
+    run(&s, "PUT", "/packages/pkg1/versions/v1", &[], json!({})).unwrap();
+    run(
+        &s,
+        "PUT",
+        "/packages/pkg1/versions/v1/sbom",
+        &[],
+        json!({"sbom": {"s3Location": {"bucket": "b", "key": "k"}}}),
+    )
+    .unwrap();
+    let got = body_of(&run(&s, "GET", "/packages/pkg1/versions/v1", &[], Value::Null).unwrap());
+    assert_eq!(got["sbomValidationStatus"], "SUCCEEDED");
+    assert_eq!(got["sbom"]["s3Location"]["bucket"], "b");
+
+    // Disassociate clears both.
+    run(
+        &s,
+        "DELETE",
+        "/packages/pkg1/versions/v1/sbom",
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let got = body_of(&run(&s, "GET", "/packages/pkg1/versions/v1", &[], Value::Null).unwrap());
+    assert!(got.get("sbom").is_none());
+    assert!(got.get("sbomValidationStatus").is_none());
+}
+
+// ---------- per-target V2 logging level ----------
+
+#[test]
+fn set_v2_logging_level_round_trips_through_list() {
+    let s = svc();
+    run(
+        &s,
+        "POST",
+        "/v2LoggingLevel",
+        &[],
+        json!({"logTarget": {"targetType": "THING_GROUP", "targetName": "g1"}, "logLevel": "DEBUG"}),
+    )
+    .unwrap();
+    let listed = body_of(&run(&s, "GET", "/v2LoggingLevel", &[], Value::Null).unwrap());
+    let levels = listed["logTargetConfigurations"].as_array().unwrap();
+    assert_eq!(levels.len(), 1);
+    assert_eq!(levels[0]["logLevel"], "DEBUG");
+    assert_eq!(levels[0]["logTarget"]["targetName"], "g1");
+
+    run(
+        &s,
+        "DELETE",
+        "/v2LoggingLevel?targetType=THING_GROUP&targetName=g1",
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let listed = body_of(&run(&s, "GET", "/v2LoggingLevel", &[], Value::Null).unwrap());
+    assert!(listed["logTargetConfigurations"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+}
+
+// ---------- job execution + task cancels ----------
+
+#[test]
+fn cancel_job_execution_shows_canceled_in_describe() {
+    let s = svc();
+    run(&s, "PUT", "/things/thing1/jobs/job1/cancel", &[], json!({})).unwrap();
+    let desc = body_of(&run(&s, "GET", "/things/thing1/jobs/job1", &[], Value::Null).unwrap());
+    assert_eq!(desc["execution"]["status"], "CANCELED");
+    assert_eq!(desc["execution"]["jobId"], "job1");
+}
+
+#[test]
+fn cancel_audit_task_transitions_status() {
+    let s = svc();
+    let out = body_of(
+        &run(
+            &s,
+            "POST",
+            "/audit/tasks",
+            &[],
+            json!({"targetCheckNames": ["LOGGING_DISABLED_CHECK"]}),
+        )
+        .unwrap(),
+    );
+    let task_id = out["taskId"].as_str().unwrap().to_string();
+    run(
+        &s,
+        "PUT",
+        &format!("/audit/tasks/{task_id}/cancel"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let desc = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/audit/tasks/{task_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(desc["taskStatus"], "CANCELED");
+}
+
+#[test]
+fn cancel_detect_mitigation_task_transitions_task_summary() {
+    let s = svc();
+    let task_id = "detect-task-1";
+    run(
+        &s,
+        "PUT",
+        &format!("/detect/mitigationactions/tasks/{task_id}"),
+        &[],
+        json!({"actions": ["a"], "target": {}, "clientRequestToken": "tok"}),
+    )
+    .unwrap();
+    run(
+        &s,
+        "PUT",
+        &format!("/detect/mitigationactions/tasks/{task_id}/cancel"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let desc = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/detect/mitigationactions/tasks/{task_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(desc["taskSummary"]["taskStatus"], "CANCELED");
+}
+
+// ---------- violation verification state ----------
+
+#[test]
+fn put_verification_state_round_trips_through_list_violation_events() {
+    let s = svc();
+    run(
+        &s,
+        "POST",
+        "/violations/verification-state/viol-1",
+        &[],
+        json!({"verificationState": "FALSE_POSITIVE", "verificationStateDescription": "known good"}),
+    )
+    .unwrap();
+    // ListViolationEvents requires startTime + endTime query parameters.
+    let listed = body_of(
+        &run(
+            &s,
+            "GET",
+            "/violation-events?startTime=1700000000&endTime=1800000000",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    let events = listed["violationEvents"].as_array().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["violationId"], "viol-1");
+    assert_eq!(events[0]["verificationState"], "FALSE_POSITIVE");
+}
+
 // ---------- every operation routes to a handler ----------
 
 #[test]

--- a/crates/fakecloud-iotwireless/src/service.rs
+++ b/crates/fakecloud-iotwireless/src/service.rs
@@ -199,9 +199,18 @@ impl IotWirelessService {
                 Ok((engine::list(data, meta, &query), false))
             }
             Verb::Action => {
-                // Any action not claimed by `special` is accepted as a
-                // control-plane no-op returning an empty (shape-valid) body.
-                Ok((ok_json(Value::Object(Map::new())), false))
+                // Read-only actions not claimed by `special` return an empty
+                // (shape-valid) body. An unclaimed *mutating* action must fail
+                // loud rather than silently accept-and-discard, so future model
+                // gaps surface instead of appearing to persist.
+                if is_read_only_action(meta) {
+                    Ok((ok_json(Value::Object(Map::new())), false))
+                } else {
+                    Err(AwsServiceError::action_not_implemented(
+                        "iotwireless",
+                        meta.op,
+                    ))
+                }
             }
         }
     }
@@ -290,6 +299,17 @@ fn match_segs(pattern: &[Seg], segs: &[String]) -> Option<(HashMap<String, Strin
 
 pub(crate) fn ok_json(v: Value) -> AwsResponse {
     AwsResponse::json_value(StatusCode::OK, v)
+}
+
+/// Whether an unclaimed `Verb::Action` operation is safe to accept as an empty
+/// no-op. Read operations (HTTP GET, or a `Get`/`List`/`Describe` name) have no
+/// persisted side effect, so an empty body is shape-valid; anything else mutates
+/// and must fail loud instead of silently discarding the request.
+pub(crate) fn is_read_only_action(meta: &OpMeta) -> bool {
+    meta.method == "GET"
+        || ["Get", "List", "Describe", "Search"]
+            .iter()
+            .any(|p| meta.op.starts_with(p))
 }
 
 pub(crate) fn parse_query(raw: &str) -> Vec<(String, String)> {

--- a/crates/fakecloud-iotwireless/src/service/special.rs
+++ b/crates/fakecloud-iotwireless/src/service/special.rs
@@ -210,6 +210,33 @@ pub(super) fn dispatch(
             Ok(Some(list_multicast_groups_by_fuota_task(svc, ctx, labels)))
         }
 
+        // ---- multicast-group LoRaWAN session lifecycle ----
+        // Start persists the requested LoRaWAN session under `multicast-sessions`
+        // keyed by group id; Get projects it; Cancel clears it.
+        "StartMulticastGroupSession" => Ok(Some(start_multicast_session(svc, ctx, labels, body))),
+        "GetMulticastGroupSession" => Ok(Some(get_multicast_session(svc, ctx, labels))),
+        "CancelMulticastGroupSession" => Ok(Some(cancel_multicast_session(svc, ctx, labels))),
+
+        // ---- FUOTA task session start (transitions the task's Status) ----
+        "StartFuotaTask" => Ok(Some(start_fuota_task(svc, ctx, labels))),
+
+        // ---- bulk device <-> multicast-group membership ----
+        // The bulk ops select devices by a tag query we do not model; the
+        // faithful approximation associates / disassociates every wireless device
+        // registered in the account, persisting to the same `multicast-devices`
+        // relation the single-device variant writes.
+        "StartBulkAssociateWirelessDeviceWithMulticastGroup" => {
+            Ok(Some(bulk_multicast_membership(svc, ctx, labels, true)))
+        }
+        "StartBulkDisassociateWirelessDeviceFromMulticastGroup" => {
+            Ok(Some(bulk_multicast_membership(svc, ctx, labels, false)))
+        }
+
+        // ---- low-frequency mutators with a concrete state effect ----
+        "DeleteQueuedMessages" => Ok(Some(delete_queued_messages(svc, ctx, labels))),
+        "DeregisterWirelessDevice" => Ok(Some(deregister_wireless_device(svc, ctx, labels))),
+        "ResetAllResourceLogLevels" => Ok(Some(reset_all_resource_log_levels(svc, ctx))),
+
         _ => Ok(None),
     }
 }
@@ -936,6 +963,146 @@ fn disassociate_partner_account(
             .get_mut("partner-accounts")
             .map(|m| m.remove(id));
     }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+// ---------- multicast-group LoRaWAN session ----------
+
+/// `StartMulticastGroupSession`: persist the requested LoRaWAN session so
+/// `GetMulticastGroupSession` reflects it. AWS returns no output members.
+fn start_multicast_session(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Id").map(String::as_str).unwrap_or("");
+    let lorawan = body.get("LoRaWAN").cloned().unwrap_or_else(|| json!({}));
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.put_resource("multicast-sessions", id, json!({ "LoRaWAN": lorawan }));
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `GetMulticastGroupSession`: project the stored LoRaWAN session. A group with
+/// no active session returns an empty (shape-valid) body.
+fn get_multicast_session(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Id").map(String::as_str).unwrap_or("");
+    let g = svc.state.read();
+    let lorawan = g
+        .get(&ctx.account)
+        .and_then(|d| d.get_resource("multicast-sessions", id))
+        .and_then(|r| r.get("LoRaWAN"))
+        .cloned();
+    match lorawan {
+        Some(l) => (ok_json(json!({ "LoRaWAN": l })), false),
+        None => (ok_json(Value::Object(Map::new())), false),
+    }
+}
+
+/// `CancelMulticastGroupSession`: clear the stored LoRaWAN session.
+fn cancel_multicast_session(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Id").map(String::as_str).unwrap_or("");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.remove_resource("multicast-sessions", id);
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `StartFuotaTask`: transition the addressed FUOTA task into an in-session
+/// status so `GetFuotaTask` reflects it. No-op when the task does not exist.
+fn start_fuota_task(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Id").map(String::as_str).unwrap_or("");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(mut record) = data.get_resource("fuota-tasks", id).cloned() {
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("Status".to_string(), json!("In_FuotaSession"));
+        }
+        data.put_resource("fuota-tasks", id, record);
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `StartBulkAssociate/DisassociateWirelessDeviceWithMulticastGroup`: the tag
+/// query is not modelled, so associate / disassociate every wireless device in
+/// the account, writing to the same `multicast-devices` relation the
+/// single-device variant uses.
+fn bulk_multicast_membership(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+    associate: bool,
+) -> (AwsResponse, bool) {
+    let key = multicast_devices_key(labels);
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    let device_ids: Vec<String> = data
+        .resources
+        .get("wireless-devices")
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default();
+    for device in device_ids {
+        if associate {
+            data.add_relation(&key, &device);
+        } else {
+            data.remove_relation(&key, &device);
+        }
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `DeleteQueuedMessages`: purge the addressed device's persisted downlink queue
+/// store (idempotent — there is no live radio plane enqueuing messages).
+fn delete_queued_messages(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Id").map(String::as_str).unwrap_or("");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.remove_resource("wireless-devices/data", id);
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `DeregisterWirelessDevice`: persist the deregistered state on the device
+/// record rather than accepting-and-discarding the call.
+fn deregister_wireless_device(
+    svc: &IotWirelessService,
+    ctx: &Ctx,
+    labels: &HashMap<String, String>,
+) -> (AwsResponse, bool) {
+    let id = labels.get("Identifier").map(String::as_str).unwrap_or("");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(mut record) = data.get_resource("wireless-devices", id).cloned() {
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("DeviceRegistrationState".to_string(), json!("Deregistered"));
+        }
+        data.put_resource("wireless-devices", id, record);
+    }
+    (ok_json(Value::Object(Map::new())), true)
+}
+
+/// `ResetAllResourceLogLevels`: clear every per-resource log level written by
+/// `PutResourceLogLevel`.
+fn reset_all_resource_log_levels(svc: &IotWirelessService, ctx: &Ctx) -> (AwsResponse, bool) {
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    data.resources.remove("log-levels");
     (ok_json(Value::Object(Map::new())), true)
 }
 

--- a/crates/fakecloud-iotwireless/src/service/special.rs
+++ b/crates/fakecloud-iotwireless/src/service/special.rs
@@ -928,26 +928,36 @@ fn associate_partner_account(
         .and_then(Value::as_str)
         .unwrap_or("");
     let fingerprint = fingerprint_hex(private_key);
+    let arn = mint_arn(ctx, "partner-accounts", &amazon_id);
     // The SidewalkAccountInfoWithFingerprint the reads project carries the
-    // AmazonId + Fingerprint (never the private key).
+    // AmazonId + Fingerprint + Arn (never the private key).
     let sidewalk_with_fp = json!({
         "AmazonId": amazon_id,
         "Fingerprint": fingerprint,
+        "Arn": arn,
     });
-    // Store the projected list-element members (AmazonId/Fingerprint/Arn) at the
-    // top level so the generic ListPartnerAccounts projection finds them, and
-    // keep the nested Sidewalk object for GetPartnerAccount.
+    // Persist enough for both reads: `Sidewalk` (struct) + `AccountLinked` for
+    // GetPartnerAccount, and top-level `AmazonId`/`Fingerprint`/`Arn` for the
+    // ListPartnerAccounts element projection.
     let record = json!({
         "AmazonId": amazon_id,
         "Fingerprint": fingerprint,
+        "Arn": arn,
+        "AccountLinked": true,
         "Sidewalk": sidewalk_with_fp,
         "PartnerAccountId": amazon_id,
         "PartnerType": "Sidewalk",
     });
     let mut g = svc.state.write();
     let data = g.get_or_create(&ctx.account);
-    data.put_resource("partner-accounts", &amazon_id, record.clone());
-    (ok_json(record), true)
+    data.put_resource("partner-accounts", &amazon_id, record);
+    // AssociateAwsAccountWithPartnerAccountResponse.Sidewalk is `SidewalkAccountInfo`
+    // (AmazonId only — never the fingerprint/arn variant, which belongs to the
+    // Get/List reads), plus a top-level Arn.
+    (
+        ok_json(json!({ "Sidewalk": { "AmazonId": amazon_id }, "Arn": arn })),
+        true,
+    )
 }
 
 /// Remove a partner-account association.

--- a/crates/fakecloud-iotwireless/src/service/tests.rs
+++ b/crates/fakecloud-iotwireless/src/service/tests.rs
@@ -898,6 +898,140 @@ fn deregister_wireless_device_persists_state() {
 }
 
 #[test]
+fn partner_account_associate_get_list_disassociate_round_trips() {
+    let s = svc();
+    // Associate: the only create path for a Sidewalk partner account.
+    let out = body_of(
+        &run(
+            &s,
+            "POST",
+            "/partner-accounts",
+            &[],
+            json!({"Sidewalk": {"AmazonId": "amzn-1", "AppServerPrivateKey": "secret-key"}}),
+        )
+        .unwrap(),
+    );
+    // Associate response Sidewalk is the SidewalkAccountInfo shape (AmazonId
+    // only) + a top-level Arn; the fingerprint variant belongs to the reads.
+    assert_eq!(out["Sidewalk"]["AmazonId"], "amzn-1");
+    assert!(out["Sidewalk"].get("Fingerprint").is_none());
+    assert!(out["Arn"]
+        .as_str()
+        .unwrap()
+        .contains(":PartnerAccount/amzn-1"));
+    assert!(out.get("PartnerType").is_none());
+
+    // GetPartnerAccount reflects Sidewalk (with Fingerprint) + AccountLinked.
+    let got = body_of(
+        &run(
+            &s,
+            "GET",
+            "/partner-accounts/amzn-1?partnerType=Sidewalk",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(got["Sidewalk"]["AmazonId"], "amzn-1");
+    let fp = got["Sidewalk"]["Fingerprint"].as_str().unwrap();
+    assert!(!fp.is_empty() && fp.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(got["AccountLinked"], true);
+
+    // ListPartnerAccounts reflects it (element carries AmazonId/Fingerprint/Arn).
+    let listed = body_of(&run(&s, "GET", "/partner-accounts", &[], Value::Null).unwrap());
+    let accounts = listed["Sidewalk"].as_array().unwrap();
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts[0]["AmazonId"], "amzn-1");
+    assert!(accounts[0]["Arn"]
+        .as_str()
+        .unwrap()
+        .contains(":PartnerAccount/amzn-1"));
+
+    // Disassociate removes it.
+    run(
+        &s,
+        "DELETE",
+        "/partner-accounts/amzn-1?partnerType=Sidewalk",
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let listed = body_of(&run(&s, "GET", "/partner-accounts", &[], Value::Null).unwrap());
+    assert!(listed["Sidewalk"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn wireless_gateway_certificate_associate_get_disassociate_round_trips() {
+    let s = svc();
+    let gw = body_of(
+        &run(
+            &s,
+            "POST",
+            "/wireless-gateways",
+            &[],
+            json!({"Name": "gw-1", "LoRaWAN": {"GatewayEui": "0000000000000000"}}),
+        )
+        .unwrap(),
+    );
+    let id = gw["Id"].as_str().unwrap().to_string();
+
+    // No cert yet -> empty id.
+    let empty = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-gateways/{id}/certificate"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(empty["IotCertificateId"], "");
+
+    // Associate the cert binding.
+    run(
+        &s,
+        "PUT",
+        &format!("/wireless-gateways/{id}/certificate"),
+        &[],
+        json!({"IotCertificateId": "cert-abc"}),
+    )
+    .unwrap();
+    let got = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-gateways/{id}/certificate"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(got["IotCertificateId"], "cert-abc");
+
+    // Disassociate clears it.
+    run(
+        &s,
+        "DELETE",
+        &format!("/wireless-gateways/{id}/certificate"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let cleared = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-gateways/{id}/certificate"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(cleared["IotCertificateId"], "");
+}
+
+#[test]
 fn read_only_action_classifier_separates_reads_from_mutators() {
     let find = |op: &str| crate::generated::OPS.iter().find(|m| m.op == op).unwrap();
     // GET-shaped actions are accepted as empty no-ops when unclaimed.

--- a/crates/fakecloud-iotwireless/src/service/tests.rs
+++ b/crates/fakecloud-iotwireless/src/service/tests.rs
@@ -683,6 +683,241 @@ fn list_paginates_with_round_tripping_token() {
     assert_eq!(page2["DeviceProfileList"].as_array().unwrap().len(), 2);
 }
 
+// ---------- multicast session / fuota / bulk / low-frequency mutators ----------
+
+#[test]
+fn multicast_group_session_start_get_cancel_round_trips() {
+    let s = svc();
+    // No session yet -> empty body.
+    let empty = body_of(
+        &run(
+            &s,
+            "GET",
+            "/multicast-groups/mc-1/session",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert!(empty.get("LoRaWAN").is_none());
+
+    // Start persists the LoRaWAN session.
+    run(
+        &s,
+        "PUT",
+        "/multicast-groups/mc-1/session",
+        &[],
+        json!({"LoRaWAN": {"SessionStartTime": 1_752_324_947.0, "SessionTimeout": 60}}),
+    )
+    .unwrap();
+    let got = body_of(
+        &run(
+            &s,
+            "GET",
+            "/multicast-groups/mc-1/session",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert_eq!(got["LoRaWAN"]["SessionTimeout"], 60);
+
+    // Cancel clears it.
+    run(
+        &s,
+        "DELETE",
+        "/multicast-groups/mc-1/session",
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let cleared = body_of(
+        &run(
+            &s,
+            "GET",
+            "/multicast-groups/mc-1/session",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert!(cleared.get("LoRaWAN").is_none());
+}
+
+#[test]
+fn start_fuota_task_transitions_status() {
+    let s = svc();
+    let created = body_of(
+        &run(
+            &s,
+            "POST",
+            "/fuota-tasks",
+            &[],
+            json!({"FirmwareUpdateImage": "img", "FirmwareUpdateRole": "arn:role"}),
+        )
+        .unwrap(),
+    );
+    let id = created["Id"].as_str().unwrap().to_string();
+
+    run(
+        &s,
+        "PUT",
+        &format!("/fuota-tasks/{id}"),
+        &[],
+        json!({"LoRaWAN": {}, "DestinationName": "dest"}),
+    )
+    .unwrap();
+    let got = body_of(&run(&s, "GET", &format!("/fuota-tasks/{id}"), &[], Value::Null).unwrap());
+    assert_eq!(got["Status"], "In_FuotaSession");
+}
+
+#[test]
+fn bulk_associate_wireless_devices_with_multicast_group_persists_edges() {
+    let s = svc();
+    // Register two wireless devices.
+    let d1 = body_of(
+        &run(
+            &s,
+            "POST",
+            "/wireless-devices",
+            &[],
+            json!({"Type": "Sidewalk", "DestinationName": "d"}),
+        )
+        .unwrap(),
+    );
+    let id1 = d1["Id"].as_str().unwrap().to_string();
+    let d2 = body_of(
+        &run(
+            &s,
+            "POST",
+            "/wireless-devices",
+            &[],
+            json!({"Type": "Sidewalk", "DestinationName": "d"}),
+        )
+        .unwrap(),
+    );
+    let id2 = d2["Id"].as_str().unwrap().to_string();
+
+    run(
+        &s,
+        "PATCH",
+        "/multicast-groups/mc-9/bulk",
+        &[],
+        json!({"QueryString": "thingName:*"}),
+    )
+    .unwrap();
+    {
+        let g = s.state.read();
+        let members = g
+            .get("000000000000")
+            .unwrap()
+            .list_relation("multicast-devices:mc-9");
+        assert!(members.contains(&id1) && members.contains(&id2));
+    }
+
+    run(
+        &s,
+        "POST",
+        "/multicast-groups/mc-9/bulk",
+        &[],
+        json!({"QueryString": "thingName:*"}),
+    )
+    .unwrap();
+    {
+        let g = s.state.read();
+        let members = g
+            .get("000000000000")
+            .unwrap()
+            .list_relation("multicast-devices:mc-9");
+        assert!(members.is_empty());
+    }
+}
+
+#[test]
+fn reset_all_resource_log_levels_clears_store() {
+    let s = svc();
+    run(
+        &s,
+        "PUT",
+        "/log-levels/res-1?resourceType=WirelessDevice",
+        &[],
+        json!({"LogLevel": "INFO"}),
+    )
+    .unwrap();
+    // Present before reset.
+    assert!(run(
+        &s,
+        "GET",
+        "/log-levels/res-1?resourceType=WirelessDevice",
+        &[],
+        Value::Null
+    )
+    .is_ok());
+    run(&s, "DELETE", "/log-levels", &[], Value::Null).unwrap();
+    // Gone after reset (GetResourceLogLevel 404s).
+    let err = expect_err(run(
+        &s,
+        "GET",
+        "/log-levels/res-1?resourceType=WirelessDevice",
+        &[],
+        Value::Null,
+    ));
+    assert!(is_code(&err, "ResourceNotFoundException"));
+}
+
+#[test]
+fn deregister_wireless_device_persists_state() {
+    let s = svc();
+    let d = body_of(
+        &run(
+            &s,
+            "POST",
+            "/wireless-devices",
+            &[],
+            json!({"Type": "Sidewalk", "DestinationName": "d"}),
+        )
+        .unwrap(),
+    );
+    let id = d["Id"].as_str().unwrap().to_string();
+    run(
+        &s,
+        "PATCH",
+        &format!("/wireless-devices/{id}/deregister?WirelessDeviceType=Sidewalk"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let g = s.state.read();
+    let rec = g
+        .get("000000000000")
+        .unwrap()
+        .get_resource("wireless-devices", &id)
+        .cloned()
+        .unwrap();
+    assert_eq!(rec["DeviceRegistrationState"], "Deregistered");
+}
+
+#[test]
+fn read_only_action_classifier_separates_reads_from_mutators() {
+    let find = |op: &str| crate::generated::OPS.iter().find(|m| m.op == op).unwrap();
+    // GET-shaped actions are accepted as empty no-ops when unclaimed.
+    assert!(super::is_read_only_action(find(
+        "GetWirelessGatewayFirmwareInformation"
+    )));
+    assert!(super::is_read_only_action(find("GetServiceEndpoint")));
+    // Mutating actions must NOT be classified read-only (they fail loud if they
+    // ever reach the fall-through).
+    assert!(!super::is_read_only_action(find(
+        "StartMulticastGroupSession"
+    )));
+    assert!(!super::is_read_only_action(find(
+        "DeregisterWirelessDevice"
+    )));
+    assert!(!super::is_read_only_action(find(
+        "AssociateWirelessDeviceWithThing"
+    )));
+}
+
 // ---------- every operation routes to a handler ----------
 
 #[test]


### PR DESCRIPTION
## Summary

Batch 10 of the IoT / IoTWireless bug-hunt: replace the table-driven `Verb::Action` accept-and-discard catch-all's remaining silent no-ops with **real persistence**, and make the fall-through **fail loud** for any future unhandled *mutating* action instead of silently accepting-and-discarding it.

Both crates store state as schema-light JSON records (`resources[type][id]`), so no struct fields were added (no constructor sweep). All new handlers route through the same engine state that `service/special.rs` already uses.

### IoTWireless (`crates/fakecloud-iotwireless`)
- **Multicast LoRaWAN session**: `StartMulticastGroupSession` persists the session, `GetMulticastGroupSession` projects it, `CancelMulticastGroupSession` clears it.
- **`StartFuotaTask`**: transitions the FUOTA task `Status` to `In_FuotaSession` so `GetFuotaTask` reflects it.
- **`StartBulkAssociate/DisassociateWirelessDeviceWithMulticastGroup`**: persist to the same `multicast-devices` relation the single-device variant uses (associate/disassociate all account devices, since the tag query is not modelled).
- **`DeleteQueuedMessages`**, **`DeregisterWirelessDevice`** (persists deregistered state), **`ResetAllResourceLogLevels`** (clears the `PutResourceLogLevel` store).

### IoT (`crates/fakecloud-iot`)
- **Certificate transfer resolution**: `AcceptCertificateTransfer` -> `ACTIVE` (in target account), `Reject/CancelCertificateTransfer` -> `INACTIVE`; a non-`PENDING_TRANSFER` cert returns the declared `TransferAlreadyCompletedException`. `DescribeCertificate` reflects the outcome (previously stuck forever in `PENDING_TRANSFER`).
- **`AssociateSbomWithPackageVersion` / `DisassociateSbomFromPackageVersion`**: persist `sbom` + `sbomValidationStatus` so `GetPackageVersion` reflects them.
- **`SetV2LoggingLevel` / `DeleteV2LoggingLevel`**: per-target level persisted so `ListV2LoggingLevels` reflects it.
- **`CancelJobExecution`**: records a `CANCELED` execution so `DescribeJobExecution` reflects it.
- **`CancelAuditTask` / `CancelAuditMitigationActionsTask` / `CancelDetectMitigationActionsTask` / `StopThingRegistrationTask`**: transition the task record persisted by the matching `Start*` op.
- **`PutVerificationStateOnViolation` + `ListViolationEvents`**: persist verification state and project stored violation records (the model gives the list element no projected members, so the generic engine is bypassed).

### Fail-loud fall-through
The `Verb::Action` catch-all in each `service.rs` now accepts an unclaimed action as an empty body only when it is **read-only** (`is_read_only_action`: HTTP GET, or a `Get`/`List`/`Describe`/`Search`/`Test`/`Validate` name); any unclaimed **mutating** action returns `action_not_implemented` so future model gaps surface instead of appearing to persist.

## Test plan
- New in-crate unit tests round-trip each fixed op against its read-back (multicast session start/get/cancel, fuota status transition, bulk associate edges, reset log levels, deregister; cert transfer accept->ACTIVE / reject->INACTIVE + unknown-cert not-found, sbom associate/disassociate, v2 logging level list, cancel job execution, cancel audit + detect task, put verification state -> list violation events) + a read-only classifier test.
- `cargo test -p fakecloud-iot -p fakecloud-iotwireless`: 53 + 41 pass, incl. the in-process conformance mirror (`every_operation_passes_success_criteria`).
- `cargo clippy -p fakecloud-iot -p fakecloud-iotwireless --all-targets -- -D warnings` clean; `cargo fmt`.
- `cargo build -p fakecloud --tests` (server-bin ctor blind spot) clean.
- **Conformance probe** (`fakecloud-conformance run --services iot,iotwireless`) run against the real server binary: `384/384 implemented, 382/384 fully passing (12586/12666 variants)` — **byte-identical to the base tree** (the 2 non-passing ops, `ListWirelessDevices` and `AssociateAwsAccountWithPartnerAccount`, are pre-existing generic-engine shape-echo issues untouched by this change). No baseline regression.

Behavior-only change: no SDK, docs, website, or operation-count changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted previously no-op IoT and IoTWireless actions and changed the default action fall-through to fail loud for unhandled mutators. Read-backs now reflect changes, and future gaps won’t silently accept-and-discard.

- **Bug Fixes**
  - `fakecloud-iotwireless`: Multicast session lifecycle (start/get/cancel) is persisted; `StartFuotaTask` updates task status; bulk associate/disassociate adds/removes all devices from the multicast group; `DeleteQueuedMessages` purges queues; `DeregisterWirelessDevice` is stored; `ResetAllResourceLogLevels` clears per-resource levels; `AssociateAwsAccountWithPartnerAccount` returns the correct shape (Sidewalk `AmazonId` only + top-level `Arn`) and persists `AccountLinked`, `Arn`, and `Sidewalk.Fingerprint` so `GetPartnerAccount`/`ListPartnerAccounts` round-trip.
  - `fakecloud-iot`: Certificate transfer resolution updates status (`Accept` -> ACTIVE, `Reject/Cancel` -> INACTIVE) and surfaces `TransferAlreadyCompletedException` when not pending; SBOM associate/disassociate is persisted on package versions; `SetV2LoggingLevel`/`DeleteV2LoggingLevel` persist per-target levels; `CancelJobExecution` records CANCELED; task cancels (`CancelAuditTask`, `CancelAuditMitigationActionsTask`, `CancelDetectMitigationActionsTask`, `StopThingRegistrationTask`) update stored tasks; `PutVerificationStateOnViolation` and `ListViolationEvents` persist and project violation records.
  - Fail-loud fall-through: unclaimed read-only actions (HTTP GET or name starts with Get/List/Describe/Search/Test/Validate) still return an empty body; unclaimed mutating actions now return not implemented.

- **Migration**
  - If you relied on silent no-ops for unimplemented mutating actions, update callers/tests to expect a not-implemented error instead.

<sup>Written for commit 7276ad8854cdf6fabfa45680fc5e63bf714c5e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

