### PR TITLE
fix(apigatewayv2,opensearch,redshift,cognito,sagemaker): persist Update/Put fields + real Get round-trip (bug-hunt)

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -1034,14 +1034,14 @@ impl ApiGatewayV2Service {
                 req_object(&b, "PortalContent")?;
                 check_length(&b, "LogoUri", None, Some(1092))?;
                 check_length(&b, "RumAppMonitorName", None, Some(255))?;
-                self.put_keyed(req, resource_id, "PortalId", "portals", aid)
+                self.put_keyed(req, resource_id, "PortalId", "portals", aid, true)
             }
             "UpdatePortal" => {
                 resource_id.ok_or_else(|| missing("PortalId"))?;
                 let b = body(req);
                 check_length(&b, "LogoUri", None, Some(1092))?;
                 check_length(&b, "RumAppMonitorName", None, Some(255))?;
-                self.put_keyed(req, resource_id, "PortalId", "portals", aid)
+                self.put_keyed(req, resource_id, "PortalId", "portals", aid, false)
             }
             "GetPortal" => self.get_keyed(resource_id, "portals", aid, &region),
             "ListPortals" => self.list_keyed("portals", aid, &region),
@@ -1091,14 +1091,28 @@ impl ApiGatewayV2Service {
                 req_str(&b, "DisplayName")?;
                 check_length(&b, "DisplayName", Some(1), Some(255))?;
                 check_length(&b, "Description", None, Some(1024))?;
-                self.put_keyed(req, resource_id, "PortalProductId", "portal_products", aid)
+                self.put_keyed(
+                    req,
+                    resource_id,
+                    "PortalProductId",
+                    "portal_products",
+                    aid,
+                    true,
+                )
             }
             "UpdatePortalProduct" => {
                 resource_id.ok_or_else(|| missing("PortalProductId"))?;
                 let b = body(req);
                 check_length(&b, "DisplayName", Some(1), Some(255))?;
                 check_length(&b, "Description", None, Some(1024))?;
-                self.put_keyed(req, resource_id, "PortalProductId", "portal_products", aid)
+                self.put_keyed(
+                    req,
+                    resource_id,
+                    "PortalProductId",
+                    "portal_products",
+                    aid,
+                    false,
+                )
             }
             "GetPortalProduct" => self.get_keyed(resource_id, "portal_products", aid, &region),
             "ListPortalProducts" => self.list_keyed("portal_products", aid, &region),
@@ -1319,21 +1333,60 @@ impl ApiGatewayV2Service {
                 no_content()
             }
             "DeleteRouteRequestParameter" => {
-                api_id.ok_or_else(|| missing("ApiId"))?;
-                resource_id.ok_or_else(|| missing("RouteId"))?;
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let route = resource_id.ok_or_else(|| missing("RouteId"))?;
                 // RequestParameterKey is segs[6]; enforce non-empty too.
-                let key = segs.get(6).map(|s| s.as_str()).unwrap_or("");
-                if !valid_path_id(key) {
+                let raw_key = segs.get(6).map(|s| s.as_str()).unwrap_or("");
+                if !valid_path_id(raw_key) {
                     return Err(missing("RequestParameterKey"));
+                }
+                // The key may be percent-encoded in the URL; match the stored
+                // (decoded) key. Previously this validated then returned 204
+                // WITHOUT removing anything, so GetRoute kept returning the
+                // parameter (bug-hunt 2026-07-16, 1.22).
+                let key = percent_encoding::percent_decode_str(raw_key)
+                    .decode_utf8_lossy()
+                    .into_owned();
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                let route_obj = state
+                    .routes
+                    .get_mut(api)
+                    .and_then(|r| r.get_mut(route))
+                    .ok_or_else(|| not_found("Route", route))?;
+                if let Some(params) = route_obj.request_parameters.as_mut() {
+                    params.remove(&key);
+                    if params.is_empty() {
+                        route_obj.request_parameters = None;
+                    }
                 }
                 no_content()
             }
             "DeleteRouteSettings" => {
-                api_id.ok_or_else(|| missing("ApiId"))?;
-                resource_id.ok_or_else(|| missing("StageName"))?;
-                let key = segs.get(6).map(|s| s.as_str()).unwrap_or("");
-                if !valid_path_id(key) {
+                let api = api_id.ok_or_else(|| missing("ApiId"))?;
+                let stage_name = resource_id.ok_or_else(|| missing("StageName"))?;
+                let raw_key = segs.get(6).map(|s| s.as_str()).unwrap_or("");
+                if !valid_path_id(raw_key) {
                     return Err(missing("RouteKey"));
+                }
+                // Actually remove the per-route entry from the stage's
+                // route_settings. Previously this no-op'd and left the override
+                // in place (bug-hunt 2026-07-16, 1.22).
+                let key = percent_encoding::percent_decode_str(raw_key)
+                    .decode_utf8_lossy()
+                    .into_owned();
+                let mut accounts = self.state.write();
+                let state = accounts.get_or_create(aid);
+                let stage = state
+                    .stages
+                    .get_mut(api)
+                    .and_then(|s| s.get_mut(stage_name))
+                    .ok_or_else(|| not_found("Stage", stage_name))?;
+                if let Some(settings) = stage.route_settings.as_mut() {
+                    settings.remove(&key);
+                    if settings.is_empty() {
+                        stage.route_settings = None;
+                    }
                 }
                 no_content()
             }
@@ -1651,13 +1704,85 @@ impl ApiGatewayV2Service {
         id_field: &str,
         store: &str,
         account_id: &str,
+        is_create: bool,
     ) -> Result<AwsResponse, AwsServiceError> {
         let id = id_opt.map(String::from).unwrap_or_else(rand_id);
         let input = body(req);
-        // Build response from scratch with Smithy-required fields. Don't
+        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        // Update is a partial patch: start from the stored record and overlay
+        // only the fields the caller actually sent. Rebuilding from defaults
+        // on every update clobbered PublishStatus back to UNPUBLISHED and reset
+        // Tags/Authorization/EndpointConfiguration — a Create->Publish->Update
+        // round-trip lost the publish state (bug-hunt 2026-07-16, 1.22). Mirror
+        // the partial-update semantics already used by `put_model`.
+        if !is_create {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(account_id);
+            let map = match store {
+                "portals" => &mut state.portals,
+                "portal_products" => &mut state.portal_products,
+                _ => return Err(missing("Store")),
+            };
+            let mut entry = map.get(&id).cloned().ok_or_else(|| not_found(store, &id))?;
+            entry["LastModified"] = json!(now);
+            match store {
+                "portals" => {
+                    if let Some(pc) = input.get("PortalContent").filter(|v| !v.is_null()) {
+                        // Merge onto the existing content so DisplayName/Theme
+                        // defaults survive a partial content patch.
+                        if let (Some(dst), Some(src)) = (
+                            entry
+                                .get_mut("PortalContent")
+                                .and_then(|v| v.as_object_mut()),
+                            pc.as_object(),
+                        ) {
+                            for (k, v) in src {
+                                dst.insert(k.clone(), v.clone());
+                            }
+                        } else {
+                            entry["PortalContent"] = pc.clone();
+                        }
+                    }
+                    if let Some(in_ec) = input.get("EndpointConfiguration") {
+                        let ec = entry
+                            .get_mut("EndpointConfiguration")
+                            .filter(|v| v.is_object());
+                        if let Some(ec) = ec {
+                            for key in [
+                                "CertificateArn",
+                                "DomainName",
+                                "certificateArn",
+                                "domainName",
+                            ] {
+                                if let Some(v) = in_ec.get(key).filter(|v| !v.is_null()) {
+                                    ec[key] = v.clone();
+                                }
+                            }
+                        }
+                    }
+                    for field in ["Authorization", "Tags", "RumAppMonitorName"] {
+                        if let Some(v) = input.get(field).filter(|v| !v.is_null()) {
+                            entry[field] = v.clone();
+                        }
+                    }
+                }
+                "portal_products" => {
+                    for field in ["Description", "DisplayName", "Tags"] {
+                        if let Some(v) = input.get(field).filter(|v| !v.is_null()) {
+                            entry[field] = v.clone();
+                        }
+                    }
+                }
+                _ => return Err(missing("Store")),
+            }
+            map.insert(id.clone(), entry.clone());
+            return ok(entry);
+        }
+
+        // Create: build response from scratch with Smithy-required fields. Don't
         // echo arbitrary input keys — probe variants send things like
         // `logoUri` that aren't on the response shape.
-        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
         let entry = match store {
             "portals" => {
                 let mut portal_content = input
@@ -2591,20 +2716,117 @@ mod tests {
             .map(|st| st.access_log_settings.is_none())
             .unwrap_or(false));
 
-        ok(
+        // DeleteRouteRequestParameter now actually removes the key from the
+        // route's request_parameters (1.22). Seed a route with two params,
+        // delete one, confirm only that one is gone.
+        {
+            let mut accounts = s.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.routes.entry(api.clone()).or_default().insert(
+                "r1".to_string(),
+                crate::state::Route {
+                    route_id: "r1".to_string(),
+                    route_key: "GET /p".to_string(),
+                    target: None,
+                    authorization_type: None,
+                    authorizer_id: None,
+                    api_key_required: None,
+                    authorization_scopes: None,
+                    model_selection_expression: None,
+                    operation_name: None,
+                    request_models: None,
+                    request_parameters: Some(
+                        [
+                            (
+                                "route.request.querystring.id".to_string(),
+                                serde_json::json!({"required": true}),
+                            ),
+                            (
+                                "route.request.header.x".to_string(),
+                                serde_json::json!({"required": false}),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    route_response_selection_expression: None,
+                },
+            );
+            state
+                .stages
+                .get_mut(&api)
+                .and_then(|m| m.get_mut("prod"))
+                .unwrap()
+                .route_settings = Some(
+                [
+                    (
+                        "GET /p".to_string(),
+                        serde_json::json!({"throttlingBurstLimit": 5}),
+                    ),
+                    (
+                        "POST /p".to_string(),
+                        serde_json::json!({"throttlingBurstLimit": 7}),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            );
+        }
+        run(
+            &s,
             "DeleteRouteRequestParameter",
             "",
-            &["v2", "apis", "a1", "routes", "r1", "requestparameters", "p"],
-            Some("a1"),
+            &[
+                "v2",
+                "apis",
+                &api,
+                "routes",
+                "r1",
+                "requestparameters",
+                "route.request.querystring.id",
+            ],
+            Some(&api),
             Some("r1"),
         );
-        ok(
+        assert!(s
+            .state
+            .read()
+            .get("000000000000")
+            .and_then(|st| st.routes.get(&api))
+            .and_then(|m| m.get("r1"))
+            .map(|r| {
+                let p = r.request_parameters.as_ref().unwrap();
+                !p.contains_key("route.request.querystring.id")
+                    && p.contains_key("route.request.header.x")
+            })
+            .unwrap_or(false));
+        run(
+            &s,
             "DeleteRouteSettings",
             "",
-            &["v2", "apis", "a1", "stages", "prod", "routesettings", "X"],
-            Some("a1"),
+            &[
+                "v2",
+                "apis",
+                &api,
+                "stages",
+                "prod",
+                "routesettings",
+                "GET %2Fp",
+            ],
+            Some(&api),
             Some("prod"),
         );
+        assert!(s
+            .state
+            .read()
+            .get("000000000000")
+            .and_then(|st| st.stages.get(&api))
+            .and_then(|m| m.get("prod"))
+            .map(|st| {
+                let rs = st.route_settings.as_ref().unwrap();
+                !rs.contains_key("GET /p") && rs.contains_key("POST /p")
+            })
+            .unwrap_or(false));
         // DeleteDeployment now validates + removes. Seed one, delete it,
         // confirm it's gone, and that a second delete 404s (1.23).
         {

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -3424,3 +3424,176 @@ async fn export_api_includes_default_route() {
         "exported spec must contain the $default path, got: {spec}"
     );
 }
+
+/// DeleteRouteRequestParameter must actually drop the key from the route's
+/// requestParameters so GetRoute no longer returns it (bug-hunt 1.22).
+#[tokio::test]
+async fn delete_route_request_parameter_removes_key() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "routeKey": "GET /pets",
+        "requestParameters": {
+            "route.request.querystring.id": {"required": true},
+            "route.request.header.x-tenant": {"required": false},
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/routes"),
+        &body.to_string(),
+    );
+    let route_id = body_json(&svc.handle(req).await.unwrap())["routeId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Delete one parameter.
+    let req = make_request(
+        Method::DELETE,
+        &format!(
+            "/v2/apis/{api_id}/routes/{route_id}/requestparameters/route.request.querystring.id"
+        ),
+        "",
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert!(resp.status.is_success());
+
+    // GetRoute no longer reports the deleted key, but keeps the other.
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/routes/{route_id}"),
+        "",
+    );
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let params = b["requestParameters"].as_object().unwrap();
+    assert!(!params.contains_key("route.request.querystring.id"));
+    assert!(params.contains_key("route.request.header.x-tenant"));
+}
+
+/// DeleteRouteSettings must remove the per-route override from the stage's
+/// routeSettings while leaving defaultRouteSettings and other keys intact
+/// (bug-hunt 1.22).
+#[tokio::test]
+async fn delete_route_settings_removes_entry() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    let body = serde_json::json!({
+        "stageName": "prod",
+        "defaultRouteSettings": {"throttlingBurstLimit": 100},
+        "routeSettings": {
+            "GET /items": {"throttlingBurstLimit": 5},
+            "POST /items": {"throttlingBurstLimit": 7},
+        },
+    });
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Delete the "GET /items" per-route setting. The routeKey is
+    // percent-encoded in the URL path.
+    let encoded = "GET%20%2Fitems";
+    let req = make_request(
+        Method::DELETE,
+        &format!("/v2/apis/{api_id}/stages/prod/routesettings/{encoded}"),
+        "",
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert!(resp.status.is_success());
+
+    let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/prod"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    let rs = b["routeSettings"].as_object().unwrap();
+    assert!(!rs.contains_key("GET /items"));
+    assert!(rs.contains_key("POST /items"));
+    // defaultRouteSettings untouched.
+    assert_eq!(b["defaultRouteSettings"]["throttlingBurstLimit"], 100);
+}
+
+/// UpdatePortal is a partial patch: a Create->Publish->Update->Get round-trip
+/// must keep PublishStatus PUBLISHED and preserve Tags the update didn't
+/// resend (bug-hunt 1.22).
+#[tokio::test]
+async fn update_portal_preserves_publish_status_and_tags() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+
+    let body = serde_json::json!({
+        "Authorization": {"AuthorizationProviderArns": []},
+        "EndpointConfiguration": {},
+        "PortalContent": {"DisplayName": "orig"},
+        "Tags": {"team": "platform"},
+    });
+    let req = make_request(Method::POST, "/v2/portals", &body.to_string());
+    let created = body_json(&svc.handle(req).await.unwrap());
+    // Portal responses are camelCased by the handler.
+    let portal_id = created["portalId"].as_str().unwrap().to_string();
+    assert_eq!(created["publishStatus"], "UNPUBLISHED");
+
+    // Publish it.
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/portals/{portal_id}/publish"),
+        r#"{"Description":"first"}"#,
+    );
+    svc.handle(req).await.unwrap();
+
+    // Update only PortalContent (not Tags, not PublishStatus).
+    let body = serde_json::json!({
+        "PortalContent": {"DisplayName": "renamed"},
+    });
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/portals/{portal_id}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    // Get it: publish state and tags survived the partial update.
+    let req = make_request(Method::GET, &format!("/v2/portals/{portal_id}"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["publishStatus"], "PUBLISHED");
+    assert_eq!(b["lastPublishedDescription"], "first");
+    assert_eq!(b["tags"]["team"], "platform");
+    assert_eq!(b["portalContent"]["displayName"], "renamed");
+}
+
+/// UpdatePortalProduct partial patch preserves fields the update omits
+/// (bug-hunt 1.22).
+#[tokio::test]
+async fn update_portal_product_preserves_untouched_fields() {
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+
+    let body = serde_json::json!({
+        "DisplayName": "product",
+        "Description": "the original description",
+        "Tags": {"owner": "team-a"},
+    });
+    let req = make_request(Method::POST, "/v2/portalproducts", &body.to_string());
+    let created = body_json(&svc.handle(req).await.unwrap());
+    let id = created["portalProductId"].as_str().unwrap().to_string();
+
+    // Update only the DisplayName.
+    let body = serde_json::json!({"DisplayName": "renamed-product"});
+    let req = make_request(
+        Method::PATCH,
+        &format!("/v2/portalproducts/{id}"),
+        &body.to_string(),
+    );
+    svc.handle(req).await.unwrap();
+
+    let req = make_request(Method::GET, &format!("/v2/portalproducts/{id}"), "");
+    let b = body_json(&svc.handle(req).await.unwrap());
+    assert_eq!(b["displayName"], "renamed-product");
+    // Description and Tags preserved.
+    assert_eq!(b["description"], "the original description");
+    assert_eq!(b["tags"]["owner"], "team-a");
+}

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -3562,6 +3562,49 @@ fn admin_get_user_not_found() {
     assert_eq!(err.code(), "UserNotFoundException");
 }
 
+/// AdminGetUser must render the MFA preferences AdminSetUserMFAPreference
+/// persisted (UserMFASettingList / PreferredMfaSetting), like real Cognito and
+/// the access-token GetUser (bug-hunt 1.23).
+#[test]
+fn admin_get_user_reports_mfa_preferences() {
+    let (svc, _) = make_svc();
+    let pool_id = create_pool(&svc);
+    admin_create_user_helper(&svc, &pool_id, "mfauser");
+
+    // Before setting a preference, the fields are absent (empty list omitted),
+    // but MFAOptions is always present.
+    let req = make_req(
+        "AdminGetUser",
+        &json!({"UserPoolId": pool_id, "Username": "mfauser"}).to_string(),
+    );
+    let b = resp_json(&svc.admin_get_user(&req).unwrap());
+    assert!(b.get("UserMFASettingList").is_none());
+    assert!(b.get("MFAOptions").is_some());
+
+    // Enable software-token MFA as the preferred method.
+    let set_req = make_req(
+        "AdminSetUserMFAPreference",
+        &json!({
+            "UserPoolId": pool_id,
+            "Username": "mfauser",
+            "SoftwareTokenMfaSettings": {"Enabled": true, "PreferredMfa": true},
+            "SMSMfaSettings": {"Enabled": false, "PreferredMfa": false},
+        })
+        .to_string(),
+    );
+    svc.admin_set_user_mfa_preference(&set_req).unwrap();
+
+    // AdminGetUser now surfaces the setting + preferred method.
+    let req = make_req(
+        "AdminGetUser",
+        &json!({"UserPoolId": pool_id, "Username": "mfauser"}).to_string(),
+    );
+    let b = resp_json(&svc.admin_get_user(&req).unwrap());
+    let list = b["UserMFASettingList"].as_array().unwrap();
+    assert!(list.iter().any(|v| v == "SOFTWARE_TOKEN_MFA"));
+    assert_eq!(b["PreferredMfaSetting"], "SOFTWARE_TOKEN_MFA");
+}
+
 // ── AdminDeleteUser ──
 
 #[test]

--- a/crates/fakecloud-cognito/src/service/users.rs
+++ b/crates/fakecloud-cognito/src/service/users.rs
@@ -269,7 +269,7 @@ impl CognitoService {
             })?;
 
         // AdminGetUser returns a flat response (not wrapped in User)
-        let response = json!({
+        let mut response = json!({
             "Username": user.username,
             "UserAttributes": user.attributes.iter().map(|a| {
                 json!({ "Name": a.name, "Value": a.value })
@@ -279,6 +279,26 @@ impl CognitoService {
             "UserStatus": user.user_status,
             "Enabled": user.enabled,
         });
+
+        // Real AdminGetUser also reports the user's MFA configuration:
+        // MFAOptions (deprecated), UserMFASettingList and PreferredMfaSetting.
+        // These were previously dropped, so AdminSetUserMFAPreference had no
+        // observable read-back through AdminGetUser (bug-hunt 2026-07-16, 1.23).
+        response["MFAOptions"] = json!(user
+            .mfa_options
+            .iter()
+            .map(|o| json!({
+                "DeliveryMedium": o.delivery_medium,
+                "AttributeName": o.attribute_name,
+            }))
+            .collect::<Vec<Value>>());
+        let (mfa_settings, preferred) = user_mfa_settings(user);
+        if !mfa_settings.is_empty() {
+            response["UserMFASettingList"] = json!(mfa_settings);
+        }
+        if let Some(pref) = preferred {
+            response["PreferredMfaSetting"] = json!(pref);
+        }
 
         Ok(AwsResponse::ok_json(response))
     }

--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -2388,6 +2388,12 @@ impl OpenSearchService {
         if let Some(desc) = b.get("Description") {
             ds["Description"] = desc.clone();
         }
+        // Status (ACTIVE|DISABLED) was previously dropped, so disabling a data
+        // source never persisted and GetDataSource kept reporting ACTIVE
+        // (bug-hunt 2026-07-16, 1.23).
+        if let Some(status) = b.get("Status").filter(|v| !v.is_null()) {
+            ds["Status"] = status.clone();
+        }
         Ok(ok(json!({ "Message": "Data source updated" })))
     }
 
@@ -2486,6 +2492,13 @@ impl OpenSearchService {
         }
         if let Some(a) = b.get("OpenSearchArns") {
             dq.open_search_arns = a.clone();
+        }
+        // DataSourceType (the S3/Glue connection config) was dropped, so a
+        // caller switching connection type never persisted and
+        // GetDirectQueryDataSource kept returning the old type
+        // (bug-hunt 2026-07-16, 1.23).
+        if let Some(dst) = b.get("DataSourceType").filter(|v| !v.is_null()) {
+            dq.data_source_type = dst.clone();
         }
         Ok(ok(json!({ "DataSourceArn": dq.arn })))
     }

--- a/crates/fakecloud-opensearch/tests/service_tests.rs
+++ b/crates/fakecloud-opensearch/tests/service_tests.rs
@@ -1319,3 +1319,108 @@ async fn get_migration_unknown_id_is_not_found() {
     assert_eq!(status, 409);
     assert_eq!(code, "ResourceNotFoundException");
 }
+
+// ---------------------------------------------------------------------------
+// Data sources — Update must persist Status and DataSourceType (bug-hunt 1.23)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn update_data_source_persists_status() {
+    let svc = service();
+    // Seed a domain, then add a data source (defaults to ACTIVE).
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain"),
+            json!({"DomainName": "dom1", "EngineVersion": "OpenSearch_2.11"}),
+        ),
+    )
+    .await;
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain/dom1/dataSource"),
+            json!({
+                "Name": "s3ds",
+                "DataSourceType": {"S3GlueDataCatalog": {"RoleArn": "arn:aws:iam::0:role/r"}},
+                "Description": "orig",
+            }),
+        ),
+    )
+    .await;
+
+    // Disable it via UpdateDataSource.
+    call(
+        &svc,
+        req(
+            Method::PUT,
+            &format!("{OS}/opensearch/domain/dom1/dataSource/s3ds"),
+            // DataSourceType is @required on UpdateDataSource.
+            json!({
+                "Status": "DISABLED",
+                "Description": "updated",
+                "DataSourceType": {"S3GlueDataCatalog": {"RoleArn": "arn:aws:iam::0:role/r"}},
+            }),
+        ),
+    )
+    .await;
+
+    // GetDataSource reflects the persisted Status + Description.
+    let resp = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("{OS}/opensearch/domain/dom1/dataSource/s3ds"),
+            json!({}),
+        ),
+    )
+    .await;
+    let v = json_of(&resp);
+    assert_eq!(v["Status"], "DISABLED");
+    assert_eq!(v["Description"], "updated");
+}
+
+#[tokio::test]
+async fn update_direct_query_data_source_persists_type() {
+    let svc = service();
+    // Add a direct-query data source with an initial S3 type.
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/directQueryDataSource"),
+            json!({
+                "DataSourceName": "dq1",
+                "DataSourceType": {"CloudWatchLog": {"RoleArn": "arn:aws:iam::0:role/a"}},
+                "Description": "orig",
+            }),
+        ),
+    )
+    .await;
+
+    // Switch the connection config to a SecurityLake type.
+    let new_type = json!({"SecurityLake": {"RoleArn": "arn:aws:iam::0:role/b"}});
+    call(
+        &svc,
+        req(
+            Method::PUT,
+            &format!("{OS}/opensearch/directQueryDataSource/dq1"),
+            json!({"DataSourceType": new_type.clone()}),
+        ),
+    )
+    .await;
+
+    let resp = call(
+        &svc,
+        req(
+            Method::GET,
+            &format!("{OS}/opensearch/directQueryDataSource/dq1"),
+            json!({}),
+        ),
+    )
+    .await;
+    let v = json_of(&resp);
+    assert_eq!(v["DataSourceType"], new_type);
+}

--- a/crates/fakecloud-redshift/src/service/helpers.rs
+++ b/crates/fakecloud-redshift/src/service/helpers.rs
@@ -76,6 +76,18 @@ pub(crate) fn long_param(req: &AwsRequest, name: &str) -> Option<i64> {
     param(req, name).and_then(|v| v.parse().ok())
 }
 
+/// Parse an ISO8601/RFC3339 timestamp query param (e.g. `StartTime`) into a
+/// UTC datetime. Returns `None` when absent or unparseable.
+pub(crate) fn timestamp_param(
+    req: &AwsRequest,
+    name: &str,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    let raw = param(req, name)?;
+    chrono::DateTime::parse_from_rfc3339(&raw)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+}
+
 /// Collect a flat scalar list serialized as `{prefix}.member.N` (also accepts
 /// the alternate `{prefix}.{alt}.N` wire form some SDKs emit).
 pub(crate) fn member_list(req: &AwsRequest, prefix: &str, alt: &str) -> Vec<String> {

--- a/crates/fakecloud-redshift/src/service/resources.rs
+++ b/crates/fakecloud-redshift/src/service/resources.rs
@@ -577,8 +577,11 @@ impl RedshiftService {
             } else {
                 "DISABLED".to_string()
             },
-            start_time: None,
-            end_time: None,
+            // StartTime/EndTime were hardcoded None, so the values a caller
+            // passed were dropped and DescribeScheduledActions never returned
+            // them, drifting the Terraform resource (bug-hunt 2026-07-16, 1.23).
+            start_time: timestamp_param(req, "StartTime"),
+            end_time: timestamp_param(req, "EndTime"),
             enable: bool_param(req, "Enable").unwrap_or(true),
         };
         acct.scheduled_actions.insert(name, a.clone());
@@ -649,6 +652,14 @@ impl RedshiftService {
         }
         if let Some(t) = extract_target_action(req) {
             a.target_action = Some(t);
+        }
+        // Modify previously never touched StartTime/EndTime, so a schedule
+        // window change silently no-op'd (bug-hunt 2026-07-16, 1.23).
+        if let Some(t) = timestamp_param(req, "StartTime") {
+            a.start_time = Some(t);
+        }
+        if let Some(t) = timestamp_param(req, "EndTime") {
+            a.end_time = Some(t);
         }
         Ok(xml_resp(
             "ModifyScheduledAction",

--- a/crates/fakecloud-redshift/src/service/tests.rs
+++ b/crates/fakecloud-redshift/src/service/tests.rs
@@ -657,3 +657,44 @@ fn tag_operations_round_trip() {
     assert!(listed.contains("<Key>team</Key>"));
     assert!(listed.contains("<Value>data</Value>"));
 }
+
+#[test]
+fn scheduled_action_start_end_time_round_trip() {
+    let svc = service();
+    // Create with an explicit schedule window.
+    let out = ok(
+        &svc,
+        "CreateScheduledAction",
+        &[
+            ("ScheduledActionName", "sa1"),
+            ("Schedule", "cron(0 10 ? * MON *)"),
+            ("IamRole", "arn:aws:iam::123456789012:role/r"),
+            ("StartTime", "2026-08-01T00:00:00Z"),
+            ("EndTime", "2026-09-01T00:00:00Z"),
+        ],
+    );
+    assert!(out.contains("<StartTime>2026-08-01T00:00:00.000Z</StartTime>"));
+    assert!(out.contains("<EndTime>2026-09-01T00:00:00.000Z</EndTime>"));
+
+    // Describe returns them too (they were previously dropped).
+    let listed = ok(&svc, "DescribeScheduledActions", &[]);
+    assert!(listed.contains("<StartTime>2026-08-01T00:00:00.000Z</StartTime>"));
+    assert!(listed.contains("<EndTime>2026-09-01T00:00:00.000Z</EndTime>"));
+
+    // Modify shifts the window; the new values persist.
+    let modified = ok(
+        &svc,
+        "ModifyScheduledAction",
+        &[
+            ("ScheduledActionName", "sa1"),
+            ("StartTime", "2026-08-15T12:30:00Z"),
+        ],
+    );
+    assert!(modified.contains("<StartTime>2026-08-15T12:30:00.000Z</StartTime>"));
+    // EndTime untouched by the modify is preserved.
+    assert!(modified.contains("<EndTime>2026-09-01T00:00:00.000Z</EndTime>"));
+
+    let after = ok(&svc, "DescribeScheduledActions", &[]);
+    assert!(after.contains("<StartTime>2026-08-15T12:30:00.000Z</StartTime>"));
+    assert!(after.contains("<EndTime>2026-09-01T00:00:00.000Z</EndTime>"));
+}

--- a/crates/fakecloud-sagemaker/src/service/special.rs
+++ b/crates/fakecloud-sagemaker/src/service/special.rs
@@ -42,9 +42,176 @@ pub(super) fn dispatch(
         "ImportHubContent" => Ok(Some(import_hub_content(svc, ctx, meta, body))),
         "AddAssociation" => Ok(Some(add_association(svc, ctx, meta, body))),
         "DeleteAssociation" => Ok(Some(delete_association(svc, ctx, body))),
+        "PutModelPackageGroupPolicy" => Ok(Some(put_mpg_policy(svc, ctx, meta, body))),
+        "GetModelPackageGroupPolicy" => Ok(get_mpg_policy(svc, ctx, body)),
+        "DeleteModelPackageGroupPolicy" => Ok(Some(delete_mpg_policy(svc, ctx, meta, body))),
+        "RegisterDevices" => Ok(Some(register_devices(svc, ctx, meta, body))),
+        "DeregisterDevices" => Ok(Some(deregister_devices(svc, ctx, meta, body))),
+        "UpdateDevices" => Ok(Some(update_devices(svc, ctx, meta, body))),
         op if is_lifecycle_transition(op) => Ok(lifecycle_transition(svc, ctx, meta, body)),
         _ => Ok(None),
     }
+}
+
+// ── Model package group resource policy ──────────────────────────────────
+//
+// `PutModelPackageGroupPolicy` / `GetModelPackageGroupPolicy` /
+// `DeleteModelPackageGroupPolicy` are all Action verbs. The generic Action arm
+// discarded the `ResourcePolicy` on Put and synthesised a placeholder `"a"` on
+// Get, so the policy never round-tripped. Persist it in account-scoped state
+// keyed by the group name (bug-hunt 2026-07-16, 1.24).
+
+fn mpg_policy_singleton(name: &str) -> String {
+    format!("ModelPackageGroupPolicy:{name}")
+}
+
+fn put_mpg_policy(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let name = str_member(body, "ModelPackageGroupName");
+    let policy = body.get("ResourcePolicy").cloned().unwrap_or(Value::Null);
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        data.singletons.insert(mpg_policy_singleton(&name), policy);
+    }
+    (engine::action(ctx, meta, body), true)
+}
+
+fn get_mpg_policy(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    body: &Map<String, Value>,
+) -> Option<(AwsResponse, bool)> {
+    let name = str_member(body, "ModelPackageGroupName");
+    let g = svc.state.read();
+    let stored = g
+        .get(&ctx.account)
+        .and_then(|data| data.singletons.get(&mpg_policy_singleton(&name)))
+        .filter(|v| !v.is_null())
+        .cloned();
+    // Return the stored policy when present; otherwise return None so the caller
+    // falls through to the generic Action arm, keeping a valid output shape for a
+    // stateless probe that never called Put.
+    let policy = stored?;
+    let mut out = Map::new();
+    out.insert("ResourcePolicy".to_string(), policy);
+    Some((ok_json(Value::Object(out)), false))
+}
+
+fn delete_mpg_policy(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let name = str_member(body, "ModelPackageGroupName");
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        data.singletons.remove(&mpg_policy_singleton(&name));
+    }
+    (engine::action(ctx, meta, body), true)
+}
+
+// ── Edge devices ─────────────────────────────────────────────────────────
+//
+// `RegisterDevices` wrote nothing (generic Action no-op) and the read siblings
+// `ListDevices` / `DescribeDevice` read the `Device` (singular) family, so
+// registration was invisible. Persist each device under the `Device` family
+// keyed by its `DeviceName` so the read siblings resolve it, and route
+// `DeregisterDevices` / `UpdateDevices` to the same family (bug-hunt
+// 2026-07-16, 1.24).
+
+const DEVICE_FAMILY: &str = "Device";
+
+fn register_devices(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let fleet = str_member(body, "DeviceFleetName");
+    let devices = body.get("Devices").and_then(Value::as_array).cloned();
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        for dev in devices.into_iter().flatten() {
+            let Some(obj) = dev.as_object() else { continue };
+            let Some(name) = obj.get("DeviceName").and_then(Value::as_str) else {
+                continue;
+            };
+            let mut record = obj.clone();
+            record
+                .entry("DeviceFleetName".to_string())
+                .or_insert_with(|| Value::String(fleet.clone()));
+            record.insert(
+                "DeviceArn".to_string(),
+                Value::String(super::mint_arn(ctx, "device", name)),
+            );
+            record
+                .entry("RegistrationTime".to_string())
+                .or_insert_with(now_epoch);
+            data.put_resource(DEVICE_FAMILY, name, Value::Object(record));
+        }
+    }
+    (engine::action(ctx, meta, body), true)
+}
+
+fn deregister_devices(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let names = body.get("DeviceNames").and_then(Value::as_array).cloned();
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        for name in names.into_iter().flatten() {
+            if let Some(n) = name.as_str() {
+                data.remove_resource(DEVICE_FAMILY, n);
+            }
+        }
+    }
+    (engine::action(ctx, meta, body), true)
+}
+
+fn update_devices(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let devices = body.get("Devices").and_then(Value::as_array).cloned();
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        for dev in devices.into_iter().flatten() {
+            let Some(obj) = dev.as_object() else { continue };
+            let Some(name) = obj.get("DeviceName").and_then(Value::as_str) else {
+                continue;
+            };
+            // Merge the update onto the existing record so registration-time
+            // fields (DeviceArn, DeviceFleetName, RegistrationTime) survive.
+            let mut record = data
+                .get_resource(DEVICE_FAMILY, name)
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            for (k, v) in obj {
+                record.insert(k.clone(), v.clone());
+            }
+            record
+                .entry("DeviceArn".to_string())
+                .or_insert_with(|| Value::String(super::mint_arn(ctx, "device", name)));
+            data.put_resource(DEVICE_FAMILY, name, Value::Object(record));
+        }
+    }
+    (engine::action(ctx, meta, body), true)
 }
 
 /// `Start*` / `Stop*` operations that transition a stored resource's status.

--- a/crates/fakecloud-sagemaker/src/service/tests.rs
+++ b/crates/fakecloud-sagemaker/src/service/tests.rs
@@ -539,3 +539,122 @@ fn string_timestamp_coerced_to_number_on_read() {
         described["CreationTime"]
     );
 }
+
+// PutModelPackageGroupPolicy persists the ResourcePolicy; Get returns the
+// stored value (not the placeholder "a"); Delete removes it (bug-hunt 1.24).
+#[test]
+fn model_package_group_policy_round_trips() {
+    let s = svc();
+    let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
+    run(
+        &s,
+        "PutModelPackageGroupPolicy",
+        json!({"ModelPackageGroupName": "grp", "ResourcePolicy": policy}),
+    )
+    .unwrap();
+
+    let got = resp_json(
+        &run(
+            &s,
+            "GetModelPackageGroupPolicy",
+            json!({"ModelPackageGroupName": "grp"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(got["ResourcePolicy"], policy);
+
+    // Delete removes it; a subsequent Get no longer returns the real policy.
+    run(
+        &s,
+        "DeleteModelPackageGroupPolicy",
+        json!({"ModelPackageGroupName": "grp"}),
+    )
+    .unwrap();
+    let after = resp_json(
+        &run(
+            &s,
+            "GetModelPackageGroupPolicy",
+            json!({"ModelPackageGroupName": "grp"}),
+        )
+        .unwrap(),
+    );
+    assert_ne!(after["ResourcePolicy"], policy);
+}
+
+// RegisterDevices persists devices so DescribeDevice / ListDevices resolve
+// them; UpdateDevices merges; DeregisterDevices removes (bug-hunt 1.24).
+#[test]
+fn register_devices_visible_to_read_siblings() {
+    let s = svc();
+    run(
+        &s,
+        "RegisterDevices",
+        json!({
+            "DeviceFleetName": "fleet1",
+            "Devices": [
+                {"DeviceName": "dev-a", "Description": "first", "IotThingName": "thing-a"},
+                {"DeviceName": "dev-b", "Description": "second"},
+            ],
+        }),
+    )
+    .unwrap();
+
+    // ListDevices sees both.
+    let listed = resp_json(&run(&s, "ListDevices", json!({})).unwrap());
+    let summaries = listed["DeviceSummaries"].as_array().unwrap();
+    assert_eq!(summaries.len(), 2);
+
+    // DescribeDevice resolves a registered device with its fleet + description.
+    let described = resp_json(
+        &run(
+            &s,
+            "DescribeDevice",
+            json!({"DeviceName": "dev-a", "DeviceFleetName": "fleet1"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(described["DeviceName"], "dev-a");
+    assert_eq!(described["DeviceFleetName"], "fleet1");
+    assert_eq!(described["Description"], "first");
+    assert!(described["DeviceArn"]
+        .as_str()
+        .unwrap()
+        .contains(":device/"));
+
+    // UpdateDevices merges a new description while keeping the fleet.
+    run(
+        &s,
+        "UpdateDevices",
+        json!({
+            "DeviceFleetName": "fleet1",
+            "Devices": [{"DeviceName": "dev-a", "Description": "updated"}],
+        }),
+    )
+    .unwrap();
+    let after = resp_json(
+        &run(
+            &s,
+            "DescribeDevice",
+            json!({"DeviceName": "dev-a", "DeviceFleetName": "fleet1"}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(after["Description"], "updated");
+    assert_eq!(after["DeviceFleetName"], "fleet1");
+
+    // DeregisterDevices removes one; the other remains.
+    run(
+        &s,
+        "DeregisterDevices",
+        json!({"DeviceFleetName": "fleet1", "DeviceNames": ["dev-a"]}),
+    )
+    .unwrap();
+    let listed = resp_json(&run(&s, "ListDevices", json!({})).unwrap());
+    assert_eq!(listed["DeviceSummaries"].as_array().unwrap().len(), 1);
+    let err = expect_err(run(
+        &s,
+        "DescribeDevice",
+        json!({"DeviceName": "dev-a", "DeviceFleetName": "fleet1"}),
+    ));
+    assert_eq!(err.code(), "ResourceNotFound");
+}


### PR DESCRIPTION
## Summary

Batch 8b bug-hunt: several service stubs accepted write fields then discarded them, so the Get/Describe read-back never reflected the write. Each is fixed so the round-trip is real.

- **apigatewayv2**
  - `DeleteRouteRequestParameter` / `DeleteRouteSettings` were validate-then-`204` no-ops that left the entry in place; they now actually remove the keyed entry from the route's `request_parameters` / stage's `route_settings` (percent-decoding the URL key).
  - `UpdatePortal` / `UpdatePortalProduct` rebuilt the record from defaults on every call, so `Create -> Publish -> Update -> Get` reported `UNPUBLISHED` and reset `Tags` / `Authorization` / `EndpointConfiguration`. `put_keyed` now takes `is_create` and does a partial merge into the stored record on update (mirroring the already-fixed `put_model`).
- **opensearch**
  - `UpdateDataSource` now persists `Status` (`ACTIVE|DISABLED`) so disabling a data source sticks.
  - `UpdateDirectQueryDataSource` now persists `DataSourceType` (the S3/Glue connection config).
- **redshift**
  - `CreateScheduledAction` / `ModifyScheduledAction` now persist `StartTime` / `EndTime` (were hardcoded `None` / never touched); `DescribeScheduledActions` already renders them.
- **cognito**
  - `AdminGetUser` now renders `MFAOptions` / `UserMFASettingList` / `PreferredMfaSetting` via the shared `user_mfa_settings` helper, so `AdminSetUserMFAPreference` is observable through `AdminGetUser` the same way the access-token `GetUser` reports it.
- **sagemaker** (via the hand-written `special::dispatch` override, not the generated table)
  - `PutModelPackageGroupPolicy` persists the `ResourcePolicy`; `GetModelPackageGroupPolicy` returns the stored value instead of the `"a"` placeholder; `DeleteModelPackageGroupPolicy` removes it. A stateless Get (no prior Put) still falls through to the generic Action arm for a valid output shape.
  - `RegisterDevices` now writes the `Device` family that `ListDevices` / `DescribeDevice` read (they read the singular family which nothing wrote); `DeregisterDevices` / `UpdateDevices` operate on the same populated family.

Behavior-only: no SDK, docs, website, or count changes.

## Test plan

- New round-trip tests for every fix:
  - apigatewayv2: delete route request-parameter -> GetRoute no longer has it; delete route-settings entry -> stage keeps the others; update portal preserves `PublishStatus`/`Tags`; update portal-product preserves untouched fields.
  - opensearch: `UpdateDataSource` Status and `UpdateDirectQueryDataSource` DataSourceType persist through Get.
  - redshift: scheduled-action `StartTime`/`EndTime` round-trip through Create/Modify/Describe.
  - cognito: `AdminGetUser` surfaces the MFA preference set via `AdminSetUserMFAPreference`.
  - sagemaker: put-policy -> get returns it, delete removes it; register-devices -> list/describe see them, update merges, deregister removes.
- `cargo test` green for all five crates (`apigatewayv2` 165, `opensearch` 38, `redshift` 25, `cognito` full, `sagemaker` 24 incl. `every_operation_passes_success_criteria`).
- `cargo clippy --all-targets -- -D warnings` clean for all five crates; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes write persistence across multiple service stubs so deletes/updates modify stored state and Get/Describe reflect those changes.

- **Bug Fixes**
  - `apigatewayv2`: `DeleteRouteRequestParameter` and `DeleteRouteSettings` now remove the keyed entries (handles percent-decoded keys). `UpdatePortal` and `UpdatePortalProduct` now patch stored records instead of rebuilding, preserving `PublishStatus`, `Tags`, `Authorization`, and `EndpointConfiguration`.
  - `opensearch`: `UpdateDataSource` now persists `Status`. `UpdateDirectQueryDataSource` now persists `DataSourceType`.
  - `redshift`: `CreateScheduledAction` and `ModifyScheduledAction` now persist `StartTime` and `EndTime`. `DescribeScheduledActions` returns them.
  - `cognito`: `AdminGetUser` now includes `MFAOptions`, `UserMFASettingList`, and `PreferredMfaSetting`, matching `AdminSetUserMFAPreference`.
  - `sagemaker`: `PutModelPackageGroupPolicy`/`GetModelPackageGroupPolicy`/`DeleteModelPackageGroupPolicy` now round-trip the `ResourcePolicy`. `RegisterDevices`/`UpdateDevices`/`DeregisterDevices` now operate on the `Device` family so `ListDevices`/`DescribeDevice` see the changes.

<sup>Written for commit 78e9d480f0e26537a18c6120cc1ee6e92fa4acfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

