### PR TITLE
fix(models): vendor Smithy models into crates + release v0.41.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acmpca"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-amplify"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appsync"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4725,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-comprehend"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-config"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-docdb"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5485,7 +5485,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5509,7 +5509,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-efs"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticbeanstalk"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-emr"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-fis"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iot"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iotdata"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iotwireless"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kafka"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesisanalyticsv2"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6099,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-managedblockchain"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mediaconvert"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mq"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mwaa"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-neptune"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6221,7 +6221,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6242,7 +6242,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6262,7 +6262,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pinpoint"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6423,7 +6423,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6443,7 +6443,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6489,7 +6489,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53resolver"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -6544,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sagemaker"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6605,7 +6605,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6637,7 +6637,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-serverlessrepo"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6679,7 +6679,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-shield"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6723,7 +6723,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6796,7 +6796,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6816,7 +6816,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-support"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-swf"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-textract"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-timestream"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transcribe"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7018,7 +7018,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-translate"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7060,7 +7060,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7105,7 +7105,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-xray"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -116,387 +116,387 @@ features = [ "json",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-shield]
 path = "crates/fakecloud-shield"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-docdb]
 path = "crates/fakecloud-docdb"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-neptune]
 path = "crates/fakecloud-neptune"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-textract]
 path = "crates/fakecloud-textract"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-transcribe]
 path = "crates/fakecloud-transcribe"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-translate]
 path = "crates/fakecloud-translate"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-swf]
 path = "crates/fakecloud-swf"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-pinpoint]
 path = "crates/fakecloud-pinpoint"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-timestream]
 path = "crates/fakecloud-timestream"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-elasticbeanstalk]
 path = "crates/fakecloud-elasticbeanstalk"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-efs]
 path = "crates/fakecloud-efs"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-mq]
 path = "crates/fakecloud-mq"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-kafka]
 path = "crates/fakecloud-kafka"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-fis]
 path = "crates/fakecloud-fis"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-emr]
 path = "crates/fakecloud-emr"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-mwaa]
 path = "crates/fakecloud-mwaa"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-kinesisanalyticsv2]
 path = "crates/fakecloud-kinesisanalyticsv2"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-route53resolver]
 path = "crates/fakecloud-route53resolver"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-acmpca]
 path = "crates/fakecloud-acmpca"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-config]
 path = "crates/fakecloud-config"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.kube]
 version = "0.95"
@@ -509,49 +509,49 @@ features = ["latest"]
 
 [workspace.dependencies.fakecloud-xray]
 path = "crates/fakecloud-xray"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-amplify]
 path = "crates/fakecloud-amplify"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-appsync]
 path = "crates/fakecloud-appsync"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-mediaconvert]
 path = "crates/fakecloud-mediaconvert"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-serverlessrepo]
 path = "crates/fakecloud-serverlessrepo"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-iot]
 path = "crates/fakecloud-iot"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-iotdata]
 path = "crates/fakecloud-iotdata"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-iotwireless]
 path = "crates/fakecloud-iotwireless"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-sagemaker]
 path = "crates/fakecloud-sagemaker"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-managedblockchain]
 path = "crates/fakecloud-managedblockchain"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-comprehend]
 path = "crates/fakecloud-comprehend"
-version = "0.41.0"
+version = "0.41.1"
 
 [workspace.dependencies.fakecloud-support]
 path = "crates/fakecloud-support"
-version = "0.41.0"
+version = "0.41.1"
 

--- a/crates/fakecloud-comprehend/model.json
+++ b/crates/fakecloud-comprehend/model.json
@@ -1,0 +1,13893 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.comprehend#AnyLengthString": {
+      "type": "string"
+    },
+    "com.amazonaws.comprehend#AttributeNamesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#AttributeNamesListItem"
+      }
+    },
+    "com.amazonaws.comprehend#AttributeNamesListItem": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#AugmentedManifestsDocumentTypeFormat": {
+      "type": "enum",
+      "members": {
+        "PLAIN_TEXT_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PLAIN_TEXT_DOCUMENT"
+          }
+        },
+        "SEMI_STRUCTURED_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEMI_STRUCTURED_DOCUMENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#AugmentedManifestsListItem": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the augmented manifest file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Split": {
+          "target": "com.amazonaws.comprehend#Split",
+          "traits": {
+            "smithy.api#documentation": "<p>The purpose of the data you've provided in the augmented manifest. You can either train or\n      test this data. If you don't specify, the default is train.</p>\n         <p>TRAIN - all of the documents in the manifest will be used for training. If no test\n      documents are provided, Amazon Comprehend will automatically reserve a portion of the training\n      documents for testing.</p>\n         <p> TEST - all of the documents in the manifest will be used for testing.</p>"
+          }
+        },
+        "AttributeNames": {
+          "target": "com.amazonaws.comprehend#AttributeNamesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON attribute that contains the annotations for your training documents. The number\n      of attribute names that you specify depends on whether your augmented manifest file is the\n      output of a single labeling job or a chained labeling job.</p>\n         <p>If your file is the output of a single labeling job, specify the LabelAttributeName key\n      that was used when the job was created in Ground Truth.</p>\n         <p>If your file is the output of a chained labeling job, specify the LabelAttributeName key\n      for one or more jobs in the chain. Each LabelAttributeName key provides the annotations from\n      an individual job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AnnotationDataS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 prefix to the annotation files that are referred in the augmented manifest\n      file.</p>"
+          }
+        },
+        "SourceDocumentsS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 prefix to the source files (PDFs) that are referred to in the augmented manifest\n      file.</p>"
+          }
+        },
+        "DocumentType": {
+          "target": "com.amazonaws.comprehend#AugmentedManifestsDocumentTypeFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of augmented manifest. PlainTextDocument or SemiStructuredDocument. If you don't\n      specify, the default is PlainTextDocument. </p>\n         <ul>\n            <li>\n               <p>\n                  <code>PLAIN_TEXT_DOCUMENT</code> A document type that represents any unicode text that\n          is encoded in UTF-8.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SEMI_STRUCTURED_DOCUMENT</code> A document type with positional and structural\n          context, like a PDF. For training with Amazon Comprehend, only PDFs are supported. For\n          inference, Amazon Comprehend support PDFs, DOCX and TXT.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An augmented manifest file that provides training data for your custom model. An augmented\n      manifest file is a labeled dataset that is produced by Amazon SageMaker Ground Truth.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectDominantLanguage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#BatchDetectDominantLanguageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#BatchDetectDominantLanguageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#BatchSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the dominant language of the input text for a batch of documents. For a list\n      of languages that Amazon Comprehend can detect, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-languages.html\">Amazon Comprehend Supported Languages</a>.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectDominantLanguageItemResult": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of the document in the input list.</p>"
+          }
+        },
+        "Languages": {
+          "target": "com.amazonaws.comprehend#ListOfDominantLanguages",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more <a>DominantLanguage</a> objects describing the dominant\n      languages in the document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of calling the  operation.\n      The operation returns one object for each document that is successfully processed by the\n      operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectDominantLanguageRequest": {
+      "type": "structure",
+      "members": {
+        "TextList": {
+          "target": "com.amazonaws.comprehend#CustomerInputStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the UTF-8 encoded text of the input documents. The list can contain a maximum of 25\n      documents. Each document should contain at least 20 characters. The maximum size of each document is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectDominantLanguageResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfDetectDominantLanguageResult",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of  objects\n      containing the results of the operation. The results are sorted in ascending order by the\n        <code>Index</code> field and match the order of the documents in the input list. If all of\n      the documents contain an error, the <code>ResultList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorList": {
+          "target": "com.amazonaws.comprehend#BatchItemErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing one  object for each document\n      that contained an error. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If there are no errors in the\n      batch, the <code>ErrorList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectEntities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#BatchDetectEntitiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#BatchDetectEntitiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#BatchSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects the text of a batch of documents for named entities and returns information\n      about them. For more information about named entities, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-entities.html\">Entities</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectEntitiesItemResult": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of the document in the input list.</p>"
+          }
+        },
+        "Entities": {
+          "target": "com.amazonaws.comprehend#ListOfEntities",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more <a>Entity</a> objects, one for each entity detected in the\n      document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of calling the  operation. The\n      operation returns one object for each document that is successfully processed by the\n      operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectEntitiesRequest": {
+      "type": "structure",
+      "members": {
+        "TextList": {
+          "target": "com.amazonaws.comprehend#CustomerInputStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the UTF-8 encoded text of the input documents. The list can contain a maximum of 25\n      documents. The maximum size of each document is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectEntitiesResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfDetectEntitiesResult",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of  objects containing the\n      results of the operation. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If all of the documents contain\n      an error, the <code>ResultList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorList": {
+          "target": "com.amazonaws.comprehend#BatchItemErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing one  object for each document\n      that contained an error. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If there are no errors in the\n      batch, the <code>ErrorList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectKeyPhrases": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#BatchDetectKeyPhrasesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#BatchDetectKeyPhrasesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#BatchSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Detects the key noun phrases found in a batch of documents.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectKeyPhrasesItemResult": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of the document in the input list.</p>"
+          }
+        },
+        "KeyPhrases": {
+          "target": "com.amazonaws.comprehend#ListOfKeyPhrases",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more <a>KeyPhrase</a> objects, one for each key phrase detected in\n      the document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of calling the  operation. The\n      operation returns one object for each document that is successfully processed by the\n      operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectKeyPhrasesRequest": {
+      "type": "structure",
+      "members": {
+        "TextList": {
+          "target": "com.amazonaws.comprehend#CustomerInputStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the UTF-8 encoded text of the input documents. The list can contain a maximum of 25\n      documents. The maximum size of each document is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectKeyPhrasesResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfDetectKeyPhrasesResult",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of  objects containing the\n      results of the operation. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If all of the documents contain\n      an error, the <code>ResultList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorList": {
+          "target": "com.amazonaws.comprehend#BatchItemErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing one  object for each document\n      that contained an error. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If there are no errors in the\n      batch, the <code>ErrorList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSentiment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#BatchDetectSentimentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#BatchDetectSentimentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#BatchSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects a batch of documents and returns an inference of the prevailing sentiment,\n        <code>POSITIVE</code>, <code>NEUTRAL</code>, <code>MIXED</code>, or <code>NEGATIVE</code>,\n      in each one.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSentimentItemResult": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of the document in the input list.</p>"
+          }
+        },
+        "Sentiment": {
+          "target": "com.amazonaws.comprehend#SentimentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The sentiment detected in the document.</p>"
+          }
+        },
+        "SentimentScore": {
+          "target": "com.amazonaws.comprehend#SentimentScore",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of its sentiment\n      detection.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of calling the  operation. The\n      operation returns one object for each document that is successfully processed by the\n      operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSentimentRequest": {
+      "type": "structure",
+      "members": {
+        "TextList": {
+          "target": "com.amazonaws.comprehend#CustomerInputStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the UTF-8 encoded text of the input documents. The list can contain a maximum of 25\n      documents. The maximum size of each document is 5 KB. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSentimentResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfDetectSentimentResult",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of  objects containing the\n      results of the operation. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If all of the documents contain\n      an error, the <code>ResultList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorList": {
+          "target": "com.amazonaws.comprehend#BatchItemErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing one  object for each document\n      that contained an error. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If there are no errors in the\n      batch, the <code>ErrorList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSyntax": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#BatchDetectSyntaxRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#BatchDetectSyntaxResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#BatchSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects the text of a batch of documents for the syntax and part of speech of the words\n      in the document and returns information about them. For more information, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-syntax.html\">Syntax</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSyntaxItemResult": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of the document in the input list.</p>"
+          }
+        },
+        "SyntaxTokens": {
+          "target": "com.amazonaws.comprehend#ListOfSyntaxTokens",
+          "traits": {
+            "smithy.api#documentation": "<p>The syntax tokens for the words in the document, one token for each word.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of calling the  operation. The\n      operation returns one object that is successfully processed by the operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSyntaxRequest": {
+      "type": "structure",
+      "members": {
+        "TextList": {
+          "target": "com.amazonaws.comprehend#CustomerInputStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the UTF-8 encoded text of the input documents. The list can contain a maximum of 25\n      documents. The maximum size for each document is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#SyntaxLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the following languages\n      supported by Amazon Comprehend: German (\"de\"), English (\"en\"), Spanish (\"es\"), French (\"fr\"),\n      Italian (\"it\"), or Portuguese (\"pt\"). All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectSyntaxResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfDetectSyntaxResult",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of  objects containing the\n      results of the operation. The results are sorted in ascending order by the <code>Index</code>\n      field and match the order of the documents in the input list. If all of the documents contain\n      an error, the <code>ResultList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorList": {
+          "target": "com.amazonaws.comprehend#BatchItemErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing one  object for each document that\n      contained an error. The results are sorted in ascending order by the <code>Index</code> field\n      and match the order of the documents in the input list. If there are no errors in the batch,\n      the <code>ErrorList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectTargetedSentiment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#BatchDetectTargetedSentimentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#BatchDetectTargetedSentimentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#BatchSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects a batch of documents and returns a sentiment analysis\n      for each entity identified in the documents.</p>\n         <p>For more information about targeted sentiment, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html\">Targeted sentiment</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectTargetedSentimentItemResult": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of this result in the input list.</p>"
+          }
+        },
+        "Entities": {
+          "target": "com.amazonaws.comprehend#ListOfTargetedSentimentEntities",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of targeted sentiment entities.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Analysis results for one of the documents in the batch.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectTargetedSentimentRequest": {
+      "type": "structure",
+      "members": {
+        "TextList": {
+          "target": "com.amazonaws.comprehend#CustomerInputStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the UTF-8 encoded text of the input documents.\n      The list can contain a maximum of 25 documents. The maximum size of each document is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. Currently, English is the only supported language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchDetectTargetedSentimentResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfDetectTargetedSentimentResult",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of objects containing the results of the operation.\n      The results are sorted in ascending order by the <code>Index</code> field and match the order of the documents in the input list.\n      If all of the documents contain an error, the <code>ResultList</code> is empty.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorList": {
+          "target": "com.amazonaws.comprehend#BatchItemErrorList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of errors that the operation can return.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#BatchItemError": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based index of the document in the input list.</p>"
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The numeric error code of the error.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A text description of the error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes an error that occurred while processing a document in a batch. The operation\n      returns on <code>BatchItemError</code> object for each document that contained an\n      error.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BatchItemErrorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchItemError"
+      }
+    },
+    "com.amazonaws.comprehend#BatchSizeLimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of documents in the request exceeds the limit of 25. Try your request again\n      with fewer documents.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#Block": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier for the block.</p>"
+          }
+        },
+        "BlockType": {
+          "target": "com.amazonaws.comprehend#BlockType",
+          "traits": {
+            "smithy.api#documentation": "<p>The block represents a line of text or one word of text.</p>\n         <ul>\n            <li>\n               <p>WORD - A word that's detected on a document page.\n        A word is one or more ISO basic Latin script characters that aren't separated by spaces.</p>\n            </li>\n            <li>\n               <p>LINE - A string of tab-delimited, contiguous words\n        that are detected on a document page</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The word or line of text extracted from the block.</p>"
+          }
+        },
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number where the block appears.</p>"
+          }
+        },
+        "Geometry": {
+          "target": "com.amazonaws.comprehend#Geometry",
+          "traits": {
+            "smithy.api#documentation": "<p>Co-ordinates of the rectangle or polygon that contains the text.</p>"
+          }
+        },
+        "Relationships": {
+          "target": "com.amazonaws.comprehend#ListOfRelationships",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of child blocks of the current block.\n      For example, a LINE object has child blocks for each WORD block that's part of the line of text. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about each word or line of text in the input document.</p>\n         <p>For additional information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/API_Block.html\">Block</a> in the Amazon Textract API reference.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#BlockReference": {
+      "type": "structure",
+      "members": {
+        "BlockId": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier for the block.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Offset of the start of the block within its parent block.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Offset of the end of the block within its parent block.</p>"
+          }
+        },
+        "ChildBlocks": {
+          "target": "com.amazonaws.comprehend#ListOfChildBlocks",
+          "traits": {
+            "smithy.api#documentation": "<p>List of child blocks within this block.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A reference to a block. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#BlockType": {
+      "type": "enum",
+      "members": {
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        },
+        "WORD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORD"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#BoundingBox": {
+      "type": "structure",
+      "members": {
+        "Height": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The height of the bounding box as a ratio of the overall document page height.</p>"
+          }
+        },
+        "Left": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The left coordinate of the bounding box as a ratio of overall document page width.</p>"
+          }
+        },
+        "Top": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The top coordinate of the bounding box as a ratio of overall document page height.</p>"
+          }
+        },
+        "Width": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The width of the bounding box as a ratio of the overall document page width.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The bounding box around the detected page\n     or around an element on a document page.\n    The left (x-coordinate) and top (y-coordinate) are coordinates that\n      represent the top and left sides of the bounding box. Note that the upper-left\n      corner of the image is the origin (0,0). </p>\n         <p>For additional information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/API_BoundingBox.html\">BoundingBox</a> in the Amazon Textract API reference.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ChildBlock": {
+      "type": "structure",
+      "members": {
+        "ChildBlockId": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier for the child block.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Offset of the start of the child block within its parent block.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Offset of the end of the child block within its parent block.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Nested block contained within a block.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ClassifierEvaluationMetrics": {
+      "type": "structure",
+      "members": {
+        "Accuracy": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The fraction of the labels that were correct recognized. It is computed by dividing the\n      number of labels in the test documents that were correctly recognized by the total number of\n      labels in the test documents.</p>"
+          }
+        },
+        "Precision": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of the usefulness of the classifier results in the test data. High precision\n      means that the classifier returned substantially more relevant results than irrelevant\n      ones.</p>"
+          }
+        },
+        "Recall": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how complete the classifier results are for the test data. High recall means\n      that the classifier returned most of the relevant results. </p>"
+          }
+        },
+        "F1Score": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how accurate the classifier results are for the test data. It is derived from\n      the <code>Precision</code> and <code>Recall</code> values. The <code>F1Score</code> is the\n      harmonic average of the two scores. The highest score is 1, and the worst score is 0. </p>"
+          }
+        },
+        "MicroPrecision": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of the usefulness of the recognizer results in the test data. High precision\n      means that the recognizer returned substantially more relevant results than irrelevant ones.\n      Unlike the Precision metric which comes from averaging the precision of all available labels,\n      this is based on the overall score of all precision scores added together.</p>"
+          }
+        },
+        "MicroRecall": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how complete the classifier results are for the test data. High recall means\n      that the classifier returned most of the relevant results. Specifically, this indicates how\n      many of the correct categories in the text that the model can predict. It is a percentage of\n      correct categories in the text that can found. Instead of averaging the recall scores of all\n      labels (as with Recall), micro Recall is based on the overall score of all recall scores added\n      together.</p>"
+          }
+        },
+        "MicroF1Score": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how accurate the classifier results are for the test data. It is a\n      combination of the <code>Micro Precision</code> and <code>Micro Recall</code> values. The\n        <code>Micro F1Score</code> is the harmonic mean of the two scores. The highest score is 1,\n      and the worst score is 0.</p>"
+          }
+        },
+        "HammingLoss": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the fraction of labels that are incorrectly predicted. Also seen as the fraction\n      of wrong labels compared to the total number of labels. Scores closer to zero are\n      better.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the result metrics for the test data associated with an documentation\n      classifier.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ClassifierMetadata": {
+      "type": "structure",
+      "members": {
+        "NumberOfLabels": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of labels in the input data. </p>"
+          }
+        },
+        "NumberOfTrainedDocuments": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents in the input data that were used to train the classifier.\n      Typically this is 80 to 90 percent of the input documents.</p>"
+          }
+        },
+        "NumberOfTestDocuments": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents in the input data that were used to test the classifier. Typically\n      this is 10 to 20 percent of the input documents, up to 10,000 documents.</p>"
+          }
+        },
+        "EvaluationMetrics": {
+          "target": "com.amazonaws.comprehend#ClassifierEvaluationMetrics",
+          "traits": {
+            "smithy.api#documentation": "<p> Describes the result metrics for the test data associated with an documentation\n      classifier.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a document classifier.</p>",
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#ClassifyDocument": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ClassifyDocumentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ClassifyDocumentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a classification request to analyze a single document in real-time. <code>ClassifyDocument</code> \n      supports the following model types:</p>\n         <ul>\n            <li>\n               <p>Custom classifier - a custom model that you have created and trained. \n        For input, you can provide plain text, a single-page document (PDF, Word, or image), or \n        Amazon Textract API output. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-document-classification.html\">Custom classification</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>Prompt safety classifier - Amazon Comprehend provides a pre-trained model for classifying \n        input prompts for generative AI applications. \n        For input, you provide English plain text input.\n        For prompt safety classification, the response includes only the <code>Classes</code> field.\n        For more information about prompt safety classifiers, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/trust-safety.html#prompt-classification\">Prompt safety classification</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <p>If the system detects errors while processing a page in the input document,\n      the API response includes an <code>Errors</code> field that describes the errors.</p>\n         <p>If the system detects a document-level error in your input document, the API returns an\n      <code>InvalidRequestException</code> error response.\n      For details about this exception, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-inputs-sync-err.html\">\n        Errors in semi-structured documents</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#ClassifyDocumentRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>The document text to be analyzed. If you enter text using this parameter,\n      do not use the <code>Bytes</code> parameter.</p>"
+          }
+        },
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the endpoint. </p>\n         <p>For prompt safety classification, Amazon Comprehend provides the endpoint ARN. For more information about prompt safety classifiers, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/trust-safety.html#prompt-classification\">Prompt safety classification</a> in the <i>Amazon Comprehend Developer Guide</i>\n         </p>\n         <p>For custom classification, you create an endpoint for your custom model. For more information, \n      see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/using-endpoints.html\">Using Amazon Comprehend endpoints</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Bytes": {
+          "target": "com.amazonaws.comprehend#SemiStructuredDocumentBlob",
+          "traits": {
+            "smithy.api#documentation": "<p>Use the <code>Bytes</code> parameter to input a text, PDF, Word or image file.</p>\n         <p>When you classify a document using a custom model, you can also use the <code>Bytes</code> parameter to input an Amazon Textract <code>DetectDocumentText</code>\n        or <code>AnalyzeDocument</code> output file.</p>\n         <p>To classify a document using the prompt safety classifier, use the <code>Text</code> parameter for input.</p>\n         <p>Provide the input document as a sequence of base64-encoded bytes.\n      If your code uses an Amazon Web Services SDK to classify documents, the SDK may encode\n      the document file bytes for you. </p>\n         <p>The maximum length of this field depends on the input document type. For details, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-inputs-sync.html\">\n        Inputs for real-time custom analysis</a> in the Comprehend Developer Guide. </p>\n         <p>If you use the <code>Bytes</code> parameter, do not use the <code>Text</code> parameter.</p>"
+          }
+        },
+        "DocumentReaderConfig": {
+          "target": "com.amazonaws.comprehend#DocumentReaderConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides configuration parameters to override the default actions for extracting text\n      from PDF documents and image files.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ClassifyDocumentResponse": {
+      "type": "structure",
+      "members": {
+        "Classes": {
+          "target": "com.amazonaws.comprehend#ListOfClasses",
+          "traits": {
+            "smithy.api#documentation": "<p>The classes used by the document being analyzed. These are used for models trained in multi-class mode.\n      Individual classes are mutually exclusive and each document is expected to have only a\n      single class assigned to it. For example, an animal can be a dog or a cat, but not both at the\n      same time. </p>\n         <p>For prompt safety classification, the response includes only two classes (SAFE_PROMPT and UNSAFE_PROMPT), \n      along with a confidence score for each class. The value range of the score is zero to one, where one is the highest confidence.</p>"
+          }
+        },
+        "Labels": {
+          "target": "com.amazonaws.comprehend#ListOfLabels",
+          "traits": {
+            "smithy.api#documentation": "<p>The labels used in the document being analyzed. These are used for multi-label trained\n      models. Individual labels represent different categories that are related in some manner and\n      are not mutually exclusive. For example, a movie can be just an action movie, or it can be an\n      action movie, a science fiction movie, and a comedy, all at the same time. </p>"
+          }
+        },
+        "DocumentMetadata": {
+          "target": "com.amazonaws.comprehend#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Extraction information about the document. This field is present\n      in the response only if your request includes the <code>Byte</code> parameter. </p>"
+          }
+        },
+        "DocumentType": {
+          "target": "com.amazonaws.comprehend#ListOfDocumentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The document type for each page in the input document. This field is present\n      in the response only if your request includes the <code>Byte</code> parameter. </p>"
+          }
+        },
+        "Errors": {
+          "target": "com.amazonaws.comprehend#ListOfErrors",
+          "traits": {
+            "smithy.api#documentation": "<p>Page-level errors that the system detected while processing the input document.\n      The field is empty if the system encountered no errors.</p>"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.comprehend#ListOfWarnings",
+          "traits": {
+            "smithy.api#documentation": "<p>Warnings detected while processing the input document.\n      The response includes a warning if there is a mismatch between the input document type \n      and the model type associated with the endpoint that you specified. The response can also include\n       warnings for individual pages that have a mismatch. </p>\n         <p>The field is empty if the system generated no warnings.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#ClientRequestTokenString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-]+$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z0-9-]{1,64}/[a-zA-Z0-9](-*[a-zA-Z0-9])*((/dataset/[a-zA-Z0-9](-*[a-zA-Z0-9])*)|(/version/[a-zA-Z0-9](-*[a-zA-Z0-9])*))?$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendArnName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendDatasetArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:flywheel/[a-zA-Z0-9](-*[a-zA-Z0-9])*/dataset/[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendEndpointArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:(document-classifier-endpoint|entity-recognizer-endpoint)/[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendEndpointName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 40
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendFlywheelArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:flywheel/[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#ComprehendModelArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:(document-classifier|entity-recognizer)/[a-zA-Z0-9](-*[a-zA-Z0-9])*(/version/[a-zA-Z0-9](-*[a-zA-Z0-9])*)?$"
+      }
+    },
+    "com.amazonaws.comprehend#Comprehend_20171127": {
+      "type": "service",
+      "version": "2017-11-27",
+      "operations": [
+        {
+          "target": "com.amazonaws.comprehend#BatchDetectDominantLanguage"
+        },
+        {
+          "target": "com.amazonaws.comprehend#BatchDetectEntities"
+        },
+        {
+          "target": "com.amazonaws.comprehend#BatchDetectKeyPhrases"
+        },
+        {
+          "target": "com.amazonaws.comprehend#BatchDetectSentiment"
+        },
+        {
+          "target": "com.amazonaws.comprehend#BatchDetectSyntax"
+        },
+        {
+          "target": "com.amazonaws.comprehend#BatchDetectTargetedSentiment"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ClassifyDocument"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ContainsPiiEntities"
+        },
+        {
+          "target": "com.amazonaws.comprehend#CreateDataset"
+        },
+        {
+          "target": "com.amazonaws.comprehend#CreateDocumentClassifier"
+        },
+        {
+          "target": "com.amazonaws.comprehend#CreateEndpoint"
+        },
+        {
+          "target": "com.amazonaws.comprehend#CreateEntityRecognizer"
+        },
+        {
+          "target": "com.amazonaws.comprehend#CreateFlywheel"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DeleteDocumentClassifier"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DeleteEndpoint"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DeleteEntityRecognizer"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DeleteFlywheel"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DeleteResourcePolicy"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeDataset"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeDocumentClassificationJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeDocumentClassifier"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeDominantLanguageDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeEndpoint"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeEntitiesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeEntityRecognizer"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeEventsDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeFlywheel"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeFlywheelIteration"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeKeyPhrasesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribePiiEntitiesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeResourcePolicy"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeSentimentDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeTargetedSentimentDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DescribeTopicsDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectDominantLanguage"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectEntities"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectKeyPhrases"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectPiiEntities"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectSentiment"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectSyntax"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectTargetedSentiment"
+        },
+        {
+          "target": "com.amazonaws.comprehend#DetectToxicContent"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ImportModel"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListDatasets"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListDocumentClassificationJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListDocumentClassifiers"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListDocumentClassifierSummaries"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListDominantLanguageDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListEndpoints"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListEntitiesDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListEntityRecognizers"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListEntityRecognizerSummaries"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListEventsDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListFlywheelIterationHistory"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListFlywheels"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListKeyPhrasesDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListPiiEntitiesDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListSentimentDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListTargetedSentimentDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ListTopicsDetectionJobs"
+        },
+        {
+          "target": "com.amazonaws.comprehend#PutResourcePolicy"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartDocumentClassificationJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartDominantLanguageDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartEntitiesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartEventsDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartFlywheelIteration"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartKeyPhrasesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartPiiEntitiesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartSentimentDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartTargetedSentimentDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StartTopicsDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopDominantLanguageDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopEntitiesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopEventsDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopKeyPhrasesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopPiiEntitiesDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopSentimentDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopTargetedSentimentDetectionJob"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopTrainingDocumentClassifier"
+        },
+        {
+          "target": "com.amazonaws.comprehend#StopTrainingEntityRecognizer"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TagResource"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UpdateEndpoint"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UpdateFlywheel"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Comprehend",
+          "arnNamespace": "comprehend",
+          "cloudFormationName": "Comprehend",
+          "cloudTrailEventSource": "comprehend.amazonaws.com",
+          "endpointPrefix": "comprehend"
+        },
+        "aws.auth#sigv4": {
+          "name": "comprehend"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<p>Amazon Comprehend is an Amazon Web Services service for gaining insight into the content of documents.\n      Use these actions to determine the topics contained in your documents, the topics they\n      discuss, the predominant sentiment expressed in them, the predominant language used, and\n      more.</p>",
+        "smithy.api#title": "Amazon Comprehend",
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://comprehend-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://comprehend-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://comprehend.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://comprehend.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 13,
+          "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://comprehend-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://comprehend-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://comprehend.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://comprehend.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://comprehend.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ConcurrentModificationException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Concurrent modification of the tags associated with an Amazon Comprehend resource is not\n      supported. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#ContainsPiiEntities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ContainsPiiEntitiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ContainsPiiEntitiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Analyzes input text for the presence of personally identifiable information (PII) and\n      returns the labels of identified PII entity types such as name, address, bank account number,\n      or phone number.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ContainsPiiEntitiesRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The maximum string size is 100 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ContainsPiiEntitiesResponse": {
+      "type": "structure",
+      "members": {
+        "Labels": {
+          "target": "com.amazonaws.comprehend#ListOfEntityLabels",
+          "traits": {
+            "smithy.api#documentation": "<p>The labels used in the document being analyzed. Individual labels represent personally\n      identifiable information (PII) entity types.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateDataset": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#CreateDatasetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#CreateDatasetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a dataset to upload training or test data for a model associated with a flywheel.\n      For more information about datasets, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#CreateDatasetRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel of the flywheel to receive the data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DatasetName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the dataset.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DatasetType": {
+          "target": "com.amazonaws.comprehend#DatasetType",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset type. You can specify that the data in a dataset is for training\n      the model or for testing the model.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.comprehend#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>Description of the dataset.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#DatasetInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the input data configuration. The type of input data varies based\n      on the format of the input and whether the data is for a classifier model or an entity recognition model.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags for the dataset.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateDatasetResponse": {
+      "type": "structure",
+      "members": {
+        "DatasetArn": {
+          "target": "com.amazonaws.comprehend#ComprehendDatasetArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the dataset.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateDocumentClassifier": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#CreateDocumentClassifierRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#CreateDocumentClassifierResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new document classifier that you can use to categorize documents. To create a\n      classifier, you provide a set of training documents that are labeled with the categories that you\n      want to use. For more information, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/training-classifier-model.html\">Training classifier models</a> \n      in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#CreateDocumentClassifierRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the document classifier.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The version name given to the newly created classifier. Version names can have a maximum\n      of 256 characters. Alphanumeric characters, hyphens (-) and underscores (_) are allowed. The\n      version name must be unique among all models with the same classifier name in the Amazon Web Services account/Amazon Web Services Region.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the document classifier. A tag is a key-value\n      pair that adds as a metadata to a resource used by Amazon Comprehend. For example, a tag with\n      \"Sales\" as the key might be added to a resource to indicate its use by the sales department.\n    </p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierOutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the location for the output files from a custom classifier job.\n      This parameter is required for a request that creates a native document model.</p>"
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your custom classifier. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Mode": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the mode in which the classifier will be trained. The classifier can be trained\n      in multi-class (single-label) mode or multi-label mode. \n      Multi-class mode identifies a single class label for each document and\n      multi-label mode identifies one or more class labels for each document. Multiple\n      labels for an individual document are separated by a delimiter. The default delimiter between\n      labels is a pipe (|).</p>"
+          }
+        },
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "ModelPolicy": {
+          "target": "com.amazonaws.comprehend#Policy",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource-based policy to attach to your custom document classifier model. You can use\n      this policy to allow another Amazon Web Services account to import your custom model.</p>\n         <p>Provide your policy as a JSON body that you enter as a UTF-8 encoded string without line\n      breaks. To provide valid JSON, enclose the attribute names and values in double quotes. If the\n      JSON body is also enclosed in double quotes, then you must escape the double quotes that are\n      inside the policy:</p>\n         <p>\n            <code>\"{\\\"attribute\\\": \\\"value\\\", \\\"attribute\\\": [\\\"value\\\"]}\"</code>\n         </p>\n         <p>To avoid escaping quotes, you can use single quotes to enclose the policy and double\n      quotes to enclose the JSON names and values:</p>\n         <p>\n            <code>'{\"attribute\": \"value\", \"attribute\": [\"value\"]}'</code>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateDocumentClassifierResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the document classifier.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#CreateEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#CreateEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a model-specific endpoint for synchronous inference for a previously trained\n      custom model \n      For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#CreateEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointName": {
+          "target": "com.amazonaws.comprehend#ComprehendEndpointName",
+          "traits": {
+            "smithy.api#documentation": "<p>This is the descriptive suffix that becomes part of the <code>EndpointArn</code> used for\n      all subsequent requests to this resource. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the model to which the endpoint will be\n      attached.</p>"
+          }
+        },
+        "DesiredInferenceUnits": {
+          "target": "com.amazonaws.comprehend#InferenceUnitsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p> The desired number of inference units to be used by the model using this endpoint.\n      \n      Each inference unit represents of a throughput of 100 characters per second.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>An idempotency token provided by the customer. If this token matches a previous endpoint\n      creation request, Amazon Comprehend will not return a <code>ResourceInUseException</code>.\n    </p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the endpoint. A tag is a key-value pair that adds\n      metadata to the endpoint. For example, a tag with \"Sales\" as the key might be added to an\n      endpoint to indicate its use by the sales department. </p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to trained custom models encrypted with a customer\n      managed key (ModelKmsKeyId).</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel to which the endpoint will be\n      attached.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateEndpointResponse": {
+      "type": "structure",
+      "members": {
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#ComprehendEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the endpoint being created.</p>"
+          }
+        },
+        "ModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the model to which the endpoint is\n      attached.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateEntityRecognizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#CreateEntityRecognizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#CreateEntityRecognizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an entity recognizer using submitted files. After your\n        <code>CreateEntityRecognizer</code> request is submitted, you can check job status using the\n        <code>DescribeEntityRecognizer</code> API. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#CreateEntityRecognizerRequest": {
+      "type": "structure",
+      "members": {
+        "RecognizerName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name given to the newly created recognizer. Recognizer names can be a maximum of 256\n      characters. Alphanumeric characters, hyphens (-) and underscores (_) are allowed. The name\n      must be unique in the account/Region.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The version name given to the newly created recognizer. Version names can be a maximum of\n      256 characters. Alphanumeric characters, hyphens (-) and underscores (_) are allowed. The\n      version name must be unique among all models with the same recognizer name in the account/Region.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the entity recognizer. A tag is a key-value pair\n      that adds as a metadata to a resource used by Amazon Comprehend. For example, a tag with\n      \"Sales\" as the key might be added to a resource to indicate its use by the sales department.\n    </p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data. The S3 bucket containing the input\n      data must be located in the same Region as the entity recognizer being created. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p> A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p> You can specify any of the following languages: English\n      (\"en\"), Spanish (\"es\"), French (\"fr\"), Italian (\"it\"), German (\"de\"), or Portuguese (\"pt\").\n      If you plan to use this entity recognizer with PDF, Word, or image input files, you must\n      specify English as the language.\n      All training documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your custom entity recognizer. For more information, see\n      <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "ModelPolicy": {
+          "target": "com.amazonaws.comprehend#Policy",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON resource-based policy to attach to your custom entity recognizer model. You can\n      use this policy to allow another Amazon Web Services account to import your custom model.</p>\n         <p>Provide your JSON as a UTF-8 encoded string without line breaks. To provide valid JSON for\n      your policy, enclose the attribute names and values in double quotes. If the JSON body is also\n      enclosed in double quotes, then you must escape the double quotes that are inside the\n      policy:</p>\n         <p>\n            <code>\"{\\\"attribute\\\": \\\"value\\\", \\\"attribute\\\": [\\\"value\\\"]}\"</code>\n         </p>\n         <p>To avoid escaping quotes, you can use single quotes to enclose the policy and double\n      quotes to enclose the JSON names and values:</p>\n         <p>\n            <code>'{\"attribute\": \"value\", \"attribute\": [\"value\"]}'</code>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateEntityRecognizerResponse": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the entity recognizer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateFlywheel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#CreateFlywheelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#CreateFlywheelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>A flywheel is an Amazon Web Services resource that orchestrates the ongoing training of a model for custom classification\n      or custom entity recognition. You can create a flywheel to start with an existing trained model, or\n      Comprehend can create and train a new model.</p>\n         <p>When you create the flywheel, Comprehend creates a data lake in your account. The data lake holds the training\n      data and test data for all versions of the model.</p>\n         <p>To use a flywheel with an existing trained model, you specify the active model version. Comprehend copies the model's\n      training data and test data into the flywheel's data lake.</p>\n         <p>To use the flywheel with a new model, you need to provide a dataset for training data (and optional test data)\n      when you create the flywheel.</p>\n         <p>For more information about flywheels, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#CreateFlywheelRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name for the flywheel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ActiveModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>To associate an existing model with the flywheel, specify the Amazon Resource Number (ARN) of the model version.\n      Do not set <code>TaskConfig</code> or <code>ModelType</code> if you specify an <code>ActiveModelArn</code>.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend the permissions required to access the flywheel data in the data lake.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TaskConfig": {
+          "target": "com.amazonaws.comprehend#TaskConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration about the model associated with the flywheel.\n      You need to set <code>TaskConfig</code> if you are creating a flywheel for a new model.</p>"
+          }
+        },
+        "ModelType": {
+          "target": "com.amazonaws.comprehend#ModelType",
+          "traits": {
+            "smithy.api#documentation": "<p>The model type. You need to set <code>ModelType</code> if you are creating a flywheel for a new model.</p>"
+          }
+        },
+        "DataLakeS3Uri": {
+          "target": "com.amazonaws.comprehend#FlywheelS3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Enter the S3 location for the data lake. You can specify a new S3 bucket or a new folder of an\n    existing S3 bucket. The flywheel creates the data lake at this location.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataSecurityConfig": {
+          "target": "com.amazonaws.comprehend#DataSecurityConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Data security configurations.</p>"
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags to associate with this flywheel.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#CreateFlywheelResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel.</p>"
+          }
+        },
+        "ActiveModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the active model version.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#CustomerInputString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#CustomerInputStringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#CustomerInputString"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DataSecurityConfig": {
+      "type": "structure",
+      "members": {
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt the volume.</p>"
+          }
+        },
+        "DataLakeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt the data in the data lake.</p>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Data security configuration.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetAugmentedManifestsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DatasetAugmentedManifestsListItem"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetAugmentedManifestsListItem": {
+      "type": "structure",
+      "members": {
+        "AttributeNames": {
+          "target": "com.amazonaws.comprehend#AttributeNamesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON attribute that contains the annotations for your training documents. The number\n      of attribute names that you specify depends on whether your augmented manifest file is the\n      output of a single labeling job or a chained labeling job.</p>\n         <p>If your file is the output of a single labeling job, specify the LabelAttributeName key\n      that was used when the job was created in Ground Truth.</p>\n         <p>If your file is the output of a chained labeling job, specify the LabelAttributeName key\n      for one or more jobs in the chain. Each LabelAttributeName key provides the annotations from\n      an individual job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the augmented manifest file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AnnotationDataS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 prefix to the annotation files that are referred in the augmented manifest\n      file.</p>"
+          }
+        },
+        "SourceDocumentsS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 prefix to the source files (PDFs) that are referred to in the augmented manifest\n      file.</p>"
+          }
+        },
+        "DocumentType": {
+          "target": "com.amazonaws.comprehend#AugmentedManifestsDocumentTypeFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of augmented manifest. If you don't specify, the default is PlainTextDocument. </p>\n         <p>\n            <code>PLAIN_TEXT_DOCUMENT</code> A document type that represents any unicode text that\n      is encoded in UTF-8.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An augmented manifest file that provides training data for your custom model.\n      An augmented manifest file is a labeled dataset that is produced by Amazon SageMaker Ground Truth.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetDataFormat": {
+      "type": "enum",
+      "members": {
+        "COMPREHEND_CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPREHEND_CSV"
+          }
+        },
+        "AUGMENTED_MANIFEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUGMENTED_MANIFEST"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DatasetDocumentClassifierInputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 URI for the input data. The S3 bucket must be in the same Region as the API\n      endpoint that you are calling. The URI can point to a single input file or it can provide the\n      prefix for a collection of input files.</p>\n         <p>For example, if you use the URI <code>S3://bucketName/prefix</code>, if the prefix is a\n      single file, Amazon Comprehend uses that file as input. If more than one file begins with the\n      prefix, Amazon Comprehend uses all of them as input.</p>\n         <p>This parameter is required if you set <code>DataFormat</code> to\n      <code>COMPREHEND_CSV</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LabelDelimiter": {
+          "target": "com.amazonaws.comprehend#LabelDelimiter",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the delimiter used to separate each label for training a multi-label classifier.\n      The default delimiter between labels is a pipe (|). You can use a different character as a\n      delimiter (if it's an allowed character) by specifying it under Delimiter for labels. If the\n      training documents use a delimiter other than the default or the delimiter you specify, the\n      labels on that line will be combined to make a single unique label, such as\n      LABELLABELLABEL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the dataset input data configuration for a document classifier model.</p>\n         <p>For more information on how the input file is formatted, see  <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/prep-classifier-data.html\">Preparing training data</a>\n      in the Comprehend Developer Guide. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetEntityRecognizerAnnotations": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies the Amazon S3 location where the training documents for an entity recognizer\n      are located. The URI must be in the same Region as the API endpoint that you are\n      calling.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the annotations associated with a entity recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetEntityRecognizerDocuments": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies the Amazon S3 location where the documents for the dataset\n      are located.  </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputFormat": {
+          "target": "com.amazonaws.comprehend#InputFormat",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies how the text in an input file should be processed. This is optional, and the\n      default is ONE_DOC_PER_LINE. ONE_DOC_PER_FILE - Each file is considered a separate document.\n      Use this option when you are processing large documents, such as newspaper articles or\n      scientific papers. ONE_DOC_PER_LINE - Each line in a file is considered a separate document.\n      Use this option when you are processing many short documents, such as text messages.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the documents submitted with a dataset for an entity recognizer model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetEntityRecognizerEntityList": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the Amazon S3 location where the entity list is located.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the dataset entity list for an entity recognizer model.</p>\n         <p>For more information on how the input file is formatted, see  <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/prep-training-data-cer.html\">Preparing training data</a>\n      in the Comprehend Developer Guide. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetEntityRecognizerInputDataConfig": {
+      "type": "structure",
+      "members": {
+        "Annotations": {
+          "target": "com.amazonaws.comprehend#DatasetEntityRecognizerAnnotations",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location of the annotation documents for your custom entity recognizer.</p>"
+          }
+        },
+        "Documents": {
+          "target": "com.amazonaws.comprehend#DatasetEntityRecognizerDocuments",
+          "traits": {
+            "smithy.api#documentation": "<p>The format and location of the training documents for your custom entity\n      recognizer.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EntityList": {
+          "target": "com.amazonaws.comprehend#DatasetEntityRecognizerEntityList",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location of the entity list for your custom entity recognizer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the format and location of the input data. You must provide either the\n      <code>Annotations</code> parameter or the <code>EntityList</code> parameter.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetFilter": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.comprehend#DatasetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the datasets based on the dataset status.</p>"
+          }
+        },
+        "DatasetType": {
+          "target": "com.amazonaws.comprehend#DatasetType",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the datasets based on the dataset type.</p>"
+          }
+        },
+        "CreationTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the datasets to include datasets created after the specified time.</p>"
+          }
+        },
+        "CreationTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the datasets to include datasets created before the specified time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filter the datasets based on creation time or dataset status.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetInputDataConfig": {
+      "type": "structure",
+      "members": {
+        "AugmentedManifests": {
+          "target": "com.amazonaws.comprehend#DatasetAugmentedManifestsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of augmented manifest files that provide training data for your custom model. An\n      augmented manifest file is a labeled dataset that is produced by Amazon SageMaker Ground\n      Truth. </p>"
+          }
+        },
+        "DataFormat": {
+          "target": "com.amazonaws.comprehend#DatasetDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            <code>COMPREHEND_CSV</code>: The data format is a two-column CSV file, where the\n      first column contains labels and the second column contains documents.</p>\n         <p>\n            <code>AUGMENTED_MANIFEST</code>: The data format  </p>"
+          }
+        },
+        "DocumentClassifierInputDataConfig": {
+          "target": "com.amazonaws.comprehend#DatasetDocumentClassifierInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input properties for training a document classifier model. </p>\n         <p>For more information on how the input file is formatted, see  <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/prep-classifier-data.html\">Preparing training data</a>\n      in the Comprehend Developer Guide. </p>"
+          }
+        },
+        "EntityRecognizerInputDataConfig": {
+          "target": "com.amazonaws.comprehend#DatasetEntityRecognizerInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input properties for training an entity recognizer model.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the format and location of the input data for the dataset.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetProperties": {
+      "type": "structure",
+      "members": {
+        "DatasetArn": {
+          "target": "com.amazonaws.comprehend#ComprehendDatasetArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the dataset.</p>"
+          }
+        },
+        "DatasetName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the dataset.</p>"
+          }
+        },
+        "DatasetType": {
+          "target": "com.amazonaws.comprehend#DatasetType",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset type (training data or test data).</p>"
+          }
+        },
+        "DatasetS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 URI where the dataset is stored.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.comprehend#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>Description of the dataset.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#DatasetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset status. While the system creates the dataset, the status is <code>CREATING</code>.\n      When the dataset is ready to use, the status changes to <code>COMPLETED</code>. </p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of the dataset.</p>"
+          }
+        },
+        "NumberOfDocuments": {
+          "target": "com.amazonaws.comprehend#NumberOfDocuments",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents in the dataset.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Creation time of the dataset.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Time when the data from the dataset becomes available in the data lake.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Properties associated with the dataset.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DatasetProperties"
+      }
+    },
+    "com.amazonaws.comprehend#DatasetStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DatasetType": {
+      "type": "enum",
+      "members": {
+        "TRAIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRAIN"
+          }
+        },
+        "TEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEST"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DeleteDocumentClassifier": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DeleteDocumentClassifierRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DeleteDocumentClassifierResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a previously created document classifier</p>\n         <p>Only those classifiers that are in terminated states (IN_ERROR, TRAINED) will be deleted.\n      If an active inference job is using the model, a <code>ResourceInUseException</code> will be\n      returned.</p>\n         <p>This is an asynchronous action that puts the classifier into a DELETING state, and it is\n      then removed by a background job. Once removed, the classifier disappears from your account\n      and is no longer available for use. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DeleteDocumentClassifierRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the document classifier. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteDocumentClassifierResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DeleteEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DeleteEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a model-specific endpoint for a previously-trained custom model. All endpoints\n      must be deleted in order for the model to be deleted.\n      For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DeleteEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#ComprehendEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the endpoint being deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteEndpointResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteEntityRecognizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DeleteEntityRecognizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DeleteEntityRecognizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an entity recognizer.</p>\n         <p>Only those recognizers that are in terminated states (IN_ERROR, TRAINED) will be deleted.\n      If an active inference job is using the model, a <code>ResourceInUseException</code> will be\n      returned.</p>\n         <p>This is an asynchronous action that puts the recognizer into a DELETING state, and it is\n      then removed by a background job. Once removed, the recognizer disappears from your account\n      and is no longer available for use. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DeleteEntityRecognizerRequest": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the entity recognizer.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteEntityRecognizerResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteFlywheel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DeleteFlywheelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DeleteFlywheelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a flywheel. When you delete the flywheel, Amazon Comprehend\n      does not delete the data lake or the model associated with the flywheel.</p>\n         <p>For more information about flywheels, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DeleteFlywheelRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteFlywheelResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteResourcePolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DeleteResourcePolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DeleteResourcePolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a resource-based policy that is attached to a custom model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DeleteResourcePolicyRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the custom model version that has the policy to delete.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyRevisionId": {
+          "target": "com.amazonaws.comprehend#PolicyRevisionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The revision ID of the policy to delete.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DeleteResourcePolicyResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDataset": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeDatasetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeDatasetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about the dataset that you specify. \n      For more information about datasets, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDatasetRequest": {
+      "type": "structure",
+      "members": {
+        "DatasetArn": {
+          "target": "com.amazonaws.comprehend#ComprehendDatasetArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the dataset.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDatasetResponse": {
+      "type": "structure",
+      "members": {
+        "DatasetProperties": {
+          "target": "com.amazonaws.comprehend#DatasetProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset properties.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDocumentClassificationJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeDocumentClassificationJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeDocumentClassificationJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a document classification job. Use this operation to\n      get the status of a classification job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDocumentClassificationJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The  \n      <code>StartDocumentClassificationJob</code> operation returns this identifier in its response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDocumentClassificationJobResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentClassificationJobProperties": {
+          "target": "com.amazonaws.comprehend#DocumentClassificationJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that describes the properties associated with the document classification\n      job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDocumentClassifier": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeDocumentClassifierRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeDocumentClassifierResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a document classifier.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDocumentClassifierRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the document classifier. The  \n      <code>CreateDocumentClassifier</code> operation returns this identifier in its response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDocumentClassifierResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierProperties": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with a document classifier.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDominantLanguageDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeDominantLanguageDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeDominantLanguageDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a dominant language detection job. Use this operation\n      to get the status of a detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDominantLanguageDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The  \n      <code>StartDominantLanguageDetectionJob</code> operation returns this identifier in its response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeDominantLanguageDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "DominantLanguageDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#DominantLanguageDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with a dominant language detection\n      job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a specific endpoint. Use this operation to get the\n      status of an endpoint.\n      For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#ComprehendEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the endpoint being described.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEndpointResponse": {
+      "type": "structure",
+      "members": {
+        "EndpointProperties": {
+          "target": "com.amazonaws.comprehend#EndpointProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes information associated with the specific endpoint.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEntitiesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeEntitiesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeEntitiesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with an entities detection job. Use this operation to get\n      the status of a detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEntitiesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The \n        <code>StartEntitiesDetectionJob</code> operation returns this identifier in its response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEntitiesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "EntitiesDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#EntitiesDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with an entities detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEntityRecognizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeEntityRecognizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeEntityRecognizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details about an entity recognizer including status, S3 buckets containing\n      training data, recognizer metadata, metrics, and so on.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEntityRecognizerRequest": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the entity recognizer.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEntityRecognizerResponse": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerProperties": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes information associated with an entity recognizer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEventsDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeEventsDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeEventsDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the status and details of an events detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEventsDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the events detection job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeEventsDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "EventsDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#EventsDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with an event detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeFlywheel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeFlywheelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeFlywheelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides configuration information about the flywheel. For more information about flywheels, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeFlywheelIteration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeFlywheelIterationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeFlywheelIterationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieve the configuration properties of a flywheel iteration.\n      For more information about flywheels, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeFlywheelIterationRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FlywheelIterationId": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationId",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeFlywheelIterationResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelIterationProperties": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration properties of a flywheel iteration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeFlywheelRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeFlywheelResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelProperties": {
+          "target": "com.amazonaws.comprehend#FlywheelProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The flywheel properties.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeKeyPhrasesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeKeyPhrasesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeKeyPhrasesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a key phrases detection job. Use this operation to get\n      the status of a detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeKeyPhrasesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The \n        <code>StartKeyPhrasesDetectionJob</code> operation returns this identifier in its\n      response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeKeyPhrasesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "KeyPhrasesDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#KeyPhrasesDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with a key phrases detection job.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribePiiEntitiesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribePiiEntitiesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribePiiEntitiesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a PII entities detection job. For example, you can use\n      this operation to get the job status.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribePiiEntitiesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The  operation returns this identifier in its\n      response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribePiiEntitiesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "PiiEntitiesDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#PiiEntitiesDetectionJobProperties"
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeResourcePolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeResourcePolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeResourcePolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the details of a resource-based policy that is attached to a custom model, including\n      the JSON body of the policy.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeResourcePolicyRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the custom model version that has the resource policy.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeResourcePolicyResponse": {
+      "type": "structure",
+      "members": {
+        "ResourcePolicy": {
+          "target": "com.amazonaws.comprehend#Policy",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON body of the resource-based policy.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the policy was created.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the policy was last modified.</p>"
+          }
+        },
+        "PolicyRevisionId": {
+          "target": "com.amazonaws.comprehend#PolicyRevisionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The revision ID of the policy. Each time you modify a policy, Amazon Comprehend assigns a\n      new revision ID, and it deletes the prior version of the policy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeSentimentDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeSentimentDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeSentimentDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a sentiment detection job. Use this operation to get\n      the status of a detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeSentimentDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The  operation returns this identifier in its\n      response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeSentimentDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "SentimentDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#SentimentDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with a sentiment detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeTargetedSentimentDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeTargetedSentimentDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeTargetedSentimentDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a targeted sentiment detection job. Use this operation\n      to get the status of the job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeTargetedSentimentDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Comprehend generated for the job. The  \n      <code>StartTargetedSentimentDetectionJob</code> operation returns this identifier in its\n      response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeTargetedSentimentDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "TargetedSentimentDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#TargetedSentimentDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with a targeted sentiment detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeTopicsDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DescribeTopicsDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DescribeTopicsDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with a topic detection job. Use this operation to get\n      the status of a detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DescribeTopicsDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned by the user to the detection job.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DescribeTopicsDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "TopicsDetectionJobProperties": {
+          "target": "com.amazonaws.comprehend#TopicsDetectionJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of properties for the requested job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#Description": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^([a-zA-Z0-9_])[\\\\a-zA-Z0-9_@#%*+=:?./!\\s-]*$"
+      }
+    },
+    "com.amazonaws.comprehend#DetectDominantLanguage": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectDominantLanguageRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectDominantLanguageResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Determines the dominant language of the input text. For a list of languages that Amazon\n      Comprehend can detect, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-languages.html\">Amazon Comprehend Supported Languages</a>. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectDominantLanguageRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The string must contain at least 20 characters. The maximum string size is 100 KB.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectDominantLanguageResponse": {
+      "type": "structure",
+      "members": {
+        "Languages": {
+          "target": "com.amazonaws.comprehend#ListOfDominantLanguages",
+          "traits": {
+            "smithy.api#documentation": "<p>Array of languages that Amazon Comprehend detected in the input text. \n      The array is sorted in descending order of the score \n      (the dominant language is always the first element in the array).</p>\n         <p>For each language, the\n      response returns the RFC 5646 language code and the level of confidence that Amazon Comprehend\n      has in the accuracy of its inference. For more information about RFC 5646, see <a href=\"https://tools.ietf.org/html/rfc5646\">Tags for Identifying Languages</a> on the\n        <i>IETF Tools</i> web site.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectEntities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectEntitiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectEntitiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Detects named entities in input text when you use the pre-trained model.\n      Detects custom entities if you have a custom entity recognition model. </p>\n         <p>\n      When detecting named entities using the pre-trained model, use plain text as the input.\n      For more information about named entities, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-entities.html\">Entities</a> in the Comprehend Developer Guide.</p>\n         <p>When you use a custom entity recognition model,\n      you can input plain text or you can upload a single-page input document (text, PDF, Word, or image). </p>\n         <p>If the system detects errors while processing a page in the input document, the API response\n       includes an entry in <code>Errors</code> for each error. </p>\n         <p>If the system detects a document-level error in your input document, the API returns an\n       <code>InvalidRequestException</code> error response.\n      For details about this exception, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-inputs-sync-err.html\">\n        Errors in semi-structured documents</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectEntitiesRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The maximum string size is 100 KB. If you enter text using this parameter,\n    do not use the <code>Bytes</code> parameter.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. If your request includes the endpoint for a custom entity recognition model, Amazon\n      Comprehend uses the language of your custom model, and it ignores any language code that you\n      specify here.</p>\n         <p>All input documents must be in the same language.</p>"
+          }
+        },
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name of an endpoint that is associated with a custom entity\n      recognition model. Provide an endpoint if you want to detect entities by using your own custom\n      model instead of the default model that is used by Amazon Comprehend.</p>\n         <p>If you specify an endpoint, Amazon Comprehend uses the language of your custom model, and\n      it ignores any language code that you provide in your request.</p>\n         <p>For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>"
+          }
+        },
+        "Bytes": {
+          "target": "com.amazonaws.comprehend#SemiStructuredDocumentBlob",
+          "traits": {
+            "smithy.api#documentation": "<p>This field applies only when you use a custom entity recognition model that\n      was trained with PDF annotations. For other cases,\n      enter your text input in the <code>Text</code> field.</p>\n         <p>\n      Use the <code>Bytes</code> parameter to input a text, PDF, Word or image file.\n      Using a plain-text file in the <code>Bytes</code> parameter is equivelent to using the\n      <code>Text</code> parameter (the <code>Entities</code> field in the response is identical).</p>\n         <p>You can also use the <code>Bytes</code> parameter to input an Amazon Textract <code>DetectDocumentText</code>\n      or <code>AnalyzeDocument</code> output file.</p>\n         <p>Provide the input document as a sequence of base64-encoded bytes.\n      If your code uses an Amazon Web Services SDK to detect entities, the SDK may encode\n      the document file bytes for you. </p>\n         <p>The maximum length of this field depends on the input document type. For details, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-inputs-sync.html\">\n        Inputs for real-time custom analysis</a> in the Comprehend Developer Guide. </p>\n         <p>If you use the <code>Bytes</code> parameter, do not use the <code>Text</code> parameter.</p>"
+          }
+        },
+        "DocumentReaderConfig": {
+          "target": "com.amazonaws.comprehend#DocumentReaderConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides configuration parameters to override the default actions for extracting text\n      from PDF documents and image files.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectEntitiesResponse": {
+      "type": "structure",
+      "members": {
+        "Entities": {
+          "target": "com.amazonaws.comprehend#ListOfEntities",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of entities identified in the input text. For each entity, the response\n      provides the entity text, entity type, where the entity text begins and ends, and the level of\n      confidence that Amazon Comprehend has in the detection. </p>\n         <p>If your request uses a custom entity recognition model, Amazon Comprehend detects the\n      entities that the model is trained to recognize. Otherwise, it detects the default entity\n      types. For a list of default entity types, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-entities.html\">Entities</a> in the Comprehend Developer Guide.\n    </p>"
+          }
+        },
+        "DocumentMetadata": {
+          "target": "com.amazonaws.comprehend#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the document, discovered during text extraction. This field is present\n      in the response only if your request used the <code>Byte</code> parameter. </p>"
+          }
+        },
+        "DocumentType": {
+          "target": "com.amazonaws.comprehend#ListOfDocumentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The document type for each page in the input document. This field is present\n      in the response only if your request used the <code>Byte</code> parameter. </p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.comprehend#ListOfBlocks",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about each block of text in the input document.\n      Blocks are nested. A page block contains a block for each line of text,\n      which contains a block for each word. </p>\n         <p>The <code>Block</code> content for a Word input document does not include a <code>Geometry</code> field.</p>\n         <p>The <code>Block</code> field is not present in the response for plain-text inputs.</p>"
+          }
+        },
+        "Errors": {
+          "target": "com.amazonaws.comprehend#ListOfErrors",
+          "traits": {
+            "smithy.api#documentation": "<p>Page-level errors that the system detected while processing the input document.\n      The field is empty if the system encountered no errors.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectKeyPhrases": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectKeyPhrasesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectKeyPhrasesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Detects the key noun phrases found in the text. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectKeyPhrasesRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The string must contain less than 100 KB of UTF-8 encoded\n      characters.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectKeyPhrasesResponse": {
+      "type": "structure",
+      "members": {
+        "KeyPhrases": {
+          "target": "com.amazonaws.comprehend#ListOfKeyPhrases",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of key phrases that Amazon Comprehend identified in the input text. For\n      each key phrase, the response provides the text of the key phrase, where the key phrase begins\n      and ends, and the level of confidence that Amazon Comprehend has in the accuracy of the\n      detection. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectPiiEntities": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectPiiEntitiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectPiiEntitiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects the input text for entities that contain personally identifiable information\n      (PII) and returns information about them.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectPiiEntitiesRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The maximum string size is 100 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input text.   \n      Enter the language code for English (en) or Spanish (es).</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectPiiEntitiesResponse": {
+      "type": "structure",
+      "members": {
+        "Entities": {
+          "target": "com.amazonaws.comprehend#ListOfPiiEntities",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of PII entities identified in the input text. For each entity, the response\n      provides the entity type, where the entity text begins and ends, and the level of confidence\n      that Amazon Comprehend has in the detection.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectSentiment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectSentimentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectSentimentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects text and returns an inference of the prevailing sentiment\n        (<code>POSITIVE</code>, <code>NEUTRAL</code>, <code>MIXED</code>, or <code>NEGATIVE</code>). </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectSentimentRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The maximum string size is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectSentimentResponse": {
+      "type": "structure",
+      "members": {
+        "Sentiment": {
+          "target": "com.amazonaws.comprehend#SentimentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The inferred sentiment that Amazon Comprehend has the highest level of confidence\n      in.</p>"
+          }
+        },
+        "SentimentScore": {
+          "target": "com.amazonaws.comprehend#SentimentScore",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that lists the sentiments, and their corresponding confidence\n      levels.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectSyntax": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectSyntaxRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectSyntaxResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects text for syntax and the part of speech of words in the document. For more\n      information, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-syntax.html\">Syntax</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectSyntaxRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 string. The maximum string size is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#SyntaxLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents. You can specify any of the following languages\n      supported by Amazon Comprehend: German (\"de\"), English (\"en\"), Spanish (\"es\"), French (\"fr\"),\n      Italian (\"it\"), or Portuguese (\"pt\").</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectSyntaxResponse": {
+      "type": "structure",
+      "members": {
+        "SyntaxTokens": {
+          "target": "com.amazonaws.comprehend#ListOfSyntaxTokens",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of syntax tokens describing the text. For each token, the response provides\n      the text, the token type, where the text begins and ends, and the level of confidence that\n      Amazon Comprehend has that the token is correct. For a list of token types, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-syntax.html\">Syntax</a> in the Comprehend Developer Guide.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectTargetedSentiment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectTargetedSentimentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectTargetedSentimentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Inspects the input text and returns a sentiment analysis for each entity identified in the text.</p>\n         <p>For more information about targeted sentiment, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html\">Targeted sentiment</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectTargetedSentimentRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>A UTF-8 text string. The maximum string length is 5 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. Currently, English is the only supported language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectTargetedSentimentResponse": {
+      "type": "structure",
+      "members": {
+        "Entities": {
+          "target": "com.amazonaws.comprehend#ListOfTargetedSentimentEntities",
+          "traits": {
+            "smithy.api#documentation": "<p>Targeted sentiment analysis for each of the entities identified in the input text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectToxicContent": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#DetectToxicContentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#DetectToxicContentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#UnsupportedLanguageException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Performs toxicity analysis on the list of text strings that you provide as input.\n      The API response contains a results list that matches the size of the input list.\n      For more information about toxicity detection, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/toxicity-detection.html\">Toxicity detection</a> in the <i>Amazon Comprehend Developer Guide</i>.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DetectToxicContentRequest": {
+      "type": "structure",
+      "members": {
+        "TextSegments": {
+          "target": "com.amazonaws.comprehend#ListOfTextSegments",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of up to 10 text strings. Each string has a maximum size of 1 KB, and\n      the maximum size of the list is 10 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input text. Currently, English is the only supported language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#DetectToxicContentResponse": {
+      "type": "structure",
+      "members": {
+        "ResultList": {
+          "target": "com.amazonaws.comprehend#ListOfToxicLabels",
+          "traits": {
+            "smithy.api#documentation": "<p>Results of the content moderation analysis.\n      Each entry in the results list contains a list of toxic content types identified in \n      the text, along with a confidence score for each content type. \n      The results list also includes a toxicity score for each entry in the results list.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClass": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the class.</p>"
+          }
+        },
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score that Amazon Comprehend has this class correctly attributed.</p>"
+          }
+        },
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number in the input document. This field is present\n      in the response only if your request includes the <code>Byte</code> parameter. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the class that categorizes the document being analyzed</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassificationConfig": {
+      "type": "structure",
+      "members": {
+        "Mode": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Classification mode indicates whether the documents are <code>MULTI_CLASS</code> or <code>MULTI_LABEL</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Labels": {
+          "target": "com.amazonaws.comprehend#LabelsList",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more labels to associate with the custom classifier.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration required for a document classification model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassificationJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list based on job status. Returns only jobs with the specified status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of document classification jobs. For more\n      information, see the  operation. You can\n      provide only one filter parameter in each request.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassificationJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the document classification job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the document classification job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:document-classification-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:document-classification-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned to the document classification job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the document classification job. If the status is\n        <code>FAILED</code>, the <code>Message</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of the job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the document classification job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the document classification job completed.</p>"
+          }
+        },
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the document classifier. </p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the document\n      classification job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the document\n      classification job.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your document classification job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a document classification job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassificationJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentClassificationJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:document-classifier/[a-zA-Z0-9](-*[a-zA-Z0-9])*(/version/[a-zA-Z0-9](-*[a-zA-Z0-9])*)?$"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierAugmentedManifestsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#AugmentedManifestsListItem"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierDataFormat": {
+      "type": "enum",
+      "members": {
+        "COMPREHEND_CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPREHEND_CSV"
+          }
+        },
+        "AUGMENTED_MANIFEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUGMENTED_MANIFEST"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierDocumentTypeFormat": {
+      "type": "enum",
+      "members": {
+        "PLAIN_TEXT_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PLAIN_TEXT_DOCUMENT"
+          }
+        },
+        "SEMI_STRUCTURED_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEMI_STRUCTURED_DOCUMENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierDocuments": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 URI location of the training documents specified in the S3Uri CSV file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TestS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 URI location of the test documents included in the TestS3Uri CSV file.\n      This field is not required if you do not specify a test CSV file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The location of the training documents. This parameter is required in a request to create a semi-structured document classification model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierEndpointArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:([0-9]{12}|aws):document-classifier-endpoint/[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierFilter": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.comprehend#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of classifiers based on status.</p>"
+          }
+        },
+        "DocumentClassifierName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned to the document classifier</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of classifiers based on the time that the classifier was submitted for\n      processing. Returns only classifiers submitted before the specified time. Classifiers are\n      returned in ascending order, oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of classifiers based on the time that the classifier was submitted for\n      processing. Returns only classifiers submitted after the specified time. Classifiers are\n      returned in descending order, newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of document classifiers. You can only specify\n      one filtering parameter in a request. For more information, see the \n        <code>ListDocumentClassifiers</code> operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierInputDataConfig": {
+      "type": "structure",
+      "members": {
+        "DataFormat": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of your training data:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPREHEND_CSV</code>: A two-column CSV file, where labels are provided in the\n          first column, and documents are provided in the second. If you use this value, you must\n          provide the <code>S3Uri</code> parameter in your request.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AUGMENTED_MANIFEST</code>: A labeled dataset that is produced by Amazon\n          SageMaker Ground Truth. This file is in JSON lines format. Each line is a complete JSON\n          object that contains a training document and its associated labels. </p>\n               <p>If you use this value, you must provide the <code>AugmentedManifests</code> parameter\n          in your request.</p>\n            </li>\n         </ul>\n         <p>If you don't specify a value, Amazon Comprehend uses <code>COMPREHEND_CSV</code> as the\n      default.</p>"
+          }
+        },
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 URI for the input data. The S3 bucket must be in the same Region as the API\n      endpoint that you are calling. The URI can point to a single input file or it can provide the\n      prefix for a collection of input files.</p>\n         <p>For example, if you use the URI <code>S3://bucketName/prefix</code>, if the prefix is a\n      single file, Amazon Comprehend uses that file as input. If more than one file begins with the\n      prefix, Amazon Comprehend uses all of them as input.</p>\n         <p>This parameter is required if you set <code>DataFormat</code> to\n        <code>COMPREHEND_CSV</code>.</p>"
+          }
+        },
+        "TestS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>This specifies the Amazon S3 location that contains the test annotations for the document classifier. \n      The URI must be in the same Amazon Web Services Region as the API endpoint that you are calling. </p>"
+          }
+        },
+        "LabelDelimiter": {
+          "target": "com.amazonaws.comprehend#LabelDelimiter",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the delimiter used to separate each label for training a multi-label classifier.\n      The default delimiter between labels is a pipe (|). You can use a different character as a\n      delimiter (if it's an allowed character) by specifying it under Delimiter for labels. If the\n      training documents use a delimiter other than the default or the delimiter you specify, the\n      labels on that line will be combined to make a single unique label, such as\n      LABELLABELLABEL.</p>"
+          }
+        },
+        "AugmentedManifests": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierAugmentedManifestsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of augmented manifest files that provide training data for your custom model. An\n      augmented manifest file is a labeled dataset that is produced by Amazon SageMaker Ground\n      Truth.</p>\n         <p>This parameter is required if you set <code>DataFormat</code> to\n        <code>AUGMENTED_MANIFEST</code>.</p>"
+          }
+        },
+        "DocumentType": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierDocumentTypeFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of input documents for training the model. Provide plain-text documents to create a plain-text model, and\n    provide semi-structured documents to create a native document model.</p>"
+          }
+        },
+        "Documents": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierDocuments",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location of the training documents.  \n      This parameter is required in a request to create a native document model.</p>"
+          }
+        },
+        "DocumentReaderConfig": {
+          "target": "com.amazonaws.comprehend#DocumentReaderConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input properties for training a document classifier. </p>\n         <p>For more information on how the input file is formatted, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/prep-classifier-data.html\">Preparing training data</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierMode": {
+      "type": "enum",
+      "members": {
+        "MULTI_CLASS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI_CLASS"
+          }
+        },
+        "MULTI_LABEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI_LABEL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierOutputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>When you use the <code>OutputDataConfig</code> object while creating a custom\n      classifier, you specify the Amazon S3 location where you want to write the confusion matrix\n      and other output files.\n      The URI must be in the same Region as the API endpoint that you are calling. The location is\n      used as the prefix for the actual location of this output file.</p>\n         <p>When the custom classifier job is finished, the service creates the output file in a\n      directory specific to the job. The <code>S3Uri</code> field contains the location of the\n      output file, called <code>output.tar.gz</code>. It is a compressed archive that contains the\n      confusion matrix.</p>"
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt the\n      output results from an analysis job. The KmsKeyId can be one of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>KMS Key Alias: <code>\"alias/ExampleAlias\"</code>\n               </p>\n            </li>\n            <li>\n               <p>ARN of a KMS Key Alias:\n            <code>\"arn:aws:kms:us-west-2:111122223333:alias/ExampleAlias\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "FlywheelStatsS3Prefix": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 prefix for the data lake location of the flywheel statistics.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provide the location for output data from a custom classifier job. This field is mandatory \n      if you are training a native document model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierProperties": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the document classifier.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the documents that the classifier was trained\n      on.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the document classifier. If the status is <code>TRAINED</code> the\n      classifier is ready to use. If the status is <code>TRAINED_WITH_WARNINGS</code> the\n      classifier training succeeded, but you should review the warnings returned in the \n      <code>CreateDocumentClassifier</code> response.</p>\n         <p>  If the status is <code>FAILED</code> you can see additional\n      information about why the classifier wasn't trained in the <code>Message</code> field.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the status of the classifier.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the document classifier was submitted for training.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that training the document classifier completed.</p>"
+          }
+        },
+        "TrainingStartTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the time when the training starts on documentation classifiers. You are billed\n      for the time interval between this time and the value of TrainingEndTime. </p>"
+          }
+        },
+        "TrainingEndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that training of the document classifier was completed. Indicates the time when\n      the training completes on documentation classifiers. You are billed for the time interval\n      between this time and the value of TrainingStartTime.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the document classifier\n      for training.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierOutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Provides output results configuration parameters for custom classifier jobs.</p>"
+          }
+        },
+        "ClassifierMetadata": {
+          "target": "com.amazonaws.comprehend#ClassifierMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the document classifier, including the number of documents used for\n      training the classifier, the number of documents used for test the classifier, and an accuracy\n      rating.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your custom classifier. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Mode": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the mode in which the specific classifier was trained. This also indicates the\n      format of input documents and the format of the confusion matrix. Each classifier can only be\n      trained in one mode and this cannot be changed once the classifier is trained.</p>"
+          }
+        },
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The version name that you assigned to the document classifier.</p>"
+          }
+        },
+        "SourceModelArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the source model. This model was imported from a\n      different Amazon Web Services account to create the document classifier model in your Amazon Web Services account.</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a document classifier.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentClassifierProperties"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierSummariesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentClassifierSummary"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentClassifierSummary": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned the document classifier.</p>"
+          }
+        },
+        "NumberOfVersions": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of versions you created.</p>"
+          }
+        },
+        "LatestVersionCreatedAt": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the latest document classifier version was submitted for processing.</p>"
+          }
+        },
+        "LatestVersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The version name you assigned to the latest document classifier version.</p>"
+          }
+        },
+        "LatestVersionStatus": {
+          "target": "com.amazonaws.comprehend#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the latest document classifier version.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes information about a document classifier and its versions.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentLabel": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the label.</p>"
+          }
+        },
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score that Amazon Comprehend has this label correctly attributed.</p>"
+          }
+        },
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number where the label occurs. This field is present\n      in the response only if your request includes the <code>Byte</code> parameter. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies one of the label or labels that categorize the document being analyzed.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentMetadata": {
+      "type": "structure",
+      "members": {
+        "Pages": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of pages in the document.</p>"
+          }
+        },
+        "ExtractedCharacters": {
+          "target": "com.amazonaws.comprehend#ListOfExtractedCharacters",
+          "traits": {
+            "smithy.api#documentation": "<p>List of pages in the document, with the number of characters extracted from each page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the document, discovered during text extraction.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentReadAction": {
+      "type": "enum",
+      "members": {
+        "TEXTRACT_DETECT_DOCUMENT_TEXT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_DETECT_DOCUMENT_TEXT"
+          }
+        },
+        "TEXTRACT_ANALYZE_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_ANALYZE_DOCUMENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DocumentReadFeatureTypes": {
+      "type": "enum",
+      "members": {
+        "TABLES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLES"
+          }
+        },
+        "FORMS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FORMS"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>TABLES or FORMS</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentReadMode": {
+      "type": "enum",
+      "members": {
+        "SERVICE_DEFAULT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SERVICE_DEFAULT"
+          }
+        },
+        "FORCE_DOCUMENT_READ_ACTION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FORCE_DOCUMENT_READ_ACTION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DocumentReaderConfig": {
+      "type": "structure",
+      "members": {
+        "DocumentReadAction": {
+          "target": "com.amazonaws.comprehend#DocumentReadAction",
+          "traits": {
+            "smithy.api#documentation": "<p>This field defines the Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.\n      Enter one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TEXTRACT_DETECT_DOCUMENT_TEXT</code> - The Amazon Comprehend service uses the <code>DetectDocumentText</code>\n           API operation. </p>\n            </li>\n            <li>\n               <p>\n                  <code>TEXTRACT_ANALYZE_DOCUMENT</code> - The Amazon Comprehend service uses the <code>AnalyzeDocument</code>\n          API operation. </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "DocumentReadMode": {
+          "target": "com.amazonaws.comprehend#DocumentReadMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the text extraction actions for PDF files. Enter one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SERVICE_DEFAULT</code> - use the Amazon Comprehend service defaults for PDF files.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FORCE_DOCUMENT_READ_ACTION</code> - Amazon Comprehend uses the Textract API specified by\n          DocumentReadAction for all PDF files, including digital PDF files. </p>\n            </li>\n         </ul>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.comprehend#ListOfDocumentReadFeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the type of Amazon Textract features to apply. If you chose <code>TEXTRACT_ANALYZE_DOCUMENT</code>\n      as the read action, you must specify one or both of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TABLES</code> - Returns additional information about any tables that are detected in the input document. </p>\n            </li>\n            <li>\n               <p>\n                  <code>FORMS</code> - Returns additional information about any forms that are detected in the input document. </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides configuration parameters to override the default actions for extracting text from PDF documents and image files. </p>\n         <p> By default, Amazon Comprehend performs the following actions to extract text from files, based on the input file type: </p>\n         <ul>\n            <li>\n               <p>\n                  <b>Word files</b> - Amazon Comprehend parser extracts the text. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Digital PDF files</b> - Amazon Comprehend parser extracts the text. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Image files and scanned PDF files</b> - Amazon Comprehend uses the Amazon Textract <code>DetectDocumentText</code>\n          API to extract the text. </p>\n            </li>\n         </ul>\n         <p>\n            <code>DocumentReaderConfig</code> does not apply to plain text files or Word files.</p>\n         <p>\n        For image files and PDF documents, you can override these default actions using the fields listed below.\n        For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">\n        Setting text extraction options</a> in the Comprehend Developer Guide.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#DocumentType": {
+      "type": "enum",
+      "members": {
+        "NATIVE_PDF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NATIVE_PDF"
+          }
+        },
+        "SCANNED_PDF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCANNED_PDF"
+          }
+        },
+        "MS_WORD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MS_WORD"
+          }
+        },
+        "IMAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IMAGE"
+          }
+        },
+        "PLAIN_TEXT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PLAIN_TEXT"
+          }
+        },
+        "TEXTRACT_DETECT_DOCUMENT_TEXT_JSON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_DETECT_DOCUMENT_TEXT_JSON"
+          }
+        },
+        "TEXTRACT_ANALYZE_DOCUMENT_JSON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_ANALYZE_DOCUMENT_JSON"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#DocumentTypeListItem": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.comprehend#DocumentType",
+          "traits": {
+            "smithy.api#documentation": "<p>Document type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Document type for each page in the document.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DominantLanguage": {
+      "type": "structure",
+      "members": {
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The RFC 5646 language code for the dominant language. For more information about RFC\n      5646, see <a href=\"https://tools.ietf.org/html/rfc5646\">Tags for Identifying\n        Languages</a> on the <i>IETF Tools</i> web site.</p>"
+          }
+        },
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of the\n      detection.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the code for the dominant language in the input text and the level of\n      confidence that Amazon Comprehend has in the accuracy of the detection.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DominantLanguageDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of dominant language detection jobs. For more\n      information, see the \n      operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DominantLanguageDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the dominant language detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the dominant language detection job. It is a unique,\n      fully qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID.\n      The format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:dominant-language-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:dominant-language-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned to the dominant language detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the dominant language detection job. If the status is\n        <code>FAILED</code>, the <code>Message</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description for the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the dominant language detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the dominant language detection job completed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the dominant language\n      detection job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the dominant language\n      detection job.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your dominant language detection job. For more information, see\n      <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a dominant language detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#DominantLanguageDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DominantLanguageDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#Double": {
+      "type": "double"
+    },
+    "com.amazonaws.comprehend#EndpointFilter": {
+      "type": "structure",
+      "members": {
+        "ModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the model to which the endpoint is attached.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#EndpointStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of the endpoint being returned. Possible values are: Creating, Ready,\n      Updating, Deleting, Failed.</p>"
+          }
+        },
+        "CreationTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a date before which the returned endpoint or endpoints were created.</p>"
+          }
+        },
+        "CreationTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a date after which the returned endpoint or endpoints were created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The filter used to determine which endpoints are returned. You can filter jobs on their\n      name, model, status, or the date and time that they were created. You can only set one filter\n      at a time. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#EndpointProperties": {
+      "type": "structure",
+      "members": {
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#ComprehendEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the endpoint.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#EndpointStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the status of the endpoint. Because the endpoint updates and creation are\n      asynchronous, so customers will need to wait for the endpoint to be <code>Ready</code> status\n      before making inference requests.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a reason for failure in cases of <code>Failed</code> status.</p>"
+          }
+        },
+        "ModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the model to which the endpoint is attached.</p>"
+          }
+        },
+        "DesiredModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the new model to use for updating an existing endpoint. This ARN is going to be\n      different from the model ARN when the update is in progress</p>"
+          }
+        },
+        "DesiredInferenceUnits": {
+          "target": "com.amazonaws.comprehend#InferenceUnitsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The desired number of inference units to be used by the model using this endpoint.\n      \n      Each inference unit represents of a throughput of 100 characters per second.</p>"
+          }
+        },
+        "CurrentInferenceUnits": {
+          "target": "com.amazonaws.comprehend#InferenceUnitsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of inference units currently used by the model using this endpoint.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time of the endpoint.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the endpoint was last modified.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to trained custom models encrypted with a customer\n      managed key (ModelKmsKeyId).</p>"
+          }
+        },
+        "DesiredDataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Data access role ARN to use in case the new model is encrypted with a customer KMS\n      key.</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies information about the specified endpoint.\n      For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EndpointPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EndpointProperties"
+      }
+    },
+    "com.amazonaws.comprehend#EndpointStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "IN_SERVICE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_SERVICE"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#EntitiesDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of dominant language detection jobs. For more\n      information, see the  operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntitiesDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the entities detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the entities detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:entities-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:entities-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned the entities detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the entities detection job. If the status is <code>FAILED</code>,\n      the <code>Message</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the entities detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the entities detection job completed</p>"
+          }
+        },
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the entity recognizer.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the entities detection\n      job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the entities detection\n      job. </p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your entity detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the flywheel associated with this job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about an entities detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntitiesDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EntitiesDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#Entity": {
+      "type": "structure",
+      "members": {
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of the\n      detection.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.comprehend#EntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The entity type. For entity detection using the built-in model, this field contains one of the\n      standard entity types listed below.</p>\n         <p>For custom entity detection, this field contains one of the\n      entity types that you specified when you trained your custom model.</p>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The text of the entity.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the first character in the\n      entity.</p>\n         <p>This field is empty for non-text input.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the last character in the\n      entity.</p>\n         <p>This field is empty for non-text input.</p>"
+          }
+        },
+        "BlockReferences": {
+          "target": "com.amazonaws.comprehend#ListOfBlockReferences",
+          "traits": {
+            "smithy.api#documentation": "<p>A reference to each block for this entity. This field is empty for plain-text input.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about an entity. </p>\n         <p> </p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityLabel": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.comprehend#PiiEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the label.</p>"
+          }
+        },
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of the\n      detection.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies one of the label or labels that categorize the personally identifiable\n      information (PII) entity being analyzed.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognitionConfig": {
+      "type": "structure",
+      "members": {
+        "EntityTypes": {
+          "target": "com.amazonaws.comprehend#EntityTypesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Up to 25 entity types that the model is trained to recognize.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration required for an entity recognition model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerAnnotations": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies the Amazon S3 location where the annotations for an entity recognizer are\n      located. The URI must be in the same Region as the API endpoint that you are calling.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TestS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies the Amazon S3 location where the test annotations for an entity recognizer are\n      located. The URI must be in the same Region as the API endpoint that you are calling.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the annotations associated with a entity recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:entity-recognizer/[a-zA-Z0-9](-*[a-zA-Z0-9])*(/version/[a-zA-Z0-9](-*[a-zA-Z0-9])*)?$"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerAugmentedManifestsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#AugmentedManifestsListItem"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerDataFormat": {
+      "type": "enum",
+      "members": {
+        "COMPREHEND_CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPREHEND_CSV"
+          }
+        },
+        "AUGMENTED_MANIFEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUGMENTED_MANIFEST"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerDocuments": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies the Amazon S3 location where the training documents for an entity recognizer\n      are located. The URI must be in the same Region as the API endpoint that you are\n      calling.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TestS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies the Amazon S3 location where the test documents for an entity recognizer are\n      located. The URI must be in the same Amazon Web Services Region as the API endpoint that you are\n      calling.</p>"
+          }
+        },
+        "InputFormat": {
+          "target": "com.amazonaws.comprehend#InputFormat",
+          "traits": {
+            "smithy.api#documentation": "<p> Specifies how the text in an input file should be processed. This is optional, and the\n      default is ONE_DOC_PER_LINE. ONE_DOC_PER_FILE - Each file is considered a separate document.\n      Use this option when you are processing large documents, such as newspaper articles or\n      scientific papers. ONE_DOC_PER_LINE - Each line in a file is considered a separate document.\n      Use this option when you are processing many short documents, such as text messages.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the training documents submitted with an entity recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerEndpointArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:comprehend:[a-zA-Z0-9-]*:[0-9]{12}:entity-recognizer-endpoint/[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerEntityList": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the Amazon S3 location where the entity list is located. The URI must be in the\n      same Region as the API endpoint that you are calling.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the entity list submitted with an entity recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerEvaluationMetrics": {
+      "type": "structure",
+      "members": {
+        "Precision": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of the usefulness of the recognizer results in the test data. High precision\n      means that the recognizer returned substantially more relevant results than irrelevant ones.\n    </p>"
+          }
+        },
+        "Recall": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how complete the recognizer results are for the test data. High recall means\n      that the recognizer returned most of the relevant results.</p>"
+          }
+        },
+        "F1Score": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how accurate the recognizer results are for the test data. It is derived from\n      the <code>Precision</code> and <code>Recall</code> values. The <code>F1Score</code> is the\n      harmonic average of the two scores. For plain text entity recognizer models, the range is 0 to 100,\n      where 100 is the best score. For PDF/Word entity recognizer models, the range is 0 to 1,\n      where 1 is the best score.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about the accuracy of an entity recognizer. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerFilter": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.comprehend#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of an entity recognizer.</p>"
+          }
+        },
+        "RecognizerName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned the entity recognizer.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of entities based on the time that the list was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of entities based on the time that the list was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of entity recognizers. You can only specify one\n      filtering parameter in a request. For more information, see the \n        <code>ListEntityRecognizers</code> operation./></p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerInputDataConfig": {
+      "type": "structure",
+      "members": {
+        "DataFormat": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of your training data:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPREHEND_CSV</code>: A CSV file that supplements your training documents. The\n          CSV file contains information about the custom entities that your trained model will\n          detect. The required format of the file depends on whether you are providing annotations\n          or an entity list.</p>\n               <p>If you use this value, you must provide your CSV file by using either the\n            <code>Annotations</code> or <code>EntityList</code> parameters. You must provide your\n          training documents by using the <code>Documents</code> parameter.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AUGMENTED_MANIFEST</code>: A labeled dataset that is produced by Amazon\n          SageMaker Ground Truth. This file is in JSON lines format. Each line is a complete JSON\n          object that contains a training document and its labels. Each label annotates a named\n          entity in the training document. </p>\n               <p>If you use this value, you must provide the <code>AugmentedManifests</code> parameter\n          in your request.</p>\n            </li>\n         </ul>\n         <p>If you don't specify a value, Amazon Comprehend uses <code>COMPREHEND_CSV</code> as the\n      default.</p>"
+          }
+        },
+        "EntityTypes": {
+          "target": "com.amazonaws.comprehend#EntityTypesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The entity types in the labeled training data that Amazon Comprehend uses to train the\n      custom entity recognizer. Any entity types that you don't specify are ignored.</p>\n         <p>A maximum of 25 entity types can be used at one time to train an entity recognizer. Entity\n      types must not contain the following invalid characters: \\n (line break), \\\\n (escaped line\n      break), \\r (carriage return), \\\\r (escaped carriage return), \\t (tab), \\\\t (escaped tab),\n      space, and , (comma). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Documents": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerDocuments",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location of the folder that contains the training documents for your custom entity\n      recognizer.</p>\n         <p>This parameter is required if you set <code>DataFormat</code> to\n        <code>COMPREHEND_CSV</code>.</p>"
+          }
+        },
+        "Annotations": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerAnnotations",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location of the CSV file that annotates your training documents.</p>"
+          }
+        },
+        "EntityList": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerEntityList",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location of the CSV file that has the entity list for your custom entity\n      recognizer.</p>"
+          }
+        },
+        "AugmentedManifests": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerAugmentedManifestsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of augmented manifest files that provide training data for your custom model. An\n      augmented manifest file is a labeled dataset that is produced by Amazon SageMaker Ground\n      Truth.</p>\n         <p>This parameter is required if you set <code>DataFormat</code> to\n        <code>AUGMENTED_MANIFEST</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the format and location of the input data.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerMetadata": {
+      "type": "structure",
+      "members": {
+        "NumberOfTrainedDocuments": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p> The number of documents in the input data that were used to train the entity recognizer.\n      Typically this is 80 to 90 percent of the input documents.</p>"
+          }
+        },
+        "NumberOfTestDocuments": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p> The number of documents in the input data that were used to test the entity recognizer.\n      Typically this is 10 to 20 percent of the input documents.</p>"
+          }
+        },
+        "EvaluationMetrics": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerEvaluationMetrics",
+          "traits": {
+            "smithy.api#documentation": "<p>Detailed information about the accuracy of an entity recognizer.</p>"
+          }
+        },
+        "EntityTypes": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerMetadataEntityTypesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Entity types from the metadata of an entity recognizer.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about an entity recognizer.</p>",
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerMetadataEntityTypesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EntityRecognizerMetadataEntityTypesListItem"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerMetadataEntityTypesListItem": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>Type of entity from the list of entity types in the metadata of an entity recognizer.\n    </p>"
+          }
+        },
+        "EvaluationMetrics": {
+          "target": "com.amazonaws.comprehend#EntityTypesEvaluationMetrics",
+          "traits": {
+            "smithy.api#documentation": "<p>Detailed information about the accuracy of the entity recognizer for a specific item on\n      the list of entity types. </p>"
+          }
+        },
+        "NumberOfTrainMentions": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the number of times the given entity type was seen in the training data. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Individual item from the list of entity types in the metadata of an entity\n      recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerOutputDataConfig": {
+      "type": "structure",
+      "members": {
+        "FlywheelStatsS3Prefix": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 prefix for the data lake location of the flywheel statistics.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output data configuration.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerProperties": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the entity recognizer.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p> The language of the input documents. All documents must be in the same language. Only\n      English (\"en\") is currently supported.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the entity recognizer.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p> A description of the status of the recognizer.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the recognizer was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the recognizer creation completed.</p>"
+          }
+        },
+        "TrainingStartTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that training of the entity recognizer started.</p>"
+          }
+        },
+        "TrainingEndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that training of the entity recognizer was completed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerInputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data properties of an entity recognizer.</p>"
+          }
+        },
+        "RecognizerMetadata": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p> Provides information about an entity recognizer.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your custom entity recognizer. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The version name you assigned to the entity recognizer.</p>"
+          }
+        },
+        "SourceModelArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the source model. This model was imported from a\n      different Amazon Web Services account to create the entity recognizer model in your Amazon Web Services account.</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerOutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Output data configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes information about an entity recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EntityRecognizerProperties"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerSummariesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EntityRecognizerSummary"
+      }
+    },
+    "com.amazonaws.comprehend#EntityRecognizerSummary": {
+      "type": "structure",
+      "members": {
+        "RecognizerName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p> The name that you assigned the entity recognizer.</p>"
+          }
+        },
+        "NumberOfVersions": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p> The number of versions you created.</p>"
+          }
+        },
+        "LatestVersionCreatedAt": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p> The time that the latest entity recognizer version was submitted for processing.</p>"
+          }
+        },
+        "LatestVersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p> The version name you assigned to the latest entity recognizer version.</p>"
+          }
+        },
+        "LatestVersionStatus": {
+          "target": "com.amazonaws.comprehend#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p> Provides the status of the latest entity recognizer version.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Describes the information about an entity recognizer and its versions.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityType": {
+      "type": "enum",
+      "members": {
+        "PERSON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERSON"
+          }
+        },
+        "LOCATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOCATION"
+          }
+        },
+        "ORGANIZATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ORGANIZATION"
+          }
+        },
+        "COMMERCIAL_ITEM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMMERCIAL_ITEM"
+          }
+        },
+        "EVENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EVENT"
+          }
+        },
+        "DATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATE"
+          }
+        },
+        "QUANTITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUANTITY"
+          }
+        },
+        "TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TITLE"
+          }
+        },
+        "OTHER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OTHER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#EntityTypeName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 64
+        },
+        "smithy.api#pattern": "^(?![^\\n\\r\\t,]*\\\\n|\\\\r|\\\\t)[^\\n\\r\\t,]+$"
+      }
+    },
+    "com.amazonaws.comprehend#EntityTypesEvaluationMetrics": {
+      "type": "structure",
+      "members": {
+        "Precision": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of the usefulness of the recognizer results for a specific entity type in the\n      test data. High precision means that the recognizer returned substantially more relevant\n      results than irrelevant ones. </p>"
+          }
+        },
+        "Recall": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how complete the recognizer results are for a specific entity type in the\n      test data. High recall means that the recognizer returned most of the relevant results.</p>"
+          }
+        },
+        "F1Score": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>A measure of how accurate the recognizer results are for a specific entity type in the\n      test data. It is derived from the <code>Precision</code> and <code>Recall</code> values. The\n        <code>F1Score</code> is the harmonic average of the two scores. The highest score is 1, and\n      the worst score is 0. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about the accuracy of an entity recognizer for a specific entity\n      type. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#EntityTypesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EntityTypesListItem"
+      }
+    },
+    "com.amazonaws.comprehend#EntityTypesListItem": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.comprehend#EntityTypeName",
+          "traits": {
+            "smithy.api#documentation": "<p>An entity type within a labeled training dataset that Amazon Comprehend uses to train a\n      custom entity recognizer.</p>\n         <p>Entity types must not contain the following invalid characters: \\n (line break), \\\\n\n      (escaped line break, \\r (carriage return), \\\\r (escaped carriage return), \\t (tab), \\\\t\n      (escaped tab), and , (comma).</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An entity type within a labeled training dataset that Amazon Comprehend uses to train a\n      custom entity recognizer.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ErrorsListItem": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number where the error occurred.</p>"
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.comprehend#PageBasedErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>Error code for the cause of the error.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Text message explaining the reason for the error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Text extraction encountered one or more page-level errors in the input document.</p>\n         <p>The <code>ErrorCode</code> contains one of the following values:</p>\n         <ul>\n            <li>\n               <p>TEXTRACT_BAD_PAGE - Amazon Textract cannot read the page. For more information\n          about page limits in Amazon Textract, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/limits-document.html\">\n            Page Quotas in Amazon Textract</a>.</p>\n            </li>\n            <li>\n               <p>TEXTRACT_PROVISIONED_THROUGHPUT_EXCEEDED - The number of requests exceeded your throughput limit.\n          For more information about throughput quotas in Amazon Textract, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/limits-quotas-explained.html\">\n            Default quotas in Amazon Textract</a>.</p>\n            </li>\n            <li>\n               <p>PAGE_CHARACTERS_EXCEEDED - Too many text characters on the page (10,000 characters maximum).</p>\n            </li>\n            <li>\n               <p>PAGE_SIZE_EXCEEDED - The maximum page size is 10 MB.</p>\n            </li>\n            <li>\n               <p>INTERNAL_SERVER_ERROR - The request encountered a service issue. Try the API request again.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.comprehend#EventTypeString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 40
+        },
+        "smithy.api#pattern": "^[A-Z_]*$"
+      }
+    },
+    "com.amazonaws.comprehend#EventsDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the events detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of event detection jobs.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EventsDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the events detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the events detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:events-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:events-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name you assigned the events detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the events detection job.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of the events detection job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the events detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the events detection job completed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the events detection\n      job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the events detection\n      job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "TargetEventTypes": {
+          "target": "com.amazonaws.comprehend#TargetEventTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The types of events that are detected by the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about an events detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#EventsDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EventsDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#ExtractedCharactersListItem": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number.</p>"
+          }
+        },
+        "Count": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of characters extracted from each page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Array of the number of characters extracted from each page.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#Float": {
+      "type": "float"
+    },
+    "com.amazonaws.comprehend#FlywheelFilter": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.comprehend#FlywheelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the flywheels based on the flywheel status.</p>"
+          }
+        },
+        "CreationTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the flywheels to include flywheels created after the specified time.</p>"
+          }
+        },
+        "CreationTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the flywheels to include flywheels created before the specified time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filter the flywheels based on creation time or flywheel status.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelIterationFilter": {
+      "type": "structure",
+      "members": {
+        "CreationTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the flywheel iterations to include iterations created after the specified time.</p>"
+          }
+        },
+        "CreationTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the flywheel iterations to include iterations created before the specified time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filter the flywheel iterations based on creation time.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelIterationId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[0-9]{8}T[0-9]{6}Z$"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelIterationProperties": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "FlywheelIterationId": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationId",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation start time of the flywheel iteration.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The completion time of this flywheel iteration.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the flywheel iteration.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of the flywheel iteration.</p>"
+          }
+        },
+        "EvaluatedModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the evaluated model associated with this flywheel iteration.</p>"
+          }
+        },
+        "EvaluatedModelMetrics": {
+          "target": "com.amazonaws.comprehend#FlywheelModelEvaluationMetrics"
+        },
+        "TrainedModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the trained model associated with this flywheel iteration.</p>"
+          }
+        },
+        "TrainedModelMetrics": {
+          "target": "com.amazonaws.comprehend#FlywheelModelEvaluationMetrics",
+          "traits": {
+            "smithy.api#documentation": "<p>The metrics associated with the trained model.</p>"
+          }
+        },
+        "EvaluationManifestS3Prefix": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration properties of a flywheel iteration.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelIterationPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#FlywheelIterationProperties"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelIterationStatus": {
+      "type": "enum",
+      "members": {
+        "TRAINING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRAINING"
+          }
+        },
+        "EVALUATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EVALUATING"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "STOP_REQUESTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOP_REQUESTED"
+          }
+        },
+        "STOPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOPPED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelModelEvaluationMetrics": {
+      "type": "structure",
+      "members": {
+        "AverageF1Score": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>The average F1 score from the evaluation metrics.</p>"
+          }
+        },
+        "AveragePrecision": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>Average precision metric for the model.</p>"
+          }
+        },
+        "AverageRecall": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>Average recall metric for the model.</p>"
+          }
+        },
+        "AverageAccuracy": {
+          "target": "com.amazonaws.comprehend#Double",
+          "traits": {
+            "smithy.api#documentation": "<p>Average accuracy metric for the model.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The evaluation metrics associated with the evaluated model.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelProperties": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel.</p>"
+          }
+        },
+        "ActiveModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the active model version.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend permission to access the flywheel data.</p>"
+          }
+        },
+        "TaskConfig": {
+          "target": "com.amazonaws.comprehend#TaskConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration about the model associated with a flywheel.</p>"
+          }
+        },
+        "DataLakeS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon S3 URI of the data lake location. </p>"
+          }
+        },
+        "DataSecurityConfig": {
+          "target": "com.amazonaws.comprehend#DataSecurityConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Data security configuration.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#FlywheelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the flywheel.</p>"
+          }
+        },
+        "ModelType": {
+          "target": "com.amazonaws.comprehend#ModelType",
+          "traits": {
+            "smithy.api#documentation": "<p>Model type of the flywheel's model.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of the flywheel.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Creation time of the flywheel.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Last modified time for the flywheel.</p>"
+          }
+        },
+        "LatestFlywheelIteration": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationId",
+          "traits": {
+            "smithy.api#documentation": "<p>The most recent flywheel iteration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The flywheel properties.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelS3Uri": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        },
+        "smithy.api#pattern": "^s3://[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9](/.*)?$"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelSummary": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel</p>"
+          }
+        },
+        "ActiveModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the active model version for the flywheel.</p>"
+          }
+        },
+        "DataLakeS3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon S3 URI of the data lake location. </p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.comprehend#FlywheelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the flywheel.</p>"
+          }
+        },
+        "ModelType": {
+          "target": "com.amazonaws.comprehend#ModelType",
+          "traits": {
+            "smithy.api#documentation": "<p>Model type of the flywheel's model.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of the flywheel.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Creation time of the flywheel.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Last modified time for the flywheel.</p>"
+          }
+        },
+        "LatestFlywheelIteration": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationId",
+          "traits": {
+            "smithy.api#documentation": "<p>The most recent flywheel iteration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Flywheel summary information.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#FlywheelSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#FlywheelSummary"
+      }
+    },
+    "com.amazonaws.comprehend#Geometry": {
+      "type": "structure",
+      "members": {
+        "BoundingBox": {
+          "target": "com.amazonaws.comprehend#BoundingBox",
+          "traits": {
+            "smithy.api#documentation": "<p>An axis-aligned coarse representation of the location of the recognized item on the\n      document page.</p>"
+          }
+        },
+        "Polygon": {
+          "target": "com.amazonaws.comprehend#Polygon",
+          "traits": {
+            "smithy.api#documentation": "<p>Within the bounding box, a fine-grained polygon around the recognized item.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the location of items on a document page.</p>\n         <p>For additional information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/API_Geometry.html\">Geometry</a> in the Amazon Textract API reference.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#IamRoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:iam::[0-9]{12}:role/.+$"
+      }
+    },
+    "com.amazonaws.comprehend#ImportModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ImportModelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ImportModelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new custom model that replicates a source custom model that you import. The\n      source model can be in your Amazon Web Services account or another one.</p>\n         <p>If the source model is in another Amazon Web Services account, then it must have a resource-based policy\n      that authorizes you to import it.</p>\n         <p>The source model must be in the same Amazon Web Services Region that you're using when you import. You\n      can't import a model that's in a different Region.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ImportModelRequest": {
+      "type": "structure",
+      "members": {
+        "SourceModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the custom model to import.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ModelName": {
+          "target": "com.amazonaws.comprehend#ComprehendArnName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name to assign to the custom model that is created in Amazon Comprehend by this\n      import.</p>"
+          }
+        },
+        "VersionName": {
+          "target": "com.amazonaws.comprehend#VersionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The version name given to the custom model that is created by this import. Version names\n      can have a maximum of 256 characters. Alphanumeric characters, hyphens (-) and underscores (_)\n      are allowed. The version name must be unique among all models with the same classifier name in\n      the account/Region.</p>"
+          }
+        },
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend permission to use Amazon Key Management Service (KMS) to encrypt or decrypt the custom\n      model.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the custom model that is created by this import. A tag is a\n      key-value pair that adds as a metadata to a resource used by Amazon Comprehend. For example, a\n      tag with \"Sales\" as the key might be added to a resource to indicate its use by the sales\n      department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ImportModelResponse": {
+      "type": "structure",
+      "members": {
+        "ModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the custom model being imported.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#InferenceUnitsInteger": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.comprehend#InputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 URI for the input data. The URI must be in same Region as the API\n      endpoint that you are calling. The URI can point to a single input file or it can provide the\n      prefix for a collection of data files. </p>\n         <p>For example, if you use the URI <code>S3://bucketName/prefix</code>, if the prefix is a\n      single file, Amazon Comprehend uses that file as input. If more than one file begins with the\n      prefix, Amazon Comprehend uses all of them as input.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputFormat": {
+          "target": "com.amazonaws.comprehend#InputFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies how the text in an input file should be processed:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ONE_DOC_PER_FILE</code> - Each file is considered a separate document. Use\n          this option when you are processing large documents, such as newspaper articles or\n          scientific papers.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ONE_DOC_PER_LINE</code> - Each line in a file is considered a separate\n          document. Use this option when you are processing many short documents, such as text\n          messages.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DocumentReaderConfig": {
+          "target": "com.amazonaws.comprehend#DocumentReaderConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides configuration parameters to override the default actions for extracting text\n      from PDF documents and image files.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input properties for an inference job. The document reader config field applies\n      only to non-text inputs for custom analysis.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#InputFormat": {
+      "type": "enum",
+      "members": {
+        "ONE_DOC_PER_FILE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ONE_DOC_PER_FILE"
+          }
+        },
+        "ONE_DOC_PER_LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ONE_DOC_PER_LINE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#Integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.comprehend#InternalServerException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An internal server error occurred. Retry your request.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.comprehend#InvalidFilterException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The filter specified for the operation is invalid. Specify a different\n      filter.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#InvalidRequestDetail": {
+      "type": "structure",
+      "members": {
+        "Reason": {
+          "target": "com.amazonaws.comprehend#InvalidRequestDetailReason",
+          "traits": {
+            "smithy.api#documentation": "<p>Reason codes include the following values:</p>\n         <ul>\n            <li>\n               <p>DOCUMENT_SIZE_EXCEEDED - Document size is too large. Check the size of your file and resubmit the request.</p>\n            </li>\n            <li>\n               <p>UNSUPPORTED_DOC_TYPE - Document type is not supported. Check the file type and resubmit the request.</p>\n            </li>\n            <li>\n               <p>PAGE_LIMIT_EXCEEDED - Too many pages in the document. Check the number of pages in your file and resubmit the request.</p>\n            </li>\n            <li>\n               <p>TEXTRACT_ACCESS_DENIED - Access denied to Amazon Textract. Verify that your account has permission to use Amazon Textract API operations and resubmit the request.</p>\n            </li>\n            <li>\n               <p>NOT_TEXTRACT_JSON - Document is not Amazon Textract JSON format. Verify the format and resubmit the request.</p>\n            </li>\n            <li>\n               <p>MISMATCHED_TOTAL_PAGE_COUNT - Check the number of pages in your file and resubmit the request.</p>\n            </li>\n            <li>\n               <p>INVALID_DOCUMENT - Invalid document. Check the file and resubmit the request.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides additional detail about why the request failed.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#InvalidRequestDetailReason": {
+      "type": "enum",
+      "members": {
+        "DOCUMENT_SIZE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOCUMENT_SIZE_EXCEEDED"
+          }
+        },
+        "UNSUPPORTED_DOC_TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNSUPPORTED_DOC_TYPE"
+          }
+        },
+        "PAGE_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PAGE_LIMIT_EXCEEDED"
+          }
+        },
+        "TEXTRACT_ACCESS_DENIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_ACCESS_DENIED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#InvalidRequestException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        },
+        "Reason": {
+          "target": "com.amazonaws.comprehend#InvalidRequestReason"
+        },
+        "Detail": {
+          "target": "com.amazonaws.comprehend#InvalidRequestDetail"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request is invalid.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#InvalidRequestReason": {
+      "type": "enum",
+      "members": {
+        "INVALID_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INVALID_DOCUMENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#JobId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 32
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+      }
+    },
+    "com.amazonaws.comprehend#JobName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+      }
+    },
+    "com.amazonaws.comprehend#JobNotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified job was not found. Check the job ID and try again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.comprehend#JobStatus": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "STOP_REQUESTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOP_REQUESTED"
+          }
+        },
+        "STOPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOPPED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#KeyPhrase": {
+      "type": "structure",
+      "members": {
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of the\n      detection.</p>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The text of a key noun phrase.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the first character in the\n      key phrase.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the last character in the\n      key phrase.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes a key noun phrase.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#KeyPhrasesDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of dominant language detection jobs. For more\n      information, see the  operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#KeyPhrasesDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the key phrases detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the key phrases detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:key-phrases-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:key-phrases-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned the key phrases detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the key phrases detection job. If the status is <code>FAILED</code>,\n      the <code>Message</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the key phrases detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the key phrases detection job completed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the key phrases detection\n      job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the key phrases detection\n      job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your key phrases detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a key phrases detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#KeyPhrasesDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#KeyPhrasesDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#KmsKeyId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^\\p{ASCII}+$"
+      }
+    },
+    "com.amazonaws.comprehend#KmsKeyValidationException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The KMS customer managed key (CMK) entered cannot be validated. Verify the key and\n      re-enter it.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#LabelDelimiter": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        },
+        "smithy.api#pattern": "^[ ~!@#$%^*\\-_+=|\\\\:;\\t>?/]$"
+      }
+    },
+    "com.amazonaws.comprehend#LabelListItem": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5000
+        },
+        "smithy.api#pattern": "^\\P{C}*$"
+      }
+    },
+    "com.amazonaws.comprehend#LabelsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#LabelListItem"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.comprehend#LanguageCode": {
+      "type": "enum",
+      "members": {
+        "EN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en"
+          }
+        },
+        "ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es"
+          }
+        },
+        "FR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fr"
+          }
+        },
+        "DE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "de"
+          }
+        },
+        "IT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "it"
+          }
+        },
+        "PT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pt"
+          }
+        },
+        "AR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ar"
+          }
+        },
+        "HI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "hi"
+          }
+        },
+        "JA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ja"
+          }
+        },
+        "KO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ko"
+          }
+        },
+        "ZH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh"
+          }
+        },
+        "ZH_TW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh-TW"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListDatasets": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListDatasetsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListDatasetsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List the datasets that you have configured in this Region. For more information about datasets, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListDatasetsRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel.</p>"
+          }
+        },
+        "Filter": {
+          "target": "com.amazonaws.comprehend#DatasetFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the datasets to be returned in the response.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>Maximum number of results to return in a response. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDatasetsResponse": {
+      "type": "structure",
+      "members": {
+        "DatasetPropertiesList": {
+          "target": "com.amazonaws.comprehend#DatasetPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The dataset properties list.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassificationJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListDocumentClassificationJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListDocumentClassificationJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the documentation classification jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassificationJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#DocumentClassificationJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their names, status, or the\n      date and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassificationJobsResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentClassificationJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#DocumentClassificationJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassifierSummaries": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListDocumentClassifierSummariesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListDocumentClassifierSummariesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of summaries of the document classifiers that you have created</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassifierSummariesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return on each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassifierSummariesResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierSummariesList": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierSummariesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of summaries of document classifiers.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassifiers": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListDocumentClassifiersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListDocumentClassifiersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the document classifiers that you have created.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassifiersRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDocumentClassifiersResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierPropertiesList": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDominantLanguageDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListDominantLanguageDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListDominantLanguageDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the dominant language detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListDominantLanguageDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#DominantLanguageDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters that jobs that are returned. You can filter jobs on their name, status, or the\n      date and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListDominantLanguageDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "DominantLanguageDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#DominantLanguageDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEndpoints": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListEndpointsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListEndpointsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of all existing endpoints that you've created.\n      For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "EndpointPropertiesList",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListEndpointsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#EndpointFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the endpoints that are returned. You can filter endpoints on their name, model,\n      status, or the date and time that they were created. You can only set one filter at a time.\n    </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEndpointsResponse": {
+      "type": "structure",
+      "members": {
+        "EndpointPropertiesList": {
+          "target": "com.amazonaws.comprehend#EndpointPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Displays a list of endpoint properties being retrieved by the service in response to the\n      request.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEntitiesDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListEntitiesDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListEntitiesDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the entity detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListEntitiesDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#EntitiesDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEntitiesDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "EntitiesDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#EntitiesDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEntityRecognizerSummaries": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListEntityRecognizerSummariesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListEntityRecognizerSummariesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of summaries for the entity recognizers that you have created.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListEntityRecognizerSummariesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return on each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEntityRecognizerSummariesResponse": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerSummariesList": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerSummariesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list entity recognizer summaries.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEntityRecognizers": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListEntityRecognizersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListEntityRecognizersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the properties of all entity recognizers that you created, including\n      recognizers currently in training. Allows you to filter the list of recognizers based on\n      criteria such as status and submission time. This call returns up to 500 entity recognizers in\n      the list, with a default number of 100 recognizers in the list.</p>\n         <p>The results of this list are not in any particular order. Please get the list and sort\n      locally if needed.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListEntityRecognizersRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of entities returned. You can filter on <code>Status</code>,\n        <code>SubmitTimeBefore</code>, or <code>SubmitTimeAfter</code>. You can only set one filter\n      at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p> The maximum number of results to return on each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEntityRecognizersResponse": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerPropertiesList": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of properties of an entity recognizer.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEventsDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListEventsDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListEventsDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the events detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListEventsDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#EventsDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListEventsDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "EventsDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#EventsDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListFlywheelIterationHistory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListFlywheelIterationHistoryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListFlywheelIterationHistoryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the history of a flywheel iteration.\n      For more information about flywheels, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListFlywheelIterationHistoryRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the flywheel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filter": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filter the flywheel iteration history based on creation time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Next token</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>Maximum number of iteration history results to return</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListFlywheelIterationHistoryResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelIterationPropertiesList": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of flywheel iteration properties</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Next token</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListFlywheels": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListFlywheelsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListFlywheelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the flywheels that you have created.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListFlywheelsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#FlywheelFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the flywheels that are returned. You can filter flywheels on their status,\n      or the date and time that they were submitted. You can only set one filter at a time.\n    </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>Maximum number of results to return in a response. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListFlywheelsResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelSummaryList": {
+          "target": "com.amazonaws.comprehend#FlywheelSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of flywheel properties retrieved by the service in response to the request.\n       </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListKeyPhrasesDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListKeyPhrasesDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListKeyPhrasesDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Get a list of key phrase detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListKeyPhrasesDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#KeyPhrasesDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListKeyPhrasesDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "KeyPhrasesDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#KeyPhrasesDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListOfBlockReferences": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BlockReference"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfBlocks": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#Block"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfChildBlocks": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#ChildBlock"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfClasses": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentClass"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDescriptiveMentionIndices": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#Integer"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDetectDominantLanguageResult": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchDetectDominantLanguageItemResult"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDetectEntitiesResult": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchDetectEntitiesItemResult"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDetectKeyPhrasesResult": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchDetectKeyPhrasesItemResult"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDetectSentimentResult": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchDetectSentimentItemResult"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDetectSyntaxResult": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchDetectSyntaxItemResult"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDetectTargetedSentimentResult": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#BatchDetectTargetedSentimentItemResult"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDocumentReadFeatureTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentReadFeatureTypes"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDocumentType": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentTypeListItem"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfDominantLanguages": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DominantLanguage"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfEntities": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#Entity"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfEntityLabels": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EntityLabel"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfErrors": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#ErrorsListItem"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfExtractedCharacters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#ExtractedCharactersListItem"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfKeyPhrases": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#KeyPhrase"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfLabels": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#DocumentLabel"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfMentions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#TargetedSentimentMention"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfPiiEntities": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#PiiEntity"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfPiiEntityTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#PiiEntityType"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfRelationships": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#RelationshipsListItem"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfSyntaxTokens": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#SyntaxToken"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfTargetedSentimentEntities": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#TargetedSentimentEntity"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfTextSegments": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#TextSegment"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListOfToxicContent": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#ToxicContent"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfToxicLabels": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#ToxicLabels"
+      }
+    },
+    "com.amazonaws.comprehend#ListOfWarnings": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#WarningsListItem"
+      }
+    },
+    "com.amazonaws.comprehend#ListPiiEntitiesDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListPiiEntitiesDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListPiiEntitiesDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the PII entity detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "PiiEntitiesDetectionJobPropertiesList",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListPiiEntitiesDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#PiiEntitiesDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListPiiEntitiesDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "PiiEntitiesDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#PiiEntitiesDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListSentimentDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListSentimentDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListSentimentDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of sentiment detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListSentimentDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#SentimentDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListSentimentDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "SentimentDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#SentimentDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all tags associated with a given Amazon Comprehend resource. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the given Amazon Comprehend resource you are querying.\n    </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the given Amazon Comprehend resource you are\n      querying.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags associated with the Amazon Comprehend resource being queried. A tag is a key-value\n      pair that adds as a metadata to a resource used by Amazon Comprehend. For example, a tag with\n      \"Sales\" as the key might be added to a resource to indicate its use by the sales department.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListTargetedSentimentDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListTargetedSentimentDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListTargetedSentimentDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of targeted sentiment detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListTargetedSentimentDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#TargetedSentimentDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. You can filter jobs on their name, status, or the date\n      and time that they were submitted. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListTargetedSentimentDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "TargetedSentimentDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#TargetedSentimentDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListTopicsDetectionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#ListTopicsDetectionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#ListTopicsDetectionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the topic detection jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ListTopicsDetectionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.comprehend#TopicsDetectionJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the jobs that are returned. Jobs can be filtered on their name, status, or the\n      date and time that they were submitted. You can set only one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.comprehend#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#ListTopicsDetectionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "TopicsDetectionJobPropertiesList": {
+          "target": "com.amazonaws.comprehend#TopicsDetectionJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#MaskCharacter": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        },
+        "smithy.api#pattern": "^[!@#$%&*]$"
+      }
+    },
+    "com.amazonaws.comprehend#MaxResultsInteger": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 500
+        }
+      }
+    },
+    "com.amazonaws.comprehend#MentionSentiment": {
+      "type": "structure",
+      "members": {
+        "Sentiment": {
+          "target": "com.amazonaws.comprehend#SentimentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The sentiment of the mention. </p>"
+          }
+        },
+        "SentimentScore": {
+          "target": "com.amazonaws.comprehend#SentimentScore"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the sentiment and sentiment score for one mention of an entity.</p>\n         <p>For more information about targeted sentiment, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html\">Targeted sentiment</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ModelStatus": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "TRAINING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRAINING"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "STOP_REQUESTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOP_REQUESTED"
+          }
+        },
+        "STOPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOPPED"
+          }
+        },
+        "IN_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_ERROR"
+          }
+        },
+        "TRAINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRAINED"
+          }
+        },
+        "TRAINED_WITH_WARNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRAINED_WITH_WARNING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ModelType": {
+      "type": "enum",
+      "members": {
+        "DOCUMENT_CLASSIFIER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOCUMENT_CLASSIFIER"
+          }
+        },
+        "ENTITY_RECOGNIZER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENTITY_RECOGNIZER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#NumberOfDocuments": {
+      "type": "long"
+    },
+    "com.amazonaws.comprehend#NumberOfTopicsInteger": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.comprehend#OutputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>When you use the <code>OutputDataConfig</code> object with asynchronous operations, you\n      specify the Amazon S3 location where you want to write the output data. The URI must be in the\n      same Region as the API endpoint that you are calling. The location is used as the prefix for\n      the actual location of the output file.</p>\n         <p>When the topic detection job is finished, the service creates an output file in a\n      directory specific to the job. The <code>S3Uri</code> field contains the location of the\n      output file, called <code>output.tar.gz</code>. It is a compressed archive that contains the\n      ouput of the operation.</p>\n         <p>\n      For a PII entity detection job, the output file is plain text, not a compressed archive.\n      The output file name is the same as the input file, with <code>.out</code> appended at the end.\n    </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt the\n      output results from an analysis job. Specify the Key Id of a symmetric key, because you cannot use an asymmetric\n       key for uploading data to S3.</p>\n         <p>The KmsKeyId can be one of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>KMS Key Alias: <code>\"alias/ExampleAlias\"</code>\n               </p>\n            </li>\n            <li>\n               <p>ARN of a KMS Key Alias:\n            <code>\"arn:aws:kms:us-west-2:111122223333:alias/ExampleAlias\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides configuration parameters for the output of inference jobs.</p>\n         <p></p>"
+      }
+    },
+    "com.amazonaws.comprehend#PageBasedErrorCode": {
+      "type": "enum",
+      "members": {
+        "TEXTRACT_BAD_PAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_BAD_PAGE"
+          }
+        },
+        "TEXTRACT_PROVISIONED_THROUGHPUT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEXTRACT_PROVISIONED_THROUGHPUT_EXCEEDED"
+          }
+        },
+        "PAGE_CHARACTERS_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PAGE_CHARACTERS_EXCEEDED"
+          }
+        },
+        "PAGE_SIZE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PAGE_SIZE_EXCEEDED"
+          }
+        },
+        "INTERNAL_SERVER_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_SERVER_ERROR"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#PageBasedWarningCode": {
+      "type": "enum",
+      "members": {
+        "INFERENCING_PLAINTEXT_WITH_NATIVE_TRAINED_MODEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INFERENCING_PLAINTEXT_WITH_NATIVE_TRAINED_MODEL"
+          }
+        },
+        "INFERENCING_NATIVE_DOCUMENT_WITH_PLAINTEXT_TRAINED_MODEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INFERENCING_NATIVE_DOCUMENT_WITH_PLAINTEXT_TRAINED_MODEL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#PartOfSpeechTag": {
+      "type": "structure",
+      "members": {
+        "Tag": {
+          "target": "com.amazonaws.comprehend#PartOfSpeechTagType",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the part of speech that the token represents.</p>"
+          }
+        },
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence that Amazon Comprehend has that the part of speech was correctly\n      identified.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Identifies the part of speech represented by the token and gives the confidence that\n      Amazon Comprehend has that the part of speech was correctly identified. For more information\n      about the parts of speech that Amazon Comprehend can identify, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-syntax.html\">Syntax</a> in the Comprehend Developer Guide.\n       </p>"
+      }
+    },
+    "com.amazonaws.comprehend#PartOfSpeechTagType": {
+      "type": "enum",
+      "members": {
+        "ADJ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADJ"
+          }
+        },
+        "ADP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADP"
+          }
+        },
+        "ADV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADV"
+          }
+        },
+        "AUX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUX"
+          }
+        },
+        "CONJ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONJ"
+          }
+        },
+        "CCONJ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CCONJ"
+          }
+        },
+        "DET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DET"
+          }
+        },
+        "INTJ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTJ"
+          }
+        },
+        "NOUN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOUN"
+          }
+        },
+        "NUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NUM"
+          }
+        },
+        "O": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "O"
+          }
+        },
+        "PART": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PART"
+          }
+        },
+        "PRON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PRON"
+          }
+        },
+        "PROPN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROPN"
+          }
+        },
+        "PUNCT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PUNCT"
+          }
+        },
+        "SCONJ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCONJ"
+          }
+        },
+        "SYM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SYM"
+          }
+        },
+        "VERB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VERB"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntitiesDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of PII entity detection jobs.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntitiesDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the PII entities detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the PII entities detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:pii-entities-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:pii-entities-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned the PII entities detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the PII entities detection job. If the status is\n      <code>FAILED</code>, the <code>Message</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the PII entities detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the PII entities detection job completed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input properties for a PII entities detection job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#PiiOutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the PII entities\n      detection job.</p>"
+          }
+        },
+        "RedactionConfig": {
+          "target": "com.amazonaws.comprehend#RedactionConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides configuration parameters for PII entity redaction.</p>\n         <p>This parameter is required if you set the <code>Mode</code> parameter to\n        <code>ONLY_REDACTION</code>. In that case, you must provide a <code>RedactionConfig</code>\n      definition that includes the <code>PiiEntityTypes</code> parameter.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "Mode": {
+          "target": "com.amazonaws.comprehend#PiiEntitiesDetectionMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the output provides the locations (offsets) of PII entities or a file in\n      which PII entities are redacted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a PII entities detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntitiesDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#PiiEntitiesDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntitiesDetectionMaskMode": {
+      "type": "enum",
+      "members": {
+        "MASK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MASK"
+          }
+        },
+        "REPLACE_WITH_PII_ENTITY_TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REPLACE_WITH_PII_ENTITY_TYPE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntitiesDetectionMode": {
+      "type": "enum",
+      "members": {
+        "ONLY_REDACTION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ONLY_REDACTION"
+          }
+        },
+        "ONLY_OFFSETS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ONLY_OFFSETS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntity": {
+      "type": "structure",
+      "members": {
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of the\n      detection.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.comprehend#PiiEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The entity's type.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the first character in the\n      entity.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the last character in the\n      entity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a PII entity.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#PiiEntityType": {
+      "type": "enum",
+      "members": {
+        "BANK_ACCOUNT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BANK_ACCOUNT_NUMBER"
+          }
+        },
+        "BANK_ROUTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BANK_ROUTING"
+          }
+        },
+        "CREDIT_DEBIT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREDIT_DEBIT_NUMBER"
+          }
+        },
+        "CREDIT_DEBIT_CVV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREDIT_DEBIT_CVV"
+          }
+        },
+        "CREDIT_DEBIT_EXPIRY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREDIT_DEBIT_EXPIRY"
+          }
+        },
+        "PIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PIN"
+          }
+        },
+        "EMAIL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL"
+          }
+        },
+        "ADDRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADDRESS"
+          }
+        },
+        "NAME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NAME"
+          }
+        },
+        "PHONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PHONE"
+          }
+        },
+        "SSN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSN"
+          }
+        },
+        "DATE_TIME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATE_TIME"
+          }
+        },
+        "PASSPORT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PASSPORT_NUMBER"
+          }
+        },
+        "DRIVER_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DRIVER_ID"
+          }
+        },
+        "URL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "URL"
+          }
+        },
+        "AGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AGE"
+          }
+        },
+        "USERNAME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "USERNAME"
+          }
+        },
+        "PASSWORD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PASSWORD"
+          }
+        },
+        "AWS_ACCESS_KEY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_ACCESS_KEY"
+          }
+        },
+        "AWS_SECRET_KEY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_SECRET_KEY"
+          }
+        },
+        "IP_ADDRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IP_ADDRESS"
+          }
+        },
+        "MAC_ADDRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAC_ADDRESS"
+          }
+        },
+        "ALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL"
+          }
+        },
+        "LICENSE_PLATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LICENSE_PLATE"
+          }
+        },
+        "VEHICLE_IDENTIFICATION_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VEHICLE_IDENTIFICATION_NUMBER"
+          }
+        },
+        "UK_NATIONAL_INSURANCE_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UK_NATIONAL_INSURANCE_NUMBER"
+          }
+        },
+        "CA_SOCIAL_INSURANCE_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CA_SOCIAL_INSURANCE_NUMBER"
+          }
+        },
+        "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER"
+          }
+        },
+        "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER"
+          }
+        },
+        "IN_PERMANENT_ACCOUNT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PERMANENT_ACCOUNT_NUMBER"
+          }
+        },
+        "IN_NREGA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_NREGA"
+          }
+        },
+        "INTERNATIONAL_BANK_ACCOUNT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNATIONAL_BANK_ACCOUNT_NUMBER"
+          }
+        },
+        "SWIFT_CODE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SWIFT_CODE"
+          }
+        },
+        "UK_NATIONAL_HEALTH_SERVICE_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UK_NATIONAL_HEALTH_SERVICE_NUMBER"
+          }
+        },
+        "CA_HEALTH_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CA_HEALTH_NUMBER"
+          }
+        },
+        "IN_AADHAAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_AADHAAR"
+          }
+        },
+        "IN_VOTER_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_VOTER_NUMBER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#PiiOutputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.comprehend#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>When you use the <code>PiiOutputDataConfig</code> object with asynchronous operations,\n      you specify the Amazon S3 location where you want to write the output data. </p>\n         <p>\n      For a PII entity detection job, the output file is plain text, not a compressed archive.\n      The output file name is the same as the input file, with <code>.out</code> appended at the end.\n    </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt the\n      output results from an analysis job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides configuration parameters for the output of PII entity detection jobs.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#Point": {
+      "type": "structure",
+      "members": {
+        "X": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the X coordinate for a point on a polygon</p>"
+          }
+        },
+        "Y": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the Y coordinate for a point on a polygon</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The X and Y coordinates of a point on a document page.</p>\n         <p>For additional information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/API_Point.html\">Point</a> in the Amazon Textract API reference.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#Policy": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 20000
+        },
+        "smithy.api#pattern": "^[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+$"
+      }
+    },
+    "com.amazonaws.comprehend#PolicyRevisionId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[0-9A-Fa-f]+$"
+      }
+    },
+    "com.amazonaws.comprehend#Polygon": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#Point"
+      }
+    },
+    "com.amazonaws.comprehend#PutResourcePolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#PutResourcePolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#PutResourcePolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Attaches a resource-based policy to a custom model. You can use this policy to authorize\n      an entity in another Amazon Web Services account to import the custom model, which replicates it in Amazon\n      Comprehend in their account.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#PutResourcePolicyRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the custom model to attach the policy to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourcePolicy": {
+          "target": "com.amazonaws.comprehend#Policy",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON resource-based policy to attach to your custom model. Provide your JSON as a\n      UTF-8 encoded string without line breaks. To provide valid JSON for your policy, enclose the\n      attribute names and values in double quotes. If the JSON body is also enclosed in double\n      quotes, then you must escape the double quotes that are inside the policy:</p>\n         <p>\n            <code>\"{\\\"attribute\\\": \\\"value\\\", \\\"attribute\\\": [\\\"value\\\"]}\"</code>\n         </p>\n         <p>To avoid escaping quotes, you can use single quotes to enclose the policy and double\n      quotes to enclose the JSON names and values:</p>\n         <p>\n            <code>'{\"attribute\": \"value\", \"attribute\": [\"value\"]}'</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyRevisionId": {
+          "target": "com.amazonaws.comprehend#PolicyRevisionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The revision ID that Amazon Comprehend assigned to the policy that you are updating. If\n      you are creating a new policy that has no prior version, don't use this parameter. Amazon\n      Comprehend creates the revision ID for you.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#PutResourcePolicyResponse": {
+      "type": "structure",
+      "members": {
+        "PolicyRevisionId": {
+          "target": "com.amazonaws.comprehend#PolicyRevisionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The revision ID of the policy. Each time you modify a policy, Amazon Comprehend assigns a\n      new revision ID, and it deletes the prior version of the policy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#RedactionConfig": {
+      "type": "structure",
+      "members": {
+        "PiiEntityTypes": {
+          "target": "com.amazonaws.comprehend#ListOfPiiEntityTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of the types of PII entities that Amazon Comprehend detects in the input text for\n      your request.</p>"
+          }
+        },
+        "MaskMode": {
+          "target": "com.amazonaws.comprehend#PiiEntitiesDetectionMaskMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the PII entity is redacted with the mask character or the entity\n      type.</p>"
+          }
+        },
+        "MaskCharacter": {
+          "target": "com.amazonaws.comprehend#MaskCharacter",
+          "traits": {
+            "smithy.api#documentation": "<p>A character that replaces each character in the redacted PII entity.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides configuration parameters for PII entity redaction.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#RelationshipType": {
+      "type": "enum",
+      "members": {
+        "CHILD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHILD"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#RelationshipsListItem": {
+      "type": "structure",
+      "members": {
+        "Ids": {
+          "target": "com.amazonaws.comprehend#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifers of the child blocks.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.comprehend#RelationshipType",
+          "traits": {
+            "smithy.api#documentation": "<p>Only supported relationship is a child relationship.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>List of child blocks for the current block.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#ResourceInUseException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified resource name is already in use. Use a different name and try your request\n      again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#ResourceLimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The maximum number of resources per account has been exceeded. Review the resources, and\n      then try your request again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified resource ARN was not found. Check the ARN and try your request again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.comprehend#ResourceUnavailableException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified resource is not available. Check the resource and try your request\n      again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.comprehend#S3Uri": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^s3://[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9](/.*)?$"
+      }
+    },
+    "com.amazonaws.comprehend#SecurityGroupId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 32
+        },
+        "smithy.api#pattern": "^[-0-9a-zA-Z]+$"
+      }
+    },
+    "com.amazonaws.comprehend#SecurityGroupIds": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#SecurityGroupId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.comprehend#SemiStructuredDocumentBlob": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.comprehend#SentimentDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of dominant language detection jobs. For more\n      information, see the  operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#SentimentDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the sentiment detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the sentiment detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:sentiment-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:sentiment-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned to the sentiment detection job</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the sentiment detection job. If the status is <code>FAILED</code>,\n      the <code>Messages</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the sentiment detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the sentiment detection job ended.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration that you supplied when you created the sentiment detection\n      job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration that you supplied when you created the sentiment detection\n      job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your sentiment detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a sentiment detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#SentimentDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#SentimentDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#SentimentScore": {
+      "type": "structure",
+      "members": {
+        "Positive": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of its detection of\n      the <code>POSITIVE</code> sentiment.</p>"
+          }
+        },
+        "Negative": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of its detection of\n      the <code>NEGATIVE</code> sentiment.</p>"
+          }
+        },
+        "Neutral": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of its detection of\n      the <code>NEUTRAL</code> sentiment.</p>"
+          }
+        },
+        "Mixed": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The level of confidence that Amazon Comprehend has in the accuracy of its detection of\n      the <code>MIXED</code> sentiment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the level of confidence that Amazon Comprehend has in the accuracy of its\n      detection of sentiments.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#SentimentType": {
+      "type": "enum",
+      "members": {
+        "POSITIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POSITIVE"
+          }
+        },
+        "NEGATIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEGATIVE"
+          }
+        },
+        "NEUTRAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEUTRAL"
+          }
+        },
+        "MIXED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MIXED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#Split": {
+      "type": "enum",
+      "members": {
+        "TRAIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TRAIN"
+          }
+        },
+        "TEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEST"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#StartDocumentClassificationJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartDocumentClassificationJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartDocumentClassificationJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous document classification job using a custom classification model.  Use the \n      <code>DescribeDocumentClassificationJob</code>\n          operation to track the progress of the job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartDocumentClassificationJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the document classifier to use to process the\n      job.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you do not set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your document classification job. For more information, see\n      <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the document classification job. A tag is a key-value pair that\n      adds metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the\n      key might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel associated with the model to use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartDocumentClassificationJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of the job, use this identifier\n      with the <code>DescribeDocumentClassificationJob</code> operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the document classification job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:document-classification-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:document-classification-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job:</p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. For details, use the \n          <code>DescribeDocumentClassificationJob</code> operation.</p>\n            </li>\n            <li>\n               <p>STOP_REQUESTED - Amazon Comprehend has received a stop request for the job and is\n          processing the request.</p>\n            </li>\n            <li>\n               <p>STOPPED - The job was successfully stopped without completing.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the custom classification model.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartDominantLanguageDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartDominantLanguageDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartDominantLanguageDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous dominant language detection job for a collection of documents. Use\n      the  operation to track the status\n      of a job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartDominantLanguageDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/security_iam_id-based-policy-examples.html#auth-role-permissions\">Role-based permissions</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier for the job.</p>"
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you do not set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your dominant language detection job. For more information,\n      see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon VPC</a>. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the dominant language detection job. A tag is a key-value pair\n      that adds metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as\n      the key might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartDominantLanguageDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of a job, use this identifier with\n      the  operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the dominant language detection job. It is a unique,\n      fully qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID.\n      The format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:dominant-language-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:dominant-language-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job. </p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and is queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. To get details, use the  operation.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartEntitiesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartEntitiesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartEntitiesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous entity detection job for a collection of documents. Use the  operation to track the status of a job.</p>\n         <p>This API can be used for either standard entity detection or custom entity recognition. In\n      order to be used for custom entity recognition, the optional <code>EntityRecognizerArn</code>\n      must be used in order to provide access to the recognizer being used to detect the custom\n      entity.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartEntitiesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/security_iam_id-based-policy-examples.html#auth-role-permissions\">Role-based permissions</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the specific entity recognizer to be used\n      by the <code>StartEntitiesDetectionJob</code>. This ARN is optional and is only used for a\n      custom entity recognition job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. All documents must be in the same language. You can\n      specify any of the languages supported by Amazon Comprehend. If custom entities recognition is\n      used, this parameter is ignored and the language used for training the model is used\n      instead.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your entity detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the entities detection job. A tag is a key-value pair that adds\n      metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the key\n      might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel associated with the model to use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartEntitiesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of job, use this identifier with\n      the  operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the entities detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:entities-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:entities-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job. </p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and is queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. To get details, use the  operation.</p>\n            </li>\n            <li>\n               <p>STOP_REQUESTED - Amazon Comprehend has received a stop request for the job and is\n          processing the request.</p>\n            </li>\n            <li>\n               <p>STOPPED - The job was successfully stopped without completing.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the custom entity recognition model.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartEventsDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartEventsDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartEventsDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous event detection job for a collection of documents.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartEventsDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the events detection job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>An unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "TargetEventTypes": {
+          "target": "com.amazonaws.comprehend#TargetEventTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The types of events to detect in the input documents.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the events detection job. A tag is a key-value pair that adds\n      metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the key\n      might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartEventsDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>An unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the events detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:events-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:events-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the events detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartFlywheelIteration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartFlywheelIterationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartFlywheelIterationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Start the flywheel iteration.This operation uses any new datasets to train a new model version.\n      For more information about flywheels, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/flywheels-about.html\">\n      Flywheel overview</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartFlywheelIterationRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the flywheel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartFlywheelIterationResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "FlywheelIterationId": {
+          "target": "com.amazonaws.comprehend#FlywheelIterationId",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartKeyPhrasesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartKeyPhrasesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartKeyPhrasesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous key phrase detection job for a collection of documents. Use the\n         operation to track the status of a\n      job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartKeyPhrasesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/security_iam_id-based-policy-examples.html#auth-role-permissions\">Role-based permissions</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p> Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your key phrases detection job. For more information, see\n      <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the key phrases detection job. A tag is a key-value pair that\n      adds metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the\n      key might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartKeyPhrasesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of a job, use this identifier with\n      the  operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the key phrase detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:key-phrases-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:key-phrases-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job. </p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and is queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. To get details, use the  operation.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartPiiEntitiesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartPiiEntitiesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartPiiEntitiesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous PII entity detection job for a collection of documents.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartPiiEntitiesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input properties for a PII entities detection job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides con\ufb01guration parameters for the output of PII entity detection jobs.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Mode": {
+          "target": "com.amazonaws.comprehend#PiiEntitiesDetectionMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the output provides the locations (offsets) of PII entities or a file in\n      which PII entities are redacted.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RedactionConfig": {
+          "target": "com.amazonaws.comprehend#RedactionConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides configuration parameters for PII entity redaction.</p>\n         <p>This parameter is required if you set the <code>Mode</code> parameter to\n        <code>ONLY_REDACTION</code>. In that case, you must provide a <code>RedactionConfig</code>\n      definition that includes the <code>PiiEntityTypes</code> parameter.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. \n      Enter the language code for English (en) or Spanish (es).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the PII entities detection job. A tag is a key-value pair that\n      adds metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the\n      key might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartPiiEntitiesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the PII entity detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:pii-entities-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:pii-entities-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartSentimentDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartSentimentDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartSentimentDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous sentiment detection job for a collection of documents. Use the\n         operation to track the status of a\n      job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartSentimentDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/security_iam_id-based-policy-examples.html#auth-role-permissions\">Role-based permissions</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. You can specify any of the primary languages\n      supported by Amazon Comprehend. All documents must be in the same language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your sentiment detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the sentiment detection job. A tag is a key-value pair that\n      adds metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the\n      key might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartSentimentDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of a job, use this identifier with\n      the  operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the sentiment detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:sentiment-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:sentiment-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job. </p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and is queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. To get details, use the  operation.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartTargetedSentimentDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartTargetedSentimentDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartTargetedSentimentDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous targeted sentiment detection job for a collection of documents. Use the\n      <code>DescribeTargetedSentimentDetectionJob</code> operation to track the status of a\n      job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartTargetedSentimentDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/security_iam_id-based-policy-examples.html#auth-role-permissions\">Role-based permissions</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language of the input documents. Currently, English is the only supported language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you don't set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n          <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig"
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the targeted sentiment detection job. A tag is a key-value pair that\n      adds metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the\n      key might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartTargetedSentimentDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of a job, use this identifier with\n      the <code>DescribeTargetedSentimentDetectionJob</code> operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the targeted sentiment detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:targeted-sentiment-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:targeted-sentiment-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job. </p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and is queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. To get details, use the \n          <code>DescribeTargetedSentimentDetectionJob</code> operation.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartTopicsDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StartTopicsDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StartTopicsDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous topic detection job. Use the\n        <code>DescribeTopicDetectionJob</code> operation to track the status of a job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StartTopicsDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input data for the job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies where to send the output files. The output is a compressed archive with two\n      files, <code>topic-terms.csv</code> that lists the terms associated with each topic, and\n        <code>doc-topics.csv</code> that lists the documents associated with each topic</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data. For more information, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/security_iam_id-based-policy-examples.html#auth-role-permissions\">Role-based permissions</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the job.</p>"
+          }
+        },
+        "NumberOfTopics": {
+          "target": "com.amazonaws.comprehend#NumberOfTopicsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of topics to detect.</p>"
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.comprehend#ClientRequestTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. If you do not set the client request token, Amazon\n      Comprehend generates one.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for your topic detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the topics detection job. A tag is a key-value pair that adds\n      metadata to a resource used by Amazon Comprehend. For example, a tag with \"Sales\" as the key\n      might be added to a resource to indicate its use by the sales department.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StartTopicsDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of the job, use this identifier\n      with the <code>DescribeTopicDetectionJob</code> operation.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the topics detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:topics-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:document-classification-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job: </p>\n         <ul>\n            <li>\n               <p>SUBMITTED - The job has been received and is queued for processing.</p>\n            </li>\n            <li>\n               <p>IN_PROGRESS - Amazon Comprehend is processing the job.</p>\n            </li>\n            <li>\n               <p>COMPLETED - The job was successfully completed and the output is\n          available.</p>\n            </li>\n            <li>\n               <p>FAILED - The job did not complete. To get details, use the\n            <code>DescribeTopicDetectionJob</code> operation.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopDominantLanguageDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopDominantLanguageDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopDominantLanguageDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a dominant language detection job in progress.</p>\n         <p>If the job state is <code>IN_PROGRESS</code> the job is marked for termination and put\n      into the <code>STOP_REQUESTED</code> state. If the job completes before it can be stopped, it\n      is put into the <code>COMPLETED</code> state; otherwise the job is stopped and put into the\n        <code>STOPPED</code> state.</p>\n         <p>If the job is in the <code>COMPLETED</code> or <code>FAILED</code> state when you call the\n        <code>StopDominantLanguageDetectionJob</code> operation, the operation returns a 400\n      Internal Request Exception. </p>\n         <p>When a job is stopped, any documents already processed are written to the output\n      location.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopDominantLanguageDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the dominant language detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopDominantLanguageDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the dominant language detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Either <code>STOP_REQUESTED</code> if the job is currently running, or\n        <code>STOPPED</code> if the job was previously stopped with the\n        <code>StopDominantLanguageDetectionJob</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopEntitiesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopEntitiesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopEntitiesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops an entities detection job in progress.</p>\n         <p>If the job state is <code>IN_PROGRESS</code> the job is marked for termination and put\n      into the <code>STOP_REQUESTED</code> state. If the job completes before it can be stopped, it\n      is put into the <code>COMPLETED</code> state; otherwise the job is stopped and put into the\n        <code>STOPPED</code> state.</p>\n         <p>If the job is in the <code>COMPLETED</code> or <code>FAILED</code> state when you call the\n        <code>StopDominantLanguageDetectionJob</code> operation, the operation returns a 400\n      Internal Request Exception. </p>\n         <p>When a job is stopped, any documents already processed are written to the output\n      location.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopEntitiesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the entities detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopEntitiesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the entities detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Either <code>STOP_REQUESTED</code> if the job is currently running, or\n        <code>STOPPED</code> if the job was previously stopped with the\n        <code>StopEntitiesDetectionJob</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopEventsDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopEventsDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopEventsDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops an events detection job in progress.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopEventsDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the events detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopEventsDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the events detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the events detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopKeyPhrasesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopKeyPhrasesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopKeyPhrasesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a key phrases detection job in progress.</p>\n         <p>If the job state is <code>IN_PROGRESS</code> the job is marked for termination and put\n      into the <code>STOP_REQUESTED</code> state. If the job completes before it can be stopped, it\n      is put into the <code>COMPLETED</code> state; otherwise the job is stopped and put into the\n        <code>STOPPED</code> state.</p>\n         <p>If the job is in the <code>COMPLETED</code> or <code>FAILED</code> state when you call the\n        <code>StopDominantLanguageDetectionJob</code> operation, the operation returns a 400\n      Internal Request Exception. </p>\n         <p>When a job is stopped, any documents already processed are written to the output\n      location.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopKeyPhrasesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the key phrases detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopKeyPhrasesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the key phrases detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Either <code>STOP_REQUESTED</code> if the job is currently running, or\n        <code>STOPPED</code> if the job was previously stopped with the\n        <code>StopKeyPhrasesDetectionJob</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopPiiEntitiesDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopPiiEntitiesDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopPiiEntitiesDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a PII entities detection job in progress.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopPiiEntitiesDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the PII entities detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopPiiEntitiesDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the PII entities detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the PII entities detection job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopSentimentDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopSentimentDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopSentimentDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a sentiment detection job in progress.</p>\n         <p>If the job state is <code>IN_PROGRESS</code>, the job is marked for termination and put\n      into the <code>STOP_REQUESTED</code> state. If the job completes before it can be stopped, it\n      is put into the <code>COMPLETED</code> state; otherwise the job is be stopped and put into the\n        <code>STOPPED</code> state.</p>\n         <p>If the job is in the <code>COMPLETED</code> or <code>FAILED</code> state when you call the\n        <code>StopDominantLanguageDetectionJob</code> operation, the operation returns a 400\n      Internal Request Exception. </p>\n         <p>When a job is stopped, any documents already processed are written to the output\n      location.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopSentimentDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the sentiment detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopSentimentDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the sentiment detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Either <code>STOP_REQUESTED</code> if the job is currently running, or\n        <code>STOPPED</code> if the job was previously stopped with the\n        <code>StopSentimentDetectionJob</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopTargetedSentimentDetectionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopTargetedSentimentDetectionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopTargetedSentimentDetectionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#JobNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a targeted sentiment detection job in progress.</p>\n         <p>If the job state is <code>IN_PROGRESS</code>, the job is marked for termination and put\n      into the <code>STOP_REQUESTED</code> state. If the job completes before it can be stopped, it\n      is put into the <code>COMPLETED</code> state; otherwise the job is be stopped and put into the\n      <code>STOPPED</code> state.</p>\n         <p>If the job is in the <code>COMPLETED</code> or <code>FAILED</code> state when you call the\n      <code>StopDominantLanguageDetectionJob</code> operation, the operation returns a 400\n      Internal Request Exception. </p>\n         <p>When a job is stopped, any documents already processed are written to the output\n      location.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopTargetedSentimentDetectionJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the targeted sentiment detection job to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopTargetedSentimentDetectionJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the targeted sentiment detection job to stop.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Either <code>STOP_REQUESTED</code> if the job is currently running, or\n      <code>STOPPED</code> if the job was previously stopped with the\n      <code>StopSentimentDetectionJob</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopTrainingDocumentClassifier": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopTrainingDocumentClassifierRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopTrainingDocumentClassifierResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a document classifier training job while in progress.</p>\n         <p>If the training job state is <code>TRAINING</code>, the job is marked for termination and\n      put into the <code>STOP_REQUESTED</code> state. If the training job completes before it can be\n      stopped, it is put into the <code>TRAINED</code>; otherwise the training job is stopped and\n      put into the <code>STOPPED</code> state and the service sends back an HTTP 200 response with\n      an empty HTTP body. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopTrainingDocumentClassifierRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentClassifierArn": {
+          "target": "com.amazonaws.comprehend#DocumentClassifierArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the document classifier currently being\n      trained.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopTrainingDocumentClassifierResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopTrainingEntityRecognizer": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#StopTrainingEntityRecognizerRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#StopTrainingEntityRecognizerResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops an entity recognizer training job while in progress.</p>\n         <p>If the training job state is <code>TRAINING</code>, the job is marked for termination and\n      put into the <code>STOP_REQUESTED</code> state. If the training job completes before it can be\n      stopped, it is put into the <code>TRAINED</code>; otherwise the training job is stopped and\n      putted into the <code>STOPPED</code> state and the service sends back an HTTP 200 response\n      with an empty HTTP body.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#StopTrainingEntityRecognizerRequest": {
+      "type": "structure",
+      "members": {
+        "EntityRecognizerArn": {
+          "target": "com.amazonaws.comprehend#EntityRecognizerArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the entity recognizer currently being\n      trained.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#StopTrainingEntityRecognizerResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#String": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.comprehend#StringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#String"
+      }
+    },
+    "com.amazonaws.comprehend#SubnetId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 32
+        },
+        "smithy.api#pattern": "^[-0-9a-zA-Z]+$"
+      }
+    },
+    "com.amazonaws.comprehend#Subnets": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#SubnetId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 16
+        }
+      }
+    },
+    "com.amazonaws.comprehend#SyntaxLanguageCode": {
+      "type": "enum",
+      "members": {
+        "EN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en"
+          }
+        },
+        "ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es"
+          }
+        },
+        "FR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fr"
+          }
+        },
+        "DE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "de"
+          }
+        },
+        "IT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "it"
+          }
+        },
+        "PT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pt"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#SyntaxToken": {
+      "type": "structure",
+      "members": {
+        "TokenId": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for a token.</p>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The word that was recognized in the source text.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the first character in the\n      word.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The zero-based offset from the beginning of the source text to the last character in the\n      word.</p>"
+          }
+        },
+        "PartOfSpeech": {
+          "target": "com.amazonaws.comprehend#PartOfSpeechTag",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the part of speech label and the confidence level that Amazon Comprehend has that\n      the part of speech was correctly identified. For more information, see\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-syntax.html\">Syntax</a> in the Comprehend Developer Guide.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a work in the input text that was recognized and assigned a part of speech.\n      There is one syntax token record for each word in the source text.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.comprehend#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The initial part of a key-value pair that forms a tag associated with a given resource.\n      For instance, if you want to show which resources are used by which departments, you might use\n      \u201cDepartment\u201d as the key portion of the pair, with multiple possible values such as \u201csales,\u201d\n      \u201clegal,\u201d and \u201cadministration.\u201d </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.comprehend#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p> The second part of a key-value pair that forms a tag associated with a given resource.\n      For instance, if you want to show which resources are used by which departments, you might use\n      \u201cDepartment\u201d as the initial (key) portion of the pair, with a value of \u201csales\u201d to indicate the\n      sales department. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair that adds as a metadata to a resource used by Amazon Comprehend. For\n      example, a tag with the key-value pair \u2018Department\u2019:\u2019Sales\u2019 might be added to a resource to\n      indicate its use by a particular department. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.comprehend#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#TagKey"
+      }
+    },
+    "com.amazonaws.comprehend#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#Tag"
+      }
+    },
+    "com.amazonaws.comprehend#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associates a specific tag with an Amazon Comprehend resource. A tag is a key-value pair\n      that adds as a metadata to a resource used by Amazon Comprehend. For example, a tag with\n      \"Sales\" as the key might be added to a resource to indicate its use by the sales department.\n    </p>"
+      }
+    },
+    "com.amazonaws.comprehend#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the given Amazon Comprehend resource to which you want\n      to associate the tags. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.comprehend#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags being associated with a specific Amazon Comprehend resource. There can be a maximum\n      of 50 tags (both existing and pending) associated with a specific resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.comprehend#TargetEventTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#EventTypeString"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.comprehend#TargetedSentimentDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters on the name of the job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on job status. Returns only jobs with the specified\n      status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted before the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Returns only jobs submitted after the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of dominant language detection jobs. For more\n      information, see the <code>ListTargetedSentimentDetectionJobs</code> operation.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TargetedSentimentDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the targeted sentiment detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the targeted sentiment detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:targeted-sentiment-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:targeted-sentiment-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assigned to the targeted sentiment detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the targeted sentiment detection job. If the status is <code>FAILED</code>,\n      the <code>Messages</code> field shows the reason for the failure.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the targeted sentiment detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the targeted sentiment detection job ended.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig"
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig"
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input documents.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your input data.</p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt the\n      data on the storage volume attached to the ML compute instance(s) that process the\n      targeted sentiment detection job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n          <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a targeted sentiment detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TargetedSentimentDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#TargetedSentimentDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#TargetedSentimentEntity": {
+      "type": "structure",
+      "members": {
+        "DescriptiveMentionIndex": {
+          "target": "com.amazonaws.comprehend#ListOfDescriptiveMentionIndices",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more index into the Mentions array that provides the best name for the entity group.</p>"
+          }
+        },
+        "Mentions": {
+          "target": "com.amazonaws.comprehend#ListOfMentions",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of mentions of the entity in the document. The array represents a co-reference group.\n      See <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html#how-targeted-sentiment-values\">\n        Co-reference group</a> for an example. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about one of the entities found by targeted sentiment analysis.</p>\n         <p>For more information about targeted sentiment, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html\">Targeted sentiment</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TargetedSentimentEntityType": {
+      "type": "enum",
+      "members": {
+        "PERSON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERSON"
+          }
+        },
+        "LOCATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOCATION"
+          }
+        },
+        "ORGANIZATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ORGANIZATION"
+          }
+        },
+        "FACILITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FACILITY"
+          }
+        },
+        "BRAND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BRAND"
+          }
+        },
+        "COMMERCIAL_ITEM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMMERCIAL_ITEM"
+          }
+        },
+        "MOVIE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MOVIE"
+          }
+        },
+        "MUSIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MUSIC"
+          }
+        },
+        "BOOK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOK"
+          }
+        },
+        "SOFTWARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOFTWARE"
+          }
+        },
+        "GAME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GAME"
+          }
+        },
+        "PERSONAL_TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERSONAL_TITLE"
+          }
+        },
+        "EVENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EVENT"
+          }
+        },
+        "DATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATE"
+          }
+        },
+        "QUANTITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUANTITY"
+          }
+        },
+        "ATTRIBUTE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ATTRIBUTE"
+          }
+        },
+        "OTHER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OTHER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#TargetedSentimentMention": {
+      "type": "structure",
+      "members": {
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>Model confidence that the entity is relevant. Value range is zero to one, where one is highest confidence.</p>"
+          }
+        },
+        "GroupScore": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence that all the entities mentioned in the group relate to the same entity.</p>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The text in the document that identifies the entity.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.comprehend#TargetedSentimentEntityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the entity. Amazon Comprehend supports a variety of <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html#how-targeted-sentiment-entities\">entity types</a>.</p>"
+          }
+        },
+        "MentionSentiment": {
+          "target": "com.amazonaws.comprehend#MentionSentiment",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the sentiment and sentiment score for the mention.</p>"
+          }
+        },
+        "BeginOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The offset into the document text where the mention begins.</p>"
+          }
+        },
+        "EndOffset": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The offset into the document text where the mention ends.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about one mention of an entity. The mention information includes the location of the mention\n      in the text and the sentiment of the mention.</p>\n         <p>For more information about targeted sentiment, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/how-targeted-sentiment.html\">Targeted sentiment</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TaskConfig": {
+      "type": "structure",
+      "members": {
+        "LanguageCode": {
+          "target": "com.amazonaws.comprehend#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>Language code for the language that the model supports.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DocumentClassificationConfig": {
+          "target": "com.amazonaws.comprehend#DocumentClassificationConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration required for a document classification model.</p>"
+          }
+        },
+        "EntityRecognitionConfig": {
+          "target": "com.amazonaws.comprehend#EntityRecognitionConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration required for an entity recognition model.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration about the model associated with a flywheel.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TextSegment": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.comprehend#CustomerInputString",
+          "traits": {
+            "smithy.api#documentation": "<p>The text content.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>One of the of text strings. Each string has a size limit of 1KB.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TextSizeLimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The size of the input text exceeds the limit. Use a smaller document.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#Timestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.comprehend#TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of requests exceeds the limit. Resubmit your request later.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.comprehend#TooManyTagKeysException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request contains more tag keys than can be associated with a resource (50 tag keys per\n      resource).</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#TooManyTagsException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request contains more tags than can be associated with a resource (50 tags per\n      resource). The maximum number of tags includes both existing tags and those included in your\n      current request. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#TopicsDetectionJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of topic detection jobs based on job status. Returns only jobs with\n      the specified status.</p>"
+          }
+        },
+        "SubmitTimeBefore": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Only returns jobs submitted before the specified time. Jobs are returned in descending order,\n      newest to oldest.</p>"
+          }
+        },
+        "SubmitTimeAfter": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing.\n      Only returns jobs submitted after the specified time. Jobs are returned in ascending order,\n      oldest to newest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering topic detection jobs. For more information, see\n        .</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TopicsDetectionJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.comprehend#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier assigned to the topic detection job.</p>"
+          }
+        },
+        "JobArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the topics detection job. It is a unique, fully\n      qualified identifier for the job. It includes the Amazon Web Services account, Amazon Web Services Region, and the job ID. The\n      format of the ARN is as follows:</p>\n         <p>\n            <code>arn:<partition>:comprehend:<region>:<account-id>:topics-detection-job/<job-id></code>\n         </p>\n         <p>The following is an example job ARN:</p>\n         <p>\n            <code>arn:aws:comprehend:us-west-2:111122223333:topics-detection-job/1234abcd12ab34cd56ef1234567890ab</code>\n         </p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.comprehend#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the topic detection job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.comprehend#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the topic detection job. If the status is <code>Failed</code>,\n      the reason for the failure is shown in the <code>Message</code> field.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.comprehend#AnyLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description for the status of a job.</p>"
+          }
+        },
+        "SubmitTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the topic detection job was submitted for processing.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.comprehend#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the topic detection job was completed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.comprehend#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input data configuration supplied when you created the topic detection\n      job.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.comprehend#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output data configuration supplied when you created the topic detection\n      job.</p>"
+          }
+        },
+        "NumberOfTopics": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of topics to detect supplied when you created the topic detection job. The\n      default is 10. </p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend read access to your job data. </p>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the Amazon Web Services Key Management Service (KMS) key that Amazon Comprehend uses to encrypt\n      data on the storage volume attached to the ML compute instance(s) that process the analysis\n      job. The VolumeKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration parameters for a private Virtual Private Cloud (VPC) containing the\n      resources you are using for your topic detection job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a topic detection job.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#TopicsDetectionJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.comprehend#TopicsDetectionJobProperties"
+      }
+    },
+    "com.amazonaws.comprehend#ToxicContent": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.comprehend#ToxicContentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the toxic content type.</p>"
+          }
+        },
+        "Score": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p> \n      Model confidence in the detected content type. Value range is zero to one, where one is highest confidence.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Toxic content analysis result for one string. For more information about toxicity detection, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/toxicity-detection.html\">Toxicity detection</a> in the <i>Amazon Comprehend Developer Guide</i>\n         </p>"
+      }
+    },
+    "com.amazonaws.comprehend#ToxicContentType": {
+      "type": "enum",
+      "members": {
+        "GRAPHIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GRAPHIC"
+          }
+        },
+        "HARASSMENT_OR_ABUSE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HARASSMENT_OR_ABUSE"
+          }
+        },
+        "HATE_SPEECH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HATE_SPEECH"
+          }
+        },
+        "INSULT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSULT"
+          }
+        },
+        "PROFANITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROFANITY"
+          }
+        },
+        "SEXUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEXUAL"
+          }
+        },
+        "VIOLENCE_OR_THREAT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VIOLENCE_OR_THREAT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.comprehend#ToxicLabels": {
+      "type": "structure",
+      "members": {
+        "Labels": {
+          "target": "com.amazonaws.comprehend#ListOfToxicContent",
+          "traits": {
+            "smithy.api#documentation": "<p>Array of toxic content types identified in the string.</p>"
+          }
+        },
+        "Toxicity": {
+          "target": "com.amazonaws.comprehend#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>Overall toxicity score for the string. Value range is zero to one, where one is the highest confidence.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Toxicity analysis result for one string. For more information about toxicity detection, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/toxicity-detection.html\">Toxicity detection</a> in the <i>Amazon Comprehend Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#UnsupportedLanguageException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.comprehend#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Comprehend can't process the language of the input text. For a list of supported languages,\n      <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/supported-languages.html\">Supported languages</a> in the Comprehend Developer Guide.\n    </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.comprehend#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyTagKeysException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes a specific tag associated with an Amazon Comprehend resource. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.comprehend#ComprehendArn",
+          "traits": {
+            "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the given Amazon Comprehend resource from which you\n      want to remove the tags. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.comprehend#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The initial part of a key-value pair that forms a tag being removed from a given resource.\n      For example, a tag with \"Sales\" as the key might be added to a resource to indicate its use by\n      the sales department. Keys must be unique and cannot be duplicated for a particular resource.\n    </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#UpdateDataSecurityConfig": {
+      "type": "structure",
+      "members": {
+        "ModelKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt\n      trained custom models. The ModelKmsKeyId can be either of the following formats:</p>\n         <ul>\n            <li>\n               <p>KMS Key ID: <code>\"1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n            <li>\n               <p>Amazon Resource Name (ARN) of a KMS Key:\n            <code>\"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\"</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "VolumeKmsKeyId": {
+          "target": "com.amazonaws.comprehend#KmsKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID for the KMS key that Amazon Comprehend uses to encrypt the volume.</p>"
+          }
+        },
+        "VpcConfig": {
+          "target": "com.amazonaws.comprehend#VpcConfig"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Data security configuration.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#UpdateEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#UpdateEndpointRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#UpdateEndpointResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates information about the specified endpoint.\n      For information about endpoints, see <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/manage-endpoints.html\">Managing endpoints</a>.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#UpdateEndpointRequest": {
+      "type": "structure",
+      "members": {
+        "EndpointArn": {
+          "target": "com.amazonaws.comprehend#ComprehendEndpointArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the endpoint being updated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DesiredModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the new model to use when updating an existing endpoint.</p>"
+          }
+        },
+        "DesiredInferenceUnits": {
+          "target": "com.amazonaws.comprehend#InferenceUnitsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p> The desired number of inference units to be used by the model using this endpoint.\n      \n      Each inference unit represents of a throughput of 100 characters per second.</p>"
+          }
+        },
+        "DesiredDataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Data access role ARN to use in case the new model is encrypted with a customer CMK.</p>"
+          }
+        },
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#UpdateEndpointResponse": {
+      "type": "structure",
+      "members": {
+        "DesiredModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the new model.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#UpdateFlywheel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.comprehend#UpdateFlywheelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.comprehend#UpdateFlywheelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.comprehend#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#KmsKeyValidationException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.comprehend#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update the configuration information for an existing flywheel.</p>"
+      }
+    },
+    "com.amazonaws.comprehend#UpdateFlywheelRequest": {
+      "type": "structure",
+      "members": {
+        "FlywheelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendFlywheelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the flywheel to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ActiveModelArn": {
+          "target": "com.amazonaws.comprehend#ComprehendModelArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Number (ARN) of the active model version.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.comprehend#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that\n      grants Amazon Comprehend permission to access the flywheel data.</p>"
+          }
+        },
+        "DataSecurityConfig": {
+          "target": "com.amazonaws.comprehend#UpdateDataSecurityConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Flywheel data security configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.comprehend#UpdateFlywheelResponse": {
+      "type": "structure",
+      "members": {
+        "FlywheelProperties": {
+          "target": "com.amazonaws.comprehend#FlywheelProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The flywheel properties.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.comprehend#VersionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
+      }
+    },
+    "com.amazonaws.comprehend#VpcConfig": {
+      "type": "structure",
+      "members": {
+        "SecurityGroupIds": {
+          "target": "com.amazonaws.comprehend#SecurityGroupIds",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID number for a security group on an instance of your private VPC. Security groups on\n      your VPC function serve as a virtual firewall to control inbound and outbound traffic and\n      provides security for the resources that you\u2019ll be accessing on the VPC. This ID number is\n      preceded by \"sg-\", for instance: \"sg-03b388029b0a285ea\". For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html\">Security\n        Groups for your VPC</a>. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Subnets": {
+          "target": "com.amazonaws.comprehend#Subnets",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID for each subnet being used in your private VPC. This subnet is a subset of the a\n      range of IPv4 addresses used by the VPC and is specific to a given availability zone in the\n      VPC\u2019s Region. This ID number is preceded by \"subnet-\", for instance:\n      \"subnet-04ccf456919e69055\". For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html\">VPCs and\n        Subnets</a>. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Configuration parameters for an optional private Virtual Private Cloud (VPC) containing\n      the resources you are using for the job. For more information, see <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html\">Amazon\n        VPC</a>. </p>"
+      }
+    },
+    "com.amazonaws.comprehend#WarningsListItem": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.comprehend#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Page number in the input document.</p>"
+          }
+        },
+        "WarnCode": {
+          "target": "com.amazonaws.comprehend#PageBasedWarningCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of warning.</p>"
+          }
+        },
+        "WarnMessage": {
+          "target": "com.amazonaws.comprehend#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Text message associated with the warning.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The system identified one of the following warnings while processing the input document:</p>\n         <ul>\n            <li>\n               <p>The document to classify is plain text, but the classifier is a native document model.</p>\n            </li>\n            <li>\n               <p>The document to classify is semi-structured, but the classifier is a plain-text model.</p>\n            </li>\n         </ul>"
+      }
+    }
+  }
+}

--- a/crates/fakecloud-comprehend/src/validate.rs
+++ b/crates/fakecloud-comprehend/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored Comprehend Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/comprehend.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 /// The embedded model parses to exactly this many operations; a mismatch means
 /// the vendored model drifted from the implemented surface.

--- a/crates/fakecloud-config/model.json
+++ b/crates/fakecloud-config/model.json
@@ -1,0 +1,19052 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.configservice#ARN": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#AccountAggregationSource": {
+      "type": "structure",
+      "members": {
+        "AccountIds": {
+          "target": "com.amazonaws.configservice#AccountAggregationSourceAccountList",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the account being aggregated.\n\t\t</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AllAwsRegions": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If true, aggregate existing Config regions and future\n\t\t\tregions.</p>"
+          }
+        },
+        "AwsRegions": {
+          "target": "com.amazonaws.configservice#AggregatorRegionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The source regions being aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A collection of accounts and regions.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AccountAggregationSourceAccountList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AccountId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.configservice#AccountAggregationSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AccountAggregationSource"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.configservice#AccountId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^\\d{12}$"
+      }
+    },
+    "com.amazonaws.configservice#AggregateComplianceByConfigRule": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>"
+          }
+        },
+        "Compliance": {
+          "target": "com.amazonaws.configservice#Compliance",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether an Amazon Web Services resource or Config rule is\n\t\t\tcompliant and provides the number of contributors that affect the\n\t\t\tcompliance.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the source account.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region from where the data is aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates whether an Config rule is compliant based on\n\t\t\taccount ID, region, compliance, and rule name.</p>\n         <p>A rule is compliant if all of the resources that the rule\n\t\t\tevaluated comply with it. It is noncompliant if any of these\n\t\t\tresources do not comply.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateComplianceByConfigRuleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateComplianceByConfigRule"
+      }
+    },
+    "com.amazonaws.configservice#AggregateComplianceByConformancePack": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the conformance pack.</p>"
+          }
+        },
+        "Compliance": {
+          "target": "com.amazonaws.configservice#AggregateConformancePackCompliance",
+          "traits": {
+            "smithy.api#documentation": "<p>The compliance status of the conformance pack.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit Amazon Web Services account ID of the source account.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source Amazon Web Services Region from where the data is aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides aggregate compliance of the conformance pack. Indicates whether a conformance pack is compliant based on the name of the conformance pack, account ID, and region.</p>\n         <p>A conformance pack is compliant if all of the rules in a conformance packs are compliant. It is noncompliant if any of the rules are not compliant.\n\t\t\tThe compliance status of a conformance pack is INSUFFICIENT_DATA only if all rules within a conformance pack cannot be evaluated due to insufficient data.\n\t\t\tIf some of the rules in a conformance pack are compliant but the compliance status of other rules in that same conformance pack is INSUFFICIENT_DATA, the conformance pack shows \n\t\t\tcompliant.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateComplianceByConformancePackList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateComplianceByConformancePack"
+      }
+    },
+    "com.amazonaws.configservice#AggregateComplianceCount": {
+      "type": "structure",
+      "members": {
+        "GroupName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID or region based on the GroupByKey\n\t\t\tvalue.</p>"
+          }
+        },
+        "ComplianceSummary": {
+          "target": "com.amazonaws.configservice#ComplianceSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of compliant and noncompliant Config\n\t\t\trules.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the number of compliant and noncompliant rules for one\n\t\t\tor more accounts and regions in an aggregator.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateComplianceCountList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateComplianceCount"
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackCompliance": {
+      "type": "structure",
+      "members": {
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The compliance status of the conformance pack.</p>"
+          }
+        },
+        "CompliantRuleCount": {
+          "target": "com.amazonaws.configservice#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of compliant Config Rules.</p>"
+          }
+        },
+        "NonCompliantRuleCount": {
+          "target": "com.amazonaws.configservice#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of noncompliant Config Rules.</p>"
+          }
+        },
+        "TotalRuleCount": {
+          "target": "com.amazonaws.configservice#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Total number of compliant rules, noncompliant rules, and the rules that do not have any applicable resources to evaluate upon resulting in insufficient data.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the number of compliant and noncompliant rules within a conformance pack.\n\t\t\tAlso provides the compliance status of the conformance pack and the total rule count which includes compliant rules, noncompliant rules, and rules that cannot be evaluated due to insufficient data.</p>\n         <p>A conformance pack is compliant if all of the rules in a conformance packs are compliant. It is noncompliant if any of the rules are not compliant.\n\t\t\tThe compliance status of a conformance pack is INSUFFICIENT_DATA only if all rules within a conformance pack cannot be evaluated due to insufficient data.\n\t\t\tIf some of the rules in a conformance pack are compliant but the compliance status of other rules in that same conformance pack is INSUFFICIENT_DATA, the conformance pack shows compliant.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackComplianceCount": {
+      "type": "structure",
+      "members": {
+        "CompliantConformancePackCount": {
+          "target": "com.amazonaws.configservice#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Number of compliant conformance packs.</p>"
+          }
+        },
+        "NonCompliantConformancePackCount": {
+          "target": "com.amazonaws.configservice#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Number of noncompliant conformance packs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of conformance packs that are compliant and noncompliant.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackComplianceFilters": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the conformance pack.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The compliance status of the conformance pack.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit Amazon Web Services account ID of the source account.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source Amazon Web Services Region from where the data is aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the conformance packs based on an account ID, region, compliance type, and the name of the conformance pack.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackComplianceSummary": {
+      "type": "structure",
+      "members": {
+        "ComplianceSummary": {
+          "target": "com.amazonaws.configservice#AggregateConformancePackComplianceCount",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an <code>AggregateConformancePackComplianceCount</code> object. </p>"
+          }
+        },
+        "GroupName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Groups the result based on Amazon Web Services account ID or Amazon Web Services Region.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a summary of compliance based on either account ID or region. </p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackComplianceSummaryFilters": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit Amazon Web Services account ID of the source account.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source Amazon Web Services Region from where the data is aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the results based on account ID and region. </p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackComplianceSummaryGroupKey": {
+      "type": "enum",
+      "members": {
+        "ACCOUNT_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_ID"
+          }
+        },
+        "AWS_REGION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_REGION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#AggregateConformancePackComplianceSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateConformancePackComplianceSummary"
+      }
+    },
+    "com.amazonaws.configservice#AggregateEvaluationResult": {
+      "type": "structure",
+      "members": {
+        "EvaluationResultIdentifier": {
+          "target": "com.amazonaws.configservice#EvaluationResultIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>Uniquely identifies the evaluation result.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource compliance status.</p>\n         <p>For the <code>AggregationEvaluationResult</code> data type, Config supports only the <code>COMPLIANT</code> and\n\t\t\t\t<code>NON_COMPLIANT</code>. Config does not support the\n\t\t\t\t<code>NOT_APPLICABLE</code> and <code>INSUFFICIENT_DATA</code>\n\t\t\tvalue.</p>"
+          }
+        },
+        "ResultRecordedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when Config recorded the aggregate evaluation\n\t\t\tresult.</p>"
+          }
+        },
+        "ConfigRuleInvokedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Config rule evaluated the Amazon Web Services\n\t\t\tresource.</p>"
+          }
+        },
+        "Annotation": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Supplementary information about how the agrregate evaluation\n\t\t\tdetermined the compliance.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the source account.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region from where the data is aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of an Config evaluation for an account ID and\n\t\t\tregion in an aggregator. Provides the Amazon Web Services resource that was\n\t\t\tevaluated, the compliance of the resource, related time stamps, and\n\t\t\tsupplementary information. </p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregateEvaluationResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateEvaluationResult"
+      }
+    },
+    "com.amazonaws.configservice#AggregateResourceIdentifier": {
+      "type": "structure",
+      "members": {
+        "SourceAccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the source account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region where data is aggregated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon Web Services resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details that identify a resource that is collected by Config aggregator, including the resource type, ID, (if available) the custom resource name, the source account, and source region.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregatedSourceStatus": {
+      "type": "structure",
+      "members": {
+        "SourceId": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The source account ID or an organization.</p>"
+          }
+        },
+        "SourceType": {
+          "target": "com.amazonaws.configservice#AggregatedSourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The source account or an organization.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region authorized to collect aggregated data.</p>"
+          }
+        },
+        "LastUpdateStatus": {
+          "target": "com.amazonaws.configservice#AggregatedSourceStatusType",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the last updated status type.</p>\n         <ul>\n            <li>\n               <p>Valid value FAILED indicates errors while moving\n\t\t\t\t\tdata.</p>\n            </li>\n            <li>\n               <p>Valid value SUCCEEDED indicates the data was\n\t\t\t\t\tsuccessfully moved.</p>\n            </li>\n            <li>\n               <p>Valid value OUTDATED indicates the data is not the most\n\t\t\t\t\trecent.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the last update.</p>"
+          }
+        },
+        "LastErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code that Config returned when the source account\n\t\t\taggregation last failed.</p>"
+          }
+        },
+        "LastErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The message indicating that the source account aggregation\n\t\t\tfailed due to an error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The current sync status between the source and the aggregator\n\t\t\taccount.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregatedSourceStatusList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregatedSourceStatus"
+      }
+    },
+    "com.amazonaws.configservice#AggregatedSourceStatusType": {
+      "type": "enum",
+      "members": {
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "OUTDATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OUTDATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#AggregatedSourceStatusTypeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregatedSourceStatusType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.configservice#AggregatedSourceType": {
+      "type": "enum",
+      "members": {
+        "ACCOUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT"
+          }
+        },
+        "ORGANIZATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ORGANIZATION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#AggregationAuthorization": {
+      "type": "structure",
+      "members": {
+        "AggregationAuthorizationArn": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the aggregation\n\t\t\tobject.</p>"
+          }
+        },
+        "AuthorizedAccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the account authorized to aggregate\n\t\t\tdata.</p>"
+          }
+        },
+        "AuthorizedAwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region authorized to collect aggregated data.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp when the aggregation authorization was\n\t\t\tcreated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the authorizations granted to\n\t\t\taggregator accounts and regions.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregationAuthorizationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregationAuthorization"
+      }
+    },
+    "com.amazonaws.configservice#AggregatorFilterResourceType": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.configservice#AggregatorFilterType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resource type filter to apply. <code>INCLUDE</code> specifies that the list of resource types in the <code>Value</code> field will be aggregated and no other resource types will be filtered.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.configservice#ResourceTypeValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>Comma-separate list of resource types to filter your aggregated configuration recorders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object to filter the configuration recorders based on the resource types in scope for recording.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregatorFilterServicePrincipal": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.configservice#AggregatorFilterType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of service principal filter to apply. <code>INCLUDE</code> specifies that the list of service principals in the <code>Value</code> field will be aggregated and no other service principals will be filtered.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.configservice#ServicePrincipalValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>Comma-separated list of service principals for the linked Amazon Web Services services to filter your aggregated service-linked configuration recorders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object to filter service-linked configuration recorders in an aggregator based on the linked Amazon Web Services service.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregatorFilterType": {
+      "type": "enum",
+      "members": {
+        "INCLUDE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INCLUDE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#AggregatorFilters": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#AggregatorFilterResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>An object to filter the configuration recorders based on the resource types in scope for recording.</p>"
+          }
+        },
+        "ServicePrincipal": {
+          "target": "com.amazonaws.configservice#AggregatorFilterServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>An object to filter service-linked configuration recorders in an aggregator based on the linked Amazon Web Services service.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object to filter the data you specify for an aggregator.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AggregatorRegionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#String"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.configservice#AllSupported": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.configservice#AmazonResourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.configservice#Annotation": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#AssociateResourceTypes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#AssociateResourceTypesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#AssociateResourceTypesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds all resource types specified in the <code>ResourceTypes</code> list to the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> of specified configuration recorder and includes those resource types when recording.</p>\n         <p>For this operation, the specified configuration recorder must use a <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> that is either <code>INCLUSION_BY_RESOURCE_TYPES</code> or <code>EXCLUSION_BY_RESOURCE_TYPES</code>.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AssociateResourceTypesRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceTypes": {
+          "target": "com.amazonaws.configservice#ResourceTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of resource types you want to add to the recording group of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#AssociateResourceTypesResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorder": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorder",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#AutoRemediationAttemptSeconds": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 2678000
+        }
+      }
+    },
+    "com.amazonaws.configservice#AutoRemediationAttempts": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#AvailabilityZone": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#AwsRegion": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.configservice#AzureClientIdentifier": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#AzureConnectorConfiguration": {
+      "type": "structure",
+      "members": {
+        "tenantIdentifier": {
+          "target": "com.amazonaws.configservice#AzureTenantIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The Azure tenant identifier.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "clientIdentifier": {
+          "target": "com.amazonaws.configservice#AzureClientIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The Azure client identifier.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration details for connecting to Microsoft Azure.</p>"
+      }
+    },
+    "com.amazonaws.configservice#AzureTenantIdentifier": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#BaseConfigurationItem": {
+      "type": "structure",
+      "members": {
+        "version": {
+          "target": "com.amazonaws.configservice#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the resource configuration.</p>"
+          }
+        },
+        "accountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit Amazon Web Services account ID associated with the resource.</p>"
+          }
+        },
+        "configurationItemCaptureTime": {
+          "target": "com.amazonaws.configservice#ConfigurationItemCaptureTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the recording of configuration changes was initiated for the resource.</p>"
+          }
+        },
+        "configurationItemStatus": {
+          "target": "com.amazonaws.configservice#ConfigurationItemStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration item status. Valid values include:</p>\n         <ul>\n            <li>\n               <p>OK \u2013 The resource configuration has been updated.</p>\n            </li>\n            <li>\n               <p>ResourceDiscovered \u2013 The resource was newly discovered.</p>\n            </li>\n            <li>\n               <p>ResourceNotRecorded \u2013 The resource was discovered, but its configuration was not recorded since the recorder doesn't record resources of this type.</p>\n            </li>\n            <li>\n               <p>ResourceDeleted \u2013 The resource was deleted</p>\n            </li>\n            <li>\n               <p>ResourceDeletedNotRecorded \u2013 The resource was deleted, but its configuration was not recorded since the recorder doesn't record resources of this type.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "configurationStateId": {
+          "target": "com.amazonaws.configservice#ConfigurationStateId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that indicates the ordering of the configuration\n\t\t\titems of a resource.</p>"
+          }
+        },
+        "arn": {
+          "target": "com.amazonaws.configservice#ARN",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource.</p>"
+          }
+        },
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of Amazon Web Services resource.</p>"
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example., sg-xxxxxx).</p>"
+          }
+        },
+        "resourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name of the resource, if available.</p>"
+          }
+        },
+        "awsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region where the resource resides.</p>"
+          }
+        },
+        "availabilityZone": {
+          "target": "com.amazonaws.configservice#AvailabilityZone",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone associated with the resource.</p>"
+          }
+        },
+        "resourceCreationTime": {
+          "target": "com.amazonaws.configservice#ResourceCreationTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp when the resource was created.</p>"
+          }
+        },
+        "configuration": {
+          "target": "com.amazonaws.configservice#Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>A JSON-encoded string that contains the contents for the resource configuration. This string needs to be deserialized using <code>json.loads()</code> before you can access the contents.\n</p>"
+          }
+        },
+        "supplementaryConfiguration": {
+          "target": "com.amazonaws.configservice#SupplementaryConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A string to string map that contains additional contents for the resource configuration.Config returns this field for certain\n\t\t\tresource types to supplement the information returned for the\n\t\t\t<code>configuration</code> field.</p>\n         <p>This string needs to be deserialized using <code>json.loads()</code> before you can access the contents.</p>"
+          }
+        },
+        "recordingFrequency": {
+          "target": "com.amazonaws.configservice#RecordingFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The recording frequency that Config uses to record configuration changes for the resource.</p>\n         <note>\n            <p>This field only appears in the API response when <code>DAILY</code> recording is enabled for a resource type.\n\t\t\t\tIf this field is not present, <code>CONTINUOUS</code> recording is enabled for that resource type. For more information on daily recording and continuous recording, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-recording-frequency\">Recording Frequency</a> in the <i>Config\n\t\t\t\t\t\tDeveloper Guide</i>.</p>\n         </note>"
+          }
+        },
+        "configurationItemDeliveryTime": {
+          "target": "com.amazonaws.configservice#ConfigurationItemDeliveryTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when configuration changes for the resource were delivered.</p>\n         <note>\n            <p>This field is optional and is not guaranteed to be present in a configuration item  (CI). If you are using daily recording,\n\t\t\tthis field will be populated. However, if you are using continuous recording,\n\t\t\tthis field will be omitted since the delivery time is instantaneous as the CI is available right away. For more information on daily recording and continuous recording, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-recording-frequency\">Recording Frequency</a> in the <i>Config\n\t\t\t\t\tDeveloper Guide</i>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The detailed configurations of a specified resource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#BaseConfigurationItems": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#BaseConfigurationItem"
+      }
+    },
+    "com.amazonaws.configservice#BaseResourceId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 768
+        }
+      }
+    },
+    "com.amazonaws.configservice#BatchGetAggregateResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#BatchGetAggregateResourceConfigRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#BatchGetAggregateResourceConfigResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the current configuration items for resources that are present in your Config aggregator. The operation also returns a list of resources that are not processed in the current request. \n\t\t\tIf there are no unprocessed resources, the operation returns an empty <code>unprocessedResourceIdentifiers</code> list. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>The API does not return results for deleted resources.</p>\n               </li>\n               <li>\n                  <p> The API does not return tags and relationships.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#BatchGetAggregateResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceIdentifiers": {
+          "target": "com.amazonaws.configservice#ResourceIdentifiersList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of aggregate ResourceIdentifiers objects. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#BatchGetAggregateResourceConfigResponse": {
+      "type": "structure",
+      "members": {
+        "BaseConfigurationItems": {
+          "target": "com.amazonaws.configservice#BaseConfigurationItems",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the current configuration of one or more resources.</p>"
+          }
+        },
+        "UnprocessedResourceIdentifiers": {
+          "target": "com.amazonaws.configservice#UnprocessedResourceIdentifierList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of resource identifiers that were not processed with current scope. The list is empty if all the resources are processed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#BatchGetResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#BatchGetResourceConfigRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#BatchGetResourceConfigResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoAvailableConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the <code>BaseConfigurationItem</code> for one or more requested resources.\n\t\t\tThe operation also returns a list of resources that are\n\t\t\tnot processed in the current request. If there are no unprocessed\n\t\t\tresources, the operation returns an empty unprocessedResourceKeys\n\t\t\tlist. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>The API does not return results for deleted\n\t\t\t\t\t\tresources.</p>\n               </li>\n               <li>\n                  <p> The API does not return any tags for the requested\n\t\t\t\t\t\tresources. This information is filtered out of the\n\t\t\t\t\t\tsupplementaryConfiguration section of the API\n\t\t\t\t\t\tresponse.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#BatchGetResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "resourceKeys": {
+          "target": "com.amazonaws.configservice#ResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of resource keys to be processed with the current\n\t\t\trequest. Each element in the list consists of the resource type and\n\t\t\tresource ID.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#BatchGetResourceConfigResponse": {
+      "type": "structure",
+      "members": {
+        "baseConfigurationItems": {
+          "target": "com.amazonaws.configservice#BaseConfigurationItems",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the current configuration of one or more\n\t\t\tresources.</p>"
+          }
+        },
+        "unprocessedResourceKeys": {
+          "target": "com.amazonaws.configservice#ResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of resource keys that were not processed with the\n\t\t\tcurrent response. The unprocessesResourceKeys value is in the same\n\t\t\tform as ResourceKeys, so the value can be directly provided to a\n\t\t\tsubsequent BatchGetResourceConfig operation.\n\t\t\t\n\t\t\tIf there are no unprocessed resource keys, the response contains an\n\t\t\tempty unprocessedResourceKeys list. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#Boolean": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.configservice#ChannelName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#ChronologicalOrder": {
+      "type": "enum",
+      "members": {
+        "Reverse": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Reverse"
+          }
+        },
+        "Forward": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Forward"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ClientToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 64,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#Compliance": {
+      "type": "structure",
+      "members": {
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether an Amazon Web Services resource or Config rule is\n\t\t\tcompliant.</p>\n         <p>A resource is compliant if it complies with all of the Config rules that evaluate it. A resource is noncompliant if it does\n\t\t\tnot comply with one or more of these rules.</p>\n         <p>A rule is compliant if all of the resources that the rule\n\t\t\tevaluates comply with it. A rule is noncompliant if any of these\n\t\t\tresources do not comply.</p>\n         <p>Config returns the <code>INSUFFICIENT_DATA</code> value\n\t\t\twhen no evaluation results are available for the Amazon Web Services resource or Config rule.</p>\n         <p>For the <code>Compliance</code> data type, Config supports\n\t\t\tonly <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and\n\t\t\t\t<code>INSUFFICIENT_DATA</code> values. Config does not\n\t\t\tsupport the <code>NOT_APPLICABLE</code> value for the\n\t\t\t\t<code>Compliance</code> data type.</p>"
+          }
+        },
+        "ComplianceContributorCount": {
+          "target": "com.amazonaws.configservice#ComplianceContributorCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources or Config rules that cause a\n\t\t\tresult of <code>NON_COMPLIANT</code>, up to a maximum\n\t\t\tnumber.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates whether an Amazon Web Services resource or Config rule is\n\t\t\tcompliant and provides the number of contributors that affect the\n\t\t\tcompliance.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceByConfigRule": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit64",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>"
+          }
+        },
+        "Compliance": {
+          "target": "com.amazonaws.configservice#Compliance",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the Config rule is compliant.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates whether an Config rule is compliant. A rule is\n\t\t\tcompliant if all of the resources that the rule evaluated comply\n\t\t\twith it. A rule is noncompliant if any of these resources do not\n\t\t\tcomply.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceByConfigRules": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ComplianceByConfigRule"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceByResource": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "Compliance": {
+          "target": "com.amazonaws.configservice#Compliance",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the Amazon Web Services resource complies with all of the Config rules that evaluated it.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates whether an Amazon Web Services resource that is evaluated according\n\t\t\tto one or more Config rules is compliant. A resource is\n\t\t\tcompliant if it complies with all of the rules that evaluate it. A\n\t\t\tresource is noncompliant if it does not comply with one or more of\n\t\t\tthese rules.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceByResources": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ComplianceByResource"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceContributorCount": {
+      "type": "structure",
+      "members": {
+        "CappedCount": {
+          "target": "com.amazonaws.configservice#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources or Config rules responsible for\n\t\t\tthe current compliance of the item.</p>"
+          }
+        },
+        "CapExceeded": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Indicates whether the maximum count is reached.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of Amazon Web Services resources or Config rules responsible for\n\t\t\tthe current compliance of the item, up to a maximum\n\t\t\tnumber.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceResourceTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit256"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ComplianceScore": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#ComplianceSummariesByResourceType": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ComplianceSummaryByResourceType"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceSummary": {
+      "type": "structure",
+      "members": {
+        "CompliantResourceCount": {
+          "target": "com.amazonaws.configservice#ComplianceContributorCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Config rules or Amazon Web Services resources that are\n\t\t\tcompliant, up to a maximum of 25 for rules and 100 for\n\t\t\tresources.</p>"
+          }
+        },
+        "NonCompliantResourceCount": {
+          "target": "com.amazonaws.configservice#ComplianceContributorCount",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Config rules or Amazon Web Services resources that are\n\t\t\tnoncompliant, up to a maximum of 25 for rules and 100 for\n\t\t\tresources.</p>"
+          }
+        },
+        "ComplianceSummaryTimestamp": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that Config created the compliance\n\t\t\tsummary.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of Config rules or Amazon Web Services resources that are\n\t\t\tcompliant and noncompliant.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceSummaryByResourceType": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of Amazon Web Services resource.</p>"
+          }
+        },
+        "ComplianceSummary": {
+          "target": "com.amazonaws.configservice#ComplianceSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources that are compliant or noncompliant,\n\t\t\tup to a maximum of 100 for each.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of Amazon Web Services resources of a specific type that are\n\t\t\tcompliant or noncompliant, up to a maximum of 100 for\n\t\t\teach.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ComplianceType": {
+      "type": "enum",
+      "members": {
+        "Compliant": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLIANT"
+          }
+        },
+        "Non_Compliant": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NON_COMPLIANT"
+          }
+        },
+        "Not_Applicable": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOT_APPLICABLE"
+          }
+        },
+        "Insufficient_Data": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSUFFICIENT_DATA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ComplianceTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ComplianceType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 3
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigExportDeliveryInfo": {
+      "type": "structure",
+      "members": {
+        "lastStatus": {
+          "target": "com.amazonaws.configservice#DeliveryStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status of the last attempted delivery.</p>"
+          }
+        },
+        "lastErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code from the last attempted delivery.</p>"
+          }
+        },
+        "lastErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message from the last attempted delivery.</p>"
+          }
+        },
+        "lastAttemptTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the last attempted delivery.</p>"
+          }
+        },
+        "lastSuccessfulTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the last successful delivery.</p>"
+          }
+        },
+        "nextDeliveryTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the next delivery occurs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides status of the delivery of the snapshot or the\n\t\t\tconfiguration history to the specified Amazon S3 bucket. Also\n\t\t\tprovides the status of notifications about the Amazon S3 delivery to\n\t\t\tthe specified Amazon SNS topic.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRule": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assign to the Config rule. The name is\n\t\t\trequired if you are adding a new rule.</p>"
+          }
+        },
+        "ConfigRuleArn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Config\n\t\t\trule.</p>"
+          }
+        },
+        "ConfigRuleId": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit64",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Config rule.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.configservice#EmptiableStringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The description that you provide for the Config\n\t\t\trule.</p>"
+          }
+        },
+        "Scope": {
+          "target": "com.amazonaws.configservice#Scope",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines which resources can trigger an evaluation for the rule.\n\t\t\tThe scope can include one or more resource types, a combination of\n\t\t\tone resource type and one resource ID, or a combination of a tag key\n\t\t\tand value. Specify a scope to constrain the resources that can\n\t\t\ttrigger an evaluation for the rule. If you do not specify a scope,\n\t\t\tevaluations are triggered when any resource in the recording group\n\t\t\tchanges.</p>"
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.configservice#Source",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the rule owner (<code>Amazon Web Services</code> for managed rules, <code>CUSTOM_POLICY</code> for Custom Policy rules, and <code>CUSTOM_LAMBDA</code> for Custom Lambda rules), the rule identifier,\n\t\t\tand the notifications that cause the function to evaluate your Amazon Web Services\n\t\t\tresources.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputParameters": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A string, in JSON format, that is passed to the Config rule\n\t\t\tLambda function.</p>"
+          }
+        },
+        "MaximumExecutionFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum frequency with which Config runs evaluations\n\t\t\tfor a rule. You can specify a value for\n\t\t\t\t<code>MaximumExecutionFrequency</code> when:</p>\n         <ul>\n            <li>\n               <p>This is for an Config managed rule that is triggered at\n\t\t\t\t\ta periodic frequency.</p>\n            </li>\n            <li>\n               <p>Your custom rule is triggered when Config delivers\n\t\t\t\t\tthe configuration snapshot. For more information, see <a>ConfigSnapshotDeliveryProperties</a>.</p>\n            </li>\n         </ul>\n         <note>\n            <p>By default, rules with a periodic trigger are evaluated\n\t\t\t\tevery 24 hours. To change the frequency, specify a valid value\n\t\t\t\tfor the <code>MaximumExecutionFrequency</code>\n\t\t\t\tparameter.</p>\n         </note>"
+          }
+        },
+        "ConfigRuleState": {
+          "target": "com.amazonaws.configservice#ConfigRuleState",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the Config rule is active or is currently\n\t\t\tbeing deleted by Config. It can also indicate the evaluation\n\t\t\tstatus for the Config rule.</p>\n         <p>Config sets the state of the rule to\n\t\t\t\t<code>EVALUATING</code> temporarily after you use the\n\t\t\t\t<code>StartConfigRulesEvaluation</code> request to evaluate your\n\t\t\tresources against the Config rule.</p>\n         <p>Config sets the state of the rule to\n\t\t\t\t<code>DELETING_RESULTS</code> temporarily after you use the\n\t\t\t\t<code>DeleteEvaluationResults</code> request to delete the\n\t\t\tcurrent evaluation results for the Config rule.</p>\n         <p>Config temporarily sets the state of a rule to\n\t\t\t\t<code>DELETING</code> after you use the\n\t\t\t\t<code>DeleteConfigRule</code> request to delete the rule. After\n\t\t\tConfig deletes the rule, the rule and all of its evaluations are\n\t\t\terased and are no longer available.</p>"
+          }
+        },
+        "CreatedBy": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Service principal name of the service that created the\n\t\t\trule.</p>\n         <note>\n            <p>The field is populated only if the service-linked rule is\n\t\t\t\tcreated by a service. The field is empty if you create your own\n\t\t\t\trule.</p>\n         </note>"
+          }
+        },
+        "EvaluationModes": {
+          "target": "com.amazonaws.configservice#EvaluationModes",
+          "traits": {
+            "smithy.api#documentation": "<p>The modes the Config rule can be evaluated in. The valid values are distinct objects. By default, the value is Detective evaluation mode only.</p>"
+          }
+        },
+        "RuleEvaluationVisibility": {
+          "target": "com.amazonaws.configservice#RuleEvaluationVisibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether you can get <a>Evaluation</a>s for the Config rule. You can get <a>Evaluation</a>s for the Amazon Web Services Config rule if this value is <code>EXTERNAL</code>. You cannot get <a>Evaluation</a>s for the Amazon Web Services Config rule if this value is <code>INTERNAL</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Config rules evaluate the configuration settings of your Amazon Web Services resources. A rule can run when Config detects a configuration change to\n\t\t\tan Amazon Web Services resource or at a periodic frequency that you choose (for\n\t\t\texample, every 24 hours). There are two types of rules: <i>Config Managed Rules</i> and <i>Config Custom Rules</i>.</p>\n         <p>Config Managed Rules are predefined,\n\t\t\t\tcustomizable rules created by Config. For a list of managed rules, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html\">List of Config\n\t\t\t\t\tManaged Rules</a>.</p>\n         <p>Config Custom Rules are rules that you create from scratch. There are two ways to create Config custom rules: with Lambda functions\n\t\t\t\t(<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/gettingstarted-concepts.html#gettingstarted-concepts-function\"> Lambda Developer Guide</a>) and with Guard (<a href=\"https://github.com/aws-cloudformation/cloudformation-guard\">Guard GitHub\n\t\t\t\t\t\tRepository</a>), a policy-as-code language.\n\t\t\t\t\n\t\t\t\tConfig custom rules created with Lambda\n\t\t\t\tare called <i>Config Custom Lambda Rules</i> and Config custom rules created with\n\t\t\t\tGuard are called <i>Config Custom Policy Rules</i>.</p>\n         <p>For more information about developing and using Config\n\t\t\trules, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html\">Evaluating Resource with Config Rules</a>\n\t\t\tin the <i>Config Developer Guide</i>.</p>\n         <note>\n            <p>You can use the Amazon Web Services CLI and Amazon Web Services SDKs if you want to create\n\t\t\t\ta rule that triggers evaluations for your resources when Config delivers the configuration snapshot. For more\n\t\t\t\tinformation, see <a>ConfigSnapshotDeliveryProperties</a>.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleComplianceFilters": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The rule compliance status.</p>\n         <p>For the <code>ConfigRuleComplianceFilters</code> data type, Config supports only <code>COMPLIANT</code> and\n\t\t\t\t<code>NON_COMPLIANT</code>. Config does not support the\n\t\t\t\t<code>NOT_APPLICABLE</code> and the\n\t\t\t\t<code>INSUFFICIENT_DATA</code> values.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the source account.\n\t\t\t</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region where the data is aggregated.\n\t\t\t</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the compliance results based on account ID, region,\n\t\t\tcompliance type, and rule name.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleComplianceSummaryFilters": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the source account.</p>"
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region where the data is aggregated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the results based on the account IDs and\n\t\t\tregions.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleComplianceSummaryGroupKey": {
+      "type": "enum",
+      "members": {
+        "ACCOUNT_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_ID"
+          }
+        },
+        "AWS_REGION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_REGION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleEvaluationStatus": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>"
+          }
+        },
+        "ConfigRuleArn": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Config\n\t\t\trule.</p>"
+          }
+        },
+        "ConfigRuleId": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Config rule.</p>"
+          }
+        },
+        "LastSuccessfulInvocationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that Config last successfully invoked the Config rule to evaluate your Amazon Web Services resources.</p>"
+          }
+        },
+        "LastFailedInvocationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that Config last failed to invoke the Config\n\t\t\trule to evaluate your Amazon Web Services resources.</p>"
+          }
+        },
+        "LastSuccessfulEvaluationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that Config last successfully evaluated your Amazon Web Services\n\t\t\tresources against the rule.</p>"
+          }
+        },
+        "LastFailedEvaluationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that Config last failed to evaluate your Amazon Web Services\n\t\t\tresources against the rule.</p>"
+          }
+        },
+        "FirstActivatedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that you first activated the Config\n\t\t\trule.</p>"
+          }
+        },
+        "LastDeactivatedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that you last turned off the Config rule.</p>"
+          }
+        },
+        "LastErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code that Config returned when the rule last\n\t\t\tfailed.</p>"
+          }
+        },
+        "LastErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message that Config returned when the rule last\n\t\t\tfailed.</p>"
+          }
+        },
+        "FirstEvaluationStarted": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Indicates whether Config has evaluated your resources\n\t\t\tagainst the rule at least once.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>true</code> - Config has evaluated your Amazon Web Services\n\t\t\t\t\tresources against the rule at least once.</p>\n            </li>\n            <li>\n               <p>\n                  <code>false</code> - Config has not finished evaluating your Amazon Web Services resources against the\n\t\t\t\t\trule\n\t\t\t\t\tat least once.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "LastDebugLogDeliveryStatus": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the last attempted delivery of a debug log for your Config Custom Policy rules. Either <code>Successful</code> or <code>Failed</code>.</p>"
+          }
+        },
+        "LastDebugLogDeliveryStatusReason": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason Config was not able to deliver a debug log. This is for the last\n\t\t\tfailed attempt to retrieve a debug log for your Config Custom Policy rules.</p>"
+          }
+        },
+        "LastDebugLogDeliveryTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time Config last attempted to deliver a debug log for your Config Custom Policy rules.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Status information for your Config Managed rules and Config Custom Policy rules. The\n\t\t\tstatus includes information such as the last time the rule ran, the\n\t\t\tlast time it failed, and the related error for the last\n\t\t\tfailure.</p>\n         <p>This operation does not return status information about Config Custom Lambda rules.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleEvaluationStatusList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigRuleEvaluationStatus"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleNames": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigRuleName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigRuleState": {
+      "type": "enum",
+      "members": {
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "DELETING_RESULTS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING_RESULTS"
+          }
+        },
+        "EVALUATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EVALUATING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigRules": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigRule"
+      }
+    },
+    "com.amazonaws.configservice#ConfigSnapshotDeliveryProperties": {
+      "type": "structure",
+      "members": {
+        "deliveryFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The frequency with which Config delivers configuration\n\t\t\tsnapshots.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides options for how often Config delivers\n\t\t\tconfiguration snapshots to the Amazon S3 bucket in your delivery\n\t\t\tchannel.</p>\n         <p>The frequency for a rule that triggers evaluations for your\n\t\t\tresources when Config delivers the configuration snapshot is set\n\t\t\tby one of two values, depending on which is less frequent:</p>\n         <ul>\n            <li>\n               <p>The value for the <code>deliveryFrequency</code>\n\t\t\t\t\tparameter within the delivery channel configuration, which\n\t\t\t\t\tsets how often Config delivers configuration snapshots.\n\t\t\t\t\tThis value also sets how often Config invokes\n\t\t\t\t\tevaluations for Config rules.</p>\n            </li>\n            <li>\n               <p>The value for the\n\t\t\t\t\t\t<code>MaximumExecutionFrequency</code> parameter, which\n\t\t\t\t\tsets the maximum frequency with which Config invokes\n\t\t\t\t\tevaluations for the rule. For more information, see <a>ConfigRule</a>.</p>\n            </li>\n         </ul>\n         <p>If the <code>deliveryFrequency</code> value is less frequent\n\t\t\tthan the <code>MaximumExecutionFrequency</code> value for a rule,\n\t\t\tConfig invokes the rule only as often as the\n\t\t\t\t<code>deliveryFrequency</code> value.</p>\n         <ol>\n            <li>\n               <p>For example, you want your rule to run evaluations when\n\t\t\t\t\tConfig delivers the configuration snapshot.</p>\n            </li>\n            <li>\n               <p>You specify the <code>MaximumExecutionFrequency</code>\n\t\t\t\t\tvalue for <code>Six_Hours</code>. </p>\n            </li>\n            <li>\n               <p>You then specify the delivery channel\n\t\t\t\t\t\t<code>deliveryFrequency</code> value for\n\t\t\t\t\t\t<code>TwentyFour_Hours</code>.</p>\n            </li>\n            <li>\n               <p>Because the value for <code>deliveryFrequency</code> is\n\t\t\t\t\tless frequent than <code>MaximumExecutionFrequency</code>,\n\t\t\t\t\tConfig invokes evaluations for the rule every 24 hours.\n\t\t\t\t</p>\n            </li>\n         </ol>\n         <p>You should set the <code>MaximumExecutionFrequency</code> value\n\t\t\tto be at least as frequent as the <code>deliveryFrequency</code>\n\t\t\tvalue. You can view the <code>deliveryFrequency</code> value by\n\t\t\tusing the <code>DescribeDeliveryChannnels</code> action.</p>\n         <p>To update the <code>deliveryFrequency</code> with which Config delivers your configuration snapshots, use the\n\t\t\t\t<code>PutDeliveryChannel</code> action.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigStreamDeliveryInfo": {
+      "type": "structure",
+      "members": {
+        "lastStatus": {
+          "target": "com.amazonaws.configservice#DeliveryStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status of the last attempted delivery.</p>\n         <p>\n            <b>Note</b> Providing an SNS topic on a\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeliveryChannel.html\">DeliveryChannel</a> for Config is optional. If the SNS\n\t\t\tdelivery is turned off, the last status will be <b>Not_Applicable</b>.</p>"
+          }
+        },
+        "lastErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code from the last attempted delivery.</p>"
+          }
+        },
+        "lastErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message from the last attempted delivery.</p>"
+          }
+        },
+        "lastStatusChangeTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time from the last status change.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list that contains the status of the delivery of the\n\t\t\tconfiguration stream notification to the Amazon SNS topic.</p>"
+      }
+    },
+    "com.amazonaws.configservice#Configuration": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#ConfigurationAggregator": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the aggregator.</p>"
+          }
+        },
+        "ConfigurationAggregatorArn": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the aggregator.</p>"
+          }
+        },
+        "AccountAggregationSources": {
+          "target": "com.amazonaws.configservice#AccountAggregationSourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a list of source accounts and regions to be\n\t\t\taggregated.</p>"
+          }
+        },
+        "OrganizationAggregationSource": {
+          "target": "com.amazonaws.configservice#OrganizationAggregationSource",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides an organization and list of regions to be\n\t\t\taggregated.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp when the configuration aggregator was\n\t\t\tcreated.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the last update.</p>"
+          }
+        },
+        "CreatedBy": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Web Services service that created the configuration aggregator.</p>"
+          }
+        },
+        "AggregatorFilters": {
+          "target": "com.amazonaws.configservice#AggregatorFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>An object to filter the data you specify for an aggregator.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details about the configuration aggregator, including\n\t\t\tinformation about source accounts, regions, and metadata of the\n\t\t\taggregator. </p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationAggregatorArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^arn:aws[a-z\\-]*:config:[a-z\\-\\d]+:\\d+:config-aggregator/config-aggregator-[a-z\\d]+$"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationAggregatorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationAggregator"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationAggregatorName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[\\w\\-]+$"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationAggregatorNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationAggregatorName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationItem": {
+      "type": "structure",
+      "members": {
+        "version": {
+          "target": "com.amazonaws.configservice#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the resource configuration.</p>"
+          }
+        },
+        "accountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit Amazon Web Services account ID associated with the\n\t\t\tresource.</p>"
+          }
+        },
+        "configurationItemCaptureTime": {
+          "target": "com.amazonaws.configservice#ConfigurationItemCaptureTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the recording of configuration changes was\n\t\t\tinitiated for the resource.</p>"
+          }
+        },
+        "configurationItemStatus": {
+          "target": "com.amazonaws.configservice#ConfigurationItemStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration item status. Valid values include:</p>\n         <ul>\n            <li>\n               <p>OK \u2013 The resource configuration has been updated</p>\n            </li>\n            <li>\n               <p>ResourceDiscovered \u2013 The resource was newly discovered</p>\n            </li>\n            <li>\n               <p>ResourceNotRecorded \u2013 The resource was discovered but its configuration was not recorded since the recorder doesn't record resources of this type</p>\n            </li>\n            <li>\n               <p>ResourceDeleted \u2013 The resource was deleted</p>\n            </li>\n            <li>\n               <p>ResourceDeletedNotRecorded \u2013 The resource was deleted but its configuration was not recorded since the recorder doesn't  record resources of this type</p>\n            </li>\n         </ul>"
+          }
+        },
+        "configurationStateId": {
+          "target": "com.amazonaws.configservice#ConfigurationStateId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that indicates the ordering of the configuration\n\t\t\titems of a resource.</p>"
+          }
+        },
+        "configurationItemMD5Hash": {
+          "target": "com.amazonaws.configservice#ConfigurationItemMD5Hash",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique MD5 hash that represents the configuration item's\n\t\t\tstate.</p>\n         <p>You can use MD5 hash to compare the states of two or more\n\t\t\tconfiguration items that are associated with the same\n\t\t\tresource.</p>"
+          }
+        },
+        "arn": {
+          "target": "com.amazonaws.configservice#ARN",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) associated with the resource.</p>"
+          }
+        },
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of Amazon Web Services resource.</p>"
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example,\n\t\t\t<code>sg-xxxxxx</code>).</p>"
+          }
+        },
+        "resourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name of the resource, if available.</p>"
+          }
+        },
+        "awsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region where the resource resides.</p>"
+          }
+        },
+        "availabilityZone": {
+          "target": "com.amazonaws.configservice#AvailabilityZone",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone associated with the resource.</p>"
+          }
+        },
+        "resourceCreationTime": {
+          "target": "com.amazonaws.configservice#ResourceCreationTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp when the resource was created.</p>"
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.configservice#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>A mapping of key value tags associated with the\n\t\t\tresource.</p>"
+          }
+        },
+        "relatedEvents": {
+          "target": "com.amazonaws.configservice#RelatedEventList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of CloudTrail event IDs.</p>\n         <p>A populated field indicates that the current configuration was\n\t\t\tinitiated by the events recorded in the CloudTrail log. For more\n\t\t\tinformation about CloudTrail, see <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/what_is_cloud_trail_top_level.html\">What Is CloudTrail</a>.</p>\n         <p>An empty field indicates that the current configuration was not\n\t\t\tinitiated by any event. As of Version 1.3, the relatedEvents field is empty. \n\t\t\tYou can access the <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_LookupEvents.html\">LookupEvents API</a> in the <i>CloudTrail API Reference</i> to retrieve the events for the resource.</p>"
+          }
+        },
+        "relationships": {
+          "target": "com.amazonaws.configservice#RelationshipList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of related Amazon Web Services resources.</p>"
+          }
+        },
+        "configuration": {
+          "target": "com.amazonaws.configservice#Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>A JSON-encoded string that contains the contents for the resource configuration. This string needs to be deserialized using <code>json.loads()</code> before you can access the contents.</p>"
+          }
+        },
+        "supplementaryConfiguration": {
+          "target": "com.amazonaws.configservice#SupplementaryConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>A string to string map that contains additional contents for the resource configuration.Config returns this field for certain\n\t\t\tresource types to supplement the information returned for the\n\t\t\t<code>configuration</code> field.</p>\n         <p>This string to string map needs to be deserialized using <code>json.loads()</code> before you can accessing the contents.</p>"
+          }
+        },
+        "recordingFrequency": {
+          "target": "com.amazonaws.configservice#RecordingFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The recording frequency that Config uses to record configuration changes for the resource.</p>\n         <note>\n            <p>This field only appears in the API response when <code>DAILY</code> recording is enabled for a resource type.\n\t\t\t\tIf this field is not present, <code>CONTINUOUS</code> recording is enabled for that resource type. For more information on daily recording and continuous recording, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-recording-frequency\">Recording Frequency</a> in the <i>Config\n\t\t\t\t\t\tDeveloper Guide</i>.</p>\n         </note>"
+          }
+        },
+        "configurationItemDeliveryTime": {
+          "target": "com.amazonaws.configservice#ConfigurationItemDeliveryTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when configuration changes for the resource were delivered.</p>\n         <note>\n            <p>This field is optional and is not guaranteed to be present in a configuration item  (CI). If you are using daily recording,\n\t\t\tthis field will be populated. However, if you are using continuous recording,\n\t\t\tthis field will be omitted since the delivery time is instantaneous as the CI is available right away.</p>\n            <p>For more information on daily recording and continuous recording, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-recording-frequency\">Recording Frequency</a> in the <i>Config\n\t\t\t\t\tDeveloper Guide</i>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list that contains detailed configurations of a specified\n\t\t\tresource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationItemCaptureTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#ConfigurationItemDeliveryTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#ConfigurationItemList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationItem"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationItemMD5Hash": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#ConfigurationItemStatus": {
+      "type": "enum",
+      "members": {
+        "OK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OK"
+          }
+        },
+        "ResourceDiscovered": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ResourceDiscovered"
+          }
+        },
+        "ResourceNotRecorded": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ResourceNotRecorded"
+          }
+        },
+        "ResourceDeleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ResourceDeleted"
+          }
+        },
+        "ResourceDeletedNotRecorded": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ResourceDeletedNotRecorded"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorder": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the specified configuration recorder.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration recorder.</p>\n         <p>For customer managed configuration recorders, Config automatically assigns the name of \"default\" when creating a configuration recorder if you do not specify a name at creation time.</p>\n         <p>For service-linked configuration recorders, Config automatically assigns a name that has the prefix \"<code>AWSConfigurationRecorderFor</code>\" to a new service-linked configuration recorder.</p>\n         <note>\n            <p>\n               <b>Changing the name of a configuration recorder</b>\n            </p>\n            <p>To change the name of the customer managed configuration recorder, you must delete it and create a new customer managed configuration recorder with a new name.</p>\n            <p>You cannot change the name of a service-linked configuration recorder.</p>\n         </note>"
+          }
+        },
+        "roleARN": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role assumed by Config and used by the specified configuration recorder.</p>\n         <note>\n            <p>\n               <b>The server will reject a request without a defined <code>roleARN</code> for the configuration recorder</b>\n            </p>\n            <p>While the API model does not require this field, the server will reject a request without a defined <code>roleARN</code> for the configuration recorder.</p>\n            <p>\n               <b>Policies and compliance results</b>\n            </p>\n            <p>\n               <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html\">IAM policies</a>\n\t\t\t\tand <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies.html\">other policies managed in Organizations</a>\n\t\t\t\tcan impact whether Config\n\t\t\t\thas permissions to record configuration changes for your resources. Additionally, rules directly evaluate the configuration of a resource and rules don't take into account these policies when running evaluations.\n\t\t\t\tMake sure that the policies in effect align with how you intend to use Config.</p>\n            <p>\n               <b>Keep Minimum Permisions When Reusing an IAM role</b>\n            </p>\n            <p>If you use an Amazon Web Services service that uses Config, such as Security Hub CSPM or\n\t\t\t\tControl Tower, and an IAM role has already been created, make sure that the\n\t\t\t\tIAM role that you use when setting up Config keeps the same minimum\n\t\t\t\tpermissions as the pre-existing IAM role. You must do this to ensure that the\n\t\t\t\tother Amazon Web Services service continues to run as expected. </p>\n            <p>For example, if Control Tower has an IAM role that allows Config to read\n\t\t\t\tS3 objects, make sure that the same permissions are granted\n\t\t\t\tto the IAM role you use when setting up Config. Otherwise, it may\n\t\t\t\tinterfere with how Control Tower operates.</p>\n            <p>\n               <b>The service-linked IAM role for Config must be used for service-linked configuration recorders</b>\n            </p>\n            <p>For service-linked configuration recorders, you must use the service-linked IAM role for Config: <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/using-service-linked-roles.html\">AWSServiceRoleForConfig</a>.</p>\n         </note>"
+          }
+        },
+        "recordingGroup": {
+          "target": "com.amazonaws.configservice#RecordingGroup",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies which resource types are in scope for the configuration recorder to record.</p>\n         <note>\n            <p>\n               <b> High Number of Config Evaluations</b>\n            </p>\n            <p>You might notice increased activity in your account during your initial month recording with Config when compared to subsequent months. During the\n\t\t\t\tinitial bootstrapping process, Config runs evaluations on all the resources in your account that you have selected\n\t\t\t\tfor Config to record.</p>\n            <p>If you are running ephemeral workloads, you may see increased activity from Config as it records configuration changes associated with creating and deleting these\n\t\t\t\ttemporary resources. An <i>ephemeral workload</i> is a temporary use of computing resources that are loaded\n\t\t\t\tand run when needed. Examples include Amazon Elastic Compute Cloud (Amazon EC2)\n\t\t\t\tSpot Instances, Amazon EMR jobs, and Auto Scaling.</p>\n            <p>If you want to avoid the increased activity from running ephemeral workloads, you can set up the configuration recorder to exclude these resource types from being recorded, or run these types of workloads in a separate account with Config turned off to avoid\n\t\t\t\tincreased configuration recording and rule evaluations.</p>\n         </note>"
+          }
+        },
+        "recordingMode": {
+          "target": "com.amazonaws.configservice#RecordingMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the default recording frequency for the configuration recorder.\n\t\t\t\n\t\t\tConfig supports <i>Continuous recording</i> and <i>Daily recording</i>.</p>\n         <ul>\n            <li>\n               <p>Continuous recording allows you to record configuration changes continuously whenever a change occurs.</p>\n            </li>\n            <li>\n               <p>Daily recording allows you to receive a configuration item (CI) representing the most recent state of your resources over the last 24-hour period, only if it\u2019s different from the previous CI recorded.\n\t\t\t</p>\n            </li>\n         </ul>\n         <note>\n            <p>\n               <b>Some resource types require continuous recording</b>\n            </p>\n            <p>Firewall Manager depends on continuous recording to monitor your resources. If you are using Firewall Manager,\n\t\t\tit is recommended that you set the recording frequency to Continuous.</p>\n         </note>\n         <p>You can also override the recording frequency for specific resource types.</p>"
+          }
+        },
+        "recordingScope": {
+          "target": "com.amazonaws.configservice#RecordingScope",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigurationItem.html\">ConfigurationItems</a> in scope for the specified configuration recorder are recorded for free (<code>INTERNAL</code>) or if it impacts the costs to your bill (<code>PAID</code>).</p>"
+          }
+        },
+        "servicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>For service-linked configuration recorders, specifies the linked Amazon Web Services service for the configuration recorder.</p>"
+          }
+        },
+        "connectorArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector that specifies the connection between a third-party cloud service provider and Config.</p>"
+          }
+        },
+        "scopeConfiguration": {
+          "target": "com.amazonaws.configservice#ScopeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the scope of resources to record from the third-party cloud service provider connected through the connector.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Records configuration changes to the resource types in scope.</p>\n         <p>For more information about the configuration recorder,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/stop-start-recorder.html\">\n               <b>Working with the Configuration Recorder</b>\n            </a> in the <i>Config Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderFilter": {
+      "type": "structure",
+      "members": {
+        "filterName": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the type of filter. Currently, only <code>recordingScope</code> is supported.</p>"
+          }
+        },
+        "filterValue": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderFilterValues",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the filter. For <code>recordingScope</code>, valid values include: <code>INTERNAL</code> and <code>PAID</code>.</p>\n         <p>\n            <code>INTERNAL</code> indicates that the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigurationItem.html\">ConfigurationItems</a> in scope for the configuration recorder are recorded for free.</p>\n         <p>\n            <code>PAID</code> indicates that the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigurationItem.html\">ConfigurationItems</a> in scope for the configuration recorder impact the costs to your bill.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters configuration recorders by recording scope.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationRecorderFilter"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderFilterName": {
+      "type": "enum",
+      "members": {
+        "RecordingScope": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "recordingScope"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderFilterValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^[0-9a-zA-Z\\\\*\\\\.\\\\\\/\\\\?-]*$"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderFilterValues": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationRecorderFilterValue"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationRecorder"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RecorderName"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderStatus": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the configuration recorder.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration recorder.</p>"
+          }
+        },
+        "lastStartTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the recorder was last started.</p>"
+          }
+        },
+        "lastStopTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the recorder was last stopped.</p>"
+          }
+        },
+        "recording": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether or not the recorder is currently\n\t\t\trecording.</p>"
+          }
+        },
+        "lastStatus": {
+          "target": "com.amazonaws.configservice#RecorderStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the latest recording event processed by the recorder.</p>"
+          }
+        },
+        "lastErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The latest error code from when the recorder last failed.</p>"
+          }
+        },
+        "lastErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The latest error message from when the recorder last failed.</p>"
+          }
+        },
+        "lastStatusChangeTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the latest change in status of an recording event processed by the recorder.</p>"
+          }
+        },
+        "servicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>For service-linked configuration recorders, the service principal of the linked Amazon Web Services service.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The current status of the configuration recorder.</p>\n         <p>For a detailed status of recording events over time, add your Config events to CloudWatch metrics and use CloudWatch metrics.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderStatusList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationRecorderStatus"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigurationRecorderSummary"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationRecorderSummary": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "servicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>For service-linked configuration recorders, indicates which Amazon Web Services service the configuration recorder is linked to.</p>"
+          }
+        },
+        "recordingScope": {
+          "target": "com.amazonaws.configservice#RecordingScope",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigurationItem.html\">ConfigurationItems</a> in scope for the configuration recorder are recorded for free (<code>INTERNAL</code>) or if you are charged a service fee for recording (<code>PAID</code>).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "provider": {
+          "target": "com.amazonaws.configservice#Provider",
+          "traits": {
+            "smithy.api#documentation": "<p>For service-linked configuration recorders that record resources from a third-party cloud service provider, indicates the cloud service provider. Currently, <code>AZURE</code> is supported.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of a configuration recorder, including the <code>arn</code>, <code>name</code>, <code>servicePrincipal</code>, <code>recordingScope</code>, and <code>provider</code>.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConfigurationStateId": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#ConflictException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutServiceLinkedConfigurationRecorder.html\">PutServiceLinkedConfigurationRecorder</a>, you cannot create a service-linked recorder because a service-linked recorder already exists for the specified service.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutThirdPartyServiceLinkedConfigurationRecorder.html\">PutThirdPartyServiceLinkedConfigurationRecorder</a>, you cannot create a service-linked recorder because the specified service principal does not support multiple configuration recorders and one already exists.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutThirdPartyServiceLinkedConfigurationRecorder.html\">PutThirdPartyServiceLinkedConfigurationRecorder</a>, another in-progress operation is currently referencing the same connector or service principal. Please try again later.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConnector.html\">PutConnector</a>, you cannot create a connector because a connector already exists for the specified connector configuration.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteServiceLinkedConfigurationRecorder.html\">DeleteServiceLinkedConfigurationRecorder</a>, you cannot delete the service-linked recorder because it is currently in use by the linked Amazon Web Services service.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteServiceLinkedConfigurationRecorder.html\">DeleteServiceLinkedConfigurationRecorder</a>, another in-progress operation is currently referencing the same connector. Please try again later.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteConnector.html\">DeleteConnector</a>, another in-progress operation is currently referencing the connector. Please try again later.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteDeliveryChannel.html\">DeleteDeliveryChannel</a>, you cannot delete the specified delivery channel because the customer managed configuration recorder is running. Use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_StopConfigurationRecorder.html\">StopConfigurationRecorder</a> operation to stop the customer managed configuration\n\t\t\trecorder.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_AssociateResourceTypes.html\">AssociateResourceTypes</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DisassociateResourceTypes.html\">DisassociateResourceTypes</a>, one of the following errors:</p>\n         <ul>\n            <li>\n               <p>For service-linked configuration recorders, the configuration recorder is not in use by the service. No association or dissociation of resource types is permitted.</p>\n            </li>\n            <li>\n               <p>For service-linked configuration recorders, your requested change to the configuration recorder has been denied by its linked Amazon Web Services service.</p>\n            </li>\n         </ul>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceFilters": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ConformancePackConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by Config rule names.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by compliance.</p>\n         <p>The allowed values are <code>COMPLIANT</code> and <code>NON_COMPLIANT</code>. <code>INSUFFICIENT_DATA</code> is not supported.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the conformance pack by compliance types and Config rule names.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceResourceIds": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit256"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceScore": {
+      "type": "structure",
+      "members": {
+        "Score": {
+          "target": "com.amazonaws.configservice#ComplianceScore",
+          "traits": {
+            "smithy.api#documentation": "<p>Compliance score for the conformance pack. Conformance packs with no evaluation results will have a compliance score of <code>INSUFFICIENT_DATA</code>.</p>"
+          }
+        },
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the conformance pack.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.configservice#LastUpdatedTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the conformance pack compliance score was last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A compliance score is the percentage of the number of compliant rule-resource combinations in a conformance pack compared to the number of total possible rule-resource combinations in the conformance pack.\n\t\t\tThis metric provides you with a high-level view of the compliance state of your conformance packs. You can use it to identify, investigate, and understand\n\t\t\tthe level of compliance in your conformance packs.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceScores": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackComplianceScore"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceScoresFilters": {
+      "type": "structure",
+      "members": {
+        "ConformancePackNames": {
+          "target": "com.amazonaws.configservice#ConformancePackNameFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of the conformance packs whose compliance scores you want to include in the conformance pack compliance score result set.\n\t\t\tYou can include up to 25 conformance packs in the <code>ConformancePackNames</code> array of strings, each with a character limit of 256 characters for the conformance pack name.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of filters to apply to the conformance pack compliance score result set. </p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceSummary": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the conformance pack name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackComplianceStatus": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Summary includes the name and status of the conformance pack.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackComplianceSummary"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackComplianceType": {
+      "type": "enum",
+      "members": {
+        "COMPLIANT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLIANT"
+          }
+        },
+        "NON_COMPLIANT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NON_COMPLIANT"
+          }
+        },
+        "INSUFFICIENT_DATA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSUFFICIENT_DATA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackConfigRuleNames": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit64"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackDetail": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackArn": {
+          "target": "com.amazonaws.configservice#ConformancePackArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackId": {
+          "target": "com.amazonaws.configservice#ConformancePackId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DeliveryS3Bucket": {
+          "target": "com.amazonaws.configservice#DeliveryS3Bucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where Config stores conformance pack templates. </p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "DeliveryS3KeyPrefix": {
+          "target": "com.amazonaws.configservice#DeliveryS3KeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix for the Amazon S3 bucket.</p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "ConformancePackInputParameters": {
+          "target": "com.amazonaws.configservice#ConformancePackInputParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackInputParameter</code> objects.</p>"
+          }
+        },
+        "LastUpdateRequestedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The last time a conformation pack update was requested. </p>"
+          }
+        },
+        "CreatedBy": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services service that created the conformance pack.</p>"
+          }
+        },
+        "TemplateSSMDocumentDetails": {
+          "target": "com.amazonaws.configservice#TemplateSSMDocumentDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the name or Amazon Resource Name (ARN) of the Amazon Web Services Systems Manager document (SSM document) and the version of the SSM document that is used to create a conformance pack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details of a conformance pack. A conformance pack is a collection of Config rules and remediation actions that can be easily deployed in an account and a region.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackDetail"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackEvaluationFilters": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ConformancePackConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by Config rule names.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by compliance.</p>\n         <p>The allowed values are <code>COMPLIANT</code> and <code>NON_COMPLIANT</code>. <code>INSUFFICIENT_DATA</code> is not supported.</p>"
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by the resource type (for example, <code>\"AWS::EC2::Instance\"</code>). </p>"
+          }
+        },
+        "ResourceIds": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceResourceIds",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by resource IDs.</p>\n         <note>\n            <p>This is valid only when you provide resource type. If there is no resource type, you will see an error.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters a conformance pack by Config rule names, compliance types, Amazon Web Services resource types, and resource IDs.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackEvaluationResult": {
+      "type": "structure",
+      "members": {
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The compliance type. The allowed values are <code>COMPLIANT</code> and <code>NON_COMPLIANT</code>. <code>INSUFFICIENT_DATA</code> is not supported.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EvaluationResultIdentifier": {
+          "target": "com.amazonaws.configservice#EvaluationResultIdentifier",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigRuleInvokedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when Config rule evaluated Amazon Web Services resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResultRecordedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when Config recorded the evaluation result. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Annotation": {
+          "target": "com.amazonaws.configservice#Annotation",
+          "traits": {
+            "smithy.api#documentation": "<p>Supplementary information about how the evaluation determined the compliance. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of a conformance pack evaluation. Provides Config rule and Amazon Web Services resource type that was evaluated, the compliance of the conformance pack, related time stamps, and supplementary information. </p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackInputParameter": {
+      "type": "structure",
+      "members": {
+        "ParameterName": {
+          "target": "com.amazonaws.configservice#ParameterName",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ParameterValue": {
+          "target": "com.amazonaws.configservice#ParameterValue",
+          "traits": {
+            "smithy.api#documentation": "<p>Another part of the key-value pair. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input parameters in the form of key-value pairs for the conformance pack, both of which you define. \n\t\t\tKeys can have a maximum character length of 255 characters, and values can have a maximum length of 4096 characters.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackInputParameters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackInputParameter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 60
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[a-zA-Z][-a-zA-Z0-9]*$"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackNameFilter": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackNamesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackNamesToSummarizeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackRuleCompliance": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the Config rule.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>Compliance of the Config rule.</p>"
+          }
+        },
+        "Controls": {
+          "target": "com.amazonaws.configservice#ControlsList",
+          "traits": {
+            "smithy.api#documentation": "<p>Controls for the conformance pack. A control is a process to prevent or detect problems while meeting objectives.\n\t\t\tA control can align with a specific compliance regime or map to internal controls defined by an organization.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Compliance information of one or more Config rules within a conformance pack. You can filter using Config rule names and compliance types.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackRuleComplianceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackRuleCompliance"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackRuleEvaluationResultsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackEvaluationResult"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackState": {
+      "type": "enum",
+      "members": {
+        "CREATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+          }
+        },
+        "CREATE_COMPLETE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_COMPLETE"
+          }
+        },
+        "CREATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_FAILED"
+          }
+        },
+        "DELETE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+          }
+        },
+        "DELETE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackStatusDetail": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackId": {
+          "target": "com.amazonaws.configservice#ConformancePackId",
+          "traits": {
+            "smithy.api#documentation": "<p>ID of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackArn": {
+          "target": "com.amazonaws.configservice#ConformancePackArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of comformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackState": {
+          "target": "com.amazonaws.configservice#ConformancePackState",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status of conformance pack.</p>\n         <p>Config sets the state of the conformance pack to:</p>\n         <ul>\n            <li>\n               <p>CREATE_IN_PROGRESS when a conformance pack creation is in progress for an account.</p>\n            </li>\n            <li>\n               <p>CREATE_COMPLETE when a conformance pack has been successfully created in your account.</p>\n            </li>\n            <li>\n               <p>CREATE_FAILED when a conformance pack creation failed in your account.</p>\n            </li>\n            <li>\n               <p>DELETE_IN_PROGRESS when a conformance pack deletion is in progress. </p>\n            </li>\n            <li>\n               <p>DELETE_FAILED when a conformance pack deletion failed in your account.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "StackArn": {
+          "target": "com.amazonaws.configservice#StackArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of CloudFormation stack. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackStatusReason": {
+          "target": "com.amazonaws.configservice#ConformancePackStatusReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason of conformance pack creation failure.</p>"
+          }
+        },
+        "LastUpdateRequestedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>Last time when conformation pack creation and update was requested.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LastUpdateCompletedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>Last time when conformation pack creation and update was successful.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Status details of a conformance pack.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackStatusDetailsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConformancePackStatusDetail"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackStatusReason": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2000
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConformancePackTemplateValidationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a template that is not valid or supported.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#Connector": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.configservice#ConnectorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the connector.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "connectorConfiguration": {
+          "target": "com.amazonaws.configservice#ConnectorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The provider-specific configuration for connecting to the third-party cloud service provider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "createdTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the connector was created.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of the connector, including the connector configuration and connector ARN.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConnectorConfiguration": {
+      "type": "structure",
+      "members": {
+        "azure": {
+          "target": "com.amazonaws.configservice#AzureConnectorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration for an Azure connector.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The provider-specific configuration for connecting to the third-party cloud service provider. You must specify exactly one provider configuration.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConnectorFilter": {
+      "type": "structure",
+      "members": {
+        "filterName": {
+          "target": "com.amazonaws.configservice#ConnectorFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the filter. Currently, only <code>provider</code> is supported.</p>"
+          }
+        },
+        "filterValues": {
+          "target": "com.amazonaws.configservice#FilterValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the filter. For <code>provider</code>, valid values include: <code>AZURE</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters connectors based on the connector provider.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ConnectorFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConnectorFilter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConnectorFilterName": {
+      "type": "enum",
+      "members": {
+        "provider": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "provider"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConnectorName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConnectorSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConnectorSummary"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ConnectorSummary": {
+      "type": "structure",
+      "members": {
+        "arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.configservice#ConnectorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the connector.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "provider": {
+          "target": "com.amazonaws.configservice#Provider",
+          "traits": {
+            "smithy.api#documentation": "<p>The third-party cloud service provider. Currently, <code>AZURE</code> is supported.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tenantIdentifier": {
+          "target": "com.amazonaws.configservice#AzureTenantIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>The Azure tenant identifier for the connector.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "createdTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the connector was created.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of a connector.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ControlsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit128"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.configservice#CosmosPageLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#CustomPolicyDetails": {
+      "type": "structure",
+      "members": {
+        "PolicyRuntime": {
+          "target": "com.amazonaws.configservice#PolicyRuntime",
+          "traits": {
+            "smithy.api#documentation": "<p>The runtime system for your Config Custom Policy rule. Guard is a policy-as-code language that allows you to write policies that are enforced by Config Custom Policy rules. For more information about Guard, see the <a href=\"https://github.com/aws-cloudformation/cloudformation-guard\">Guard GitHub\n\t\t\t\t\tRepository</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyText": {
+          "target": "com.amazonaws.configservice#PolicyText",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy definition containing the logic for your Config Custom Policy rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EnableDebugLogDelivery": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>The boolean expression for enabling debug logging for your Config Custom Policy rule. The default value is <code>false</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the runtime system, policy definition, and whether debug logging enabled. You can\n\t\t\tspecify the following CustomPolicyDetails parameter values \n\t\t\tonly\n\t\t\tfor Config Custom Policy rules.</p>"
+      }
+    },
+    "com.amazonaws.configservice#Date": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#DebugLogDeliveryAccounts": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AccountId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.configservice#DeleteAggregationAuthorization": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteAggregationAuthorizationRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the authorization granted to the specified\n\t\t\tconfiguration aggregator account in a specified region.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteAggregationAuthorizationRequest": {
+      "type": "structure",
+      "members": {
+        "AuthorizedAccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the account authorized to aggregate\n\t\t\tdata.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizedAwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region authorized to collect aggregated data.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteConfigRuleRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified Config rule and all of its evaluation\n\t\t\tresults.</p>\n         <p>Config sets the state of a rule to <code>DELETING</code>\n\t\t\tuntil the deletion is complete. You cannot update a rule while it is\n\t\t\tin this state. If you make a <code>PutConfigRule</code> or\n\t\t\t\t<code>DeleteConfigRule</code> request for the rule, you will\n\t\t\treceive a <code>ResourceInUseException</code>.</p>\n         <p>You can check the state of a rule by using the\n\t\t\t\t<code>DescribeConfigRules</code> request.</p>\n         <note>\n            <p>\n               <b>Recommendation: Consider excluding the <code>AWS::Config::ResourceCompliance</code> resource type from recording before deleting rules</b>\n            </p>\n            <p>Deleting rules creates configuration items (CIs) for <code>AWS::Config::ResourceCompliance</code>\n\t\t\t\tthat can affect your costs for the configuration recorder. If you are deleting rules which evaluate a large number of resource types,\n\t\t\t\tthis can lead to a spike in the number of CIs recorded.</p>\n            <p>To avoid the associated costs, you can opt to disable recording \n\t\t\t\tfor the <code>AWS::Config::ResourceCompliance</code> resource type before deleting rules, and re-enable recording after the rules have been deleted.</p>\n            <p>However, since deleting rules is an asynchronous process, it might take an hour or more to complete. During the time\n\t\t\t\twhen recording is disabled for <code>AWS::Config::ResourceCompliance</code>, rule evaluations will not be recorded in the associated resource\u2019s history.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule that you want to\n\t\t\tdelete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteConfigurationAggregator": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteConfigurationAggregatorRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified configuration aggregator and the\n\t\t\taggregated data associated with the aggregator.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteConfigurationAggregatorRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#UnmodifiableEntityException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the customer managed configuration recorder.</p>\n         <p>This operation does not delete the configuration information that\n\t\t\twas previously recorded. You will be able to access the previously\n\t\t\trecorded information by using the\n\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_GetResourceConfigHistory.html\">GetResourceConfigHistory</a> operation, but you will not\n\t\t\tbe able to access this information in the Config console until\n\t\t\tyou have created a new customer managed configuration recorder.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderName": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the customer managed configuration recorder that you want to delete. You can\n\t\t\tretrieve the name of your configuration recorders by using the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeConfigurationRecorders.html\">DescribeConfigurationRecorders</a> operation.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request object for the\n\t\t\t\t<code>DeleteConfigurationRecorder</code> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteConformancePack": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteConformancePackRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified conformance pack and all the Config rules, remediation actions, and all evaluation results within that \n\t\t\tconformance pack.</p>\n         <p>Config sets the conformance pack to <code>DELETE_IN_PROGRESS</code> until the deletion is complete. \n\t\t\tYou cannot update a conformance pack while it is in this state.</p>\n         <note>\n            <p>\n               <b>Recommendation: Consider excluding the <code>AWS::Config::ResourceCompliance</code> resource type from recording before deleting rules</b>\n            </p>\n            <p>Deleting rules creates configuration items (CIs) for <code>AWS::Config::ResourceCompliance</code>\n\t\t\t\tthat can affect your costs for the configuration recorder. If you are deleting rules which evaluate a large number of resource types,\n\t\t\t\tthis can lead to a spike in the number of CIs recorded.</p>\n            <p>To avoid the associated costs, you can opt to disable recording \n\t\t\t\tfor the <code>AWS::Config::ResourceCompliance</code> resource type before deleting rules, and re-enable recording after the rules have been deleted.</p>\n            <p>However, since deleting rules is an asynchronous process, it might take an hour or more to complete. During the time\n\t\t\t\twhen recording is disabled for <code>AWS::Config::ResourceCompliance</code>, rule evaluations will not be recorded in the associated resource\u2019s history.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteConformancePackRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack you want to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteConnector": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteConnectorRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified connector.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteConnectorRequest": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector that you want to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteDeliveryChannel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteDeliveryChannelRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#LastDeliveryChannelDeleteFailedException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchDeliveryChannelException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the delivery channel.</p>\n         <p>Before you can delete the delivery channel, you must stop the customer managed configuration recorder. You can use the <a>StopConfigurationRecorder</a> operation to stop the customer managed configuration recorder.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteDeliveryChannelRequest": {
+      "type": "structure",
+      "members": {
+        "DeliveryChannelName": {
+          "target": "com.amazonaws.configservice#ChannelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the delivery channel that you want to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>DeleteDeliveryChannel</a>\n\t\t\taction. The action accepts the following data, in JSON format.\n\t\t</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteEvaluationResults": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteEvaluationResultsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DeleteEvaluationResultsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the evaluation results for the specified Config\n\t\t\trule. You can specify one Config rule per request. After you\n\t\t\tdelete the evaluation results, you can call the <a>StartConfigRulesEvaluation</a> API to start evaluating\n\t\t\tyour Amazon Web Services resources against the rule.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteEvaluationResultsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit64",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule for which you want to delete\n\t\t\tthe evaluation results.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteEvaluationResultsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>The output when you delete the evaluation results for the\n\t\t\tspecified Config rule.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteOrganizationConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteOrganizationConfigRuleRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified organization Config rule and all of its evaluation results from all member accounts in that organization. </p>\n         <p>Only a management account and a delegated administrator account can delete an organization Config rule.\n\t\tWhen calling this API with a delegated administrator, you must ensure Organizations \n\t\t\t<code>ListDelegatedAdministrator</code> permissions are added.</p>\n         <p>Config sets the state of a rule to DELETE_IN_PROGRESS until the deletion is complete. \n\t\t\tYou cannot update a rule while it is in this state.</p>\n         <note>\n            <p>\n               <b>Recommendation: Consider excluding the <code>AWS::Config::ResourceCompliance</code> resource type from recording before deleting rules</b>\n            </p>\n            <p>Deleting rules creates configuration items (CIs) for <code>AWS::Config::ResourceCompliance</code>\n\t\t\t\tthat can affect your costs for the configuration recorder. If you are deleting rules which evaluate a large number of resource types,\n\t\t\t\tthis can lead to a spike in the number of CIs recorded.</p>\n            <p>To avoid the associated costs, you can opt to disable recording \n\t\t\t\tfor the <code>AWS::Config::ResourceCompliance</code> resource type before deleting rules, and re-enable recording after the rules have been deleted.</p>\n            <p>However, since deleting rules is an asynchronous process, it might take an hour or more to complete. During the time\n\t\t\t\twhen recording is disabled for <code>AWS::Config::ResourceCompliance</code>, rule evaluations will not be recorded in the associated resource\u2019s history.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteOrganizationConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleName": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of organization Config rule that you want to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteOrganizationConformancePack": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteOrganizationConformancePackRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified organization conformance pack and all of the Config rules and remediation actions from\n\t\t\tall member accounts in that organization. </p>\n         <p> Only a management account or a delegated administrator account can delete an organization conformance pack.\n\tWhen calling this API with a delegated administrator, you must ensure Organizations \n\t\t<code>ListDelegatedAdministrator</code> permissions are added.</p>\n         <p>Config sets the state of a conformance pack to DELETE_IN_PROGRESS until the deletion is complete. \n\t\t\t\tYou cannot update a conformance pack while it is in this state. </p>\n         <note>\n            <p>\n               <b>Recommendation: Consider excluding the <code>AWS::Config::ResourceCompliance</code> resource type from recording before deleting rules</b>\n            </p>\n            <p>Deleting rules creates configuration items (CIs) for <code>AWS::Config::ResourceCompliance</code>\n\t\t\t\tthat can affect your costs for the configuration recorder. If you are deleting rules which evaluate a large number of resource types,\n\t\t\t\tthis can lead to a spike in the number of CIs recorded.</p>\n            <p>To avoid the associated costs, you can opt to disable recording \n\t\t\t\tfor the <code>AWS::Config::ResourceCompliance</code> resource type before deleting rules, and re-enable recording after the rules have been deleted.</p>\n            <p>However, since deleting rules is an asynchronous process, it might take an hour or more to complete. During the time\n\t\t\t\twhen recording is disabled for <code>AWS::Config::ResourceCompliance</code>, rule evaluations will not be recorded in the associated resource\u2019s history.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteOrganizationConformancePackRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackName": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of organization conformance pack that you want to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeletePendingAggregationRequest": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeletePendingAggregationRequestRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes pending authorization requests for a specified\n\t\t\taggregator account in a specified region.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeletePendingAggregationRequestRequest": {
+      "type": "structure",
+      "members": {
+        "RequesterAccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the account requesting to aggregate\n\t\t\tdata.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RequesterAwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region requesting to aggregate data.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteRemediationConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteRemediationConfigurationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DeleteRemediationConfigurationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchRemediationConfigurationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#RemediationInProgressException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the remediation configuration.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteRemediationConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule for which you want to delete remediation configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of a resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteRemediationConfigurationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteRemediationExceptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteRemediationExceptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DeleteRemediationExceptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchRemediationExceptionException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes one or more remediation exceptions mentioned in the resource keys.</p>\n         <note>\n            <p>Config generates a remediation exception when a problem occurs executing a remediation action to a specific resource. \n\t\t\tRemediation exceptions blocks auto-remediation until the exception is cleared.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteRemediationExceptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule for which you want to delete remediation exception configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceKeys": {
+          "target": "com.amazonaws.configservice#RemediationExceptionResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>An exception list of resource exception keys to be processed with the current request. Config adds exception for each resource key. For example, Config adds 3 exceptions for 3 resource keys. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteRemediationExceptionsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedBatches": {
+          "target": "com.amazonaws.configservice#FailedDeleteRemediationExceptionsBatches",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of failed delete remediation exceptions batch objects. Each object in the batch consists of a list of failed items and failure messages.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteResourceConfigRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoRunningConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Records the configuration state for a custom resource that has been deleted.  This API records a new ConfigurationItem with a ResourceDeleted status. You can retrieve the ConfigurationItems recorded for this resource in your Config History.\n\t\t\t </p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#ResourceTypeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier of the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteRetentionConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteRetentionConfigurationRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchRetentionConfigurationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the retention configuration.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteRetentionConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "RetentionConfigurationName": {
+          "target": "com.amazonaws.configservice#RetentionConfigurationName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the retention configuration to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteServiceLinkedConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteServiceLinkedConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DeleteServiceLinkedConfigurationRecorderResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an existing service-linked configuration recorder.</p>\n         <p>This operation does not delete the configuration information that was previously recorded. You will be able to access the previously\n\t\t\trecorded information by using the\n\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_GetResourceConfigHistory.html\">GetResourceConfigHistory</a> operation, but you will not\n\t\t\tbe able to access this information in the Config console until\n\t\t\tyou have created a new service-linked configuration recorder for the same service.</p>\n         <note>\n            <p>\n               <b>The recording scope determines if you receive configuration items</b>\n            </p>\n            <p>The recording scope is set by the service that is linked to the configuration recorder and determines whether you receive configuration items (CIs) in the delivery channel. If the recording scope is internal, you will not receive CIs in the delivery channel.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteServiceLinkedConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ServicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>The service principal of the Amazon Web Services service for the service-linked configuration recorder that you want to delete. This field is only supported for Amazon Web Services service principals. For third-party service-linked configuration recorders, use <code>Arn</code> instead.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the service-linked configuration recorder that you want to delete. For third-party service-linked configuration recorders, you must use <code>Arn</code>. You must specify exactly one of <code>Arn</code> or <code>ServicePrincipal</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteServiceLinkedConfigurationRecorderResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteStoredQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeleteStoredQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DeleteStoredQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the stored query for a single Amazon Web Services account and a single Amazon Web Services Region.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeleteStoredQueryRequest": {
+      "type": "structure",
+      "members": {
+        "QueryName": {
+          "target": "com.amazonaws.configservice#QueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the query that you want to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeleteStoredQueryResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DeliverConfigSnapshot": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DeliverConfigSnapshotRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DeliverConfigSnapshotResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoAvailableConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoRunningConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchDeliveryChannelException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Schedules delivery of a configuration snapshot to the Amazon S3\n\t\t\tbucket in the specified delivery channel. After the delivery has\n\t\t\tstarted, Config sends the following notifications using an\n\t\t\tAmazon SNS topic that you have specified.</p>\n         <ul>\n            <li>\n               <p>Notification of the start of the delivery.</p>\n            </li>\n            <li>\n               <p>Notification of the completion of the delivery, if the\n\t\t\t\t\tdelivery was successfully completed.</p>\n            </li>\n            <li>\n               <p>Notification of delivery failure, if the delivery\n\t\t\t\t\tfailed.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.configservice#DeliverConfigSnapshotRequest": {
+      "type": "structure",
+      "members": {
+        "deliveryChannelName": {
+          "target": "com.amazonaws.configservice#ChannelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the delivery channel through which the snapshot is\n\t\t\tdelivered.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>DeliverConfigSnapshot</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DeliverConfigSnapshotResponse": {
+      "type": "structure",
+      "members": {
+        "configSnapshotId": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the snapshot that is being created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output for the <a>DeliverConfigSnapshot</a>\n\t\t\taction, in JSON format.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DeliveryChannel": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.configservice#ChannelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the delivery channel. By default, Config\n\t\t\tassigns the name \"default\" when creating the delivery channel. To\n\t\t\tchange the delivery channel name, you must use the\n\t\t\tDeleteDeliveryChannel action to delete your current delivery\n\t\t\tchannel, and then you must use the PutDeliveryChannel command to\n\t\t\tcreate a delivery channel that has the desired name.</p>"
+          }
+        },
+        "s3BucketName": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket to which Config delivers\n\t\t\tconfiguration snapshots and configuration history files.</p>\n         <p>If you specify a bucket that belongs to another Amazon Web Services account,\n\t\t\tthat bucket must have policies that grant access permissions to Config. For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html\">Permissions for the Amazon S3 Bucket</a> in the <i>Config\n\t\t\tDeveloper Guide</i>.</p>"
+          }
+        },
+        "s3KeyPrefix": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix for the specified Amazon S3 bucket.</p>"
+          }
+        },
+        "s3KmsKeyArn": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Key Management Service (KMS ) KMS key (KMS key) used to encrypt objects delivered by Config.\n\t\t\tMust belong to the same Region as the destination S3 bucket.</p>"
+          }
+        },
+        "snsTopicARN": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which\n\t\t\tConfig sends notifications about configuration\n\t\t\tchanges.</p>\n         <p>If you choose a topic from another account, the topic must have\n\t\t\tpolicies that grant access permissions to Config. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/sns-topic-policy.html\">Permissions for the Amazon SNS Topic</a> in the <i>Config\n\t\t\tDeveloper Guide</i>.</p>"
+          }
+        },
+        "configSnapshotDeliveryProperties": {
+          "target": "com.amazonaws.configservice#ConfigSnapshotDeliveryProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The options for how often Config delivers configuration\n\t\t\tsnapshots to the Amazon S3 bucket.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The channel through which Config delivers notifications and\n\t\t\tupdated configuration states.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DeliveryChannelList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#DeliveryChannel"
+      }
+    },
+    "com.amazonaws.configservice#DeliveryChannelNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ChannelName"
+      }
+    },
+    "com.amazonaws.configservice#DeliveryChannelStatus": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the delivery channel.</p>"
+          }
+        },
+        "configSnapshotDeliveryInfo": {
+          "target": "com.amazonaws.configservice#ConfigExportDeliveryInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the status of the delivery of the snapshot to\n\t\t\tthe specified Amazon S3 bucket.</p>"
+          }
+        },
+        "configHistoryDeliveryInfo": {
+          "target": "com.amazonaws.configservice#ConfigExportDeliveryInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the status of the delivery of the\n\t\t\tconfiguration history to the specified Amazon S3 bucket.</p>"
+          }
+        },
+        "configStreamDeliveryInfo": {
+          "target": "com.amazonaws.configservice#ConfigStreamDeliveryInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the status of the delivery of the\n\t\t\tconfiguration stream notification to the specified Amazon SNS\n\t\t\ttopic.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of a specified delivery channel.</p>\n         <p>Valid values: <code>Success</code> | <code>Failure</code>\n         </p>"
+      }
+    },
+    "com.amazonaws.configservice#DeliveryChannelStatusList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#DeliveryChannelStatus"
+      }
+    },
+    "com.amazonaws.configservice#DeliveryS3Bucket": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 63
+        }
+      }
+    },
+    "com.amazonaws.configservice#DeliveryS3KeyPrefix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.configservice#DeliveryStatus": {
+      "type": "enum",
+      "members": {
+        "Success": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Success"
+          }
+        },
+        "Failure": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Failure"
+          }
+        },
+        "Not_Applicable": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Not_Applicable"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregateComplianceByConfigRules": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeAggregateComplianceByConfigRulesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeAggregateComplianceByConfigRulesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of compliant and noncompliant rules with the\n\t\t\tnumber of resources for compliant and noncompliant rules. Does not display rules that do not have compliance results. \n\t\t\t</p>\n         <note>\n            <p>The results can return an empty result page, but if you\n\t\t\t\thave a <code>nextToken</code>, the results are displayed on the next\n\t\t\t\tpage.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregateComplianceByConfigRulesRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConfigRuleComplianceFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by ConfigRuleComplianceFilters object.\n\t\t</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#GroupByAPILimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page.\n\t\t\tThe default is\n\t\t\tmaximum.\n\t\t\tIf you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregateComplianceByConfigRulesResponse": {
+      "type": "structure",
+      "members": {
+        "AggregateComplianceByConfigRules": {
+          "target": "com.amazonaws.configservice#AggregateComplianceByConfigRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of AggregateComplianceByConfigRule\n\t\t\tobject.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregateComplianceByConformancePacks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeAggregateComplianceByConformancePacksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeAggregateComplianceByConformancePacksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of the existing and deleted conformance packs and their associated compliance status with the count of compliant and noncompliant Config rules within each \n\t\t\tconformance pack. Also returns the total rule count which includes compliant rules, noncompliant rules, and rules that cannot be evaluated due to insufficient data.</p>\n         <note>\n            <p>The results can return an empty result page, but if you have a <code>nextToken</code>, the results are displayed on the next page.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "AggregateComplianceByConformancePacks",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregateComplianceByConformancePacksRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#AggregateConformancePackComplianceFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the result by <code>AggregateConformancePackComplianceFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of conformance packs compliance details returned on each page. The default is maximum. If you specify 0, Config uses the default. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregateComplianceByConformancePacksResponse": {
+      "type": "structure",
+      "members": {
+        "AggregateComplianceByConformancePacks": {
+          "target": "com.amazonaws.configservice#AggregateComplianceByConformancePackList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns the <code>AggregateComplianceByConformancePack</code> object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregationAuthorizations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeAggregationAuthorizationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeAggregationAuthorizationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of authorizations granted to various aggregator\n\t\t\taccounts and regions.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "AggregationAuthorizations",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregationAuthorizationsRequest": {
+      "type": "structure",
+      "members": {
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of AggregationAuthorizations returned on\n\t\t\teach page. The default is maximum. If you specify 0, Config uses\n\t\t\tthe default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeAggregationAuthorizationsResponse": {
+      "type": "structure",
+      "members": {
+        "AggregationAuthorizations": {
+          "target": "com.amazonaws.configservice#AggregationAuthorizationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of authorizations granted to various aggregator\n\t\t\taccounts and regions.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeComplianceByConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeComplianceByConfigRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeComplianceByConfigRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates whether the specified Config rules are compliant.\n\t\t\tIf a rule is noncompliant, this operation returns the number of Amazon Web Services\n\t\t\tresources that do not comply with the rule.</p>\n         <p>A rule is compliant if all of the evaluated resources comply\n\t\t\twith it. It is noncompliant if any of these resources do not\n\t\t\tcomply.</p>\n         <p>If Config has no current evaluation results for the rule,\n\t\t\tit returns <code>INSUFFICIENT_DATA</code>. This result might\n\t\t\tindicate one of the following conditions:</p>\n         <ul>\n            <li>\n               <p>Config has never invoked an evaluation for the\n\t\t\t\t\trule. To check whether it has, use the\n\t\t\t\t\t\t<code>DescribeConfigRuleEvaluationStatus</code> action\n\t\t\t\t\tto get the <code>LastSuccessfulInvocationTime</code> and\n\t\t\t\t\t\t<code>LastFailedInvocationTime</code>.</p>\n            </li>\n            <li>\n               <p>The rule's Lambda function is failing to send\n\t\t\t\t\tevaluation results to Config. Verify that the role you\n\t\t\t\t\tassigned to your configuration recorder includes the\n\t\t\t\t\t\t<code>config:PutEvaluations</code> permission. If the\n\t\t\t\t\trule is a custom rule, verify that the Lambda execution\n\t\t\t\t\trole includes the <code>config:PutEvaluations</code>\n\t\t\t\t\tpermission.</p>\n            </li>\n            <li>\n               <p>The rule's Lambda function has returned\n\t\t\t\t\t\t<code>NOT_APPLICABLE</code> for all evaluation results.\n\t\t\t\t\tThis can occur if the resources were deleted or removed from\n\t\t\t\t\tthe rule's scope.</p>\n            </li>\n         </ul>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ComplianceByConfigRules"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeComplianceByConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify one or more Config rule names to filter the results\n\t\t\tby rule.</p>"
+          }
+        },
+        "ComplianceTypes": {
+          "target": "com.amazonaws.configservice#ComplianceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by compliance.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeComplianceByConfigRuleResponse": {
+      "type": "structure",
+      "members": {
+        "ComplianceByConfigRules": {
+          "target": "com.amazonaws.configservice#ComplianceByConfigRules",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether each of the specified Config rules is\n\t\t\tcompliant.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeComplianceByResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeComplianceByResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeComplianceByResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates whether the specified Amazon Web Services resources are compliant. If\n\t\t\ta resource is noncompliant, this operation returns the number of Config rules that the resource does not comply with.</p>\n         <p>A resource is compliant if it complies with all the Config\n\t\t\trules that evaluate it. It is noncompliant if it does not comply\n\t\t\twith one or more of these rules.</p>\n         <p>If Config has no current evaluation results for the\n\t\t\tresource, it returns <code>INSUFFICIENT_DATA</code>. This result\n\t\t\tmight indicate one of the following conditions about the rules that\n\t\t\tevaluate the resource:</p>\n         <ul>\n            <li>\n               <p>Config has never invoked an evaluation for the\n\t\t\t\t\trule. To check whether it has, use the\n\t\t\t\t\t\t<code>DescribeConfigRuleEvaluationStatus</code> action\n\t\t\t\t\tto get the <code>LastSuccessfulInvocationTime</code> and\n\t\t\t\t\t\t<code>LastFailedInvocationTime</code>.</p>\n            </li>\n            <li>\n               <p>The rule's Lambda function is failing to send\n\t\t\t\t\tevaluation results to Config. Verify that the role that\n\t\t\t\t\tyou assigned to your configuration recorder includes the\n\t\t\t\t\t\t<code>config:PutEvaluations</code> permission. If the\n\t\t\t\t\trule is a custom rule, verify that the Lambda execution\n\t\t\t\t\trole includes the <code>config:PutEvaluations</code>\n\t\t\t\t\tpermission.</p>\n            </li>\n            <li>\n               <p>The rule's Lambda function has returned\n\t\t\t\t\t\t<code>NOT_APPLICABLE</code> for all evaluation results.\n\t\t\t\t\tThis can occur if the resources were deleted or removed from\n\t\t\t\t\tthe rule's scope.</p>\n            </li>\n         </ul>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ComplianceByResources",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeComplianceByResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The types of Amazon Web Services resources for which you want compliance\n\t\t\tinformation (for example, <code>AWS::EC2::Instance</code>). For this operation, you can specify that the resource type is an Amazon Web Services account by\n\t\t\tspecifying <code>AWS::::Account</code>.</p>"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource for which you want compliance\n\t\t\tinformation. You can specify only one resource ID. If you specify a\n\t\t\tresource ID, you must also specify a type for\n\t\t\t\t<code>ResourceType</code>.</p>"
+          }
+        },
+        "ComplianceTypes": {
+          "target": "com.amazonaws.configservice#ComplianceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by compliance.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page.\n\t\t\tThe default is 10. You cannot specify a number greater than 100. If\n\t\t\tyou specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeComplianceByResourceResponse": {
+      "type": "structure",
+      "members": {
+        "ComplianceByResources": {
+          "target": "com.amazonaws.configservice#ComplianceByResources",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the specified Amazon Web Services resource complies with all\n\t\t\tof the Config rules that evaluate it.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRuleEvaluationStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConfigRuleEvaluationStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConfigRuleEvaluationStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns status information for each of your Config managed rules. The status includes information such as the last time Config invoked the rule, the last time Config failed to invoke\n\t\t\tthe rule, and the related error for the last failure.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConfigRulesEvaluationStatus",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRuleEvaluationStatusRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config managed rules for which you want\n\t\t\tstatus information. If you do not specify any names, Config\n\t\t\treturns status information for all Config managed rules that you\n\t\t\tuse.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#RuleLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of rule evaluation results that you want\n\t\t\treturned.</p>\n         <p>This parameter is required if the rule limit for your account\n\t\t\tis more than the default of 1000 rules.</p>\n         <p>For information about requesting a rule limit increase, see\n\t\t\t\t<a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_config\">Config Limits</a> in the <i>Amazon Web Services General\n\t\t\t\tReference Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRuleEvaluationStatusResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigRulesEvaluationStatus": {
+          "target": "com.amazonaws.configservice#ConfigRuleEvaluationStatusList",
+          "traits": {
+            "smithy.api#documentation": "<p>Status information about your Config managed rules.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRules": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConfigRulesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConfigRulesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details about your Config rules.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConfigRules"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRulesFilters": {
+      "type": "structure",
+      "members": {
+        "EvaluationMode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode of an evaluation. The valid values are Detective or Proactive.</p>"
+          }
+        },
+        "RuleEvaluationVisibility": {
+          "target": "com.amazonaws.configservice#RuleEvaluationVisibility",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by <code>RuleEvaluationVisibility</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a filtered list of Detective or Proactive Config rules. By default, if the filter is not defined, this API returns an unfiltered list. For more information on Detective or Proactive Config rules,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config-rules.html\">\n               <b>Evaluation Mode</b>\n            </a> in the <i>Config Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRulesRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of the Config rules for which you want details.\n\t\t\tIf you do not specify any names, Config returns details for all\n\t\t\tyour rules.</p>"
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#DescribeConfigRulesFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of Detective or Proactive Config rules. By default, this API returns an unfiltered list. For more information on Detective or Proactive Config rules,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config-rules.html\">\n               <b>Evaluation Mode</b>\n            </a> in the <i>Config Developer Guide</i>.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigRulesResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigRules": {
+          "target": "com.amazonaws.configservice#ConfigRules",
+          "traits": {
+            "smithy.api#documentation": "<p>The details about your Config rules.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationAggregatorSourcesStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationAggregatorSourcesStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationAggregatorSourcesStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns status information for sources within an aggregator.\n\t\t\tThe status includes information about the last time Config verified authorization between the source account and an aggregator account. In case of a failure, the status contains the related error code or message. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "AggregatedSourceStatusList",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationAggregatorSourcesStatusRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "UpdateStatus": {
+          "target": "com.amazonaws.configservice#AggregatedSourceStatusTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the status type.</p>\n         <ul>\n            <li>\n               <p>Valid value FAILED indicates errors while moving\n\t\t\t\t\tdata.</p>\n            </li>\n            <li>\n               <p>Valid value SUCCEEDED indicates the data was\n\t\t\t\t\tsuccessfully moved.</p>\n            </li>\n            <li>\n               <p>Valid value OUTDATED indicates the data is not the most\n\t\t\t\t\trecent.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of AggregatorSourceStatus returned on each\n\t\t\tpage. The default is maximum. If you specify 0, Config uses the\n\t\t\tdefault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationAggregatorSourcesStatusResponse": {
+      "type": "structure",
+      "members": {
+        "AggregatedSourceStatusList": {
+          "target": "com.amazonaws.configservice#AggregatedSourceStatusList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an AggregatedSourceStatus object.\n\t\t\t</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationAggregators": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationAggregatorsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationAggregatorsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the details of one or more configuration aggregators.\n\t\t\tIf the configuration aggregator is not specified, this operation\n\t\t\treturns the details for all the configuration aggregators associated\n\t\t\twith the account. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConfigurationAggregators",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationAggregatorsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorNames": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregators.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of configuration aggregators returned on\n\t\t\teach page. The default is maximum. If you specify 0, Config uses\n\t\t\tthe default.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationAggregatorsResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregators": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a ConfigurationAggregators object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationRecorderStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationRecorderStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationRecorderStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the current status of the configuration\n\t\t\trecorder you specify as well as the status of the last recording event for the configuration recorders.</p>\n         <p>For a detailed status of recording events over time, add your Config events to Amazon CloudWatch metrics and use CloudWatch metrics.</p>\n         <p>If a configuration recorder is not specified, this operation returns the status for the customer managed configuration recorder configured for the\n\t\t\taccount, if applicable.</p>\n         <note>\n            <p>When making a request to this operation, you can only specify one configuration recorder.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationRecorderStatusRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderNames": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration recorder. If the name is not\n\t\t\tspecified, the operation returns the status for the customer managed configuration recorder configured for the\n\t\t\taccount, if applicable.</p>\n         <note>\n            <p>When making a request to this operation, you can only specify one configuration recorder.</p>\n         </note>"
+          }
+        },
+        "ServicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>For service-linked configuration recorders, you can use the service principal of the linked Amazon Web Services service to specify the configuration recorder. This field is only supported for Amazon Web Services service principals. For third-party service-linked configuration recorders, use <code>Arn</code> instead.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the configuration recorder that you want to specify.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>DescribeConfigurationRecorderStatus</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationRecorderStatusResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecordersStatus": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderStatusList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains status of the specified\n\t\t\trecorders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output for the <a>DescribeConfigurationRecorderStatus</a> action, in JSON\n\t\t\tformat.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationRecorders": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationRecordersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConfigurationRecordersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details for the configuration recorder you specify.</p>\n         <p>If a configuration recorder is not specified, this operation returns details for the customer managed configuration recorder configured for the\n\t\t\taccount, if applicable.</p>\n         <note>\n            <p>When making a request to this operation, you can only specify one configuration recorder.</p>\n         </note>",
+        "smithy.test#smokeTests": [
+          {
+            "id": "DescribeConfigurationRecordersSuccess",
+            "params": {},
+            "vendorParams": {
+              "region": "us-west-2"
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "expect": {
+              "success": {}
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationRecordersRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderNames": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of names of the configuration recorders that you want to specify.</p>\n         <note>\n            <p>When making a request to this operation, you can only specify one configuration recorder.</p>\n         </note>"
+          }
+        },
+        "ServicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>For service-linked configuration recorders, you can use the service principal of the linked Amazon Web Services service to specify the configuration recorder. This field is only supported for Amazon Web Services service principals. For third-party service-linked configuration recorders, use <code>Arn</code> instead.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the configuration recorder that you want to specify.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>DescribeConfigurationRecorders</a> action.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConfigurationRecordersResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorders": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the descriptions of the specified\n\t\t\tconfiguration recorders.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output for the <a>DescribeConfigurationRecorders</a> action.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackCompliance": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConformancePackComplianceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConformancePackComplianceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleInConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConformancePackException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns compliance details for each rule in that conformance pack.</p>\n         <note>\n            <p>You must provide exact rule names.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConformancePackRuleComplianceList",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackComplianceLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackComplianceRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>ConformancePackComplianceFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#DescribeConformancePackComplianceLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of Config rules within a conformance pack are returned on each page.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackComplianceResponse": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackRuleComplianceList": {
+          "target": "com.amazonaws.configservice#ConformancePackRuleComplianceList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of <code>ConformancePackRuleCompliance</code> objects.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConformancePackStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConformancePackStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides one or more conformance packs deployment status.</p>\n         <note>\n            <p>If there are no conformance packs then you will see an empty result.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConformancePackStatusDetails",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackStatusRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackNames": {
+          "target": "com.amazonaws.configservice#ConformancePackNamesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Comma-separated list of conformance pack names.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#PageSizeLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of conformance packs status returned on each page.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePackStatusResponse": {
+      "type": "structure",
+      "members": {
+        "ConformancePackStatusDetails": {
+          "target": "com.amazonaws.configservice#ConformancePackStatusDetailsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackStatusDetail</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePacks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeConformancePacksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeConformancePacksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConformancePackException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of one or more conformance packs.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConformancePackDetails",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePacksRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackNames": {
+          "target": "com.amazonaws.configservice#ConformancePackNamesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Comma-separated list of conformance pack names for which you want details. If you do not specify any names, Config returns details for all your conformance packs. </p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#PageSizeLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of conformance packs returned on each page.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeConformancePacksResponse": {
+      "type": "structure",
+      "members": {
+        "ConformancePackDetails": {
+          "target": "com.amazonaws.configservice#ConformancePackDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of <code>ConformancePackDetail</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeDeliveryChannelStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeDeliveryChannelStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeDeliveryChannelStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchDeliveryChannelException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the current status of the specified delivery channel.\n\t\t\tIf a delivery channel is not specified, this operation returns the\n\t\t\tcurrent status of all delivery channels associated with the\n\t\t\taccount.</p>\n         <note>\n            <p>Currently, you can specify only one delivery channel per\n\t\t\t\tregion in your account.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DescribeDeliveryChannelStatusRequest": {
+      "type": "structure",
+      "members": {
+        "DeliveryChannelNames": {
+          "target": "com.amazonaws.configservice#DeliveryChannelNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of delivery channel names.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>DeliveryChannelStatus</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeDeliveryChannelStatusResponse": {
+      "type": "structure",
+      "members": {
+        "DeliveryChannelsStatus": {
+          "target": "com.amazonaws.configservice#DeliveryChannelStatusList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the status of a specified delivery\n\t\t\tchannel.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output for the <a>DescribeDeliveryChannelStatus</a> action.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeDeliveryChannels": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeDeliveryChannelsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeDeliveryChannelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchDeliveryChannelException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details about the specified delivery channel. If a\n\t\t\tdelivery channel is not specified, this operation returns the details\n\t\t\tof all delivery channels associated with the account.</p>\n         <note>\n            <p>Currently, you can specify only one delivery channel per\n\t\t\t\tregion in your account.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#DescribeDeliveryChannelsRequest": {
+      "type": "structure",
+      "members": {
+        "DeliveryChannelNames": {
+          "target": "com.amazonaws.configservice#DeliveryChannelNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of delivery channel names.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>DescribeDeliveryChannels</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeDeliveryChannelsResponse": {
+      "type": "structure",
+      "members": {
+        "DeliveryChannels": {
+          "target": "com.amazonaws.configservice#DeliveryChannelList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list that contains the descriptions of the specified delivery\n\t\t\tchannel.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output for the <a>DescribeDeliveryChannels</a>\n\t\t\taction.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConfigRuleStatuses": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConfigRuleStatusesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConfigRuleStatusesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides organization Config rule deployment status for an organization.</p>\n         <note>\n            <p>The status is not considered successful until organization Config rule is successfully deployed in all the member \n\t\t\taccounts with an exception of excluded accounts.</p>\n            <p>When you specify the limit and the next token, you receive a paginated response.\n\t\t\tLimit and next token are not applicable if you specify organization Config rule names. \n\t\t\tIt is only applicable, when you request all the organization Config rules.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "OrganizationConfigRuleStatuses",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConfigRuleStatusesRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleNames": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of organization Config rules for which you want status details. If you do not specify any names, Config returns details for all your organization Config rules.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#CosmosPageLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of <code>OrganizationConfigRuleStatuses</code> returned on each page. If you do no specify a number, Config uses the default. The default is 100.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConfigRuleStatusesResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleStatuses": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleStatuses",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>OrganizationConfigRuleStatus</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConfigRules": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConfigRulesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConfigRulesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of organization Config rules. </p>\n         <note>\n            <p>When you specify the limit and the next token, you receive a paginated response.</p>\n            <p>Limit and next token are not applicable if you specify organization Config rule names. \n\t\t\tIt is only applicable, when you request all the organization Config rules.</p>\n            <p>\n               <i>For accounts within an organization</i>\n            </p>\n            <p>If you deploy an organizational rule or conformance pack in an organization\n\t\t\t\tadministrator account, and then establish a delegated administrator and deploy an\n\t\t\t\torganizational rule or conformance pack in the delegated administrator account, you\n\t\t\t\twon't be able to see the organizational rule or conformance pack in the organization\n\t\t\t\tadministrator account from the delegated administrator account or see the organizational\n\t\t\t\trule or conformance pack in the delegated administrator account from organization\n\t\t\t\tadministrator account. The <code>DescribeOrganizationConfigRules</code> and \n\t\t\t\t<code>DescribeOrganizationConformancePacks</code> APIs can only see and interact with\n\t\t\t\tthe organization-related resource that were deployed from within the account calling\n\t\t\t\tthose APIs.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "OrganizationConfigRules",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConfigRulesRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleNames": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of organization Config rules for which you want details. If you do not specify any names, Config returns details for all your organization Config rules.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#CosmosPageLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of organization Config rules returned on each page. If you do no specify a number, Config uses the default. The default is 100.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConfigRulesResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRules": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRules",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of <code>OrganizationConfigRule</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConformancePackStatuses": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConformancePackStatusesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConformancePackStatusesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides organization conformance pack deployment status for an organization. </p>\n         <note>\n            <p>The status is not considered successful until organization conformance pack is successfully \n\t\t\t\tdeployed in all the member accounts with an exception of excluded accounts.</p>\n            <p>When you specify the limit and the next token, you receive a paginated response. \n\t\t\t\tLimit and next token are not applicable if you specify organization conformance pack names. \n\t\t\t\tThey are only applicable, when you request all the organization conformance packs.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "OrganizationConformancePackStatuses",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConformancePackStatusesRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackNames": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of organization conformance packs for which you want status details. \n\t\t\tIf you do not specify any names, Config returns details for all your organization conformance packs. </p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#CosmosPageLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of OrganizationConformancePackStatuses returned on each page. \n\t\t\tIf you do no specify a number, Config uses the default. The default is 100. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConformancePackStatusesResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackStatuses": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackStatuses",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>OrganizationConformancePackStatus</code> objects. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConformancePacks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConformancePacksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeOrganizationConformancePacksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of organization conformance packs. </p>\n         <note>\n            <p>When you specify the limit and the next token, you receive a paginated response. </p>\n            <p>Limit and next token are not applicable if you specify organization conformance packs names. They are only applicable,\n\t\t\twhen you request all the organization conformance packs. </p>\n            <p>\n               <i>For accounts within an organization</i>\n            </p>\n            <p>If you deploy an organizational rule or conformance pack in an organization\n\t\t\t\tadministrator account, and then establish a delegated administrator and deploy an\n\t\t\t\torganizational rule or conformance pack in the delegated administrator account, you\n\t\t\t\twon't be able to see the organizational rule or conformance pack in the organization\n\t\t\t\tadministrator account from the delegated administrator account or see the organizational\n\t\t\t\trule or conformance pack in the delegated administrator account from organization\n\t\t\t\tadministrator account. The <code>DescribeOrganizationConfigRules</code> and \n\t\t\t\t<code>DescribeOrganizationConformancePacks</code> APIs can only see and interact with\n\t\t\t\tthe organization-related resource that were deployed from within the account calling\n\t\t\t\tthose APIs.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "OrganizationConformancePacks",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConformancePacksRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackNames": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assign to an organization conformance pack.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#CosmosPageLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of organization config packs returned on each page. If you do no specify a\n\t\t\tnumber, Config uses the default. The default is 100.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a\n\t\t\tpaginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeOrganizationConformancePacksResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePacks": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePacks",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of OrganizationConformancePacks objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a\n\t\t\tpaginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribePendingAggregationRequests": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribePendingAggregationRequestsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribePendingAggregationRequestsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of all pending aggregation requests.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "PendingAggregationRequests",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribePendingAggregationRequestsLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribePendingAggregationRequestsRequest": {
+      "type": "structure",
+      "members": {
+        "Limit": {
+          "target": "com.amazonaws.configservice#DescribePendingAggregationRequestsLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page.\n\t\t\tThe default is maximum. If you specify 0, Config uses the\n\t\t\tdefault.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribePendingAggregationRequestsResponse": {
+      "type": "structure",
+      "members": {
+        "PendingAggregationRequests": {
+          "target": "com.amazonaws.configservice#PendingAggregationRequestList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a PendingAggregationRequests object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationConfigurations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeRemediationConfigurationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeRemediationConfigurationsResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the details of one or more remediation configurations.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationConfigurationsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of Config rule names of remediation configurations for which you want details. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationConfigurationsResponse": {
+      "type": "structure",
+      "members": {
+        "RemediationConfigurations": {
+          "target": "com.amazonaws.configservice#RemediationConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a remediation configuration object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationExceptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeRemediationExceptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeRemediationExceptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the details of one or more remediation exceptions. A detailed view of a remediation exception for a set of resources that includes an explanation of an exception and the time when the exception will be deleted. \n\t\t\tWhen you specify the limit and the next token, you receive a paginated response. </p>\n         <note>\n            <p>Config generates a remediation exception when a problem occurs executing a remediation action to a specific resource. \n\t\t\t\tRemediation exceptions blocks auto-remediation until the exception is cleared.</p>\n            <p>When you specify the limit and the next token, you receive a paginated response. </p>\n            <p>Limit and next token are not applicable if you request resources in batch. It is only applicable, when you request all resources.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationExceptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceKeys": {
+          "target": "com.amazonaws.configservice#RemediationExceptionResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>An exception list of resource exception keys to be processed with the current request. Config adds exception for each resource key. For example, Config adds 3 exceptions for 3 resource keys. </p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of RemediationExceptionResourceKey returned on each page. The default is 25. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationExceptionsResponse": {
+      "type": "structure",
+      "members": {
+        "RemediationExceptions": {
+          "target": "com.amazonaws.configservice#RemediationExceptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of remediation exception objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationExecutionStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeRemediationExecutionStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeRemediationExecutionStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchRemediationConfigurationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a detailed view of a Remediation Execution for a set of resources including state, timestamps for when steps for the remediation execution occur, and any error messages for steps that have failed. \n\t\t\tWhen you specify the limit and the next token, you receive a paginated response.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "RemediationExecutionStatuses",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationExecutionStatusRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceKeys": {
+          "target": "com.amazonaws.configservice#ResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of resource keys to be processed with the current request. Each element in the list consists of the resource type and resource ID. </p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of RemediationExecutionStatuses returned on each page. The default is maximum. If you specify 0, Config uses the default. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRemediationExecutionStatusResponse": {
+      "type": "structure",
+      "members": {
+        "RemediationExecutionStatuses": {
+          "target": "com.amazonaws.configservice#RemediationExecutionStatuses",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of remediation execution statuses objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRetentionConfigurations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DescribeRetentionConfigurationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DescribeRetentionConfigurationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchRetentionConfigurationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the details of one or more retention configurations. If\n\t\t\tthe retention configuration name is not specified, this operation\n\t\t\treturns the details for all the retention configurations for that\n\t\t\taccount.</p>\n         <note>\n            <p>Currently, Config supports only one retention\n\t\t\t\tconfiguration per region in your account.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "RetentionConfigurations"
+        }
+      }
+    },
+    "com.amazonaws.configservice#DescribeRetentionConfigurationsRequest": {
+      "type": "structure",
+      "members": {
+        "RetentionConfigurationNames": {
+          "target": "com.amazonaws.configservice#RetentionConfigurationNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of names of retention configurations for which you want\n\t\t\tdetails. If you do not specify a name, Config returns details\n\t\t\tfor all the retention configurations for that account.</p>\n         <note>\n            <p>Currently, Config supports only one retention\n\t\t\t\tconfiguration per region in your account.</p>\n         </note>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DescribeRetentionConfigurationsResponse": {
+      "type": "structure",
+      "members": {
+        "RetentionConfigurations": {
+          "target": "com.amazonaws.configservice#RetentionConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a retention configuration object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#Description": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#DisassociateResourceTypes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#DisassociateResourceTypesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#DisassociateResourceTypesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes all resource types specified in the <code>ResourceTypes</code> list from the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> of configuration recorder and excludes these resource types when recording.</p>\n         <p>For this operation, the configuration recorder must use a <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> that is either <code>INCLUSION_BY_RESOURCE_TYPES</code> or <code>EXCLUSION_BY_RESOURCE_TYPES</code>.</p>"
+      }
+    },
+    "com.amazonaws.configservice#DisassociateResourceTypesRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceTypes": {
+          "target": "com.amazonaws.configservice#ResourceTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of resource types you want to remove from the recording group of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#DisassociateResourceTypesResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorder": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorder",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#DiscoveredResourceIdentifierList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateResourceIdentifier"
+      }
+    },
+    "com.amazonaws.configservice#EarlierTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#EmptiableStringWithCharLimit256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#Evaluation": {
+      "type": "structure",
+      "members": {
+        "ComplianceResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of Amazon Web Services resource that was evaluated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ComplianceResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource that was evaluated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the Amazon Web Services resource complies with the Config\n\t\t\trule that it was evaluated against.</p>\n         <p>For the <code>Evaluation</code> data type, Config supports\n\t\t\tonly the <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and\n\t\t\t\t<code>NOT_APPLICABLE</code> values. Config does not support\n\t\t\tthe <code>INSUFFICIENT_DATA</code> value for this data\n\t\t\ttype.</p>\n         <p>Similarly, Config does not accept\n\t\t\t\t<code>INSUFFICIENT_DATA</code> as the value for\n\t\t\t\t<code>ComplianceType</code> from a <code>PutEvaluations</code>\n\t\t\trequest. For example, an Lambda function for a custom Config\n\t\t\trule cannot pass an <code>INSUFFICIENT_DATA</code> value to Config.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Annotation": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Supplementary information about how the evaluation determined\n\t\t\tthe compliance.</p>"
+          }
+        },
+        "OrderingTimestamp": {
+          "target": "com.amazonaws.configservice#OrderingTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the event in Config that triggered the\n\t\t\tevaluation. For event-based evaluations, the time indicates when Config created the configuration item that triggered the evaluation.\n\t\t\tFor periodic evaluations, the time indicates when Config\n\t\t\ttriggered the evaluation at the frequency that you specified (for\n\t\t\texample, every 24 hours).</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Identifies an Amazon Web Services resource and indicates whether it complies\n\t\t\twith the Config rule that it was evaluated against.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationContext": {
+      "type": "structure",
+      "members": {
+        "EvaluationContextIdentifier": {
+          "target": "com.amazonaws.configservice#EvaluationContextIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique EvaluationContextIdentifier ID for an EvaluationContext.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Use EvaluationContext to group independently initiated proactive resource evaluations. For example, CFN Stack. \n\t\t\tIf you want to check just a resource definition, you do not need to provide evaluation context.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationContextIdentifier": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#EvaluationMode": {
+      "type": "enum",
+      "members": {
+        "DETECTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DETECTIVE"
+          }
+        },
+        "PROACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROACTIVE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#EvaluationModeConfiguration": {
+      "type": "structure",
+      "members": {
+        "Mode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode of an evaluation. The valid values are Detective or Proactive.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration object for Config rule evaluation mode. The supported valid values are Detective or Proactive.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationModes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#EvaluationModeConfiguration"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationResult": {
+      "type": "structure",
+      "members": {
+        "EvaluationResultIdentifier": {
+          "target": "com.amazonaws.configservice#EvaluationResultIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>Uniquely identifies the evaluation result.</p>"
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the Amazon Web Services resource complies with the Config\n\t\t\trule that evaluated it.</p>\n         <p>For the <code>EvaluationResult</code> data type, Config\n\t\t\tsupports only the <code>COMPLIANT</code>,\n\t\t\t<code>NON_COMPLIANT</code>, and <code>NOT_APPLICABLE</code> values.\n\t\t\tConfig does not support the <code>INSUFFICIENT_DATA</code> value\n\t\t\tfor the <code>EvaluationResult</code> data type.</p>"
+          }
+        },
+        "ResultRecordedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when Config recorded the evaluation\n\t\t\tresult.</p>"
+          }
+        },
+        "ConfigRuleInvokedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Config rule evaluated the Amazon Web Services\n\t\t\tresource.</p>"
+          }
+        },
+        "Annotation": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Supplementary information about how the evaluation determined\n\t\t\tthe compliance.</p>"
+          }
+        },
+        "ResultToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An encrypted token that associates an evaluation with an Config rule. The token identifies the rule, the Amazon Web Services resource being\n\t\t\tevaluated, and the event that triggered the evaluation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of an Config evaluation. Provides the Amazon Web Services\n\t\t\tresource that was evaluated, the compliance of the resource, related\n\t\t\ttime stamps, and supplementary information.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationResultIdentifier": {
+      "type": "structure",
+      "members": {
+        "EvaluationResultQualifier": {
+          "target": "com.amazonaws.configservice#EvaluationResultQualifier",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies an Config rule used to evaluate an Amazon Web Services resource,\n\t\t\tand provides the type and ID of the evaluated resource.</p>"
+          }
+        },
+        "OrderingTimestamp": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the event that triggered the evaluation of your Amazon Web Services\n\t\t\tresources. The time can indicate when Config delivered a\n\t\t\tconfiguration item change notification, or it can indicate when Config delivered the configuration snapshot, depending on which\n\t\t\tevent triggered the evaluation.</p>"
+          }
+        },
+        "ResourceEvaluationId": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationId",
+          "traits": {
+            "smithy.api#documentation": "<p>A Unique ID for an evaluation result.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Uniquely identifies an evaluation result.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationResultQualifier": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule that was used in the\n\t\t\tevaluation.</p>"
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the evaluated Amazon Web Services resource.</p>"
+          }
+        },
+        "EvaluationMode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode of an evaluation. The valid values are Detective or Proactive.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Identifies an Config rule that evaluated an Amazon Web Services resource,\n\t\t\tand provides the type and ID of the resource that the rule\n\t\t\tevaluated.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationResults": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#EvaluationResult"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationStatus": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of an execution. The valid values are In_Progress, Succeeded or Failed. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>An explanation for failed execution status.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns status details of an evaluation.</p>"
+      }
+    },
+    "com.amazonaws.configservice#EvaluationTimeout": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 3600
+        }
+      }
+    },
+    "com.amazonaws.configservice#Evaluations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#Evaluation"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#EventSource": {
+      "type": "enum",
+      "members": {
+        "Aws_Config": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "aws.config"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ExcludedAccounts": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AccountId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.configservice#ExclusionByResourceTypes": {
+      "type": "structure",
+      "members": {
+        "resourceTypes": {
+          "target": "com.amazonaws.configservice#ResourceTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>A comma-separated list of resource types to exclude from recording by the configuration\n\t\t\trecorder.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies whether the configuration recorder excludes certain resource types from being recorded.\n\t\t\tUse the <code>resourceTypes</code> field to enter a comma-separated list of resource types you want to exclude from recording.</p>\n         <p>By default, when Config adds support for a new resource type in the Region where you set up the configuration recorder,\n\t\t\tincluding global resource types, Config starts recording resources of that type automatically.</p>\n         <note>\n            <p>\n               <b>How to use the exclusion recording strategy </b>\n            </p>\n            <p>To use this option, you must set the <code>useOnly</code>\n\t\t\t\tfield of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a>\n\t\t\t\tto <code>EXCLUSION_BY_RESOURCE_TYPES</code>.</p>\n            <p>Config will then record configuration changes for all supported resource types, except the resource types that you specify to exclude from being recorded.</p>\n            <p>\n               <b>Global resource types and the exclusion recording strategy </b>\n            </p>\n            <p>Unless specifically listed as exclusions,\n\t\t\t\t<code>AWS::RDS::GlobalCluster</code> will be recorded automatically in all supported  Config Regions were the configuration recorder is enabled.</p>\n            <p>IAM users, groups, roles, and customer managed policies will be recorded in the Region where you set up the configuration recorder if that is a Region where Config was available before February 2022.\n\t\t\t\tYou cannot be record the global IAM resouce types in Regions supported by Config after February 2022. For a list of those Regions,\n\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-all\">Recording Amazon Web Services Resources | Global Resources</a>.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#ExecutionControls": {
+      "type": "structure",
+      "members": {
+        "SsmControls": {
+          "target": "com.amazonaws.configservice#SsmControls",
+          "traits": {
+            "smithy.api#documentation": "<p>A SsmControls object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The controls that Config uses for executing remediations.</p>"
+      }
+    },
+    "com.amazonaws.configservice#Expression": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 4096
+        }
+      }
+    },
+    "com.amazonaws.configservice#ExternalEvaluation": {
+      "type": "structure",
+      "members": {
+        "ComplianceResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The evaluated compliance resource type. Config accepts <code>AWS::::Account</code> resource type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ComplianceResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The evaluated compliance resource ID. Config accepts only Amazon Web Services account ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The compliance of the Amazon Web Services resource. The valid values are <code>COMPLIANT, NON_COMPLIANT, </code> and <code>NOT_APPLICABLE</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Annotation": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Supplementary information about the reason of compliance. For example, this task was completed on a specific date.</p>"
+          }
+        },
+        "OrderingTimestamp": {
+          "target": "com.amazonaws.configservice#OrderingTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the compliance was recorded. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Identifies an Amazon Web Services resource and indicates whether it complies with the Config rule that it was evaluated against.</p>"
+      }
+    },
+    "com.amazonaws.configservice#FailedDeleteRemediationExceptionsBatch": {
+      "type": "structure",
+      "members": {
+        "FailureMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a failure message for delete remediation exception. For example, Config creates an exception due to an internal error.</p>"
+          }
+        },
+        "FailedItems": {
+          "target": "com.amazonaws.configservice#RemediationExceptionResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns remediation exception resource key object of the failed items.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>List of each of the failed delete remediation exceptions with specific reasons.</p>"
+      }
+    },
+    "com.amazonaws.configservice#FailedDeleteRemediationExceptionsBatches": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#FailedDeleteRemediationExceptionsBatch"
+      }
+    },
+    "com.amazonaws.configservice#FailedRemediationBatch": {
+      "type": "structure",
+      "members": {
+        "FailureMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a failure message. For example, the resource is already compliant.</p>"
+          }
+        },
+        "FailedItems": {
+          "target": "com.amazonaws.configservice#RemediationConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns remediation configurations of the failed items.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>List of each of the failed remediations with specific reasons.</p>"
+      }
+    },
+    "com.amazonaws.configservice#FailedRemediationBatches": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#FailedRemediationBatch"
+      }
+    },
+    "com.amazonaws.configservice#FailedRemediationExceptionBatch": {
+      "type": "structure",
+      "members": {
+        "FailureMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a failure message. For example, the auto-remediation has failed.</p>"
+          }
+        },
+        "FailedItems": {
+          "target": "com.amazonaws.configservice#RemediationExceptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns remediation exception resource key object of the failed items.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>List of each of the failed remediation exceptions with specific reasons.</p>"
+      }
+    },
+    "com.amazonaws.configservice#FailedRemediationExceptionBatches": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#FailedRemediationExceptionBatch"
+      }
+    },
+    "com.amazonaws.configservice#FieldInfo": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.configservice#FieldName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the field.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about the fields such as name of the field.</p>"
+      }
+    },
+    "com.amazonaws.configservice#FieldInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#FieldInfo"
+      }
+    },
+    "com.amazonaws.configservice#FieldName": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#FilterValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#String"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateComplianceDetailsByConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetAggregateComplianceDetailsByConfigRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetAggregateComplianceDetailsByConfigRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the evaluation results for the specified Config\n\t\t\trule for a specific resource in a rule. The results indicate which\n\t\t\tAmazon Web Services resources were evaluated by the rule, when each resource was\n\t\t\tlast evaluated, and whether each resource complies with the rule. </p>\n         <note>\n            <p>The results can return an empty result page. But if you\n\t\t\t\thave a <code>nextToken</code>, the results are displayed on the next\n\t\t\t\tpage.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "AggregateEvaluationResults",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateComplianceDetailsByConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule for which you want compliance\n\t\t\tinformation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the source account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region from where the data is aggregated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ComplianceType": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource compliance status.</p>\n         <note>\n            <p>For the\n\t\t\t\t\t<code>GetAggregateComplianceDetailsByConfigRuleRequest</code>\n\t\t\t\tdata type, Config supports only the <code>COMPLIANT</code>\n\t\t\t\tand <code>NON_COMPLIANT</code>. Config does not support the\n\t\t\t\t\t<code>NOT_APPLICABLE</code> and\n\t\t\t\t\t<code>INSUFFICIENT_DATA</code> values.</p>\n         </note>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page.\n\t\t\tThe default is 50. You cannot specify a number greater than 100. If\n\t\t\tyou specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateComplianceDetailsByConfigRuleResponse": {
+      "type": "structure",
+      "members": {
+        "AggregateEvaluationResults": {
+          "target": "com.amazonaws.configservice#AggregateEvaluationResultList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an AggregateEvaluationResults object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateConfigRuleComplianceSummary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetAggregateConfigRuleComplianceSummaryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetAggregateConfigRuleComplianceSummaryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the number of compliant and noncompliant rules for one\n\t\t\tor more accounts and regions in an aggregator.</p>\n         <note>\n            <p>The results can return an empty result page, but if you\n\t\t\t\thave a nextToken, the results are displayed on the next\n\t\t\t\tpage.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateConfigRuleComplianceSummaryRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConfigRuleComplianceSummaryFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on the\n\t\t\tConfigRuleComplianceSummaryFilters object.</p>"
+          }
+        },
+        "GroupByKey": {
+          "target": "com.amazonaws.configservice#ConfigRuleComplianceSummaryGroupKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Groups the result based on ACCOUNT_ID or AWS_REGION.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#GroupByAPILimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page.\n\t\t\tThe default is 1000. You cannot specify a number greater than 1000.\n\t\t\tIf you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateConfigRuleComplianceSummaryResponse": {
+      "type": "structure",
+      "members": {
+        "GroupByKey": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Groups the result based on ACCOUNT_ID or AWS_REGION.</p>"
+          }
+        },
+        "AggregateComplianceCounts": {
+          "target": "com.amazonaws.configservice#AggregateComplianceCountList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of AggregateComplianceCounts object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use\n\t\t\tto get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateConformancePackComplianceSummary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetAggregateConformancePackComplianceSummaryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetAggregateConformancePackComplianceSummaryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the count of compliant and noncompliant conformance packs across all Amazon Web Services accounts and Amazon Web Services Regions in an aggregator. You can filter based on Amazon Web Services account ID or Amazon Web Services Region.</p>\n         <note>\n            <p>The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateConformancePackComplianceSummaryRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#AggregateConformancePackComplianceSummaryFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on the <code>AggregateConformancePackComplianceSummaryFilters</code> object.</p>"
+          }
+        },
+        "GroupByKey": {
+          "target": "com.amazonaws.configservice#AggregateConformancePackComplianceSummaryGroupKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Groups the result based on Amazon Web Services account ID or Amazon Web Services Region.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results returned on each page. The default is maximum. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateConformancePackComplianceSummaryResponse": {
+      "type": "structure",
+      "members": {
+        "AggregateConformancePackComplianceSummaries": {
+          "target": "com.amazonaws.configservice#AggregateConformancePackComplianceSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of <code>AggregateConformancePackComplianceSummary</code> object.</p>"
+          }
+        },
+        "GroupByKey": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Groups the result based on Amazon Web Services account ID or Amazon Web Services Region.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateDiscoveredResourceCounts": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetAggregateDiscoveredResourceCountsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetAggregateDiscoveredResourceCountsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the resource counts across accounts and regions that are present in your Config aggregator. You can request the resource counts by providing filters and GroupByKey.</p>\n         <p>For example, if the input contains accountID 12345678910 and region us-east-1 in filters, the API returns the count of resources in account ID 12345678910 and region us-east-1.\n\t\t\tIf the input contains ACCOUNT_ID as a GroupByKey, the API returns resource counts for all source accounts that are present in your aggregator.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateDiscoveredResourceCountsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ResourceCountFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on the <code>ResourceCountFilters</code> object.</p>"
+          }
+        },
+        "GroupByKey": {
+          "target": "com.amazonaws.configservice#ResourceCountGroupKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The key to group the resource counts.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#GroupByAPILimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of <a>GroupedResourceCount</a> objects returned on each page. The default is 1000. You cannot specify a number greater than 1000. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateDiscoveredResourceCountsResponse": {
+      "type": "structure",
+      "members": {
+        "TotalDiscoveredResources": {
+          "target": "com.amazonaws.configservice#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The total number of resources that are present in an aggregator with the filters that you provide.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "GroupByKey": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The key passed into the request object. If <code>GroupByKey</code> is not provided, the result will be empty.</p>"
+          }
+        },
+        "GroupedResourceCounts": {
+          "target": "com.amazonaws.configservice#GroupedResourceCountList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of GroupedResourceCount objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetAggregateResourceConfigRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetAggregateResourceConfigResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OversizedConfigurationItemException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceNotDiscoveredException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns configuration item that is aggregated for your specific resource in a specific source account and region.</p>\n         <note>\n            <p>The API does not return results for deleted resources.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceIdentifier": {
+          "target": "com.amazonaws.configservice#AggregateResourceIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that identifies aggregate resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetAggregateResourceConfigResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationItem": {
+          "target": "com.amazonaws.configservice#ConfigurationItem",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>ConfigurationItem</code> object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceDetailsByConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetComplianceDetailsByConfigRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetComplianceDetailsByConfigRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the evaluation results for the specified Config\n\t\t\trule. The results indicate which Amazon Web Services resources were evaluated by the\n\t\t\trule, when each resource was last evaluated, and whether each\n\t\t\tresource complies with the rule.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "EvaluationResults",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceDetailsByConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit64",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule for which you want compliance\n\t\t\tinformation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ComplianceTypes": {
+          "target": "com.amazonaws.configservice#ComplianceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by compliance.</p>\n         <p>\n            <code>INSUFFICIENT_DATA</code> is a valid <code>ComplianceType</code> that is returned when an Config rule cannot be evaluated. However, <code>INSUFFICIENT_DATA</code> cannot be used as a <code>ComplianceType</code> for filtering results.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page.\n\t\t\tThe default is 10. You cannot specify a number greater than 100. If\n\t\t\tyou specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceDetailsByConfigRuleResponse": {
+      "type": "structure",
+      "members": {
+        "EvaluationResults": {
+          "target": "com.amazonaws.configservice#EvaluationResults",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the Amazon Web Services resource complies with the specified\n\t\t\tConfig rule.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceDetailsByResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetComplianceDetailsByResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetComplianceDetailsByResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the evaluation results for the specified Amazon Web Services resource.\n\t\t\tThe results indicate which Config rules were used to evaluate\n\t\t\tthe resource, when each rule was last invoked, and whether the resource\n\t\t\tcomplies with each rule.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "EvaluationResults"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceDetailsByResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource for which you want compliance\n\t\t\tinformation.</p>"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource for which you want compliance\n\t\t\tinformation.</p>"
+          }
+        },
+        "ComplianceTypes": {
+          "target": "com.amazonaws.configservice#ComplianceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results by compliance.</p>\n         <p>\n            <code>INSUFFICIENT_DATA</code> is a valid <code>ComplianceType</code> that is returned when an Config rule cannot be evaluated. However, <code>INSUFFICIENT_DATA</code> cannot be used as a <code>ComplianceType</code> for filtering results.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        },
+        "ResourceEvaluationId": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of Amazon Web Services resource execution for which you want to retrieve evaluation results. </p>\n         <note>\n            <p>You need to only provide either a <code>ResourceEvaluationID</code> or a <code>ResourceID </code>and <code>ResourceType</code>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceDetailsByResourceResponse": {
+      "type": "structure",
+      "members": {
+        "EvaluationResults": {
+          "target": "com.amazonaws.configservice#EvaluationResults",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the specified Amazon Web Services resource complies each Config rule.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceSummaryByConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "smithy.api#Unit"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetComplianceSummaryByConfigRuleResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the number of Config rules that are compliant and\n\t\t\tnoncompliant, up to a maximum of 25 for each.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceSummaryByConfigRuleResponse": {
+      "type": "structure",
+      "members": {
+        "ComplianceSummary": {
+          "target": "com.amazonaws.configservice#ComplianceSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Config rules that are compliant and the\n\t\t\tnumber that are noncompliant, up to a maximum of 25 for\n\t\t\teach.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceSummaryByResourceType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetComplianceSummaryByResourceTypeRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetComplianceSummaryByResourceTypeResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the number of resources that are compliant and the\n\t\t\tnumber that are noncompliant. You can specify one or more resource\n\t\t\ttypes to get these numbers for each resource type. The maximum\n\t\t\tnumber returned is 100.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceSummaryByResourceTypeRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceTypes": {
+          "target": "com.amazonaws.configservice#ResourceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify one or more resource types to get the number of\n\t\t\tresources that are compliant and the number that are noncompliant\n\t\t\tfor each resource type.</p>\n         <p>For this request, you can specify an Amazon Web Services resource type such as\n\t\t\t\t<code>AWS::EC2::Instance</code>. You can specify that the\n\t\t\tresource type is an Amazon Web Services account by specifying\n\t\t\t\t<code>AWS::::Account</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetComplianceSummaryByResourceTypeResponse": {
+      "type": "structure",
+      "members": {
+        "ComplianceSummariesByResourceType": {
+          "target": "com.amazonaws.configservice#ComplianceSummariesByResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of resources that are compliant and the number that\n\t\t\tare noncompliant. If one or more resource types were provided with\n\t\t\tthe request, the numbers are returned for each resource type. The\n\t\t\tmaximum number returned is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceDetails": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetConformancePackComplianceDetailsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetConformancePackComplianceDetailsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleInConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConformancePackException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns compliance details of a conformance pack for all Amazon Web Services resources that are monitered by conformance pack.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceDetailsLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceDetailsRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConformancePackEvaluationFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>ConformancePackEvaluationFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#GetConformancePackComplianceDetailsLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluation results returned on each page. If you do no specify a number, Config uses the default. The default is 100.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceDetailsResponse": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackRuleEvaluationResults": {
+          "target": "com.amazonaws.configservice#ConformancePackRuleEvaluationResultsList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of <code>ConformancePackEvaluationResult</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceSummary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetConformancePackComplianceSummaryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetConformancePackComplianceSummaryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConformancePackException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns compliance details for the conformance pack based on the cumulative compliance results of all the rules in that conformance pack.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConformancePackComplianceSummaryList",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceSummaryRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackNames": {
+          "target": "com.amazonaws.configservice#ConformancePackNamesToSummarizeList",
+          "traits": {
+            "smithy.api#documentation": "<p>Names of conformance packs.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#PageSizeLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of conformance packs returned on each page.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetConformancePackComplianceSummaryResponse": {
+      "type": "structure",
+      "members": {
+        "ConformancePackComplianceSummaryList": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackComplianceSummary</code> objects. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetConnector": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetConnectorRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetConnectorResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the details of the specified connector.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GetConnectorRequest": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetConnectorResponse": {
+      "type": "structure",
+      "members": {
+        "Connector": {
+          "target": "com.amazonaws.configservice#Connector",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the specified connector.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetCustomRulePolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetCustomRulePolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetCustomRulePolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the policy definition containing the logic for your Config Custom Policy rule.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GetCustomRulePolicyRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of your Config Custom Policy rule.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetCustomRulePolicyResponse": {
+      "type": "structure",
+      "members": {
+        "PolicyText": {
+          "target": "com.amazonaws.configservice#PolicyText",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy definition containing the logic for your Config Custom Policy rule.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetDiscoveredResourceCounts": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetDiscoveredResourceCountsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetDiscoveredResourceCountsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the resource types, the number of each resource type,\n\t\t\tand the total number of resources that Config is recording in\n\t\t\tthis region for your Amazon Web Services account. </p>\n         <p class=\"title\">\n            <b>Example</b>\n         </p>\n         <ol>\n            <li>\n               <p>Config is recording three resource types in the US\n\t\t\t\t\tEast (Ohio) Region for your account: 25 EC2 instances, 20\n\t\t\t\t\tIAM users, and 15 S3 buckets.</p>\n            </li>\n            <li>\n               <p>You make a call to the\n\t\t\t\t\t\t<code>GetDiscoveredResourceCounts</code> action and\n\t\t\t\t\tspecify that you want all resource types. </p>\n            </li>\n            <li>\n               <p>Config returns the following:</p>\n               <ul>\n                  <li>\n                     <p>The resource types (EC2 instances, IAM users,\n\t\t\t\t\t\t\tand S3 buckets).</p>\n                  </li>\n                  <li>\n                     <p>The number of each resource type (25, 20, and\n\t\t\t\t\t\t\t15).</p>\n                  </li>\n                  <li>\n                     <p>The total number of all resources\n\t\t\t\t\t\t\t(60).</p>\n                  </li>\n               </ul>\n            </li>\n         </ol>\n         <p>The response is paginated. By default, Config lists 100\n\t\t\t\t<a>ResourceCount</a> objects on each page. You can\n\t\t\tcustomize this number with the <code>limit</code> parameter. The\n\t\t\tresponse includes a <code>nextToken</code> string. To get the next\n\t\t\tpage of results, run the request again and specify the string for\n\t\t\tthe <code>nextToken</code> parameter.</p>\n         <note>\n            <p>If you make a call to the <a>GetDiscoveredResourceCounts</a> action, you might\n\t\t\t\tnot immediately receive resource counts in the following\n\t\t\t\tsituations:</p>\n            <ul>\n               <li>\n                  <p>You are a new Config customer.</p>\n               </li>\n               <li>\n                  <p>You just enabled resource recording.</p>\n               </li>\n            </ul>\n            <p>It might take a few minutes for Config to record and\n\t\t\t\tcount your resources. Wait a few minutes and then retry the\n\t\t\t\t\t<a>GetDiscoveredResourceCounts</a> action.\n\t\t\t</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "pageSize": "limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetDiscoveredResourceCountsRequest": {
+      "type": "structure",
+      "members": {
+        "resourceTypes": {
+          "target": "com.amazonaws.configservice#ResourceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The comma-separated list that specifies the resource types that\n\t\t\tyou want Config to return (for example,\n\t\t\t\t<code>\"AWS::EC2::Instance\"</code>,\n\t\t\t<code>\"AWS::IAM::User\"</code>).</p>\n         <p>If a value for <code>resourceTypes</code> is not specified, Config returns all resource types that Config is recording in\n\t\t\tthe region for your account.</p>\n         <note>\n            <p>If the configuration recorder is turned off, Config\n\t\t\t\treturns an empty list of <a>ResourceCount</a>\n\t\t\t\tobjects. If the configuration recorder is not recording a\n\t\t\t\tspecific resource type (for example, S3 buckets), that resource\n\t\t\t\ttype is not returned in the list of <a>ResourceCount</a> objects.</p>\n         </note>"
+          }
+        },
+        "limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of <a>ResourceCount</a> objects\n\t\t\treturned on each page. The default is 100. You cannot specify a\n\t\t\tnumber greater than 100. If you specify 0, Config uses the\n\t\t\tdefault.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetDiscoveredResourceCountsResponse": {
+      "type": "structure",
+      "members": {
+        "totalDiscoveredResources": {
+          "target": "com.amazonaws.configservice#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The total number of resources that Config is recording in\n\t\t\tthe region for your account. If you specify resource types in the\n\t\t\trequest, Config returns only the total number of resources for\n\t\t\tthose resource types.</p>\n         <p class=\"title\">\n            <b>Example</b>\n         </p>\n         <ol>\n            <li>\n               <p>Config is recording three resource types in the US\n\t\t\t\t\tEast (Ohio) Region for your account: 25 EC2 instances, 20\n\t\t\t\t\tIAM users, and 15 S3 buckets, for a total of 60\n\t\t\t\t\tresources.</p>\n            </li>\n            <li>\n               <p>You make a call to the\n\t\t\t\t\t\t<code>GetDiscoveredResourceCounts</code> action and\n\t\t\t\t\tspecify the resource type,\n\t\t\t\t\t\t<code>\"AWS::EC2::Instances\"</code>, in the\n\t\t\t\t\trequest.</p>\n            </li>\n            <li>\n               <p>Config returns 25 for\n\t\t\t\t\t\t<code>totalDiscoveredResources</code>.</p>\n            </li>\n         </ol>"
+          }
+        },
+        "resourceCounts": {
+          "target": "com.amazonaws.configservice#ResourceCounts",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of <code>ResourceCount</code> objects. Each object is\n\t\t\tlisted in descending order by the number of resources.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationConfigRuleDetailedStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetOrganizationConfigRuleDetailedStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetOrganizationConfigRuleDetailedStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns detailed status for each member account within an organization for a given organization Config rule.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "OrganizationConfigRuleDetailedStatus",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationConfigRuleDetailedStatusRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleName": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of your organization Config rule for which you want status details for member accounts.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#StatusDetailFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>A <code>StatusDetailFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#CosmosPageLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of <code>OrganizationConfigRuleDetailedStatus</code> returned on each page. If you do not specify a number, Config uses the default. The default is 100.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationConfigRuleDetailedStatusResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleDetailedStatus": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleDetailedStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>MemberAccountStatus</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationConformancePackDetailedStatus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetOrganizationConformancePackDetailedStatusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetOrganizationConformancePackDetailedStatusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConformancePackException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns detailed status for each member account within an organization for a given organization conformance pack.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "OrganizationConformancePackDetailedStatuses",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationConformancePackDetailedStatusRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackName": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of organization conformance pack for which you want status details for member accounts.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#OrganizationResourceDetailedStatusFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>OrganizationResourceDetailedStatusFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#CosmosPageLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of <code>OrganizationConformancePackDetailedStatuses</code> returned on each page. \n\t\t\tIf you do not specify a number, Config uses the default. The default is 100. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationConformancePackDetailedStatusResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackDetailedStatuses": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackDetailedStatuses",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>OrganizationConformancePackDetailedStatus</code> objects. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationCustomRulePolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetOrganizationCustomRulePolicyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetOrganizationCustomRulePolicyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchOrganizationConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the policy definition containing the logic for your organization Config Custom Policy rule.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationCustomRulePolicyRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleName": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of your organization Config Custom Policy rule. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetOrganizationCustomRulePolicyResponse": {
+      "type": "structure",
+      "members": {
+        "PolicyText": {
+          "target": "com.amazonaws.configservice#PolicyText",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy definition containing the logic for your organization Config Custom Policy rule.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetResourceConfigHistory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetResourceConfigHistoryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetResourceConfigHistoryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidTimeRangeException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceNotDiscoveredException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<important>\n            <p>For accurate reporting on the compliance status, you must record the <code>AWS::Config::ResourceCompliance</code> resource type.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html\">Recording Amazon Web Services Resources</a> in the <i>Config Resources Developer Guide</i>.</p>\n         </important>\n         <p>Returns a list of configurations items (CIs) for the specified resource.</p>\n         <p>\n            <b>Contents</b>\n         </p>\n         <p>The list contains details about each state of the resource\n\t\t\tduring the specified time interval. If you specified a retention\n\t\t\tperiod to retain your CIs between a\n\t\t\tminimum of 30 days and a maximum of 7 years (2557 days), Config\n\t\t\treturns the CIs for the specified\n\t\t\tretention period. </p>\n         <p>\n            <b>Pagination</b>\n         </p>\n         <p>The response is paginated. By default, Config returns a\n\t\t\tlimit of 10 configuration items per page. You can customize this\n\t\t\tnumber with the <code>limit</code> parameter. The response includes\n\t\t\ta <code>nextToken</code> string. To get the next page of results,\n\t\t\trun the request again and specify the string for the\n\t\t\t\t<code>nextToken</code> parameter.</p>\n         <note>\n            <p>Each call to the API is limited to span a duration of seven\n\t\t\t\tdays. It is likely that the number of records returned is\n\t\t\t\tsmaller than the specified <code>limit</code>. In such cases,\n\t\t\t\tyou can make another call, using the\n\t\t\t\t<code>nextToken</code>.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "configurationItems",
+          "pageSize": "limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#GetResourceConfigHistoryRequest": {
+      "type": "structure",
+      "members": {
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example.,\n\t\t\t<code>sg-xxxxxx</code>).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "laterTime": {
+          "target": "com.amazonaws.configservice#LaterTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The chronologically latest time in the time range for which the history requested. If not specified,\n\t\t\tcurrent time is taken.</p>"
+          }
+        },
+        "earlierTime": {
+          "target": "com.amazonaws.configservice#EarlierTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The chronologically earliest time in the time range for which the history requested. If not\n\t\t\tspecified, the action returns paginated results that contain\n\t\t\tconfiguration items that start when the first configuration item was\n\t\t\trecorded.</p>"
+          }
+        },
+        "chronologicalOrder": {
+          "target": "com.amazonaws.configservice#ChronologicalOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>The chronological order for configuration items listed. By\n\t\t\tdefault, the results are listed in reverse chronological\n\t\t\torder.</p>"
+          }
+        },
+        "limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of configuration items returned on each\n\t\t\tpage. The default is 10. You cannot specify a number greater than\n\t\t\t100. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>GetResourceConfigHistory</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetResourceConfigHistoryResponse": {
+      "type": "structure",
+      "members": {
+        "configurationItems": {
+          "target": "com.amazonaws.configservice#ConfigurationItemList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of <code>ConfigurationItems</code> Objects. Contatins the configuration history for one or more\n\t\t\tresources.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output for the <a>GetResourceConfigHistory</a>\n\t\t\taction.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetResourceEvaluationSummary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetResourceEvaluationSummaryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetResourceEvaluationSummaryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a summary of resource evaluation for the specified resource evaluation ID from the proactive rules that were run. \n\t\t\tThe results indicate which evaluation context was used to evaluate the rules, which resource details were evaluated,\n\t\t\tthe evaluation mode that was run, and whether the resource details comply with the configuration of the proactive rules. </p>\n         <note>\n            <p>To see additional information about the evaluation result, such as which rule flagged a resource as NON_COMPLIANT, use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_GetComplianceDetailsByResource.html\">GetComplianceDetailsByResource</a> API.\n\t\t\tFor more information, see the  <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_GetResourceEvaluationSummary.html#API_GetResourceEvaluationSummary_Examples\">Examples</a> section.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#GetResourceEvaluationSummaryRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceEvaluationId": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique <code>ResourceEvaluationId</code> of Amazon Web Services resource execution for which you want to retrieve the evaluation summary.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetResourceEvaluationSummaryResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceEvaluationId": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique <code>ResourceEvaluationId</code> of Amazon Web Services resource execution for which you want to retrieve the evaluation summary.</p>"
+          }
+        },
+        "EvaluationMode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists results of the mode that you requested to retrieve the resource evaluation summary. The valid values are Detective or Proactive.</p>"
+          }
+        },
+        "EvaluationStatus": {
+          "target": "com.amazonaws.configservice#EvaluationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an <code>EvaluationStatus</code> object.</p>"
+          }
+        },
+        "EvaluationStartTimestamp": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The start timestamp when Config rule starts evaluating compliance for the provided resource details.</p>"
+          }
+        },
+        "Compliance": {
+          "target": "com.amazonaws.configservice#ComplianceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The compliance status of the resource evaluation summary.</p>"
+          }
+        },
+        "EvaluationContext": {
+          "target": "com.amazonaws.configservice#EvaluationContext",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an <code>EvaluationContext</code> object.</p>"
+          }
+        },
+        "ResourceDetails": {
+          "target": "com.amazonaws.configservice#ResourceDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>ResourceDetails</code> object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GetStoredQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#GetStoredQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#GetStoredQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the details of a specific stored query.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GetStoredQueryRequest": {
+      "type": "structure",
+      "members": {
+        "QueryName": {
+          "target": "com.amazonaws.configservice#QueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the query.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#GetStoredQueryResponse": {
+      "type": "structure",
+      "members": {
+        "StoredQuery": {
+          "target": "com.amazonaws.configservice#StoredQuery",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>StoredQuery</code> object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#GroupByAPILimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.configservice#GroupedResourceCount": {
+      "type": "structure",
+      "members": {
+        "GroupName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the group that can be region, account ID, or resource type. For example, region1, region2 if the region was chosen as <code>GroupByKey</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceCount": {
+          "target": "com.amazonaws.configservice#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of resources in the group.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The count of resources that are grouped by the group name.</p>"
+      }
+    },
+    "com.amazonaws.configservice#GroupedResourceCountList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#GroupedResourceCount"
+      }
+    },
+    "com.amazonaws.configservice#IdempotentParameterMismatch": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Using the same client token with one or more different parameters. Specify a new client token with the parameter changes and try again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.configservice#IncludeGlobalResourceTypes": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.configservice#IncludedRegions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ThirdPartyCloudRegion"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.configservice#InsufficientDeliveryPolicyException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Your Amazon S3 bucket policy does not allow Config to\n\t\t\twrite to it.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InsufficientPermissionsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates one of the following errors:</p>\n         <ul>\n            <li>\n               <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConfigRule.html\">PutConfigRule</a>, the rule cannot be created because the IAM role assigned to Config lacks permissions to perform the config:Put* action.</p>\n            </li>\n            <li>\n               <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConfigRule.html\">PutConfigRule</a>, the Lambda function cannot be invoked. Check the function ARN, and check the function's permissions.</p>\n            </li>\n            <li>\n               <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutOrganizationConfigRule.html\">PutOrganizationConfigRule</a>, organization Config rule cannot be created because you do not have permissions to call IAM <code>GetRole</code> action or create a service-linked role.</p>\n            </li>\n            <li>\n               <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConformancePack.html\">PutConformancePack</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutOrganizationConformancePack.html\">PutOrganizationConformancePack</a>, a conformance pack cannot be created because you do not have the following permissions: </p>\n               <ul>\n                  <li>\n                     <p>You do not have permission to call IAM <code>GetRole</code> action or create a service-linked role.</p>\n                  </li>\n                  <li>\n                     <p>You do not have permission to read Amazon S3 bucket or call SSM:GetDocument.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutServiceLinkedConfigurationRecorder.html\">PutServiceLinkedConfigurationRecorder</a>, a service-linked configuration recorder cannot be created because you do not have the following permissions: IAM <code>CreateServiceLinkedRole</code>.</p>\n            </li>\n            <li>\n               <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConnector.html\">PutConnector</a>, a connector cannot be created because you do not have the following permissions: IAM <code>CreateServiceLinkedRole</code>.</p>\n            </li>\n         </ul>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#Integer": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.configservice#InvalidConfigurationRecorderNameException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration recorder name is not valid. The prefix \"<code>AWSConfigurationRecorderFor</code>\" is reserved for service-linked configuration recorders.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidDeliveryChannelNameException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified delivery channel name is not valid.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidExpressionException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The syntax of the query is incorrect.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidLimitException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified limit is outside the allowable range.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidNextTokenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified next token is not valid. Specify the\n\t\t\t\t<code>nextToken</code> string that was returned in the previous\n\t\t\tresponse to get the next page of results.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidParameterValueException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>One or more of the specified parameters are not valid. Verify\n\t\t\tthat your parameters are valid and try again.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidRecordingGroupException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>One of the following errors:</p>\n         <ul>\n            <li>\n               <p>You have provided a combination of parameter values that is not valid. For example:</p>\n               <ul>\n                  <li>\n                     <p>Setting the <code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to <code>true</code>,\n\t\t\t\t\t\tbut providing a non-empty list for the <code>resourceTypes</code>field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>.</p>\n                  </li>\n                  <li>\n                     <p>Setting the <code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to <code>true</code>, but also setting the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>EXCLUSION_BY_RESOURCE_TYPES</code>.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Every parameter is either null, false, or empty.</p>\n            </li>\n            <li>\n               <p>You have reached the limit of the number of resource types you can provide for the recording group.</p>\n            </li>\n            <li>\n               <p>You have provided resource types or a recording strategy that are not valid.</p>\n            </li>\n         </ul>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidResultTokenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified <code>ResultToken</code> is not valid.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidRoleException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have provided a null or empty Amazon Resource Name (ARN) for the IAM role assumed by Config and used by the customer managed configuration recorder.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidS3KeyPrefixException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified Amazon S3 key prefix is not valid.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidS3KmsKeyArnException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified Amazon KMS Key ARN is not valid.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidSNSTopicARNException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified Amazon SNS topic does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#InvalidTimeRangeException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified time range is not valid. The earlier time is not\n\t\t\tchronologically before the later time.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#LastDeliveryChannelDeleteFailedException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You cannot delete the delivery channel you specified because the customer managed configuration recorder is running.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#LastUpdatedTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#LaterTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#Limit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>For <code>PutServiceLinkedConfigurationRecorder</code> API, this exception\n\t\t\tis thrown if the number of service-linked roles in the account exceeds the limit.</p>\n         <p>For <code>StartConfigRulesEvaluation</code> API, this exception\n\t\t\tis thrown if an evaluation is in progress or if you call the <a>StartConfigRulesEvaluation</a> API more than once per\n\t\t\tminute.</p>\n         <p>For <code>PutConfigurationAggregator</code> API, this exception\n\t\t\tis thrown if the number of accounts and aggregators exceeds the\n\t\t\tlimit.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#ListAggregateDiscoveredResources": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListAggregateDiscoveredResourcesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListAggregateDiscoveredResourcesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Accepts a resource type and returns a list of resource identifiers that are aggregated for a specific resource type across accounts and regions. \n\t\t\tA resource identifier includes the resource type, ID, (if available) the custom resource name, source account, and source region. \n\t\t\tYou can narrow the results to include only resources that have specific resource IDs, or a resource name, or source account ID, or source region.</p>\n         <p>For example, if the input consists of accountID 12345678910 and the region is us-east-1 for resource type <code>AWS::EC2::Instance</code> then the API returns all the EC2 instance identifiers of accountID 12345678910 and region us-east-1.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ResourceIdentifiers",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListAggregateDiscoveredResourcesRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resources that you want Config to list in the response.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ResourceFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on the <code>ResourceFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of resource identifiers returned on each page. You cannot specify a number greater than 100. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListAggregateDiscoveredResourcesResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceIdentifiers": {
+          "target": "com.amazonaws.configservice#DiscoveredResourceIdentifierList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of <code>ResourceIdentifiers</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListConfigurationRecorders": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListConfigurationRecordersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListConfigurationRecordersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of configuration recorders depending on the filters you specify.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConfigurationRecorderSummaries",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListConfigurationRecordersRequest": {
+      "type": "structure",
+      "members": {
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on a list of <code>ConfigurationRecorderFilter</code> objects that you specify.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.configservice#MaxResults",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The maximum number of results to include in the response.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>NextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListConfigurationRecordersResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderSummaries": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorderSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConfigurationRecorderSummary</code> objects that includes.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>NextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListConformancePackComplianceScores": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListConformancePackComplianceScoresRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListConformancePackComplianceScoresResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of conformance pack compliance scores. \n\t\t\tA compliance score is the percentage of the number of compliant rule-resource combinations in a conformance pack compared to the number of total possible rule-resource combinations in the conformance pack.\n\t\t\tThis metric provides you with a high-level view of the compliance state of your conformance packs. You can use it to identify, investigate, and understand\n\t\t\tthe level of compliance in your conformance packs.</p>\n         <note>\n            <p>Conformance packs with no evaluation results will have a compliance score of <code>INSUFFICIENT_DATA</code>.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListConformancePackComplianceScoresRequest": {
+      "type": "structure",
+      "members": {
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceScoresFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on the <code>ConformancePackComplianceScoresFilters</code>.</p>"
+          }
+        },
+        "SortOrder": {
+          "target": "com.amazonaws.configservice#SortOrder",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines the order in which conformance pack compliance scores are sorted. Either in ascending or descending order.</p>\n         <p>By default, conformance pack compliance scores are sorted in alphabetical order by name of the conformance pack. Conformance pack compliance scores are sorted in reverse alphabetical order if you enter <code>DESCENDING</code>.</p>\n         <p>You can sort conformance pack compliance scores by the numerical value of the compliance score by entering <code>SCORE</code> in the <code>SortBy</code> action. When compliance scores are sorted by <code>SCORE</code>, conformance packs with a compliance score of <code>INSUFFICIENT_DATA</code> will be last when sorting by ascending order and first when sorting by descending order.</p>"
+          }
+        },
+        "SortBy": {
+          "target": "com.amazonaws.configservice#SortBy",
+          "traits": {
+            "smithy.api#documentation": "<p>Sorts your conformance pack compliance scores in either ascending or descending order, depending on <code>SortOrder</code>.</p>\n         <p>By default, conformance pack compliance scores are sorted in alphabetical order by name of the conformance pack.\n\t\t\tEnter <code>SCORE</code>, to sort conformance pack compliance scores by the numerical value of the compliance score.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#PageSizeLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of conformance pack compliance scores returned on each page.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string in a prior request that you can use to get the paginated response for the next set of conformance pack compliance scores.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListConformancePackComplianceScoresResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string that you can use to get the next page of results in a paginated response.</p>"
+          }
+        },
+        "ConformancePackComplianceScores": {
+          "target": "com.amazonaws.configservice#ConformancePackComplianceScores",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackComplianceScore</code> objects.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListConnectors": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListConnectorsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListConnectorsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of connectors depending on the filters you specify.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ConnectorSummaries",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListConnectorsMaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListConnectorsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.configservice#ListConnectorsMaxResults",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results to include in the response.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>NextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        },
+        "Filters": {
+          "target": "com.amazonaws.configservice#ConnectorFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results based on a list of <code>ConnectorFilter</code> objects that you specify.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListConnectorsResponse": {
+      "type": "structure",
+      "members": {
+        "ConnectorSummaries": {
+          "target": "com.amazonaws.configservice#ConnectorSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConnectorSummary</code> objects.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>NextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListDiscoveredResources": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListDiscoveredResourcesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListDiscoveredResourcesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of resource\n\t\t\tresource identifiers for the specified resource types for the resources of that type. A <i>resource identifier</i>\n\t\t\tincludes the resource type, ID, and (if available) the custom\n\t\t\tresource name.</p>\n         <p>The results consist of resources that Config has\n\t\t\t<i>discovered</i>, including those that Config is not currently\n\t\t\trecording. You can narrow the results to include only resources that\n\t\t\thave specific resource IDs or a resource name.</p>\n         <note>\n            <p>You can specify either resource IDs or a resource name, but\n\t\t\t\tnot both, in the same request.</p>\n         </note>\n         <important>\n            <p>\n               <i>CloudFormation stack recording behavior in Config</i>\n            </p>\n            <p>When a CloudFormation stack fails to create (for example, it enters the <code>ROLLBACK_FAILED</code> state), \n\t\t\t\tConfig does not record a configuration item (CI) for that stack. Configuration items are only recorded for stacks that reach \n\t\t\t\tthe following states:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>CREATE_COMPLETE</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>UPDATE_COMPLETE</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>UPDATE_ROLLBACK_COMPLETE</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>UPDATE_ROLLBACK_FAILED</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>DELETE_FAILED</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>DELETE_COMPLETE</code>\n                  </p>\n               </li>\n            </ul>\n            <p>Because no CI is created for a failed stack creation, you won't see configuration history \n\t\t\t\tfor that stack in Config, even after the stack is deleted. This helps make sure that Config only \n\t\t\t\ttracks resources that were successfully provisioned.</p>\n         </important>",
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "resourceIdentifiers",
+          "pageSize": "limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListDiscoveredResourcesRequest": {
+      "type": "structure",
+      "members": {
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resources that you want Config to list in the\n\t\t\tresponse.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourceIds": {
+          "target": "com.amazonaws.configservice#ResourceIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>The IDs of only those resources that you want Config to\n\t\t\tlist in the response. If you do not specify this parameter, Config lists all resources of the specified type that it has\n\t\t\tdiscovered. You can list a minimum of 1 resourceID and a maximum of 20 resourceIds.</p>"
+          }
+        },
+        "resourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name of only those resources that you want Config to list in the response. If you do not specify this\n\t\t\tparameter, Config lists all resources of the specified type that\n\t\t\tit has discovered.</p>"
+          }
+        },
+        "limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of resource identifiers returned on each\n\t\t\tpage. The default is 100. You cannot specify a number greater than\n\t\t\t100. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "includeDeletedResources": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether Config includes deleted resources in the\n\t\t\tresults. By default, deleted resources are not included.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page\n\t\t\tthat you use to get the next page of results in a paginated\n\t\t\tresponse.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListDiscoveredResourcesResponse": {
+      "type": "structure",
+      "members": {
+        "resourceIdentifiers": {
+          "target": "com.amazonaws.configservice#ResourceIdentifierList",
+          "traits": {
+            "smithy.api#documentation": "<p>The details that identify a resource that is discovered by Config, including the resource type, ID, and (if available) the\n\t\t\tcustom resource name.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The string that you use in a subsequent request to get the next\n\t\t\tpage of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListResourceEvaluations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListResourceEvaluationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListResourceEvaluationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidTimeRangeException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of proactive resource evaluations.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ResourceEvaluations",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListResourceEvaluationsPageItemLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListResourceEvaluationsRequest": {
+      "type": "structure",
+      "members": {
+        "Filters": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>ResourceEvaluationFilters</code> object.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#ListResourceEvaluationsPageItemLimit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of evaluations returned on each page. The default is 10. \n\t\t\tYou cannot specify a number greater than 100. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListResourceEvaluationsResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceEvaluations": {
+          "target": "com.amazonaws.configservice#ResourceEvaluations",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>ResourceEvaluations</code> object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListStoredQueries": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListStoredQueriesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListStoredQueriesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the stored queries for a single Amazon Web Services account and a single Amazon Web Services Region. The default is 100. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListStoredQueriesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned in a previous request that you use to request the next page of results in a paginated response.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The maximum number of results to be returned with a single call.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListStoredQueriesResponse": {
+      "type": "structure",
+      "members": {
+        "StoredQueryMetadata": {
+          "target": "com.amazonaws.configservice#StoredQueryMetadataList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>StoredQueryMetadata</code> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>If the previous paginated request didn't return all of the remaining results, the response object's <code>NextToken</code> parameter value is set to a token. \n\t\t\tTo retrieve the next set of results, call this operation again and assign that token to the request object's <code>NextToken</code> parameter. \n\t\t\tIf there are no remaining results, the previous response object's <code>NextToken</code> parameter is set to <code>null</code>. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List the tags for Config resource.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Tags",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the resource for which to list the tags. The following resources are supported:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationRecorder</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigRule</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>OrganizationConfigRule</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConformancePack</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>OrganizationConformancePack</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigurationAggregator</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>AggregationAuthorization</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>StoredQuery</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>Connector</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of tags returned on each page. The limit maximum is 50. You cannot specify a number greater than 50. If you specify 0, Config uses the default. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the resource.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#Long": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.configservice#MaxActiveResourcesExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of active custom resource types in your account. There is a limit of 100,000.\n\t\t\tDelete unused resources using <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteResourceConfig.html\">DeleteResourceConfig</a>\n            <code></code>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfConfigRulesExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Failed to add the Config rule because the account already\n\t\t\tcontains the maximum number of 1000 rules. Consider deleting any\n\t\t\tdeactivated rules before you add new rules.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfConfigurationRecordersExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of configuration recorders you can\n\t\t\tcreate.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfConformancePacksExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of conformance packs you can create in an account. For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfConnectorsExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of connectors in your account.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfDeliveryChannelsExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of delivery channels\n\t\t\tyou can create.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfOrganizationConfigRulesExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of organization Config rules you can create. For more information, see see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfOrganizationConformancePacksExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of organization conformance packs you can create in an account. For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxNumberOfRetentionConfigurationsExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Failed to add the retention configuration because a retention configuration with that name already exists.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.configservice#MaximumExecutionFrequency": {
+      "type": "enum",
+      "members": {
+        "One_Hour": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "One_Hour"
+          }
+        },
+        "Three_Hours": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Three_Hours"
+          }
+        },
+        "Six_Hours": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Six_Hours"
+          }
+        },
+        "Twelve_Hours": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Twelve_Hours"
+          }
+        },
+        "TwentyFour_Hours": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TwentyFour_Hours"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#MemberAccountRuleStatus": {
+      "type": "enum",
+      "members": {
+        "CREATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_SUCCESSFUL"
+          }
+        },
+        "CREATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+          }
+        },
+        "CREATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_FAILED"
+          }
+        },
+        "DELETE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_SUCCESSFUL"
+          }
+        },
+        "DELETE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_FAILED"
+          }
+        },
+        "DELETE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_SUCCESSFUL"
+          }
+        },
+        "UPDATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#MemberAccountStatus": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of a member account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit64",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of Config rule deployed in the member account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MemberAccountRuleStatus": {
+          "target": "com.amazonaws.configservice#MemberAccountRuleStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status for Config rule in the member account.\n\t\t\tWhen management account calls <code>PutOrganizationConfigRule</code> action for the first time, Config rule status is created in the member account. \n\t\t\tWhen management account calls <code>PutOrganizationConfigRule</code> action for the second time, Config rule status is updated in the member account.   \n\t\t\tConfig rule status is deleted when the management account deletes <code>OrganizationConfigRule</code> and disables service access for <code>config-multiaccountsetup.amazonaws.com</code>. \n\t\t</p>\n         <p> Config sets the state of the rule to:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE_SUCCESSFUL</code> when Config rule has been created in the member account. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_IN_PROGRESS</code> when Config rule is being created in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_FAILED</code> when Config rule creation has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_FAILED</code> when Config rule deletion has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_IN_PROGRESS</code> when Config rule is being deleted in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_SUCCESSFUL</code> when Config rule has been deleted in the member account. </p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_SUCCESSFUL</code> when Config rule has been updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_IN_PROGRESS</code> when Config rule is being updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_FAILED</code> when Config rule deletion has failed in the member account.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error code that is returned when Config rule creation or deletion failed in the member account.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error message indicating that Config rule account creation or deletion has failed due to an error in the member account.</p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of the last status update.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Organization Config rule creation or deletion status in each member account. This includes the name of the rule, the status, error code and error message when the rule creation or deletion failed.</p>"
+      }
+    },
+    "com.amazonaws.configservice#MessageType": {
+      "type": "enum",
+      "members": {
+        "ConfigurationItemChangeNotification": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ConfigurationItemChangeNotification"
+          }
+        },
+        "ConfigurationSnapshotDeliveryCompleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ConfigurationSnapshotDeliveryCompleted"
+          }
+        },
+        "ScheduledNotification": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ScheduledNotification"
+          }
+        },
+        "OversizedConfigurationItemChangeNotification": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OversizedConfigurationItemChangeNotification"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#Name": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#NextToken": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#NoAvailableConfigurationRecorderException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There are no customer managed configuration recorders available to record your resources. Use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConfigurationRecorder.html\">PutConfigurationRecorder</a> operation to create the customer managed configuration\n\t\t\trecorder.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoAvailableDeliveryChannelException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There is no delivery channel available to record\n\t\t\tconfigurations.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoAvailableOrganizationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Organization is no longer available.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoRunningConfigurationRecorderException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There is no configuration recorder running.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchBucketException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified Amazon S3 bucket does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchConfigRuleException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Config rule in the request is not valid. Verify that the rule is an Config Process Check rule, that the rule name is correct, and that valid Amazon Resouce Names (ARNs) are used before trying again.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchConfigRuleInConformancePackException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Config rule that you passed in the filter does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchConfigurationAggregatorException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a configuration aggregator that does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchConfigurationRecorderException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a configuration recorder that does not\n\t\t\texist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchConformancePackException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You specified one or more conformance packs that do not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchDeliveryChannelException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a delivery channel that does not\n\t\t\texist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchOrganizationConfigRuleException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Config rule in the request is not valid. Verify that the rule is an organization Config Process Check rule, that the rule name is correct, and that valid Amazon Resouce Names (ARNs) are used before trying again.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchOrganizationConformancePackException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Config organization conformance pack that you passed in the filter does not exist.</p>\n         <p>For DeleteOrganizationConformancePack, you tried to delete an organization conformance pack that does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchRemediationConfigurationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You specified an Config rule without a remediation configuration.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchRemediationExceptionException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You tried to delete a remediation exception that does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#NoSuchRetentionConfigurationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a retention configuration that does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#OrderingTimestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#OrganizationAccessDeniedException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>For <code>PutConfigurationAggregator</code> API, you can see this exception for the following reasons:</p>\n         <ul>\n            <li>\n               <p>No permission to call <code>EnableAWSServiceAccess</code> API</p>\n            </li>\n            <li>\n               <p>The configuration aggregator cannot be updated because your Amazon Web Services Organization management account or the delegated administrator role changed. \n\t\t\t\tDelete this aggregator and create a new one with the current Amazon Web Services Organization.</p>\n            </li>\n            <li>\n               <p>The configuration aggregator is associated with a previous Amazon Web Services Organization and Config cannot aggregate data with current Amazon Web Services Organization. \n\t\t\t\tDelete this aggregator and create a new one with the current Amazon Web Services Organization.</p>\n            </li>\n            <li>\n               <p>You are not a registered delegated administrator for Config with permissions to call <code>ListDelegatedAdministrators</code> API. \n\t\t\tEnsure that the management account registers delagated administrator for Config service principal name before the delegated administrator creates an aggregator.</p>\n            </li>\n         </ul>\n         <p>For all <code>OrganizationConfigRule</code> and <code>OrganizationConformancePack</code> APIs, Config throws an exception if APIs are called from member accounts. All APIs must be called from organization management account.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationAggregationSource": {
+      "type": "structure",
+      "members": {
+        "RoleArn": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the IAM role used to retrieve Amazon Web Services Organization details\n\t\t\tassociated with the aggregator account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AwsRegions": {
+          "target": "com.amazonaws.configservice#AggregatorRegionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The source regions being aggregated.</p>"
+          }
+        },
+        "AllAwsRegions": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If true, aggregate existing Config regions and future\n\t\t\tregions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This object contains regions to set up the aggregator and an IAM\n\t\t\trole to retrieve organization details.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationAllFeaturesNotEnabledException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Config resource cannot be created because your organization does not have all features enabled.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRule": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleName": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assign to organization Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OrganizationConfigRuleArn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of organization Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OrganizationManagedRuleMetadata": {
+          "target": "com.amazonaws.configservice#OrganizationManagedRuleMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>OrganizationManagedRuleMetadata</code> object.</p>"
+          }
+        },
+        "OrganizationCustomRuleMetadata": {
+          "target": "com.amazonaws.configservice#OrganizationCustomRuleMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>OrganizationCustomRuleMetadata</code> object.</p>"
+          }
+        },
+        "ExcludedAccounts": {
+          "target": "com.amazonaws.configservice#ExcludedAccounts",
+          "traits": {
+            "smithy.api#documentation": "<p>A comma-separated list of accounts excluded from organization Config rule.</p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of the last update.</p>"
+          }
+        },
+        "OrganizationCustomPolicyRuleMetadata": {
+          "target": "com.amazonaws.configservice#OrganizationCustomPolicyRuleMetadataNoPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>An\n\t\t\tobject that specifies metadata for your organization's Config Custom Policy rule. The metadata includes the runtime system in use, which accounts have\n\t\t\tdebug logging enabled, and other custom rule metadata, such as resource type, resource\n\t\t\tID of Amazon Web Services resource, and organization trigger types that initiate Config to evaluate Amazon Web Services resources against a rule.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An organization Config rule that has information about Config rules that Config creates in member accounts.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleDetailedStatus": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#MemberAccountStatus"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[A-Za-z0-9-_]+$"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleNames": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit64"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleStatus": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleName": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assign to organization Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OrganizationRuleStatus": {
+          "target": "com.amazonaws.configservice#OrganizationRuleStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status of an organization Config rule. \n\t\t\tWhen management account calls PutOrganizationConfigRule action for the first time, Config rule status is created in all the member accounts. \n\t\t\tWhen management account calls PutOrganizationConfigRule action for the second time, Config rule status is updated in all the member accounts. Additionally, Config rule status is updated when one or more member accounts join or leave an organization.   \n\t\t\tConfig rule status is deleted when the management account deletes OrganizationConfigRule in all the member accounts and disables service access for <code>config-multiaccountsetup.amazonaws.com</code>.</p>\n         <p>Config sets the state of the rule to:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE_SUCCESSFUL</code> when an organization Config rule has been successfully created in all the member accounts. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_IN_PROGRESS</code> when an organization Config rule creation is in progress.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_FAILED</code> when an organization Config rule creation failed in one or more member accounts within that organization.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_FAILED</code> when an organization Config rule deletion failed in one or more member accounts within that organization.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_IN_PROGRESS</code> when an organization Config rule deletion is in progress.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_SUCCESSFUL</code> when an organization Config rule has been successfully deleted from all the member accounts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_SUCCESSFUL</code> when an organization Config rule has been successfully updated in all the member accounts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_IN_PROGRESS</code> when an organization Config rule update is in progress.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_FAILED</code> when an organization Config rule update failed in one or more member accounts within that organization.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error code that is returned when organization Config rule creation or deletion has failed.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error message indicating that organization Config rule creation or deletion failed due to an error.</p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of the last update.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the status for an organization Config rule in an organization.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleStatuses": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConfigRuleStatus"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleTriggerType": {
+      "type": "enum",
+      "members": {
+        "CONFIGURATION_ITEM_CHANGE_NOTIFICATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ConfigurationItemChangeNotification"
+          }
+        },
+        "OVERSIZED_CONFIGURATION_ITEM_CHANGE_NOTIFCATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OversizedConfigurationItemChangeNotification"
+          }
+        },
+        "SCHEDULED_NOTIFICATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ScheduledNotification"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypeNoSN": {
+      "type": "enum",
+      "members": {
+        "CONFIGURATION_ITEM_CHANGE_NOTIFICATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ConfigurationItemChangeNotification"
+          }
+        },
+        "OVERSIZED_CONFIGURATION_ITEM_CHANGE_NOTIFCATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OversizedConfigurationItemChangeNotification"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypeNoSNs": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypeNoSN"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConfigRuleTriggerType"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConfigRules": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConfigRule"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePack": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackName": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name you assign to an organization conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OrganizationConformancePackArn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of organization conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DeliveryS3Bucket": {
+          "target": "com.amazonaws.configservice#DeliveryS3Bucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where Config stores conformance pack templates.  </p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "DeliveryS3KeyPrefix": {
+          "target": "com.amazonaws.configservice#DeliveryS3KeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>Any folder structure you want to add to an Amazon S3 bucket.</p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "ConformancePackInputParameters": {
+          "target": "com.amazonaws.configservice#ConformancePackInputParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackInputParameter</code> objects.</p>"
+          }
+        },
+        "ExcludedAccounts": {
+          "target": "com.amazonaws.configservice#ExcludedAccounts",
+          "traits": {
+            "smithy.api#documentation": "<p>A comma-separated list of accounts excluded from organization conformance pack.</p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>Last time when organization conformation pack was updated.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An organization conformance pack that has information about conformance packs that Config creates in member accounts. </p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackDetailedStatus": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of a member account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of conformance pack deployed in the member account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.configservice#OrganizationResourceDetailedStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status for conformance pack in a member account.\n\t\t\tWhen management account calls <code>PutOrganizationConformancePack</code> action for the first time, conformance pack status is created in the member account. \n\t\t\tWhen management account calls <code>PutOrganizationConformancePack</code> action for the second time, conformance pack status is updated in the member account.   \n\t\t\tConformance pack status is deleted when the management account deletes <code>OrganizationConformancePack</code> and disables service access for <code>config-multiaccountsetup.amazonaws.com</code>. \n\t\t</p>\n         <p> Config sets the state of the conformance pack to:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE_SUCCESSFUL</code> when conformance pack has been created in the member account. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_IN_PROGRESS</code> when conformance pack is being created in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_FAILED</code> when conformance pack creation has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_FAILED</code> when conformance pack deletion has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_IN_PROGRESS</code> when conformance pack is being deleted in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_SUCCESSFUL</code> when conformance pack has been deleted in the member account. </p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_SUCCESSFUL</code> when conformance pack has been updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_IN_PROGRESS</code> when conformance pack is being updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_FAILED</code> when conformance pack deletion has failed in the member account.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error code that is returned when conformance pack creation or \n\t\t\tdeletion failed in the member account. </p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error message indicating that conformance pack account creation or deletion \n\t\t\thas failed due to an error in the member account. </p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of the last status update.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Organization conformance pack creation or deletion status in each member account. \n\t\t\tThis includes the name of the conformance pack, the status, error code and error message \n\t\t\twhen the conformance pack creation or deletion failed. </p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackDetailedStatuses": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConformancePackDetailedStatus"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[a-zA-Z][-a-zA-Z0-9]*$"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackNames": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConformancePackName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackStatus": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackName": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assign to organization conformance pack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.configservice#OrganizationResourceStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status of an organization conformance pack. \n\t\t\tWhen management account calls PutOrganizationConformancePack for the first time, \n\t\t\tconformance pack status is created in all the member accounts. \n\t\t\tWhen management account calls PutOrganizationConformancePack for the second time, \n\t\t\tconformance pack status is updated in all the member accounts. \n\t\t\tAdditionally, conformance pack status is updated when one or more member accounts join or leave an \n\t\t\torganization.   \n\t\t\tConformance pack status is deleted when the management account deletes \n\t\t\tOrganizationConformancePack in all the member accounts and disables service \n\t\t\taccess for <code>config-multiaccountsetup.amazonaws.com</code>.</p>\n         <p>Config sets the state of the conformance pack to:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE_SUCCESSFUL</code> when an organization conformance pack has been successfully created in all the member accounts. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_IN_PROGRESS</code> when an organization conformance pack creation is in progress.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_FAILED</code> when an organization conformance pack creation failed in one or more member accounts within that organization.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_FAILED</code> when an organization conformance pack deletion failed in one or more member accounts within that organization.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_IN_PROGRESS</code> when an organization conformance pack deletion is in progress.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_SUCCESSFUL</code> when an organization conformance pack has been successfully deleted from all the member accounts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_SUCCESSFUL</code> when an organization conformance pack has been successfully updated in all the member accounts.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_IN_PROGRESS</code> when an organization conformance pack update is in progress.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_FAILED</code> when an organization conformance pack update failed in one or more member accounts within that organization.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error code that is returned when organization conformance pack creation or deletion has failed in a member account. </p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error message indicating that organization conformance pack creation or deletion failed due to an error. </p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp of the last update.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the status for an organization conformance pack in an organization.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackStatuses": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConformancePackStatus"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePackTemplateValidationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a template that is not valid or supported.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationConformancePacks": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#OrganizationConformancePack"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationCustomPolicyRuleMetadata": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256Min0",
+          "traits": {
+            "smithy.api#documentation": "<p>The description that you provide for your organization Config Custom Policy rule.</p>"
+          }
+        },
+        "OrganizationConfigRuleTriggerTypes": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypeNoSNs",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of notification that initiates Config to run an evaluation for a rule.\n\t\t\tFor Config Custom Policy rules, Config supports change-initiated notification types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationItemChangeNotification</code> - Initiates an evaluation when Config delivers a configuration item as a result of a resource\n\t\t\t\t\tchange.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OversizedConfigurationItemChangeNotification</code> - Initiates an evaluation when\n\t\t\t\t\t\tConfig delivers an oversized configuration item. Config may generate this notification type when a resource changes and the\n\t\t\t\t\tnotification exceeds the maximum size allowed by Amazon SNS.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "InputParameters": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A string, in JSON format, that is passed to your organization Config Custom Policy rule.</p>"
+          }
+        },
+        "MaximumExecutionFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum frequency with which Config runs evaluations for a rule. Your\n\t\t\tConfig Custom Policy rule is triggered when Config delivers\n\t\t\tthe configuration snapshot. For more information, see <a>ConfigSnapshotDeliveryProperties</a>.</p>"
+          }
+        },
+        "ResourceTypesScope": {
+          "target": "com.amazonaws.configservice#ResourceTypesScope",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "ResourceIdScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit768",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "TagKeyScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit128",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>"
+          }
+        },
+        "TagValueScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).</p>"
+          }
+        },
+        "PolicyRuntime": {
+          "target": "com.amazonaws.configservice#PolicyRuntime",
+          "traits": {
+            "smithy.api#documentation": "<p>The runtime system for your organization Config Custom Policy rules. Guard is a policy-as-code language that allows you to write policies that are enforced by Config Custom Policy rules. For more information about Guard, see the <a href=\"https://github.com/aws-cloudformation/cloudformation-guard\">Guard GitHub\n\t\t\tRepository</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PolicyText": {
+          "target": "com.amazonaws.configservice#PolicyText",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy definition containing the logic for your organization Config Custom Policy rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DebugLogDeliveryAccounts": {
+          "target": "com.amazonaws.configservice#DebugLogDeliveryAccounts",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of accounts that you can enable debug logging for your organization Config Custom Policy rule. List is null when debug logging is enabled for all accounts.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An\n\t\t\tobject that specifies metadata for your organization's Config Custom Policy rule. The metadata includes the runtime system in use, which accounts have\n\t\t\tdebug logging enabled, and other custom rule metadata, such as resource type, resource\n\t\t\tID of Amazon Web Services resource, and organization trigger types that initiate Config to evaluate Amazon Web Services resources against a rule.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationCustomPolicyRuleMetadataNoPolicy": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256Min0",
+          "traits": {
+            "smithy.api#documentation": "<p>The description that you provide for your organization Config Custom Policy rule.</p>"
+          }
+        },
+        "OrganizationConfigRuleTriggerTypes": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypeNoSNs",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of notification that triggers Config to run an evaluation for a rule.\n\t\t\tFor Config Custom Policy rules, Config supports change\n\t\t\ttriggered notification types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationItemChangeNotification</code> - Triggers an evaluation when Config delivers a configuration item as a result of a resource change.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OversizedConfigurationItemChangeNotification</code> - Triggers an evaluation when Config delivers an oversized configuration item. \n\t\t\t\tConfig may generate this notification type when a resource changes and the notification exceeds the maximum size allowed by Amazon SNS.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "InputParameters": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A string, in JSON format, that is passed to your organization Config Custom Policy rule.</p>"
+          }
+        },
+        "MaximumExecutionFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum frequency with which Config runs evaluations for a rule. Your\n\t\t\tConfig Custom Policy rule is triggered when Config delivers\n\t\t\tthe configuration snapshot. For more information, see <a>ConfigSnapshotDeliveryProperties</a>.</p>"
+          }
+        },
+        "ResourceTypesScope": {
+          "target": "com.amazonaws.configservice#ResourceTypesScope",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "ResourceIdScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit768",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "TagKeyScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit128",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>"
+          }
+        },
+        "TagValueScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).</p>"
+          }
+        },
+        "PolicyRuntime": {
+          "target": "com.amazonaws.configservice#PolicyRuntime",
+          "traits": {
+            "smithy.api#documentation": "<p>The runtime system for your organization Config Custom Policy rules. Guard is a policy-as-code language that allows you to write policies that are enforced by Config Custom Policy rules. For more information about Guard, see the <a href=\"https://github.com/aws-cloudformation/cloudformation-guard\">Guard GitHub\n\t\t\tRepository</a>.</p>"
+          }
+        },
+        "DebugLogDeliveryAccounts": {
+          "target": "com.amazonaws.configservice#DebugLogDeliveryAccounts",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of accounts that you can enable debug logging for your organization Config Custom Policy rule. List is null when debug logging is enabled for all accounts.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> metadata for your organization Config Custom Policy rule including the runtime system in use, which accounts have debug logging enabled, and\n\t\t\tother custom rule metadata such as resource type, resource ID of Amazon Web Services\n\t\t\tresource, and organization trigger types that trigger Config to evaluate\n\t\t\t\tAmazon Web Services resources against a rule.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationCustomRuleMetadata": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256Min0",
+          "traits": {
+            "smithy.api#documentation": "<p>The description that you provide for your organization Config rule.</p>"
+          }
+        },
+        "LambdaFunctionArn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The lambda function ARN.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OrganizationConfigRuleTriggerTypes": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleTriggerTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of notification that triggers Config to run an evaluation for a rule. You can specify the following notification types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationItemChangeNotification</code> - Triggers an evaluation when Config delivers a configuration item as a result of a resource change.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OversizedConfigurationItemChangeNotification</code> - Triggers an evaluation when Config delivers an oversized configuration item. \n\t\t\t         \tConfig may generate this notification type when a resource changes and the notification exceeds the maximum size allowed by Amazon SNS.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ScheduledNotification</code> - Triggers a periodic evaluation at the frequency specified for <code>MaximumExecutionFrequency</code>.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputParameters": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A string, in JSON format, that is passed to your organization Config rule Lambda function.</p>"
+          }
+        },
+        "MaximumExecutionFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum frequency with which Config runs evaluations for a rule. \n\t\t\tYour custom rule is triggered when Config delivers the configuration snapshot. For more information, see <a>ConfigSnapshotDeliveryProperties</a>.</p>\n         <note>\n            <p>By default, rules with a periodic trigger are evaluated every 24 hours. To change the frequency, specify a valid \n\t\t\tvalue for the <code>MaximumExecutionFrequency</code> parameter.</p>\n         </note>"
+          }
+        },
+        "ResourceTypesScope": {
+          "target": "com.amazonaws.configservice#ResourceTypesScope",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "ResourceIdScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit768",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "TagKeyScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit128",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair that make up a tag. \n\t\t\tA key is a general label that acts like a category for more specific tag values. </p>"
+          }
+        },
+        "TagValueScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional part of a key-value pair that make up a tag. \n\t\t\tA value acts as a descriptor within a tag category (key). </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that specifies organization custom rule metadata such as resource type, resource ID of Amazon Web Services resource, Lambda function ARN, \n\t\t\tand organization trigger types that trigger Config to evaluate your Amazon Web Services resources against a rule. \n\t\t\tIt also provides the frequency with which you want Config to run evaluations for the rule if the trigger type is periodic.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationManagedRuleMetadata": {
+      "type": "structure",
+      "members": {
+        "Description": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256Min0",
+          "traits": {
+            "smithy.api#documentation": "<p>The description that you provide for your organization Config rule.</p>"
+          }
+        },
+        "RuleIdentifier": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>For organization config managed rules, a predefined identifier from a\n\t\t\tlist. For example, <code>IAM_PASSWORD_POLICY</code> is a managed\n\t\t\trule. To reference a managed rule, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html\">Using Config managed rules</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputParameters": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>A string, in JSON format, that is passed to your organization Config rule Lambda function.</p>"
+          }
+        },
+        "MaximumExecutionFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum frequency with which Config runs evaluations for a rule. This is for an Config managed rule that is triggered at a periodic frequency.</p>\n         <note>\n            <p>By default, rules with a periodic trigger are evaluated every 24 hours. To change the frequency, specify a valid \n\t\t\tvalue for the <code>MaximumExecutionFrequency</code> parameter.</p>\n         </note>"
+          }
+        },
+        "ResourceTypesScope": {
+          "target": "com.amazonaws.configservice#ResourceTypesScope",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "ResourceIdScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit768",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon Web Services resource that was evaluated.</p>"
+          }
+        },
+        "TagKeyScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit128",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair that make up a tag. \n\t\t\tA key is a general label that acts like a category for more specific tag values. </p>"
+          }
+        },
+        "TagValueScope": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional part of a key-value pair that make up a tag. \n\t\t\tA value acts as a descriptor within a tag category (key).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that specifies organization managed rule metadata such as resource type and ID of Amazon Web Services resource along with the rule identifier. \n\t\t\tIt also provides the frequency with which you want Config to run evaluations for the rule if the trigger type is periodic.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationResourceDetailedStatus": {
+      "type": "enum",
+      "members": {
+        "CREATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_SUCCESSFUL"
+          }
+        },
+        "CREATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+          }
+        },
+        "CREATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_FAILED"
+          }
+        },
+        "DELETE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_SUCCESSFUL"
+          }
+        },
+        "DELETE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_FAILED"
+          }
+        },
+        "DELETE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_SUCCESSFUL"
+          }
+        },
+        "UPDATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#OrganizationResourceDetailedStatusFilters": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the member account within an organization.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.configservice#OrganizationResourceDetailedStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status for conformance pack in a member account.\n\t\t\tWhen management account calls <code>PutOrganizationConformancePack</code> action for the first time, conformance pack status is created in the member account. \n\t\t\tWhen management account calls <code>PutOrganizationConformancePack</code> action for the second time, conformance pack status is updated in the member account.   \n\t\t\tConformance pack status is deleted when the management account deletes <code>OrganizationConformancePack</code> and disables service access for <code>config-multiaccountsetup.amazonaws.com</code>. \n\t\t</p>\n         <p> Config sets the state of the conformance pack to:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE_SUCCESSFUL</code> when conformance pack has been created in the member account. </p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_IN_PROGRESS</code> when conformance pack is being created in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_FAILED</code> when conformance pack creation has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_FAILED</code> when conformance pack deletion has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_IN_PROGRESS</code> when conformance pack is being deleted in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_SUCCESSFUL</code> when conformance pack has been deleted in the member account. </p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_SUCCESSFUL</code> when conformance pack has been updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_IN_PROGRESS</code> when conformance pack is being updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_FAILED</code> when conformance pack deletion has failed in the member account.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Status filter object to filter results based on specific member account ID or status type for an organization conformance pack.</p>"
+      }
+    },
+    "com.amazonaws.configservice#OrganizationResourceStatus": {
+      "type": "enum",
+      "members": {
+        "CREATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_SUCCESSFUL"
+          }
+        },
+        "CREATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+          }
+        },
+        "CREATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_FAILED"
+          }
+        },
+        "DELETE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_SUCCESSFUL"
+          }
+        },
+        "DELETE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_FAILED"
+          }
+        },
+        "DELETE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_SUCCESSFUL"
+          }
+        },
+        "UPDATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#OrganizationRuleStatus": {
+      "type": "enum",
+      "members": {
+        "CREATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_SUCCESSFUL"
+          }
+        },
+        "CREATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+          }
+        },
+        "CREATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATE_FAILED"
+          }
+        },
+        "DELETE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_SUCCESSFUL"
+          }
+        },
+        "DELETE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_FAILED"
+          }
+        },
+        "DELETE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_SUCCESSFUL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_SUCCESSFUL"
+          }
+        },
+        "UPDATE_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_IN_PROGRESS"
+          }
+        },
+        "UPDATE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATE_FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#OversizedConfigurationItemException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration item size is outside the allowable range.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#Owner": {
+      "type": "enum",
+      "members": {
+        "Custom_Lambda": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOM_LAMBDA"
+          }
+        },
+        "Aws": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS"
+          }
+        },
+        "Custom_Policy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOM_POLICY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#PageSizeLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.configservice#ParameterName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 255
+        }
+      }
+    },
+    "com.amazonaws.configservice#ParameterValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 4096
+        }
+      }
+    },
+    "com.amazonaws.configservice#PendingAggregationRequest": {
+      "type": "structure",
+      "members": {
+        "RequesterAccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the account requesting to aggregate\n\t\t\tdata.</p>"
+          }
+        },
+        "RequesterAwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region requesting to aggregate data. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the account ID and region of an\n\t\t\taggregator account that is requesting authorization but is not yet\n\t\t\tauthorized.</p>"
+      }
+    },
+    "com.amazonaws.configservice#PendingAggregationRequestList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#PendingAggregationRequest"
+      }
+    },
+    "com.amazonaws.configservice#Percentage": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#PolicyRuntime": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^guard\\-2\\.x\\.x$"
+      }
+    },
+    "com.amazonaws.configservice#PolicyText": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10000
+        }
+      }
+    },
+    "com.amazonaws.configservice#Provider": {
+      "type": "enum",
+      "members": {
+        "AZURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AZURE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#PutAggregationAuthorization": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutAggregationAuthorizationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutAggregationAuthorizationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Authorizes the aggregator account and region to collect data\n\t\t\tfrom the source account and region. </p>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>\n               <code>PutAggregationAuthorization</code> is an idempotent API. Subsequent requests won\u2019t create a duplicate resource if one was already created. If a following request has different <code>tags</code> values,\n\t\t\tConfig will ignore these differences and treat it as an idempotent request of the previous. In this case, <code>tags</code> will not be updated, even if they are different.</p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutAggregationAuthorizationRequest": {
+      "type": "structure",
+      "members": {
+        "AuthorizedAccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the account authorized to aggregate data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AuthorizedAwsRegion": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region authorized to collect aggregated data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tag object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutAggregationAuthorizationResponse": {
+      "type": "structure",
+      "members": {
+        "AggregationAuthorization": {
+          "target": "com.amazonaws.configservice#AggregationAuthorization",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an AggregationAuthorization object.\n\t\t\t\n\t\t</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutConfigRuleRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfConfigRulesExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds or updates an Config rule to evaluate if your\n\t\t\tAmazon Web Services resources comply with your desired configurations. For information on how many Config rules you can have per account, \n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>\n         <p>There are two types of rules: <i>Config Managed Rules</i> and <i>Config Custom Rules</i>.\n\t\t\tYou can use <code>PutConfigRule</code> to create both Config Managed Rules and  Config Custom Rules.</p>\n         <p>Config Managed Rules are predefined,\n\t\t\tcustomizable rules created by Config. For a list of managed rules, see\n\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html\">List of Config\n\t\t\t\tManaged Rules</a>. If you are adding an Config managed rule, you must specify the\n\t\t\trule's identifier for the <code>SourceIdentifier</code> key.</p>\n         <p>Config Custom Rules are rules that you create from scratch. There are two ways to create Config custom rules: with Lambda functions\n\t\t\t(<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/gettingstarted-concepts.html#gettingstarted-concepts-function\"> Lambda Developer Guide</a>) and with Guard (<a href=\"https://github.com/aws-cloudformation/cloudformation-guard\">Guard GitHub\n\t\t\t\t\tRepository</a>), a policy-as-code language.\n\t\t\t\n\t\t\tConfig custom rules created with Lambda\n\t\t\tare called <i>Config Custom Lambda Rules</i> and Config custom rules created with\n\t\t\tGuard are called <i>Config Custom Policy Rules</i>.</p>\n         <p>If you are adding a new Config Custom Lambda rule,\n\t\t\tyou first need to create an Lambda function that the rule invokes to evaluate\n\t\t\tyour resources. When you use <code>PutConfigRule</code> to add a Custom Lambda rule to Config, you must specify the Amazon Resource\n\t\t\tName (ARN) that Lambda assigns to the function. You specify the ARN\n\t\t\tin the <code>SourceIdentifier</code> key. This key is part of the\n\t\t\t<code>Source</code> object, which is part of the\n\t\t\t<code>ConfigRule</code> object. </p>\n         <p>For any new Config rule that you add, specify the\n\t\t\t\t<code>ConfigRuleName</code> in the <code>ConfigRule</code>\n\t\t\tobject. Do not specify the <code>ConfigRuleArn</code> or the\n\t\t\t<code>ConfigRuleId</code>. These values are generated by Config for new rules.</p>\n         <p>If you are updating a rule that you added previously, you can\n\t\t\tspecify the rule by <code>ConfigRuleName</code>,\n\t\t\t\t<code>ConfigRuleId</code>, or <code>ConfigRuleArn</code> in the\n\t\t\t\t<code>ConfigRule</code> data type that you use in this\n\t\t\trequest.</p>\n         <p>For more information about developing and using Config\n\t\t\trules, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html\">Evaluating Resources with Config Rules</a>\n\t\t\tin the <i>Config Developer Guide</i>.</p>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>\n               <code>PutConfigRule</code> is an idempotent API. Subsequent requests won\u2019t create a duplicate resource if one was already created. If a following request has different <code>tags</code> values,\n\t\t\tConfig will ignore these differences and treat it as an idempotent request of the previous. In this case, <code>tags</code> will not be updated, even if they are different.</p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRule": {
+          "target": "com.amazonaws.configservice#ConfigRule",
+          "traits": {
+            "smithy.api#documentation": "<p>The rule that you want to add to your account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tag object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConfigurationAggregator": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutConfigurationAggregatorRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutConfigurationAggregatorResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidRoleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableOrganizationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAllFeaturesNotEnabledException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates and updates the configuration aggregator with the\n\t\t\tselected source accounts and regions. The source account can be\n\t\t\tindividual account(s) or an organization.</p>\n         <p>\n            <code>accountIds</code> that are passed will be replaced with existing accounts.\n\t\t\tIf you want to add additional accounts into the aggregator, call <code>DescribeConfigurationAggregators</code> to get the previous accounts and then append new ones.</p>\n         <note>\n            <p>Config should be enabled in source accounts and regions\n\t\t\t\tyou want to aggregate.</p>\n            <p>If your source type is an organization, you must be signed in to the management account or a registered delegated administrator and all the features must be enabled in your organization. \n\t\t\t\tIf the caller is a management account, Config calls <code>EnableAwsServiceAccess</code> API to enable integration between Config and Organizations.\n\t\t\t\tIf the caller is a registered delegated administrator, Config calls <code>ListDelegatedAdministrators</code> API to verify whether the caller is a valid delegated administrator.</p>\n            <p>To register a delegated administrator, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/set-up-aggregator-cli.html#register-a-delegated-administrator-cli\">Register a Delegated Administrator</a> in the <i>Config developer guide</i>. </p>\n         </note>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>\n               <code>PutConfigurationAggregator</code> is an idempotent API. Subsequent requests won\u2019t create a duplicate resource if one was already created. If a following request has different <code>tags</code> values,\n\t\t\tConfig will ignore these differences and treat it as an idempotent request of the previous. In this case, <code>tags</code> will not be updated, even if they are different.</p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutConfigurationAggregatorRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AccountAggregationSources": {
+          "target": "com.amazonaws.configservice#AccountAggregationSourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of AccountAggregationSource object.\n\t\t\t\n\t\t</p>"
+          }
+        },
+        "OrganizationAggregationSource": {
+          "target": "com.amazonaws.configservice#OrganizationAggregationSource",
+          "traits": {
+            "smithy.api#documentation": "<p>An OrganizationAggregationSource object.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tag object.</p>"
+          }
+        },
+        "AggregatorFilters": {
+          "target": "com.amazonaws.configservice#AggregatorFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>An object to filter configuration recorders in an aggregator. Either <code>ResourceType</code> or <code>ServicePrincipal</code> is required.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConfigurationAggregatorResponse": {
+      "type": "structure",
+      "members": {
+        "ConfigurationAggregator": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregator",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a ConfigurationAggregator object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidConfigurationRecorderNameException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidRecordingGroupException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidRoleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfConfigurationRecordersExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#UnmodifiableEntityException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates the customer managed configuration recorder.</p>\n         <p>You can use this operation to create a new customer managed configuration recorder or to update the <code>roleARN</code> and the <code>recordingGroup</code> for an existing customer managed configuration recorder.</p>\n         <p>To start the customer managed configuration recorder and begin recording configuration changes for the resource types you specify,\n\t\t\tuse the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_StartConfigurationRecorder.html\">StartConfigurationRecorder</a> operation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/stop-start-recorder.html\">\n               <b>Working with the Configuration Recorder</b>\n            </a> in the <i>Config Developer Guide</i>.</p>\n         <note>\n            <p>\n               <b>One customer managed configuration recorder per account per Region</b>\n            </p>\n            <p>You can create only one customer managed configuration recorder for each account for each Amazon Web Services Region.</p>\n            <p>\n               <b>Default is to record all supported resource types, excluding the global IAM resource types</b>\n            </p>\n            <p>If you have not specified values for the <code>recordingGroup</code> field, the default for the customer managed configuration recorder is to record all supported resource\n\t\t\t\ttypes, excluding the global IAM resource types: <code>AWS::IAM::Group</code>, <code>AWS::IAM::Policy</code>, <code>AWS::IAM::Role</code>, and <code>AWS::IAM::User</code>.</p>\n            <p>\n               <b>Tags are added at creation and cannot be updated</b>\n            </p>\n            <p>\n               <code>PutConfigurationRecorder</code> is an idempotent API. Subsequent requests won\u2019t create a duplicate resource if one was already created. If a following request has different tags values,\n\t\t\t\tConfig will ignore these differences and treat it as an idempotent request of the previous. In this case, tags will not be updated, even if they are different.</p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorder": {
+          "target": "com.amazonaws.configservice#ConfigurationRecorder",
+          "traits": {
+            "smithy.api#documentation": "<p>An object for the configuration recorder. A configuration recorder records configuration changes for the resource types in scope.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the customer managed configuration recorder. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>PutConfigurationRecorder</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConformancePack": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutConformancePackRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutConformancePackResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConformancePackTemplateValidationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfConformancePacksExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates a conformance pack. A conformance pack is a collection of Config rules that can be easily deployed in an account and a region and across an organization.\n\t\t\tFor information on how many conformance packs you can have per account, \n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>\n         <important>\n            <p>When you use <code>PutConformancePack</code> to deploy conformance packs in your account,\n\t\t\t\tthe operation can create Config rules and remediation actions without\n\t\t\t\trequiring <code>config:PutConfigRule</code> or\n\t\t\t\t\t<code>config:PutRemediationConfigurations</code> permissions in your account IAM\n\t\t\t\tpolicies.</p>\n            <p>This API uses the <code>AWSServiceRoleForConfigConforms</code> service-linked role in your\n\t\t\t\taccount to create conformance pack resources. This service-linked role includes the\n\t\t\t\tpermissions to create Config rules and remediation configurations, even\n\t\t\t\tif your account IAM policies explicitly deny these actions.</p>\n         </important>\n         <p>This API creates a service-linked role <code>AWSServiceRoleForConfigConforms</code> in your account. \n\t\tThe service-linked role is created only when the role does not exist in your account. </p>\n         <note>\n            <p>You must specify only one of the follow parameters: <code>TemplateS3Uri</code>, <code>TemplateBody</code> or <code>TemplateSSMDocumentDetails</code>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>\n               <code>PutConformancePack</code> is an idempotent API. Subsequent requests won't create a duplicate resource if one was already created. If a following request has different <code>tags</code> values,\n\t\t\tConfig will ignore these differences and treat it as an idempotent request of the previous. In this case, <code>tags</code> will not be updated, even if they are different.</p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutConformancePackRequest": {
+      "type": "structure",
+      "members": {
+        "ConformancePackName": {
+          "target": "com.amazonaws.configservice#ConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique name of the conformance pack you want to deploy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateS3Uri": {
+          "target": "com.amazonaws.configservice#TemplateS3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the file containing the template body (<code>s3://bucketname/prefix</code>). The uri must point to a conformance pack template (max size: 300 KB) that is located in an Amazon S3 bucket in the same Region as the conformance pack. </p>\n         <note>\n            <p>You must have access to read Amazon S3 bucket.\n\t\t\tIn addition, in order to ensure a successful deployment, the template object must not be in an <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html\">archived storage class</a> if this parameter is passed.</p>\n         </note>"
+          }
+        },
+        "TemplateBody": {
+          "target": "com.amazonaws.configservice#TemplateBody",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that contains the full conformance pack template body. The structure containing the template body has a minimum length of 1 byte and a maximum length of 51,200 bytes.</p>\n         <note>\n            <p>You can use a YAML template with two resource types: Config rule (<code>AWS::Config::ConfigRule</code>) and remediation action (<code>AWS::Config::RemediationConfiguration</code>).</p>\n         </note>"
+          }
+        },
+        "DeliveryS3Bucket": {
+          "target": "com.amazonaws.configservice#DeliveryS3Bucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where Config stores conformance pack templates.</p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "DeliveryS3KeyPrefix": {
+          "target": "com.amazonaws.configservice#DeliveryS3KeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix for the Amazon S3 bucket. </p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "ConformancePackInputParameters": {
+          "target": "com.amazonaws.configservice#ConformancePackInputParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackInputParameter</code> objects.</p>"
+          }
+        },
+        "TemplateSSMDocumentDetails": {
+          "target": "com.amazonaws.configservice#TemplateSSMDocumentDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>An object of type <code>TemplateSSMDocumentDetails</code>, which contains the name or the Amazon Resource Name (ARN) of the Amazon Web Services Systems Manager document (SSM document) and the version of the SSM document that is used to create a conformance pack.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the conformance pack. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConformancePackResponse": {
+      "type": "structure",
+      "members": {
+        "ConformancePackArn": {
+          "target": "com.amazonaws.configservice#ConformancePackArn",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the conformance pack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConnector": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutConnectorRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutConnectorResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfConnectorsExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a connector that specifies the connection between a third-party cloud service provider and Config.</p>\n         <p>A connector is required to create a service-linked configuration recorder for a third-party cloud service provider using the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutThirdPartyServiceLinkedConfigurationRecorder.html\">PutThirdPartyServiceLinkedConfigurationRecorder</a> operation.</p>\n         <p>This API creates a service-linked role <code>AWSServiceRoleForConfigThirdParty</code> in your account. The service-linked role is created only when the role does not exist in your account.</p>\n         <note>\n            <p>\n               <b>Connectors cannot be updated</b>\n            </p>\n            <p>To update the connector configuration, you must delete all associated configuration recorders, delete the connector, and recreate it with the updated configuration.</p>\n         </note>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutConnectorRequest": {
+      "type": "structure",
+      "members": {
+        "ConnectorConfiguration": {
+          "target": "com.amazonaws.configservice#ConnectorConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The provider-specific configuration for connecting to the third-party cloud service provider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the connector. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutConnectorResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutDeliveryChannel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutDeliveryChannelRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientDeliveryPolicyException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidDeliveryChannelNameException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidS3KeyPrefixException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidS3KmsKeyArnException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidSNSTopicARNException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfDeliveryChannelsExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchBucketException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates a delivery channel to deliver configuration\n\t\t\tinformation and other compliance information.</p>\n         <p>You can use this operation to create a new delivery channel or to update the Amazon S3 bucket and the\n\t\t\tAmazon SNS topic of an existing delivery channel.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/manage-delivery-channel.html\">\n               <b>Working with the Delivery Channel</b>\n            </a> in the <i>Config Developer Guide.</i>\n         </p>\n         <note>\n            <p>\n               <b>One delivery channel per account per Region</b>\n            </p>\n            <p>You can have only one delivery channel for each account for each Amazon Web Services Region.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutDeliveryChannelRequest": {
+      "type": "structure",
+      "members": {
+        "DeliveryChannel": {
+          "target": "com.amazonaws.configservice#DeliveryChannel",
+          "traits": {
+            "smithy.api#documentation": "<p>An object for the delivery channel. A delivery channel sends notifications and updated configuration states.\n\t\t</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>PutDeliveryChannel</a>\n\t\t\taction.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutEvaluations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutEvaluationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutEvaluationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidResultTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by an Lambda function to deliver evaluation results to\n\t\t\tConfig. This operation is required in every Lambda function\n\t\t\tthat is invoked by an Config rule.</p>"
+      }
+    },
+    "com.amazonaws.configservice#PutEvaluationsRequest": {
+      "type": "structure",
+      "members": {
+        "Evaluations": {
+          "target": "com.amazonaws.configservice#Evaluations",
+          "traits": {
+            "smithy.api#documentation": "<p>The assessments that the Lambda function performs. Each\n\t\t\tevaluation identifies an Amazon Web Services resource and indicates whether it\n\t\t\tcomplies with the Config rule that invokes the Lambda\n\t\t\tfunction.</p>"
+          }
+        },
+        "ResultToken": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An encrypted token that associates an evaluation with an Config rule. Identifies the rule and the event that triggered the\n\t\t\tevaluation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TestMode": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Use this parameter to specify a test run for\n\t\t\t<code>PutEvaluations</code>. You can verify whether your Lambda function will deliver evaluation results to Config. No\n\t\t\tupdates occur to your existing evaluations, and evaluation results\n\t\t\tare not sent to Config.</p>\n         <note>\n            <p>When <code>TestMode</code> is <code>true</code>,\n\t\t\t\t\t<code>PutEvaluations</code> doesn't require a valid value\n\t\t\t\tfor the <code>ResultToken</code> parameter, but the value cannot\n\t\t\t\tbe null.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutEvaluationsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedEvaluations": {
+          "target": "com.amazonaws.configservice#Evaluations",
+          "traits": {
+            "smithy.api#documentation": "<p>Requests that failed because of a client or server\n\t\t\terror.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutExternalEvaluation": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutExternalEvaluationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutExternalEvaluationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Add or updates the evaluations for process checks.\t\t\n\t\t\tThis API checks if the rule is a process check when the name of the Config rule is provided.</p>"
+      }
+    },
+    "com.amazonaws.configservice#PutExternalEvaluationRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExternalEvaluation": {
+          "target": "com.amazonaws.configservice#ExternalEvaluation",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>ExternalEvaluation</code> object that provides details about compliance.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutExternalEvaluationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutOrganizationConfigRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutOrganizationConfigRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutOrganizationConfigRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfOrganizationConfigRulesExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableOrganizationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAllFeaturesNotEnabledException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds or updates an Config rule for your entire organization to evaluate if your Amazon Web Services resources comply with your \n\t\t\tdesired configurations. For information on how many organization Config rules you can have per account, \n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>\n         <p> Only a management account and a delegated administrator can create or update an organization Config rule.\n\t\tWhen calling this API with a delegated administrator, you must ensure Organizations \n\t\t<code>ListDelegatedAdministrator</code> permissions are added. An organization can have up to 3 delegated administrators.</p>\n         <p>This API enables organization service access through the <code>EnableAWSServiceAccess</code> action and creates a service-linked \n\t\t\trole <code>AWSServiceRoleForConfigMultiAccountSetup</code> in the management or delegated administrator account of your organization. \n\t\t\tThe service-linked role is created only when the role does not exist in the caller account. \n\t\t\tConfig verifies the existence of role with <code>GetRole</code> action.</p>\n         <p>To use this API with delegated administrator, register a delegated administrator by calling Amazon Web Services Organization\n\t\t\t<code>register-delegated-administrator</code> for <code>config-multiaccountsetup.amazonaws.com</code>. </p>\n         <p>There are two types of rules: <i>Config Managed Rules</i> and <i>Config Custom Rules</i>. \n\t\t\tYou can use <code>PutOrganizationConfigRule</code> to create both Config Managed Rules and Config Custom Rules.</p>\n         <p>Config Managed Rules are predefined,\n\t\t\tcustomizable rules created by Config. For a list of managed rules, see\n\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html\">List of Config\n\t\t\t\tManaged Rules</a>. If you are adding an Config managed rule, you must specify the rule's identifier for the <code>RuleIdentifier</code> key.</p>\n         <p>Config Custom Rules are rules that you create from scratch. There are two ways to create Config custom rules: with Lambda functions\n\t\t\t(<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/gettingstarted-concepts.html#gettingstarted-concepts-function\"> Lambda Developer Guide</a>) and with Guard (<a href=\"https://github.com/aws-cloudformation/cloudformation-guard\">Guard GitHub\n\t\t\t\t\tRepository</a>), a policy-as-code language.\n\t\t\t\n\t\t\tConfig custom rules created with Lambda\n\t\t\tare called <i>Config Custom Lambda Rules</i> and Config custom rules created with\n\t\t\tGuard are called <i>Config Custom Policy Rules</i>.</p>\n         <p>If you are adding a new Config Custom Lambda rule, you first need to create an Lambda function in the management account or a delegated \n\t\tadministrator that the rule invokes to evaluate your resources. You also need to create an IAM role in the managed account that can be assumed by the Lambda function.\n\t\tWhen you use <code>PutOrganizationConfigRule</code> to add a Custom Lambda rule to Config, you must \n\t\t\tspecify the Amazon Resource Name (ARN) that Lambda assigns to the function.</p>\n         <note>\n            <p>Prerequisite: Ensure you call <code>EnableAllFeatures</code> API to enable all features in an organization.</p>\n            <p>Make sure to specify one of either <code>OrganizationCustomPolicyRuleMetadata</code> for Custom Policy rules, <code>OrganizationCustomRuleMetadata</code> for Custom Lambda rules, or <code>OrganizationManagedRuleMetadata</code> for managed rules.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutOrganizationConfigRuleRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleName": {
+          "target": "com.amazonaws.configservice#OrganizationConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that you assign to an organization Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OrganizationManagedRuleMetadata": {
+          "target": "com.amazonaws.configservice#OrganizationManagedRuleMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>OrganizationManagedRuleMetadata</code> object. This object specifies organization\n\t\t\tmanaged rule metadata such as resource type and ID of Amazon Web Services resource along with the rule identifier.\n\t\t\tIt also provides the frequency with which you want Config to run evaluations for the rule if the trigger type is periodic.</p>"
+          }
+        },
+        "OrganizationCustomRuleMetadata": {
+          "target": "com.amazonaws.configservice#OrganizationCustomRuleMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>OrganizationCustomRuleMetadata</code> object. This object specifies organization custom rule metadata such as resource type,\n\t\t\tresource ID of Amazon Web Services resource, Lambda function ARN, and organization trigger types that trigger Config to evaluate your Amazon Web Services resources against a rule.\n\t\t\tIt also provides the frequency with which you want Config to run evaluations for the rule if the trigger type is periodic.</p>"
+          }
+        },
+        "ExcludedAccounts": {
+          "target": "com.amazonaws.configservice#ExcludedAccounts",
+          "traits": {
+            "smithy.api#documentation": "<p>A comma-separated list of accounts that you want to exclude from an organization Config rule.</p>"
+          }
+        },
+        "OrganizationCustomPolicyRuleMetadata": {
+          "target": "com.amazonaws.configservice#OrganizationCustomPolicyRuleMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>OrganizationCustomPolicyRuleMetadata</code> object. This object specifies metadata for your organization's Config Custom Policy rule. The metadata includes the runtime system in use, which accounts have debug\n\t\t\tlogging enabled, and other custom rule metadata, such as resource type, resource ID of\n\t\t\tAmazon Web Services resource, and organization trigger types that initiate Config to evaluate Amazon Web Services resources against a rule.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the organization Config rule. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutOrganizationConfigRuleResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConfigRuleArn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an organization Config rule.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutOrganizationConformancePack": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutOrganizationConformancePackRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutOrganizationConformancePackResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfOrganizationConformancePacksExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoAvailableOrganizationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationAllFeaturesNotEnabledException"
+        },
+        {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackTemplateValidationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deploys conformance packs across member accounts in an Amazon Web Services Organization. For information on how many organization conformance packs and how many Config rules you can have per account, \n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>\n         <p>Only a management account and a delegated administrator can call this API. \n\t\t\tWhen calling this API with a delegated administrator, you must ensure Organizations \n\t\t\t<code>ListDelegatedAdministrator</code> permissions are added. An organization can have up to 3 delegated administrators.</p>\n         <important>\n            <p>When you use <code>PutOrganizationConformancePack</code> to deploy conformance packs across\n\t\t\t\tmember accounts, the operation can create Config rules and remediation\n\t\t\t\tactions without requiring <code>config:PutConfigRule</code> or\n\t\t\t\t\t<code>config:PutRemediationConfigurations</code> permissions in member account\n\t\t\t\tIAM policies.</p>\n            <p>This API uses the <code>AWSServiceRoleForConfigConforms</code> service-linked role in each\n\t\t\t\tmember account to create conformance pack resources. This service-linked role\n\t\t\t\tincludes the permissions to create Config rules and remediation\n\t\t\t\tconfigurations, even if member account IAM policies explicitly deny these\n\t\t\t\tactions.</p>\n         </important>\n         <p>This API enables organization service access for <code>config-multiaccountsetup.amazonaws.com</code>\n\t\t\tthrough the <code>EnableAWSServiceAccess</code> action and creates a \n\t\t\tservice-linked role <code>AWSServiceRoleForConfigMultiAccountSetup</code> in the management or delegated administrator account of your organization. \n\t\t\tThe service-linked role is created only when the role does not exist in the caller account. \n\t\t\tTo use this API with delegated administrator, register a delegated administrator by calling Amazon Web Services Organization \n\t\t\t<code>register-delegate-admin</code> for <code>config-multiaccountsetup.amazonaws.com</code>.</p>\n         <note>\n            <p>Prerequisite: Ensure you call <code>EnableAllFeatures</code> API to enable all features in an organization.</p>\n            <p>You must specify either the <code>TemplateS3Uri</code> or the <code>TemplateBody</code> parameter, but not both. \n\t\t\tIf you provide both Config uses the <code>TemplateS3Uri</code> parameter and ignores the <code>TemplateBody</code> parameter.</p>\n            <p>Config sets the state of a conformance pack to CREATE_IN_PROGRESS and UPDATE_IN_PROGRESS until the conformance pack is created or updated.  \n\t\t\t\tYou cannot update a conformance pack while it is in this state.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutOrganizationConformancePackRequest": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackName": {
+          "target": "com.amazonaws.configservice#OrganizationConformancePackName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the organization conformance pack you want to create.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TemplateS3Uri": {
+          "target": "com.amazonaws.configservice#TemplateS3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Location of file containing the template body. The uri must point to the conformance pack template\n\t\t\t(max size: 300 KB).</p>\n         <note>\n            <p>You must have access to read Amazon S3 bucket.\n\t\t\tIn addition, in order to ensure a successful deployment, the template object must not be in an <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html\">archived storage class</a> if this parameter is passed.</p>\n         </note>"
+          }
+        },
+        "TemplateBody": {
+          "target": "com.amazonaws.configservice#TemplateBody",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that contains the full conformance pack template body. Structure containing the template body\n\t\t\twith a minimum length of 1 byte and a maximum length of 51,200 bytes.</p>"
+          }
+        },
+        "DeliveryS3Bucket": {
+          "target": "com.amazonaws.configservice#DeliveryS3Bucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where Config stores conformance pack templates.</p>\n         <note>\n            <p>This field is optional. If used, it must be prefixed with <code>awsconfigconforms</code>.</p>\n         </note>"
+          }
+        },
+        "DeliveryS3KeyPrefix": {
+          "target": "com.amazonaws.configservice#DeliveryS3KeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix for the Amazon S3 bucket.</p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        },
+        "ConformancePackInputParameters": {
+          "target": "com.amazonaws.configservice#ConformancePackInputParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>ConformancePackInputParameter</code> objects.</p>"
+          }
+        },
+        "ExcludedAccounts": {
+          "target": "com.amazonaws.configservice#ExcludedAccounts",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of Amazon Web Services accounts to be excluded from an organization conformance pack while deploying a conformance pack.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for the organization conformance pack. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutOrganizationConformancePackResponse": {
+      "type": "structure",
+      "members": {
+        "OrganizationConformancePackArn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the organization conformance pack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutRemediationConfigurations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutRemediationConfigurationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutRemediationConfigurationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds or updates the remediation configuration with a specific Config rule with the \n\t\t\tselected target or action. \n\t\t\tThe API creates the <code>RemediationConfiguration</code> object for the Config rule. \n\t\tThe Config rule must already exist for you to add a remediation configuration. \n\t\tThe target (SSM document) must exist and have permissions to use the target. </p>\n         <note>\n            <p>\n               <b>Be aware of backward incompatible changes</b>\n            </p>\n            <p>If you make backward incompatible changes to the SSM document, \n\t\t\tyou must call this again to ensure the remediations can run.</p>\n            <p>This API does not support adding remediation configurations for service-linked Config Rules such as Organization Config rules, \n\t\t\t\tthe rules deployed by conformance packs, and rules deployed by Amazon Web Services Security Hub.</p>\n         </note>\n         <note>\n            <p>\n               <b>Required fields</b>\n            </p>\n            <p>For manual remediation configuration, you need to provide a value for <code>automationAssumeRole</code> or use a value in the <code>assumeRole</code>field  to remediate your resources. The SSM automation document can use either as long as it maps to a valid parameter.</p>\n            <p>However, for automatic remediation configuration, the only valid <code>assumeRole</code> field value is <code>AutomationAssumeRole</code> and you need to provide a value for <code>AutomationAssumeRole</code> to remediate your resources.</p>\n         </note>\n         <note>\n            <p>\n               <b>Auto remediation can be initiated even for compliant resources</b>\n            </p>\n            <p>If you enable auto remediation for a specific Config rule using the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/emAPI_PutRemediationConfigurations.html\">PutRemediationConfigurations</a> API or the Config console,\n\t\t\t\tit initiates the remediation process for all non-compliant resources for that specific rule.\n\t\t\t\tThe auto remediation process relies on the compliance data snapshot which is captured on a periodic basis.\n\t\t\t\tAny non-compliant resource that is updated between the snapshot schedule will continue to be remediated based on the last known compliance data snapshot.</p>\n            <p>This means that in some cases auto remediation can be initiated even for compliant resources, since the bootstrap processor uses a database that can have stale evaluation results based on the last known compliance data snapshot.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutRemediationConfigurationsRequest": {
+      "type": "structure",
+      "members": {
+        "RemediationConfigurations": {
+          "target": "com.amazonaws.configservice#RemediationConfigurations",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of remediation configuration objects.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutRemediationConfigurationsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedBatches": {
+          "target": "com.amazonaws.configservice#FailedRemediationBatches",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of failed remediation batch objects.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutRemediationExceptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutRemediationExceptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutRemediationExceptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>A remediation exception is when a specified resource is no longer considered for auto-remediation. \n\t\t\tThis API adds a new exception or updates an existing exception for a specified resource with a specified Config rule. </p>\n         <note>\n            <p>\n               <b>Exceptions block auto remediation</b>\n            </p>\n            <p>Config generates a remediation exception when a problem occurs running a remediation action for a specified resource. \n\t\t\tRemediation exceptions blocks auto-remediation until the exception is cleared.</p>\n         </note>\n         <note>\n            <p>\n               <b>Manual remediation is recommended when placing an exception</b>\n            </p>\n            <p>When placing an exception on an Amazon Web Services resource, it is recommended that remediation is set as manual remediation until\n\t\t\tthe given Config rule for the specified resource evaluates the resource as <code>NON_COMPLIANT</code>.\n\t\t\tOnce the resource has been evaluated as <code>NON_COMPLIANT</code>, you can add remediation exceptions and change the remediation type back from Manual to Auto if you want to use auto-remediation.\n\t\t\tOtherwise, using auto-remediation before a <code>NON_COMPLIANT</code> evaluation result can delete resources before the exception is applied.</p>\n         </note>\n         <note>\n            <p>\n               <b>Exceptions can only be performed on non-compliant resources</b>\n            </p>\n            <p>Placing an exception can only be performed on resources that are <code>NON_COMPLIANT</code>.\n\t\t\tIf you use this API for <code>COMPLIANT</code> resources or resources that are <code>NOT_APPLICABLE</code>, a remediation exception will not be generated.\n\t\t\tFor more information on the conditions that initiate the possible Config evaluation results,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/config-concepts.html#aws-config-rules\">Concepts | Config  Rules</a> in the <i>Config Developer Guide</i>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Exceptions cannot be placed on service-linked remediation actions</b>\n            </p>\n            <p>You cannot place an exception on service-linked remediation actions, such as remediation actions put by an organizational conformance pack.</p>\n         </note>\n         <note>\n            <p>\n               <b>Auto remediation can be initiated even for compliant resources</b>\n            </p>\n            <p>If you enable auto remediation for a specific Config rule using the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/emAPI_PutRemediationConfigurations.html\">PutRemediationConfigurations</a> API or the Config console,\n\t\t\t\tit initiates the remediation process for all non-compliant resources for that specific rule.\n\t\t\t\tThe auto remediation process relies on the compliance data snapshot which is captured on a periodic basis.\n\t\t\t\tAny non-compliant resource that is updated between the snapshot schedule will continue to be remediated based on the last known compliance data snapshot.</p>\n            <p>This means that in some cases auto remediation can be initiated even for compliant resources, since the bootstrap processor uses a database that can have stale evaluation results based on the last known compliance data snapshot.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutRemediationExceptionsRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule for which you want to create remediation exception.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceKeys": {
+          "target": "com.amazonaws.configservice#RemediationExceptionResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>An exception list of resource exception keys to be processed with the current request. Config adds exception for each resource key. For example, Config adds 3 exceptions for 3 resource keys. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The message contains an explanation of the exception.</p>"
+          }
+        },
+        "ExpirationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The exception is automatically deleted after the expiration date.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutRemediationExceptionsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedBatches": {
+          "target": "com.amazonaws.configservice#FailedRemediationExceptionBatches",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of failed remediation exceptions batch objects. Each object in the batch consists of a list of failed items and failure messages.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutResourceConfigRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxActiveResourcesExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoRunningConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Records the configuration state for the resource provided in the request.\n\t\t\t \n\t\t\tThe configuration state of a resource is represented in Config as Configuration Items. \n\t\t\tOnce this API records the configuration item, you can retrieve the list of configuration items for the custom resource type using existing Config APIs. </p>\n         <note>\n            <p>The custom resource type must be registered with CloudFormation. This API accepts the configuration item registered with CloudFormation.</p>\n            <p>When you call this API, Config only stores configuration state of the resource provided in the request. This API does not change or remediate the configuration of the resource.\n\t\t\t\t</p>\n            <p>Write-only schema properites are not recorded as part of the published configuration item.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#ResourceTypeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the resource. The custom resource type must be registered with CloudFormation. </p>\n         <note>\n            <p>You cannot use the organization names \u201camzn\u201d, \u201camazon\u201d, \u201calexa\u201d, \u201ccustom\u201d with custom resource types. It is the first part of the ResourceType up to the first ::.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "SchemaVersionId": {
+          "target": "com.amazonaws.configservice#SchemaVersionId",
+          "traits": {
+            "smithy.api#documentation": "<p>Version of the schema registered for the ResourceType in CloudFormation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier of the resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the resource.</p>"
+          }
+        },
+        "Configuration": {
+          "target": "com.amazonaws.configservice#Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration object of the resource in valid JSON format. It must match the schema registered with CloudFormation.</p>\n         <note>\n            <p>The configuration JSON must not exceed 64 KB.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#Tags",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags associated with the resource.</p>\n         <note>\n            <p>This field is not to be confused with the Amazon Web Services-wide tag feature for Amazon Web Services resources.\n\t\t\tTags for <code>PutResourceConfig</code> are tags that you supply for the configuration items of your custom resources.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutRetentionConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutRetentionConfigurationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutRetentionConfigurationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#MaxNumberOfRetentionConfigurationsExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates and updates the retention configuration with details\n\t\t\tabout retention period (number of days) that Config stores your\n\t\t\thistorical information. The API creates the\n\t\t\t\t<code>RetentionConfiguration</code> object and names the object\n\t\t\tas <b>default</b>. When you have a\n\t\t\t\t<code>RetentionConfiguration</code> object named <b>default</b>, calling the API modifies the\n\t\t\tdefault object. </p>\n         <note>\n            <p>Currently, Config supports only one retention\n\t\t\t\tconfiguration per region in your account.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutRetentionConfigurationRequest": {
+      "type": "structure",
+      "members": {
+        "RetentionPeriodInDays": {
+          "target": "com.amazonaws.configservice#RetentionPeriodInDays",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of days Config stores your historical\n\t\t\tinformation.</p>\n         <note>\n            <p>Currently, only applicable to the configuration item\n\t\t\t\thistory.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutRetentionConfigurationResponse": {
+      "type": "structure",
+      "members": {
+        "RetentionConfiguration": {
+          "target": "com.amazonaws.configservice#RetentionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a retention configuration object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutServiceLinkedConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutServiceLinkedConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutServiceLinkedConfigurationRecorderResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a service-linked configuration recorder that is linked to a specific Amazon Web Services service based on the <code>ServicePrincipal</code> you specify.</p>\n         <p>The configuration recorder's <code>name</code>, <code>recordingGroup</code>, <code>recordingMode</code>, and <code>recordingScope</code> is set by the service that is linked to the configuration recorder.</p>\n         <p>For more information and a list of supported services/service principals, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/stop-start-recorder.html\">\n               <b>Working with the Configuration Recorder</b>\n            </a> in the <i>Config Developer Guide</i>.</p>\n         <p>This API creates a service-linked role <code>AWSServiceRoleForConfig</code> in your account. The service-linked role is created only when the role does not exist in your account.</p>\n         <note>\n            <p>\n               <b>The recording scope determines if you receive configuration items</b>\n            </p>\n            <p>The recording scope is set by the service that is linked to the configuration recorder and determines whether you receive configuration items (CIs) in the delivery channel. If the recording scope is internal, you will not receive CIs in the delivery channel.</p>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutServiceLinkedConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ServicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>The service principal of the Amazon Web Services service for the service-linked configuration recorder that you want to create.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for a service-linked configuration recorder. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutServiceLinkedConfigurationRecorderResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the specified configuration recorder.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the specified configuration recorder.</p>\n         <p>For service-linked configuration recorders, Config automatically assigns a name that has the prefix \"<code>AWSConfigurationRecorderFor</code>\" to the new service-linked configuration recorder.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutStoredQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutStoredQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutStoredQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.configservice#TooManyTagsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Saves a new query or updates an existing saved query. The <code>QueryName</code> must be unique for a single Amazon Web Services account and a single Amazon Web Services Region.\n\t\t\tYou can create upto 300 queries in a single Amazon Web Services account and a single Amazon Web Services Region.</p>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated</b>\n            </p>\n            <p>\n               <code>PutStoredQuery</code> is an idempotent API. Subsequent requests won\u2019t create a duplicate resource if one was already created. If a following request has different <code>tags</code> values,\n\t\t\tConfig will ignore these differences and treat it as an idempotent request of the previous. In this case, <code>tags</code> will not be updated, even if they are different.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutStoredQueryRequest": {
+      "type": "structure",
+      "members": {
+        "StoredQuery": {
+          "target": "com.amazonaws.configservice#StoredQuery",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>StoredQuery</code> objects. \n\t\t\tThe mandatory fields are <code>QueryName</code> and <code>Expression</code>.</p>\n         <note>\n            <p>When you are creating a query, you must provide a query name and an expression. \n\t\t\tWhen you are updating a query, you must provide a query name but updating the description is optional.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <code>Tags</code> object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutStoredQueryResponse": {
+      "type": "structure",
+      "members": {
+        "QueryArn": {
+          "target": "com.amazonaws.configservice#QueryArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the query. \n\t\t\tFor example, arn:partition:service:region:account-id:resource-type/resource-name/resource-id.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#PutThirdPartyServiceLinkedConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#PutThirdPartyServiceLinkedConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#PutThirdPartyServiceLinkedConfigurationRecorderResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates a service-linked configuration recorder that is linked to a third-party cloud service provider based on the <code>ConnectorArn</code> you specify.</p>\n         <p>The configuration recorder's <code>name</code>, <code>recordingGroup</code>, <code>recordingMode</code>, and <code>recordingScope</code> is set by the service that is linked to the configuration recorder.</p>\n         <p>If a service-linked configuration recorder already exists for the specified service principal and connector, calling this operation again updates the <code>ScopeConfiguration</code>.</p>\n         <note>\n            <p>\n               <b>This operation can only be called by the Amazon Web Services service linked to the configuration recorder</b>\n            </p>\n            <p>Customers cannot call this operation directly. Only the linked Amazon Web Services service can create or update the service-linked configuration recorder.</p>\n         </note>\n         <note>\n            <p>\n               <b>Tags are added at creation and cannot be updated with this operation</b>\n            </p>\n            <p>Use <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_UntagResource.html\">UntagResource</a> to update tags after creation.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#PutThirdPartyServiceLinkedConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ServicePrincipal": {
+          "target": "com.amazonaws.configservice#ServicePrincipal",
+          "traits": {
+            "smithy.api#documentation": "<p>The service principal of the Amazon Web Services service for the service-linked configuration recorder that you want to create.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConnectorArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the connector that specifies the connection between the third-party cloud service provider and Config. The specified connector must exist.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ScopeConfiguration": {
+          "target": "com.amazonaws.configservice#ScopeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the scope of resources to record from the third-party cloud service provider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags for a service-linked configuration recorder. Each tag consists of a key and an optional value, both of which you define.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#PutThirdPartyServiceLinkedConfigurationRecorderResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the specified configuration recorder.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#QueryArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 500
+        },
+        "smithy.api#pattern": "^arn:aws[a-z\\-]*:config:[a-z\\-\\d]+:\\d+:stored-query/[a-zA-Z0-9-_]+/query-[a-zA-Z\\d-_/]+$"
+      }
+    },
+    "com.amazonaws.configservice#QueryDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[\\s\\S]*$"
+      }
+    },
+    "com.amazonaws.configservice#QueryExpression": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 4096
+        },
+        "smithy.api#pattern": "^[\\s\\S]*$"
+      }
+    },
+    "com.amazonaws.configservice#QueryId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 36
+        },
+        "smithy.api#pattern": "^\\S+$"
+      }
+    },
+    "com.amazonaws.configservice#QueryInfo": {
+      "type": "structure",
+      "members": {
+        "SelectFields": {
+          "target": "com.amazonaws.configservice#FieldInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>FieldInfo</code> object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about the query.</p>"
+      }
+    },
+    "com.amazonaws.configservice#QueryName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-_]+$"
+      }
+    },
+    "com.amazonaws.configservice#RecorderName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#RecorderStatus": {
+      "type": "enum",
+      "members": {
+        "Pending": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Pending"
+          }
+        },
+        "Success": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Success"
+          }
+        },
+        "Failure": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Failure"
+          }
+        },
+        "NotApplicable": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NotApplicable"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#RecordingFrequency": {
+      "type": "enum",
+      "members": {
+        "CONTINUOUS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTINUOUS"
+          }
+        },
+        "DAILY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DAILY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#RecordingGroup": {
+      "type": "structure",
+      "members": {
+        "allSupported": {
+          "target": "com.amazonaws.configservice#AllSupported",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether Config records configuration changes for all supported resource types, excluding the global IAM resource types.</p>\n         <p>If you set this field to <code>true</code>, when Config\n\t\t\tadds support for a new resource type, Config starts recording resources of that type automatically.</p>\n         <p>If you set this field to <code>true</code>,\n\t\t\tyou cannot enumerate specific resource types to record in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>, or to exclude in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ExclusionByResourceTypes.html\">ExclusionByResourceTypes</a>.</p>\n         <note>\n            <p>\n               <b>Region availability</b>\n            </p>\n            <p>Check <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/what-is-resource-config-coverage.html\">Resource Coverage by Region Availability</a>\n\t\t\t\tto see if a resource type is supported in the Amazon Web Services Region where you set up Config.</p>\n         </note>"
+          }
+        },
+        "includeGlobalResourceTypes": {
+          "target": "com.amazonaws.configservice#IncludeGlobalResourceTypes",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>This option is a bundle which only applies to the global IAM resource types:\n\t\t\tIAM users, groups, roles, and customer managed policies. These global IAM resource types can only be recorded\n\t\t\tby Config in Regions where Config was available before February 2022.\n\t\t\tYou cannot be record the global IAM resouce types in Regions supported by Config after February 2022. For a list of those Regions,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-all\">Recording Amazon Web Services Resources | Global Resources</a>.</p>\n         <important>\n            <p>\n               <b>Aurora global clusters are recorded in all enabled Regions</b>\n            </p>\n            <p>The <code>AWS::RDS::GlobalCluster</code> resource type will be recorded in all supported Config Regions where the configuration recorder is enabled, even if <code>includeGlobalResourceTypes</code> is set<code>false</code>.\n\t\t\t\tThe <code>includeGlobalResourceTypes</code> option is a bundle which only applies to IAM users, groups, roles, and customer managed policies.\n\t\t\t</p>\n            <p>If you do not want to record <code>AWS::RDS::GlobalCluster</code> in all enabled Regions, use one of the following recording strategies:</p>\n            <ol>\n               <li>\n                  <p>\n                     <b>Record all current and future resource types with exclusions</b> (<code>EXCLUSION_BY_RESOURCE_TYPES</code>), or</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Record specific resource types</b> (<code>INCLUSION_BY_RESOURCE_TYPES</code>).</p>\n               </li>\n            </ol>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-all\">Selecting Which Resources are Recorded</a> in the <i>Config developer guide</i>.</p>\n         </important>\n         <important>\n            <p>\n               <b>includeGlobalResourceTypes and the exclusion recording strategy</b>\n            </p>\n            <p>The <code>includeGlobalResourceTypes</code> field has no impact on the <code>EXCLUSION_BY_RESOURCE_TYPES</code> recording strategy.\n\t\t\t\tThis means that the global IAM resource types (IAM users, groups, roles, and customer managed policies) will\n\t\t\t\tnot be automatically added as exclusions for <code>exclusionByResourceTypes</code> when <code>includeGlobalResourceTypes</code> is set to <code>false</code>.</p>\n            <p>The <code>includeGlobalResourceTypes</code> field should only be used to modify the <code>AllSupported</code> field, as the default for\n\t\t\t\tthe <code>AllSupported</code> field is to record configuration changes for all supported resource types excluding the global\n\t\t\t\tIAM resource types. To include the global IAM resource types when <code>AllSupported</code> is set to <code>true</code>, make sure to set <code>includeGlobalResourceTypes</code> to <code>true</code>.</p>\n            <p>To exclude the global IAM resource types for the <code>EXCLUSION_BY_RESOURCE_TYPES</code> recording strategy, you need to manually add them to the <code>resourceTypes</code> field of <code>exclusionByResourceTypes</code>.</p>\n         </important>\n         <note>\n            <p>\n               <b>Required and optional fields</b>\n            </p>\n            <p>Before you set this field to <code>true</code>,\n\t\t\tset the <code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to\n\t\t\t<code>true</code>. Optionally, you can set the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>ALL_SUPPORTED_RESOURCE_TYPES</code>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Overriding fields</b>\n            </p>\n            <p>If you set this field to <code>false</code> but list global IAM resource types in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>,\n\t\t\tConfig will still record configuration changes for those specified resource types <i>regardless</i> of if you set the <code>includeGlobalResourceTypes</code> field to false.</p>\n            <p>If you do not want to record configuration changes to the global IAM resource types (IAM users, groups, roles, and customer managed policies), make sure to not list them in the <code>resourceTypes</code> field\n\t\t\tin addition to setting the <code>includeGlobalResourceTypes</code> field to false.</p>\n         </note>"
+          }
+        },
+        "resourceTypes": {
+          "target": "com.amazonaws.configservice#ResourceTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>A comma-separated list that specifies which resource types Config\n\t\t\trecords.</p>\n         <p>For a list of valid <code>resourceTypes</code> values, see the\n\t\t\t\t<b>Resource Type Value</b> column in\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources\">Supported Amazon Web Services resource Types</a> in the <i>Config developer guide</i>.</p>\n         <note>\n            <p>\n               <b>Required and optional fields</b>\n            </p>\n            <p>Optionally, you can set the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>INCLUSION_BY_RESOURCE_TYPES</code>.</p>\n            <p>To record all configuration changes,\n\t\t\t\tset the <code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to\n\t\t\t\t<code>true</code>, and either omit this field or don't specify any resource types in this field. If you set the <code>allSupported</code> field to <code>false</code> and specify values for <code>resourceTypes</code>,\n\t\t\t\twhen Config adds support for a new type of resource,\n\t\t\t\tit will not record resources of that type unless you manually add that type to your recording group.</p>\n         </note>\n         <note>\n            <p>\n               <b>Region availability</b>\n            </p>\n            <p>Before specifying a resource type for Config to track,\n\t\t\t\tcheck <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/what-is-resource-config-coverage.html\">Resource Coverage by Region Availability</a>\n\t\t\t\tto see if the resource type is supported in the Amazon Web Services Region where you set up Config.\n\t\t\t\tIf a resource type is supported by Config in at least one Region,\n\t\t\t\tyou can enable the recording of that resource type in all Regions supported by Config,\n\t\t\t\teven if the specified resource type is not supported in the Amazon Web Services Region where you set up Config.</p>\n         </note>"
+          }
+        },
+        "exclusionByResourceTypes": {
+          "target": "com.amazonaws.configservice#ExclusionByResourceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that specifies how Config excludes resource types from being recorded by the configuration recorder.</p>\n         <note>\n            <p>\n               <b>Required fields</b>\n            </p>\n            <p>To use this option, you must set the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>EXCLUSION_BY_RESOURCE_TYPES</code>.</p>\n         </note>"
+          }
+        },
+        "recordingStrategy": {
+          "target": "com.amazonaws.configservice#RecordingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that specifies the recording strategy for the configuration recorder.</p>\n         <ul>\n            <li>\n               <p>If you set the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>ALL_SUPPORTED_RESOURCE_TYPES</code>, Config records configuration changes for all supported resource types, excluding the global IAM resource types. You also must set the <code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to <code>true</code>. When Config adds support for a new resource type, Config automatically starts recording resources of that type.</p>\n            </li>\n            <li>\n               <p>If you set the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>INCLUSION_BY_RESOURCE_TYPES</code>, Config records configuration changes for only the resource types you specify in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>.</p>\n            </li>\n            <li>\n               <p>If you set the <code>useOnly</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingStrategy.html\">RecordingStrategy</a> to <code>EXCLUSION_BY_RESOURCE_TYPES</code>, Config records configuration changes for all supported resource types\n\t\t\t\texcept the resource types that you specify to exclude from being recorded in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ExclusionByResourceTypes.html\">ExclusionByResourceTypes</a>.</p>\n            </li>\n         </ul>\n         <note>\n            <p>\n               <b>Required and optional fields</b>\n            </p>\n            <p>The <code>recordingStrategy</code> field is optional when you set the\n\t\t\t<code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to <code>true</code>.</p>\n            <p>The <code>recordingStrategy</code> field is optional when you list resource types in the\n\t\t\t\t<code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>.</p>\n            <p>The <code>recordingStrategy</code> field is required if you list resource types to exclude from recording in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ExclusionByResourceTypes.html\">ExclusionByResourceTypes</a>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Overriding fields</b>\n            </p>\n            <p>If you choose <code>EXCLUSION_BY_RESOURCE_TYPES</code> for the recording strategy, the <code>exclusionByResourceTypes</code> field will override other properties in the request.</p>\n            <p>For example, even if you set <code>includeGlobalResourceTypes</code> to false, global IAM resource types will still be automatically\n\t\t\trecorded in this option unless those resource types are specifically listed as exclusions in the <code>resourceTypes</code> field of <code>exclusionByResourceTypes</code>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Global resources types and the resource exclusion recording strategy</b>\n            </p>\n            <p>By default, if you choose the <code>EXCLUSION_BY_RESOURCE_TYPES</code> recording strategy,\n\t\t\twhen Config adds support for a new resource type in the Region where you set up the configuration recorder, including global resource types,\n\t\t\tConfig starts recording resources of that type automatically.</p>\n            <p>Unless specifically listed as exclusions,\n\t\t\t\t<code>AWS::RDS::GlobalCluster</code> will be recorded automatically in all supported Config Regions were the configuration recorder is enabled.</p>\n            <p>IAM users, groups, roles, and customer managed policies will be recorded in the Region where you set up the configuration recorder if that is a Region where Config  was available before February 2022.\n\t\t\t\tYou cannot be record the global IAM resouce types in Regions supported by Config after February 2022. For a list of those Regions,\n\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html#select-resources-all\">Recording Amazon Web Services Resources | Global Resources</a>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies which resource types Config\n\t\t\trecords for configuration changes. By default, Config records configuration changes for all current and future supported resource types in the Amazon Web Services Region where you have enabled Config,\n\t\t\texcluding the global IAM resource types: IAM users, groups, roles, and customer managed policies.</p>\n         <p>In the recording group, you specify whether you want to record all supported current and future supported resource types or to include or exclude specific resources types.\n\t\t\tFor a list of supported resource types, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources\">Supported Resource Types</a> in the <i>Config developer guide</i>.</p>\n         <p>If you don't want Config to record all current and future supported resource types (excluding the global IAM resource types), use one of the following recording strategies:</p>\n         <ol>\n            <li>\n               <p>\n                  <b>Record all current and future resource types with exclusions</b> (<code>EXCLUSION_BY_RESOURCE_TYPES</code>), or</p>\n            </li>\n            <li>\n               <p>\n                  <b>Record specific resource types</b> (<code>INCLUSION_BY_RESOURCE_TYPES</code>).</p>\n            </li>\n         </ol>\n         <p>If you use the recording strategy to <b>Record all current and future resource types</b> (<code>ALL_SUPPORTED_RESOURCE_TYPES</code>),\n\t\t\tyou can use the flag <code>includeGlobalResourceTypes</code> to include the global IAM resource types in your recording.</p>\n         <important>\n            <p>\n               <b>Aurora global clusters are recorded in all enabled Regions</b>\n            </p>\n            <p>The <code>AWS::RDS::GlobalCluster</code> resource type\n\t\t\t\twill be recorded in all supported Config Regions where the configuration recorder is enabled.</p>\n            <p>If you do not want to record <code>AWS::RDS::GlobalCluster</code> in all enabled Regions, use the <code>EXCLUSION_BY_RESOURCE_TYPES</code> or <code>INCLUSION_BY_RESOURCE_TYPES</code> recording strategy.</p>\n         </important>"
+      }
+    },
+    "com.amazonaws.configservice#RecordingMode": {
+      "type": "structure",
+      "members": {
+        "recordingFrequency": {
+          "target": "com.amazonaws.configservice#RecordingFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The default recording frequency that Config uses to record configuration changes.</p>\n         <important>\n            <p>Daily recording cannot be specified for the following resource types:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>AWS::Config::ResourceCompliance</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>AWS::Config::ConformancePackCompliance</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>AWS::Config::ConfigurationRecorder</code>\n                  </p>\n               </li>\n            </ul>\n            <p>For the <b>allSupported</b> (<code>ALL_SUPPORTED_RESOURCE_TYPES</code>) recording strategy, these resource types will be set to Continuous recording.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "recordingModeOverrides": {
+          "target": "com.amazonaws.configservice#RecordingModeOverrides",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of <code>recordingModeOverride</code> objects for you to specify your overrides for the recording mode.\n\t\t\tThe <code>recordingModeOverride</code> object in the <code>recordingModeOverrides</code> array consists of three fields: a <code>description</code>, the new <code>recordingFrequency</code>, and an array of <code>resourceTypes</code> to override.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the default recording frequency that Config uses to record configuration changes.\n\t\t\t\n\t\t\tConfig supports <i>Continuous recording</i> and <i>Daily recording</i>.</p>\n         <ul>\n            <li>\n               <p>Continuous recording allows you to record configuration changes continuously whenever a change occurs.</p>\n            </li>\n            <li>\n               <p>Daily recording allows you to receive a configuration item (CI) representing the most recent state of your resources over the last 24-hour period, only if it\u2019s different from the previous CI recorded.\n\t\t\t</p>\n            </li>\n         </ul>\n         <note>\n            <p>Firewall Manager depends on continuous recording to monitor your resources. If you are using Firewall Manager,\n\t\t\tit is recommended that you set the recording frequency to Continuous.</p>\n         </note>\n         <p>You can also override the recording frequency for specific resource types.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RecordingModeOverride": {
+      "type": "structure",
+      "members": {
+        "description": {
+          "target": "com.amazonaws.configservice#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that you provide for the override.</p>"
+          }
+        },
+        "resourceTypes": {
+          "target": "com.amazonaws.configservice#RecordingModeResourceTypesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A comma-separated list that specifies which resource types Config\n\t\t\tincludes in the override.</p>\n         <important>\n            <p>Daily recording cannot be specified for the following resource types:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>AWS::Config::ResourceCompliance</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>AWS::Config::ConformancePackCompliance</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>AWS::Config::ConfigurationRecorder</code>\n                  </p>\n               </li>\n            </ul>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "recordingFrequency": {
+          "target": "com.amazonaws.configservice#RecordingFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The recording frequency that will be applied to all the resource types specified in the override.</p>\n         <ul>\n            <li>\n               <p>Continuous recording allows you to record configuration changes continuously whenever a change occurs.</p>\n            </li>\n            <li>\n               <p>Daily recording allows you to receive a configuration item (CI) representing the most recent state of your resources over the last 24-hour period, only if it\u2019s different from the previous CI recorded.\n\t\t\t</p>\n            </li>\n         </ul>\n         <note>\n            <p>Firewall Manager depends on continuous recording to monitor your resources. If you are using Firewall Manager,\n\t\t\tit is recommended that you set the recording frequency to Continuous.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object for you to specify your overrides for the recording mode.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RecordingModeOverrides": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RecordingModeOverride"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.configservice#RecordingModeResourceTypesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceType"
+      }
+    },
+    "com.amazonaws.configservice#RecordingScope": {
+      "type": "enum",
+      "members": {
+        "INTERNAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL"
+          }
+        },
+        "PAID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PAID"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#RecordingStrategy": {
+      "type": "structure",
+      "members": {
+        "useOnly": {
+          "target": "com.amazonaws.configservice#RecordingStrategyType",
+          "traits": {
+            "smithy.api#documentation": "<p>The recording strategy for the configuration recorder.</p>\n         <ul>\n            <li>\n               <p>If you set this option to <code>ALL_SUPPORTED_RESOURCE_TYPES</code>, Config records configuration changes for all supported resource types, excluding the global IAM resource types.\n\t\t\t\tYou also must set the <code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to <code>true</code>.\n\t\t\t\tWhen Config adds support for a new resource type, Config automatically starts recording resources of that type. For a list of supported resource types,\n\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources\">Supported Resource Types</a> in the <i>Config developer guide</i>.</p>\n            </li>\n            <li>\n               <p>If you set this option to <code>INCLUSION_BY_RESOURCE_TYPES</code>, Config records\n\t\t\t\t\tconfiguration changes for only the resource types that you specify in the\n\t\t\t\t\t\t<code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>.</p>\n            </li>\n            <li>\n               <p>If you set this option to <code>EXCLUSION_BY_RESOURCE_TYPES</code>, Config records\n\t\t\t\t\tconfiguration changes for all supported resource types, except the resource\n\t\t\t\t\ttypes that you specify to exclude from being recorded in the\n\t\t\t\t\t\t<code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ExclusionByResourceTypes.html\">ExclusionByResourceTypes</a>.</p>\n            </li>\n         </ul>\n         <note>\n            <p>\n               <b>Required and optional fields</b>\n            </p>\n            <p>The <code>recordingStrategy</code> field is optional when you set the\n\t\t\t<code>allSupported</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a> to <code>true</code>.</p>\n            <p>The <code>recordingStrategy</code> field is optional when you list resource types in the\n\t\t\t\t<code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_RecordingGroup.html\">RecordingGroup</a>.</p>\n            <p>The <code>recordingStrategy</code> field is required if you list resource types to exclude from recording in the <code>resourceTypes</code> field of <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_ExclusionByResourceTypes.html\">ExclusionByResourceTypes</a>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Overriding fields</b>\n            </p>\n            <p>If you choose <code>EXCLUSION_BY_RESOURCE_TYPES</code> for the recording strategy, the <code>exclusionByResourceTypes</code> field will override other properties in the request.</p>\n            <p>For example, even if you set <code>includeGlobalResourceTypes</code> to false, global IAM resource types will still be automatically\n\t\t\trecorded in this option unless those resource types are specifically listed as exclusions in the <code>resourceTypes</code> field of <code>exclusionByResourceTypes</code>.</p>\n         </note>\n         <note>\n            <p>\n               <b>Global resource types and the exclusion recording strategy</b>\n            </p>\n            <p>By default, if you choose the <code>EXCLUSION_BY_RESOURCE_TYPES</code> recording strategy,\n\t\t\t\twhen Config adds support for a new resource type in the Region where you set up the configuration recorder, including global resource types,\n\t\t\t\tConfig starts recording resources of that type automatically.</p>\n            <p>Unless specifically listed as exclusions,\n\t\t\t\t<code>AWS::RDS::GlobalCluster</code> will be recorded automatically in all supported Config Regions were the configuration recorder is enabled.</p>\n            <p>IAM users, groups, roles, and customer managed policies will be recorded in the Region where you set up the configuration recorder if that is a Region where Config was available before February 2022.\n\t\t\t\tYou cannot be record the global IAM resouce types in Regions supported by Config after February 2022. This list where you cannot record the global IAM resource types includes the following Regions:</p>\n            <ul>\n               <li>\n                  <p>Asia Pacific (Hyderabad)</p>\n               </li>\n               <li>\n                  <p>Asia Pacific (Melbourne)</p>\n               </li>\n               <li>\n                  <p>Canada West (Calgary)</p>\n               </li>\n               <li>\n                  <p>Europe (Spain)</p>\n               </li>\n               <li>\n                  <p>Europe (Zurich)</p>\n               </li>\n               <li>\n                  <p>Israel (Tel Aviv)</p>\n               </li>\n               <li>\n                  <p>Middle East (UAE)</p>\n               </li>\n            </ul>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the recording strategy of the configuration recorder.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RecordingStrategyType": {
+      "type": "enum",
+      "members": {
+        "ALL_SUPPORTED_RESOURCE_TYPES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_SUPPORTED_RESOURCE_TYPES"
+          }
+        },
+        "INCLUSION_BY_RESOURCE_TYPES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INCLUSION_BY_RESOURCE_TYPES"
+          }
+        },
+        "EXCLUSION_BY_RESOURCE_TYPES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXCLUSION_BY_RESOURCE_TYPES"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ReevaluateConfigRuleNames": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ConfigRuleName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#RelatedEvent": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#RelatedEventList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RelatedEvent"
+      }
+    },
+    "com.amazonaws.configservice#Relationship": {
+      "type": "structure",
+      "members": {
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type of the related resource.</p>"
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the related resource (for example,\n\t\t\t\t<code>sg-xxxxxx</code>).</p>"
+          }
+        },
+        "resourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name of the related resource, if\n\t\t\tavailable.</p>"
+          }
+        },
+        "relationshipName": {
+          "target": "com.amazonaws.configservice#RelationshipName",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of relationship with the related resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The relationship of the related resource to the main\n\t\t\tresource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RelationshipList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#Relationship"
+      }
+    },
+    "com.amazonaws.configservice#RelationshipName": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#RemediationConfiguration": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetType": {
+          "target": "com.amazonaws.configservice#RemediationTargetType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the target. Target executes remediation. For example, SSM document.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetId": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>Target ID is the name of the SSM document.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetVersion": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Version of the target. For example, version of the SSM document.</p>\n         <note>\n            <p>If you make backward incompatible changes to the SSM document, \n\t\t\tyou must call PutRemediationConfiguration API again to ensure the remediations can run.</p>\n         </note>"
+          }
+        },
+        "Parameters": {
+          "target": "com.amazonaws.configservice#RemediationParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>An object of the RemediationParameterValue.</p>"
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of a resource. </p>"
+          }
+        },
+        "Automatic": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>The remediation is triggered automatically.</p>"
+          }
+        },
+        "ExecutionControls": {
+          "target": "com.amazonaws.configservice#ExecutionControls",
+          "traits": {
+            "smithy.api#documentation": "<p>An ExecutionControls object.</p>"
+          }
+        },
+        "MaximumAutomaticAttempts": {
+          "target": "com.amazonaws.configservice#AutoRemediationAttempts",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of failed attempts for auto-remediation. If you do not select a number, the default is 5.</p>\n         <p>For example, if you specify MaximumAutomaticAttempts as 5 with RetryAttemptSeconds as 50 seconds, \n\t\t\t\n\t\t\tConfig will put a RemediationException on your behalf for the failing resource after the 5th failed attempt within 50 seconds.</p>"
+          }
+        },
+        "RetryAttemptSeconds": {
+          "target": "com.amazonaws.configservice#AutoRemediationAttemptSeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>Time window to determine whether or not to add a remediation exception to prevent infinite remediation attempts.\n\t\t\tIf <code>MaximumAutomaticAttempts</code> remediation attempts have been made under <code>RetryAttemptSeconds</code>, a remediation exception will be added to the resource.\n\t\t\tIf you do not select a number, the default is 60 seconds.\n\t\t</p>\n         <p>For example, if you specify <code>RetryAttemptSeconds</code> as 50 seconds and <code>MaximumAutomaticAttempts</code> as 5, \n\t\t\tConfig will run auto-remediations 5 times within 50 seconds before adding a remediation exception to the resource.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of remediation configuration.</p>"
+          }
+        },
+        "CreatedByService": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the service that owns the service-linked rule, if applicable.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details about the remediation configuration that includes the remediation action, parameters, and data to execute the action.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RemediationConfigurations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RemediationConfiguration"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#RemediationException": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Config rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of a resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example., sg-xxxxxx).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>An explanation of an remediation exception.</p>"
+          }
+        },
+        "ExpirationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the remediation exception will be deleted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents the details about the remediation exception. The details include the rule name, an explanation of an exception, the time when the exception will be deleted, the resource ID, and resource type. </p>"
+      }
+    },
+    "com.amazonaws.configservice#RemediationExceptionResourceKey": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of a resource.</p>"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit1024",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example., sg-xxxxxx).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details that identify a resource within Config, including the resource type and resource ID. </p>"
+      }
+    },
+    "com.amazonaws.configservice#RemediationExceptionResourceKeys": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RemediationExceptionResourceKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#RemediationExceptions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RemediationException"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#RemediationExecutionState": {
+      "type": "enum",
+      "members": {
+        "QUEUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUEUED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "UNKNOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNKNOWN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#RemediationExecutionStatus": {
+      "type": "structure",
+      "members": {
+        "ResourceKey": {
+          "target": "com.amazonaws.configservice#ResourceKey"
+        },
+        "State": {
+          "target": "com.amazonaws.configservice#RemediationExecutionState",
+          "traits": {
+            "smithy.api#documentation": "<p>ENUM of the values.</p>"
+          }
+        },
+        "StepDetails": {
+          "target": "com.amazonaws.configservice#RemediationExecutionSteps",
+          "traits": {
+            "smithy.api#documentation": "<p>Details of every step.</p>"
+          }
+        },
+        "InvocationTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>Start time when the remediation was executed.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the remediation execution was last updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details of the current status of the invoked remediation action for that resource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RemediationExecutionStatuses": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RemediationExecutionStatus"
+      }
+    },
+    "com.amazonaws.configservice#RemediationExecutionStep": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the step.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.configservice#RemediationExecutionStepState",
+          "traits": {
+            "smithy.api#documentation": "<p>The valid status of the step.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An error message if the step was interrupted during execution.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the step started.</p>"
+          }
+        },
+        "StopTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the step stopped.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Name of the step from the SSM document.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RemediationExecutionStepState": {
+      "type": "enum",
+      "members": {
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "EXITED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXITED"
+          }
+        },
+        "UNKNOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNKNOWN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#RemediationExecutionSteps": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RemediationExecutionStep"
+      }
+    },
+    "com.amazonaws.configservice#RemediationInProgressException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Remediation action is in progress. You can either cancel execution in Amazon Web Services Systems Manager or wait and try again later. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#RemediationParameterValue": {
+      "type": "structure",
+      "members": {
+        "ResourceValue": {
+          "target": "com.amazonaws.configservice#ResourceValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value is dynamic and changes at run-time.</p>"
+          }
+        },
+        "StaticValue": {
+          "target": "com.amazonaws.configservice#StaticValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value is static and does not change at run-time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The value is either a dynamic (resource) value or a static value. You must select either a dynamic value or a static value.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RemediationParameters": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit256"
+      },
+      "value": {
+        "target": "com.amazonaws.configservice#RemediationParameterValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#RemediationTargetType": {
+      "type": "enum",
+      "members": {
+        "SSM_DOCUMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSM_DOCUMENT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceConcurrentModificationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Two users are trying to modify the same query at the same time. Wait for a moment and try again.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#ResourceConfiguration": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 51200
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceConfigurationSchemaType": {
+      "type": "enum",
+      "members": {
+        "CFN_RESOURCE_SCHEMA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CFN_RESOURCE_SCHEMA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceCount": {
+      "type": "structure",
+      "members": {
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type (for example,\n\t\t\t\t<code>\"AWS::EC2::Instance\"</code>).</p>"
+          }
+        },
+        "count": {
+          "target": "com.amazonaws.configservice#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of resources.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that contains the resource type and the number of\n\t\t\tresources.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceCountFilters": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the Amazon Web Services resource.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit ID of the account.</p>"
+          }
+        },
+        "Region": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The region where the account is located.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the resource count based on account ID, region, and resource type.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceCountGroupKey": {
+      "type": "enum",
+      "members": {
+        "RESOURCE_TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESOURCE_TYPE"
+          }
+        },
+        "ACCOUNT_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACCOUNT_ID"
+          }
+        },
+        "AWS_REGION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS_REGION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceCounts": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceCount"
+      }
+    },
+    "com.amazonaws.configservice#ResourceCreationTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#ResourceDeletionTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.configservice#ResourceDetails": {
+      "type": "structure",
+      "members": {
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique resource ID for an evaluation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resource being evaluated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceConfiguration": {
+          "target": "com.amazonaws.configservice#ResourceConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource definition to be evaluated as per the resource configuration schema type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceConfigurationSchemaType": {
+          "target": "com.amazonaws.configservice#ResourceConfigurationSchemaType",
+          "traits": {
+            "smithy.api#documentation": "<p>The schema type of the resource configuration.</p>\n         <note>\n            <p>You can find the\n\t\t\t<a href=\"https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html\">Resource type schema</a>, or <code>CFN_RESOURCE_SCHEMA</code>, in \"<i>Amazon Web Services public extensions</i>\" within the CloudFormation registry or with the following CLI commmand:\n\t\t\t<code>aws cloudformation describe-type --type-name \"AWS::S3::Bucket\" --type RESOURCE</code>.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html#registry-view\">Managing extensions through the CloudFormation registry</a>\n\t\t\t\tand <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\">Amazon Web Services resource and property types reference</a> in the CloudFormation User Guide.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about the resource being evaluated.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceEvaluation": {
+      "type": "structure",
+      "members": {
+        "ResourceEvaluationId": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ResourceEvaluationId of a evaluation.</p>"
+          }
+        },
+        "EvaluationMode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode of an evaluation. The valid values are Detective or Proactive.</p>"
+          }
+        },
+        "EvaluationStartTimestamp": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The starting time of an execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details of a resource evaluation.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceEvaluationFilters": {
+      "type": "structure",
+      "members": {
+        "EvaluationMode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters all resource evaluations results based on an evaluation mode.</p>\n         <important>\n            <p>Currently, <code>DECTECTIVE</code> is not supported as a valid value. Ignore other documentation stating otherwise.</p>\n         </important>"
+          }
+        },
+        "TimeWindow": {
+          "target": "com.amazonaws.configservice#TimeWindow",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>TimeWindow</code> object.</p>"
+          }
+        },
+        "EvaluationContextIdentifier": {
+          "target": "com.amazonaws.configservice#EvaluationContextIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters evaluations for a given infrastructure deployment. For example: CFN Stack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details of a resource evaluation based on the selected filter.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceEvaluationId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceEvaluationStatus": {
+      "type": "enum",
+      "members": {
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceEvaluations": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceEvaluation"
+      }
+    },
+    "com.amazonaws.configservice#ResourceFilters": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit source account ID.</p>"
+          }
+        },
+        "ResourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource.</p>"
+          }
+        },
+        "ResourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the resource.</p>"
+          }
+        },
+        "Region": {
+          "target": "com.amazonaws.configservice#AwsRegion",
+          "traits": {
+            "smithy.api#documentation": "<p>The source region.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters the results by resource account ID, region, resource ID, and resource name.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 768
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceIdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceId"
+      }
+    },
+    "com.amazonaws.configservice#ResourceIdentifier": {
+      "type": "structure",
+      "members": {
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resource.</p>"
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example,\n\t\t\t<code>sg-xxxxxx</code>).</p>"
+          }
+        },
+        "resourceName": {
+          "target": "com.amazonaws.configservice#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name of the resource (if available).</p>"
+          }
+        },
+        "resourceDeletionTime": {
+          "target": "com.amazonaws.configservice#ResourceDeletionTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the resource was deleted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details that identify a resource that is discovered by Config, including the resource type, ID, and (if available) the\n\t\t\tcustom resource name.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceIdentifierList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceIdentifier"
+      }
+    },
+    "com.amazonaws.configservice#ResourceIdentifiersList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateResourceIdentifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceInUseException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You see this exception in the following cases: </p>\n         <ul>\n            <li>\n               <p>For DeleteConfigRule, Config is deleting this rule. Try your request again later.</p>\n            </li>\n            <li>\n               <p>For DeleteConfigRule, the rule is deleting your evaluation results. Try your request again later.</p>\n            </li>\n            <li>\n               <p>For DeleteConfigRule, a remediation action is associated with the rule and Config cannot delete this rule. Delete the remediation action associated with the rule before deleting the rule and try your request again later.</p>\n            </li>\n            <li>\n               <p>For PutConfigOrganizationRule, organization Config rule deletion is in progress. Try your request again later.</p>\n            </li>\n            <li>\n               <p>For DeleteOrganizationConfigRule, organization Config rule creation is in progress. Try your request again later.</p>\n            </li>\n            <li>\n               <p>For PutConformancePack and PutOrganizationConformancePack, a conformance pack creation, update, and deletion is in progress. Try your request again later.</p>\n            </li>\n            <li>\n               <p>For DeleteConformancePack, a conformance pack creation, update, and deletion is in progress. Try your request again later.</p>\n            </li>\n         </ul>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#ResourceKey": {
+      "type": "structure",
+      "members": {
+        "resourceType": {
+          "target": "com.amazonaws.configservice#ResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.configservice#ResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the resource (for example., sg-xxxxxx). </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details that identify a resource within Config, including\n\t\t\tthe resource type and resource ID.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceKeys": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceName": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#ResourceNotDiscoveredException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a resource that is either unknown or has not\n\t\t\tbeen discovered.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have specified a resource that does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#ResourceType": {
+      "type": "enum",
+      "members": {
+        "CustomerGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::CustomerGateway"
+          }
+        },
+        "EIP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::EIP"
+          }
+        },
+        "Host": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::Host"
+          }
+        },
+        "Instance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::Instance"
+          }
+        },
+        "InternetGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::InternetGateway"
+          }
+        },
+        "NetworkAcl": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NetworkAcl"
+          }
+        },
+        "NetworkInterface": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NetworkInterface"
+          }
+        },
+        "RouteTable": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::RouteTable"
+          }
+        },
+        "SecurityGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SecurityGroup"
+          }
+        },
+        "Subnet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::Subnet"
+          }
+        },
+        "Trail": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudTrail::Trail"
+          }
+        },
+        "Volume": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::Volume"
+          }
+        },
+        "VPC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPC"
+          }
+        },
+        "VPNConnection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPNConnection"
+          }
+        },
+        "VPNGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPNGateway"
+          }
+        },
+        "RegisteredHAInstance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::RegisteredHAInstance"
+          }
+        },
+        "NatGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NatGateway"
+          }
+        },
+        "EgressOnlyInternetGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::EgressOnlyInternetGateway"
+          }
+        },
+        "VPCEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCEndpoint"
+          }
+        },
+        "VPCEndpointService": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCEndpointService"
+          }
+        },
+        "FlowLog": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::FlowLog"
+          }
+        },
+        "VPCPeeringConnection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCPeeringConnection"
+          }
+        },
+        "Domain": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Elasticsearch::Domain"
+          }
+        },
+        "Group": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::Group"
+          }
+        },
+        "Policy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::Policy"
+          }
+        },
+        "Role": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::Role"
+          }
+        },
+        "User": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::User"
+          }
+        },
+        "LoadBalancerV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticLoadBalancingV2::LoadBalancer"
+          }
+        },
+        "Certificate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ACM::Certificate"
+          }
+        },
+        "DBInstance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::DBInstance"
+          }
+        },
+        "DBSubnetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::DBSubnetGroup"
+          }
+        },
+        "DBSecurityGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::DBSecurityGroup"
+          }
+        },
+        "DBSnapshot": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::DBSnapshot"
+          }
+        },
+        "DBCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::DBCluster"
+          }
+        },
+        "DBClusterSnapshot": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::DBClusterSnapshot"
+          }
+        },
+        "EventSubscription": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::EventSubscription"
+          }
+        },
+        "Bucket": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::Bucket"
+          }
+        },
+        "AccountPublicAccessBlock": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::AccountPublicAccessBlock"
+          }
+        },
+        "Cluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::Cluster"
+          }
+        },
+        "ClusterSnapshot": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::ClusterSnapshot"
+          }
+        },
+        "ClusterParameterGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::ClusterParameterGroup"
+          }
+        },
+        "ClusterSecurityGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::ClusterSecurityGroup"
+          }
+        },
+        "ClusterSubnetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::ClusterSubnetGroup"
+          }
+        },
+        "RedshiftEventSubscription": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::EventSubscription"
+          }
+        },
+        "ManagedInstanceInventory": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSM::ManagedInstanceInventory"
+          }
+        },
+        "Alarm": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudWatch::Alarm"
+          }
+        },
+        "Stack": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFormation::Stack"
+          }
+        },
+        "LoadBalancer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticLoadBalancing::LoadBalancer"
+          }
+        },
+        "AutoScalingGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AutoScaling::AutoScalingGroup"
+          }
+        },
+        "LaunchConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AutoScaling::LaunchConfiguration"
+          }
+        },
+        "ScalingPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AutoScaling::ScalingPolicy"
+          }
+        },
+        "ScheduledAction": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AutoScaling::ScheduledAction"
+          }
+        },
+        "Table": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DynamoDB::Table"
+          }
+        },
+        "Project": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeBuild::Project"
+          }
+        },
+        "RateBasedRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAF::RateBasedRule"
+          }
+        },
+        "Rule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAF::Rule"
+          }
+        },
+        "RuleGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAF::RuleGroup"
+          }
+        },
+        "WebACL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAF::WebACL"
+          }
+        },
+        "RegionalRateBasedRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFRegional::RateBasedRule"
+          }
+        },
+        "RegionalRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFRegional::Rule"
+          }
+        },
+        "RegionalRuleGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFRegional::RuleGroup"
+          }
+        },
+        "RegionalWebACL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFRegional::WebACL"
+          }
+        },
+        "Distribution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFront::Distribution"
+          }
+        },
+        "StreamingDistribution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFront::StreamingDistribution"
+          }
+        },
+        "Function": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lambda::Function"
+          }
+        },
+        "NetworkFirewallFirewall": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkFirewall::Firewall"
+          }
+        },
+        "NetworkFirewallFirewallPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkFirewall::FirewallPolicy"
+          }
+        },
+        "NetworkFirewallRuleGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkFirewall::RuleGroup"
+          }
+        },
+        "Application": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticBeanstalk::Application"
+          }
+        },
+        "ApplicationVersion": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticBeanstalk::ApplicationVersion"
+          }
+        },
+        "Environment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticBeanstalk::Environment"
+          }
+        },
+        "WebACLV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFv2::WebACL"
+          }
+        },
+        "RuleGroupV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFv2::RuleGroup"
+          }
+        },
+        "IPSetV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFv2::IPSet"
+          }
+        },
+        "RegexPatternSetV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFv2::RegexPatternSet"
+          }
+        },
+        "ManagedRuleSetV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WAFv2::ManagedRuleSet"
+          }
+        },
+        "EncryptionConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::XRay::EncryptionConfig"
+          }
+        },
+        "AssociationCompliance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSM::AssociationCompliance"
+          }
+        },
+        "PatchCompliance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSM::PatchCompliance"
+          }
+        },
+        "Protection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Shield::Protection"
+          }
+        },
+        "RegionalProtection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ShieldRegional::Protection"
+          }
+        },
+        "ConformancePackCompliance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Config::ConformancePackCompliance"
+          }
+        },
+        "ResourceCompliance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Config::ResourceCompliance"
+          }
+        },
+        "Stage": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGateway::Stage"
+          }
+        },
+        "RestApi": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGateway::RestApi"
+          }
+        },
+        "StageV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGatewayV2::Stage"
+          }
+        },
+        "Api": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGatewayV2::Api"
+          }
+        },
+        "Pipeline": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodePipeline::Pipeline"
+          }
+        },
+        "CloudFormationProvisionedProduct": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceCatalog::CloudFormationProvisionedProduct"
+          }
+        },
+        "CloudFormationProduct": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceCatalog::CloudFormationProduct"
+          }
+        },
+        "Portfolio": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceCatalog::Portfolio"
+          }
+        },
+        "Queue": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SQS::Queue"
+          }
+        },
+        "Key": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KMS::Key"
+          }
+        },
+        "QLDBLedger": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::QLDB::Ledger"
+          }
+        },
+        "Secret": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SecretsManager::Secret"
+          }
+        },
+        "Topic": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SNS::Topic"
+          }
+        },
+        "FileData": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSM::FileData"
+          }
+        },
+        "BackupPlan": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Backup::BackupPlan"
+          }
+        },
+        "BackupSelection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Backup::BackupSelection"
+          }
+        },
+        "BackupVault": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Backup::BackupVault"
+          }
+        },
+        "BackupRecoveryPoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Backup::RecoveryPoint"
+          }
+        },
+        "ECRRepository": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECR::Repository"
+          }
+        },
+        "ECSCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECS::Cluster"
+          }
+        },
+        "ECSService": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECS::Service"
+          }
+        },
+        "ECSTaskDefinition": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECS::TaskDefinition"
+          }
+        },
+        "EFSAccessPoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EFS::AccessPoint"
+          }
+        },
+        "EFSFileSystem": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EFS::FileSystem"
+          }
+        },
+        "EKSCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EKS::Cluster"
+          }
+        },
+        "OpenSearchDomain": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::OpenSearch::Domain"
+          }
+        },
+        "TransitGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TransitGateway"
+          }
+        },
+        "KinesisStream": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Kinesis::Stream"
+          }
+        },
+        "KinesisStreamConsumer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Kinesis::StreamConsumer"
+          }
+        },
+        "CodeDeployApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeDeploy::Application"
+          }
+        },
+        "CodeDeployDeploymentConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeDeploy::DeploymentConfig"
+          }
+        },
+        "CodeDeployDeploymentGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeDeploy::DeploymentGroup"
+          }
+        },
+        "LaunchTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::LaunchTemplate"
+          }
+        },
+        "ECRPublicRepository": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECR::PublicRepository"
+          }
+        },
+        "GuardDutyDetector": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GuardDuty::Detector"
+          }
+        },
+        "EMRSecurityConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EMR::SecurityConfiguration"
+          }
+        },
+        "SageMakerCodeRepository": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::CodeRepository"
+          }
+        },
+        "Route53ResolverResolverEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::ResolverEndpoint"
+          }
+        },
+        "Route53ResolverResolverRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::ResolverRule"
+          }
+        },
+        "Route53ResolverResolverRuleAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::ResolverRuleAssociation"
+          }
+        },
+        "DMSReplicationSubnetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DMS::ReplicationSubnetGroup"
+          }
+        },
+        "DMSEventSubscription": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DMS::EventSubscription"
+          }
+        },
+        "MSKCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MSK::Cluster"
+          }
+        },
+        "StepFunctionsActivity": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::StepFunctions::Activity"
+          }
+        },
+        "WorkSpacesWorkspace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WorkSpaces::Workspace"
+          }
+        },
+        "WorkSpacesConnectionAlias": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::WorkSpaces::ConnectionAlias"
+          }
+        },
+        "SageMakerModel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::Model"
+          }
+        },
+        "ListenerV2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticLoadBalancingV2::Listener"
+          }
+        },
+        "StepFunctionsStateMachine": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::StepFunctions::StateMachine"
+          }
+        },
+        "BatchJobQueue": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Batch::JobQueue"
+          }
+        },
+        "BatchComputeEnvironment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Batch::ComputeEnvironment"
+          }
+        },
+        "AccessAnalyzerAnalyzer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AccessAnalyzer::Analyzer"
+          }
+        },
+        "AthenaWorkGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Athena::WorkGroup"
+          }
+        },
+        "AthenaDataCatalog": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Athena::DataCatalog"
+          }
+        },
+        "DetectiveGraph": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Detective::Graph"
+          }
+        },
+        "GlobalAcceleratorAccelerator": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GlobalAccelerator::Accelerator"
+          }
+        },
+        "GlobalAcceleratorEndpointGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GlobalAccelerator::EndpointGroup"
+          }
+        },
+        "GlobalAcceleratorListener": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GlobalAccelerator::Listener"
+          }
+        },
+        "TransitGatewayAttachment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TransitGatewayAttachment"
+          }
+        },
+        "TransitGatewayRouteTable": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TransitGatewayRouteTable"
+          }
+        },
+        "DMSCertificate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DMS::Certificate"
+          }
+        },
+        "AppConfigApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::Application"
+          }
+        },
+        "AppSyncGraphQLApi": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppSync::GraphQLApi"
+          }
+        },
+        "DataSyncLocationSMB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationSMB"
+          }
+        },
+        "DataSyncLocationFSxLustre": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationFSxLustre"
+          }
+        },
+        "DataSyncLocationS3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationS3"
+          }
+        },
+        "DataSyncLocationEFS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationEFS"
+          }
+        },
+        "DataSyncTask": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::Task"
+          }
+        },
+        "DataSyncLocationNFS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationNFS"
+          }
+        },
+        "NetworkInsightsAccessScopeAnalysis": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NetworkInsightsAccessScopeAnalysis"
+          }
+        },
+        "EKSFargateProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EKS::FargateProfile"
+          }
+        },
+        "GlueJob": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Glue::Job"
+          }
+        },
+        "GuardDutyThreatIntelSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GuardDuty::ThreatIntelSet"
+          }
+        },
+        "GuardDutyIPSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GuardDuty::IPSet"
+          }
+        },
+        "SageMakerWorkteam": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::Workteam"
+          }
+        },
+        "SageMakerNotebookInstanceLifecycleConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::NotebookInstanceLifecycleConfig"
+          }
+        },
+        "ServiceDiscoveryService": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceDiscovery::Service"
+          }
+        },
+        "ServiceDiscoveryPublicDnsNamespace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceDiscovery::PublicDnsNamespace"
+          }
+        },
+        "SESContactList": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::ContactList"
+          }
+        },
+        "SESConfigurationSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::ConfigurationSet"
+          }
+        },
+        "Route53HostedZone": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53::HostedZone"
+          }
+        },
+        "IoTEventsInput": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTEvents::Input"
+          }
+        },
+        "IoTEventsDetectorModel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTEvents::DetectorModel"
+          }
+        },
+        "IoTEventsAlarmModel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTEvents::AlarmModel"
+          }
+        },
+        "ServiceDiscoveryHttpNamespace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceDiscovery::HttpNamespace"
+          }
+        },
+        "EventsEventBus": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Events::EventBus"
+          }
+        },
+        "ImageBuilderContainerRecipe": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ImageBuilder::ContainerRecipe"
+          }
+        },
+        "ImageBuilderDistributionConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ImageBuilder::DistributionConfiguration"
+          }
+        },
+        "ImageBuilderInfrastructureConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ImageBuilder::InfrastructureConfiguration"
+          }
+        },
+        "DataSyncLocationObjectStorage": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationObjectStorage"
+          }
+        },
+        "DataSyncLocationHDFS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationHDFS"
+          }
+        },
+        "GlueClassifier": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Glue::Classifier"
+          }
+        },
+        "Route53RecoveryReadinessCell": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryReadiness::Cell"
+          }
+        },
+        "Route53RecoveryReadinessReadinessCheck": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryReadiness::ReadinessCheck"
+          }
+        },
+        "ECRRegistryPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECR::RegistryPolicy"
+          }
+        },
+        "BackupReportPlan": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Backup::ReportPlan"
+          }
+        },
+        "LightsailCertificate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lightsail::Certificate"
+          }
+        },
+        "RUMAppMonitor": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RUM::AppMonitor"
+          }
+        },
+        "EventsEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Events::Endpoint"
+          }
+        },
+        "SESReceiptRuleSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::ReceiptRuleSet"
+          }
+        },
+        "EventsArchive": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Events::Archive"
+          }
+        },
+        "EventsApiDestination": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Events::ApiDestination"
+          }
+        },
+        "LightsailDisk": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lightsail::Disk"
+          }
+        },
+        "FISExperimentTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::FIS::ExperimentTemplate"
+          }
+        },
+        "DataSyncLocationFSxWindows": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::LocationFSxWindows"
+          }
+        },
+        "SESReceiptFilter": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::ReceiptFilter"
+          }
+        },
+        "GuardDutyFilter": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GuardDuty::Filter"
+          }
+        },
+        "SESTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::Template"
+          }
+        },
+        "AmazonMQBroker": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AmazonMQ::Broker"
+          }
+        },
+        "AppConfigEnvironment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::Environment"
+          }
+        },
+        "AppConfigConfigurationProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::ConfigurationProfile"
+          }
+        },
+        "Cloud9EnvironmentEC2": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Cloud9::EnvironmentEC2"
+          }
+        },
+        "EventSchemasRegistry": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EventSchemas::Registry"
+          }
+        },
+        "EventSchemasRegistryPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EventSchemas::RegistryPolicy"
+          }
+        },
+        "EventSchemasDiscoverer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EventSchemas::Discoverer"
+          }
+        },
+        "FraudDetectorLabel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::FraudDetector::Label"
+          }
+        },
+        "FraudDetectorEntityType": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::FraudDetector::EntityType"
+          }
+        },
+        "FraudDetectorVariable": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::FraudDetector::Variable"
+          }
+        },
+        "FraudDetectorOutcome": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::FraudDetector::Outcome"
+          }
+        },
+        "IoTAuthorizer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::Authorizer"
+          }
+        },
+        "IoTSecurityProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::SecurityProfile"
+          }
+        },
+        "IoTRoleAlias": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::RoleAlias"
+          }
+        },
+        "IoTDimension": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::Dimension"
+          }
+        },
+        "IoTAnalyticsDatastore": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTAnalytics::Datastore"
+          }
+        },
+        "LightsailBucket": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lightsail::Bucket"
+          }
+        },
+        "LightsailStaticIp": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lightsail::StaticIp"
+          }
+        },
+        "MediaPackagePackagingGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaPackage::PackagingGroup"
+          }
+        },
+        "Route53RecoveryReadinessRecoveryGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryReadiness::RecoveryGroup"
+          }
+        },
+        "ResilienceHubResiliencyPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ResilienceHub::ResiliencyPolicy"
+          }
+        },
+        "TransferWorkflow": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Transfer::Workflow"
+          }
+        },
+        "EKSIdentityProviderConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EKS::IdentityProviderConfig"
+          }
+        },
+        "EKSAddon": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EKS::Addon"
+          }
+        },
+        "GlueMLTransform": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Glue::MLTransform"
+          }
+        },
+        "IoTPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::Policy"
+          }
+        },
+        "IoTMitigationAction": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::MitigationAction"
+          }
+        },
+        "IoTTwinMakerWorkspace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTTwinMaker::Workspace"
+          }
+        },
+        "IoTTwinMakerEntity": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTTwinMaker::Entity"
+          }
+        },
+        "IoTAnalyticsDataset": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTAnalytics::Dataset"
+          }
+        },
+        "IoTAnalyticsPipeline": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTAnalytics::Pipeline"
+          }
+        },
+        "IoTAnalyticsChannel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTAnalytics::Channel"
+          }
+        },
+        "IoTSiteWiseDashboard": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTSiteWise::Dashboard"
+          }
+        },
+        "IoTSiteWiseProject": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTSiteWise::Project"
+          }
+        },
+        "IoTSiteWisePortal": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTSiteWise::Portal"
+          }
+        },
+        "IoTSiteWiseAssetModel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTSiteWise::AssetModel"
+          }
+        },
+        "IVSChannel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IVS::Channel"
+          }
+        },
+        "IVSRecordingConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IVS::RecordingConfiguration"
+          }
+        },
+        "IVSPlaybackKeyPair": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IVS::PlaybackKeyPair"
+          }
+        },
+        "KinesisAnalyticsV2Application": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KinesisAnalyticsV2::Application"
+          }
+        },
+        "RDSGlobalCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::GlobalCluster"
+          }
+        },
+        "S3MultiRegionAccessPoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::MultiRegionAccessPoint"
+          }
+        },
+        "DeviceFarmTestGridProject": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DeviceFarm::TestGridProject"
+          }
+        },
+        "BudgetsBudgetsAction": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Budgets::BudgetsAction"
+          }
+        },
+        "LexBot": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lex::Bot"
+          }
+        },
+        "CodeGuruReviewerRepositoryAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeGuruReviewer::RepositoryAssociation"
+          }
+        },
+        "IoTCustomMetric": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::CustomMetric"
+          }
+        },
+        "Route53ResolverFirewallDomainList": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::FirewallDomainList"
+          }
+        },
+        "RoboMakerRobotApplicationVersion": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RoboMaker::RobotApplicationVersion"
+          }
+        },
+        "EC2TrafficMirrorSession": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TrafficMirrorSession"
+          }
+        },
+        "IoTSiteWiseGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTSiteWise::Gateway"
+          }
+        },
+        "LexBotAlias": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lex::BotAlias"
+          }
+        },
+        "LookoutMetricsAlert": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::LookoutMetrics::Alert"
+          }
+        },
+        "IoTAccountAuditConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::AccountAuditConfiguration"
+          }
+        },
+        "EC2TrafficMirrorTarget": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TrafficMirrorTarget"
+          }
+        },
+        "S3StorageLens": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::StorageLens"
+          }
+        },
+        "IoTScheduledAudit": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::ScheduledAudit"
+          }
+        },
+        "EventsConnection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Events::Connection"
+          }
+        },
+        "EventSchemasSchema": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EventSchemas::Schema"
+          }
+        },
+        "MediaPackagePackagingConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaPackage::PackagingConfiguration"
+          }
+        },
+        "KinesisVideoSignalingChannel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KinesisVideo::SignalingChannel"
+          }
+        },
+        "AppStreamDirectoryConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppStream::DirectoryConfig"
+          }
+        },
+        "LookoutVisionProject": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::LookoutVision::Project"
+          }
+        },
+        "Route53RecoveryControlCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryControl::Cluster"
+          }
+        },
+        "Route53RecoveryControlSafetyRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryControl::SafetyRule"
+          }
+        },
+        "Route53RecoveryControlControlPanel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryControl::ControlPanel"
+          }
+        },
+        "Route53RecoveryControlRoutingControl": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryControl::RoutingControl"
+          }
+        },
+        "Route53RecoveryReadinessResourceSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53RecoveryReadiness::ResourceSet"
+          }
+        },
+        "RoboMakerSimulationApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RoboMaker::SimulationApplication"
+          }
+        },
+        "RoboMakerRobotApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RoboMaker::RobotApplication"
+          }
+        },
+        "HealthLakeFHIRDatastore": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::HealthLake::FHIRDatastore"
+          }
+        },
+        "PinpointSegment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::Segment"
+          }
+        },
+        "PinpointApplicationSettings": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::ApplicationSettings"
+          }
+        },
+        "EventsRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Events::Rule"
+          }
+        },
+        "EC2DHCPOptions": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::DHCPOptions"
+          }
+        },
+        "EC2NetworkInsightsPath": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NetworkInsightsPath"
+          }
+        },
+        "EC2TrafficMirrorFilter": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TrafficMirrorFilter"
+          }
+        },
+        "EC2IPAM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::IPAM"
+          }
+        },
+        "IoTTwinMakerScene": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTTwinMaker::Scene"
+          }
+        },
+        "NetworkManagerTransitGatewayRegistration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::TransitGatewayRegistration"
+          }
+        },
+        "CustomerProfilesDomain": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CustomerProfiles::Domain"
+          }
+        },
+        "AutoScalingWarmPool": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AutoScaling::WarmPool"
+          }
+        },
+        "ConnectPhoneNumber": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Connect::PhoneNumber"
+          }
+        },
+        "AppConfigDeploymentStrategy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::DeploymentStrategy"
+          }
+        },
+        "AppFlowFlow": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppFlow::Flow"
+          }
+        },
+        "AuditManagerAssessment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AuditManager::Assessment"
+          }
+        },
+        "CloudWatchMetricStream": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudWatch::MetricStream"
+          }
+        },
+        "DeviceFarmInstanceProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DeviceFarm::InstanceProfile"
+          }
+        },
+        "DeviceFarmProject": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DeviceFarm::Project"
+          }
+        },
+        "EC2EC2Fleet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::EC2Fleet"
+          }
+        },
+        "EC2SubnetRouteTableAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SubnetRouteTableAssociation"
+          }
+        },
+        "ECRPullThroughCacheRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECR::PullThroughCacheRule"
+          }
+        },
+        "GroundStationConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GroundStation::Config"
+          }
+        },
+        "ImageBuilderImagePipeline": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ImageBuilder::ImagePipeline"
+          }
+        },
+        "IoTFleetMetric": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::FleetMetric"
+          }
+        },
+        "IoTWirelessServiceProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTWireless::ServiceProfile"
+          }
+        },
+        "NetworkManagerDevice": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::Device"
+          }
+        },
+        "NetworkManagerGlobalNetwork": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::GlobalNetwork"
+          }
+        },
+        "NetworkManagerLink": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::Link"
+          }
+        },
+        "NetworkManagerSite": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::Site"
+          }
+        },
+        "PanoramaPackage": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Panorama::Package"
+          }
+        },
+        "PinpointApp": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::App"
+          }
+        },
+        "RedshiftScheduledAction": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::ScheduledAction"
+          }
+        },
+        "Route53ResolverFirewallRuleGroupAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::FirewallRuleGroupAssociation"
+          }
+        },
+        "SageMakerAppImageConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::AppImageConfig"
+          }
+        },
+        "SageMakerImage": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::Image"
+          }
+        },
+        "ECSTaskSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECS::TaskSet"
+          }
+        },
+        "CassandraKeyspace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Cassandra::Keyspace"
+          }
+        },
+        "SignerSigningProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Signer::SigningProfile"
+          }
+        },
+        "AmplifyApp": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Amplify::App"
+          }
+        },
+        "AppMeshVirtualNode": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::VirtualNode"
+          }
+        },
+        "AppMeshVirtualService": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::VirtualService"
+          }
+        },
+        "AppRunnerVpcConnector": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppRunner::VpcConnector"
+          }
+        },
+        "AppStreamApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppStream::Application"
+          }
+        },
+        "CodeArtifactRepository": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeArtifact::Repository"
+          }
+        },
+        "EC2PrefixList": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::PrefixList"
+          }
+        },
+        "EC2SpotFleet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SpotFleet"
+          }
+        },
+        "EvidentlyProject": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Evidently::Project"
+          }
+        },
+        "ForecastDataset": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Forecast::Dataset"
+          }
+        },
+        "IAMSAMLProvider": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::SAMLProvider"
+          }
+        },
+        "IAMServerCertificate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::ServerCertificate"
+          }
+        },
+        "PinpointCampaign": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::Campaign"
+          }
+        },
+        "PinpointInAppTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::InAppTemplate"
+          }
+        },
+        "SageMakerDomain": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::Domain"
+          }
+        },
+        "TransferAgreement": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Transfer::Agreement"
+          }
+        },
+        "TransferConnector": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Transfer::Connector"
+          }
+        },
+        "KinesisFirehoseDeliveryStream": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KinesisFirehose::DeliveryStream"
+          }
+        },
+        "AmplifyBranch": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Amplify::Branch"
+          }
+        },
+        "AppIntegrationsEventIntegration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppIntegrations::EventIntegration"
+          }
+        },
+        "AppMeshRoute": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::Route"
+          }
+        },
+        "AthenaPreparedStatement": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Athena::PreparedStatement"
+          }
+        },
+        "EC2IPAMScope": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::IPAMScope"
+          }
+        },
+        "EvidentlyLaunch": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Evidently::Launch"
+          }
+        },
+        "ForecastDatasetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Forecast::DatasetGroup"
+          }
+        },
+        "GreengrassV2ComponentVersion": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GreengrassV2::ComponentVersion"
+          }
+        },
+        "GroundStationMissionProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GroundStation::MissionProfile"
+          }
+        },
+        "MediaConnectFlowEntitlement": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaConnect::FlowEntitlement"
+          }
+        },
+        "MediaConnectFlowVpcInterface": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaConnect::FlowVpcInterface"
+          }
+        },
+        "MediaTailorPlaybackConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaTailor::PlaybackConfiguration"
+          }
+        },
+        "MSKConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MSK::Configuration"
+          }
+        },
+        "PersonalizeDataset": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Personalize::Dataset"
+          }
+        },
+        "PersonalizeSchema": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Personalize::Schema"
+          }
+        },
+        "PersonalizeSolution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Personalize::Solution"
+          }
+        },
+        "PinpointEmailTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::EmailTemplate"
+          }
+        },
+        "PinpointEventStream": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::EventStream"
+          }
+        },
+        "ResilienceHubApp": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ResilienceHub::App"
+          }
+        },
+        "ACMPCACertificateAuthority": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ACMPCA::CertificateAuthority"
+          }
+        },
+        "AppConfigHostedConfigurationVersion": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::HostedConfigurationVersion"
+          }
+        },
+        "AppMeshVirtualGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::VirtualGateway"
+          }
+        },
+        "AppMeshVirtualRouter": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::VirtualRouter"
+          }
+        },
+        "AppRunnerService": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppRunner::Service"
+          }
+        },
+        "CustomerProfilesObjectType": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CustomerProfiles::ObjectType"
+          }
+        },
+        "DMSEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DMS::Endpoint"
+          }
+        },
+        "EC2CapacityReservation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::CapacityReservation"
+          }
+        },
+        "EC2ClientVpnEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::ClientVpnEndpoint"
+          }
+        },
+        "KendraIndex": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Kendra::Index"
+          }
+        },
+        "KinesisVideoStream": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KinesisVideo::Stream"
+          }
+        },
+        "LogsDestination": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Logs::Destination"
+          }
+        },
+        "PinpointEmailChannel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Pinpoint::EmailChannel"
+          }
+        },
+        "S3AccessPoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::AccessPoint"
+          }
+        },
+        "NetworkManagerCustomerGatewayAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::CustomerGatewayAssociation"
+          }
+        },
+        "NetworkManagerLinkAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::LinkAssociation"
+          }
+        },
+        "IoTWirelessMulticastGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTWireless::MulticastGroup"
+          }
+        },
+        "PersonalizeDatasetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Personalize::DatasetGroup"
+          }
+        },
+        "IoTTwinMakerComponentType": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTTwinMaker::ComponentType"
+          }
+        },
+        "CodeBuildReportGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeBuild::ReportGroup"
+          }
+        },
+        "SageMakerFeatureGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::FeatureGroup"
+          }
+        },
+        "MSKBatchScramSecret": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MSK::BatchScramSecret"
+          }
+        },
+        "AppStreamStack": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppStream::Stack"
+          }
+        },
+        "IoTJobTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::JobTemplate"
+          }
+        },
+        "IoTWirelessFuotaTask": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTWireless::FuotaTask"
+          }
+        },
+        "IoTProvisioningTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::ProvisioningTemplate"
+          }
+        },
+        "InspectorV2Filter": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::InspectorV2::Filter"
+          }
+        },
+        "Route53ResolverResolverQueryLoggingConfigAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::ResolverQueryLoggingConfigAssociation"
+          }
+        },
+        "ServiceDiscoveryInstance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ServiceDiscovery::Instance"
+          }
+        },
+        "TransferCertificate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Transfer::Certificate"
+          }
+        },
+        "MediaConnectFlowSource": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaConnect::FlowSource"
+          }
+        },
+        "APSRuleGroupsNamespace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::APS::RuleGroupsNamespace"
+          }
+        },
+        "CodeGuruProfilerProfilingGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeGuruProfiler::ProfilingGroup"
+          }
+        },
+        "Route53ResolverResolverQueryLoggingConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::ResolverQueryLoggingConfig"
+          }
+        },
+        "BatchSchedulingPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Batch::SchedulingPolicy"
+          }
+        },
+        "ACMPCACertificateAuthorityActivation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ACMPCA::CertificateAuthorityActivation"
+          }
+        },
+        "AppMeshGatewayRoute": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::GatewayRoute"
+          }
+        },
+        "AppMeshMesh": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppMesh::Mesh"
+          }
+        },
+        "ConnectInstance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Connect::Instance"
+          }
+        },
+        "ConnectQuickConnect": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Connect::QuickConnect"
+          }
+        },
+        "EC2CarrierGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::CarrierGateway"
+          }
+        },
+        "EC2IPAMPool": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::IPAMPool"
+          }
+        },
+        "EC2TransitGatewayConnect": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TransitGatewayConnect"
+          }
+        },
+        "EC2TransitGatewayMulticastDomain": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::TransitGatewayMulticastDomain"
+          }
+        },
+        "ECSCapacityProvider": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECS::CapacityProvider"
+          }
+        },
+        "IAMInstanceProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::InstanceProfile"
+          }
+        },
+        "IoTCACertificate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::CACertificate"
+          }
+        },
+        "IoTTwinMakerSyncJob": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTTwinMaker::SyncJob"
+          }
+        },
+        "KafkaConnectConnector": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KafkaConnect::Connector"
+          }
+        },
+        "LambdaCodeSigningConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Lambda::CodeSigningConfig"
+          }
+        },
+        "NetworkManagerConnectPeer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::ConnectPeer"
+          }
+        },
+        "ResourceExplorer2Index": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ResourceExplorer2::Index"
+          }
+        },
+        "AppStreamFleet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppStream::Fleet"
+          }
+        },
+        "CognitoUserPool": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Cognito::UserPool"
+          }
+        },
+        "CognitoUserPoolClient": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Cognito::UserPoolClient"
+          }
+        },
+        "CognitoUserPoolGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Cognito::UserPoolGroup"
+          }
+        },
+        "EC2NetworkInsightsAccessScope": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NetworkInsightsAccessScope"
+          }
+        },
+        "EC2NetworkInsightsAnalysis": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::NetworkInsightsAnalysis"
+          }
+        },
+        "GrafanaWorkspace": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Grafana::Workspace"
+          }
+        },
+        "GroundStationDataflowEndpointGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GroundStation::DataflowEndpointGroup"
+          }
+        },
+        "ImageBuilderImageRecipe": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ImageBuilder::ImageRecipe"
+          }
+        },
+        "KMSAlias": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KMS::Alias"
+          }
+        },
+        "M2Environment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::M2::Environment"
+          }
+        },
+        "QuickSightDataSource": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::QuickSight::DataSource"
+          }
+        },
+        "QuickSightTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::QuickSight::Template"
+          }
+        },
+        "QuickSightTheme": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::QuickSight::Theme"
+          }
+        },
+        "RDSOptionGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::OptionGroup"
+          }
+        },
+        "RedshiftEndpointAccess": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::EndpointAccess"
+          }
+        },
+        "Route53ResolverFirewallRuleGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Resolver::FirewallRuleGroup"
+          }
+        },
+        "SSMDocument": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSM::Document"
+          }
+        },
+        "AppConfigExtensionAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::ExtensionAssociation"
+          }
+        },
+        "AppIntegrationsApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppIntegrations::Application"
+          }
+        },
+        "AppSyncApiCache": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppSync::ApiCache"
+          }
+        },
+        "BedrockGuardrail": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Bedrock::Guardrail"
+          }
+        },
+        "BedrockKnowledgeBase": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Bedrock::KnowledgeBase"
+          }
+        },
+        "CognitoIdentityPool": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Cognito::IdentityPool"
+          }
+        },
+        "ConnectRule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Connect::Rule"
+          }
+        },
+        "ConnectUser": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Connect::User"
+          }
+        },
+        "EC2ClientVpnTargetNetworkAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::ClientVpnTargetNetworkAssociation"
+          }
+        },
+        "EC2EIPAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::EIPAssociation"
+          }
+        },
+        "EC2IPAMResourceDiscovery": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::IPAMResourceDiscovery"
+          }
+        },
+        "EC2IPAMResourceDiscoveryAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::IPAMResourceDiscoveryAssociation"
+          }
+        },
+        "EC2InstanceConnectEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::InstanceConnectEndpoint"
+          }
+        },
+        "EC2SnapshotBlockPublicAccess": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SnapshotBlockPublicAccess"
+          }
+        },
+        "EC2VPCBlockPublicAccessExclusion": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCBlockPublicAccessExclusion"
+          }
+        },
+        "EC2VPCBlockPublicAccessOptions": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCBlockPublicAccessOptions"
+          }
+        },
+        "EC2VPCEndpointConnectionNotification": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCEndpointConnectionNotification"
+          }
+        },
+        "EC2VPNConnectionRoute": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPNConnectionRoute"
+          }
+        },
+        "EvidentlySegment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Evidently::Segment"
+          }
+        },
+        "IAMOIDCProvider": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IAM::OIDCProvider"
+          }
+        },
+        "InspectorV2Activation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::InspectorV2::Activation"
+          }
+        },
+        "MSKClusterPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MSK::ClusterPolicy"
+          }
+        },
+        "MSKVpcConnection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MSK::VpcConnection"
+          }
+        },
+        "MediaConnectGateway": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaConnect::Gateway"
+          }
+        },
+        "MemoryDBSubnetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MemoryDB::SubnetGroup"
+          }
+        },
+        "OpenSearchServerlessCollection": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::OpenSearchServerless::Collection"
+          }
+        },
+        "OpenSearchServerlessVpcEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::OpenSearchServerless::VpcEndpoint"
+          }
+        },
+        "RedshiftEndpointAuthorization": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::EndpointAuthorization"
+          }
+        },
+        "Route53ProfilesProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Profiles::Profile"
+          }
+        },
+        "S3StorageLensGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::StorageLensGroup"
+          }
+        },
+        "S3ExpressBucketPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3Express::BucketPolicy"
+          }
+        },
+        "S3ExpressDirectoryBucket": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3Express::DirectoryBucket"
+          }
+        },
+        "SageMakerInferenceExperiment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::InferenceExperiment"
+          }
+        },
+        "SecurityHubStandard": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SecurityHub::Standard"
+          }
+        },
+        "TransferProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Transfer::Profile"
+          }
+        },
+        "CloudFormationStackSet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFormation::StackSet"
+          }
+        },
+        "MediaPackageV2Channel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaPackageV2::Channel"
+          }
+        },
+        "S3AccessGrantsLocation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::AccessGrantsLocation"
+          }
+        },
+        "S3AccessGrant": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::AccessGrant"
+          }
+        },
+        "S3AccessGrantsInstance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3::AccessGrantsInstance"
+          }
+        },
+        "EMRServerlessApplication": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EMRServerless::Application"
+          }
+        },
+        "ConfigAggregationAuthorization": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Config::AggregationAuthorization"
+          }
+        },
+        "BedrockApplicationInferenceProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Bedrock::ApplicationInferenceProfile"
+          }
+        },
+        "ApiGatewayV2Integration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGatewayV2::Integration"
+          }
+        },
+        "SageMakerMlflowTrackingServer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::MlflowTrackingServer"
+          }
+        },
+        "SageMakerModelBiasJobDefinition": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::ModelBiasJobDefinition"
+          }
+        },
+        "SecretsManagerRotationSchedule": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SecretsManager::RotationSchedule"
+          }
+        },
+        "DeadlineQueueFleetAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Deadline::QueueFleetAssociation"
+          }
+        },
+        "ECRRepositoryCreationTemplate": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECR::RepositoryCreationTemplate"
+          }
+        },
+        "CloudFormationLambdaHook": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFormation::LambdaHook"
+          }
+        },
+        "EC2SubnetNetworkAclAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SubnetNetworkAclAssociation"
+          }
+        },
+        "ApiGatewayUsagePlan": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGateway::UsagePlan"
+          }
+        },
+        "AppConfigExtension": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppConfig::Extension"
+          }
+        },
+        "DeadlineFleet": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Deadline::Fleet"
+          }
+        },
+        "EMRStudio": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EMR::Studio"
+          }
+        },
+        "S3TablesTableBucket": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3Tables::TableBucket"
+          }
+        },
+        "CloudFrontRealtimeLogConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFront::RealtimeLogConfig"
+          }
+        },
+        "BackupGatewayHypervisor": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::BackupGateway::Hypervisor"
+          }
+        },
+        "BCMDataExportsExport": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::BCMDataExports::Export"
+          }
+        },
+        "CloudFormationGuardHook": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFormation::GuardHook"
+          }
+        },
+        "CloudFrontPublicKey": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFront::PublicKey"
+          }
+        },
+        "CloudTrailEventDataStore": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudTrail::EventDataStore"
+          }
+        },
+        "EntityResolutionIdMappingWorkflow": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EntityResolution::IdMappingWorkflow"
+          }
+        },
+        "EntityResolutionSchemaMapping": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EntityResolution::SchemaMapping"
+          }
+        },
+        "IoTDomainConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::DomainConfiguration"
+          }
+        },
+        "PCAConnectorADDirectoryRegistration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::PCAConnectorAD::DirectoryRegistration"
+          }
+        },
+        "RDSIntegration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RDS::Integration"
+          }
+        },
+        "ConfigConformancePack": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Config::ConformancePack"
+          }
+        },
+        "RolesAnywhereProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RolesAnywhere::Profile"
+          }
+        },
+        "CodeArtifactDomain": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CodeArtifact::Domain"
+          }
+        },
+        "BackupRestoreTestingPlan": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Backup::RestoreTestingPlan"
+          }
+        },
+        "ConfigStoredQuery": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Config::StoredQuery"
+          }
+        },
+        "SageMakerDataQualityJobDefinition": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::DataQualityJobDefinition"
+          }
+        },
+        "SageMakerModelExplainabilityJobDefinition": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::ModelExplainabilityJobDefinition"
+          }
+        },
+        "SageMakerModelQualityJobDefinition": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::ModelQualityJobDefinition"
+          }
+        },
+        "SageMakerStudioLifecycleConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::StudioLifecycleConfig"
+          }
+        },
+        "SESDedicatedIpPool": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::DedicatedIpPool"
+          }
+        },
+        "SESMailManagerTrafficPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SES::MailManagerTrafficPolicy"
+          }
+        },
+        "SSMResourceDataSync": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSM::ResourceDataSync"
+          }
+        },
+        "BedrockAgentCoreRuntime": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::BedrockAgentCore::Runtime"
+          }
+        },
+        "BedrockAgentCoreBrowserCustom": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::BedrockAgentCore::BrowserCustom"
+          }
+        },
+        "ElasticLoadBalancingV2TargetGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ElasticLoadBalancingV2::TargetGroup"
+          }
+        },
+        "EMRContainersVirtualCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EMRContainers::VirtualCluster"
+          }
+        },
+        "EntityResolutionMatchingWorkflow": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EntityResolution::MatchingWorkflow"
+          }
+        },
+        "IoTCoreDeviceAdvisorSuiteDefinition": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTCoreDeviceAdvisor::SuiteDefinition"
+          }
+        },
+        "EC2SecurityGroupVpcAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SecurityGroupVpcAssociation"
+          }
+        },
+        "EC2VerifiedAccessInstance": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VerifiedAccessInstance"
+          }
+        },
+        "KafkaConnectCustomPlugin": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::KafkaConnect::CustomPlugin"
+          }
+        },
+        "NetworkManagerTransitGatewayPeering": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::NetworkManager::TransitGatewayPeering"
+          }
+        },
+        "OpenSearchServerlessSecurityConfig": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::OpenSearchServerless::SecurityConfig"
+          }
+        },
+        "RedshiftIntegration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Redshift::Integration"
+          }
+        },
+        "RolesAnywhereTrustAnchor": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::RolesAnywhere::TrustAnchor"
+          }
+        },
+        "Route53ProfilesProfileAssociation": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53Profiles::ProfileAssociation"
+          }
+        },
+        "SSMIncidentsResponsePlan": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSMIncidents::ResponsePlan"
+          }
+        },
+        "TransferServer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Transfer::Server"
+          }
+        },
+        "GlueDatabase": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Glue::Database"
+          }
+        },
+        "OrganizationsOrganizationalUnit": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Organizations::OrganizationalUnit"
+          }
+        },
+        "EC2IPAMPoolCidr": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::IPAMPoolCidr"
+          }
+        },
+        "EC2VPCGatewayAttachment": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::VPCGatewayAttachment"
+          }
+        },
+        "BedrockPrompt": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Bedrock::Prompt"
+          }
+        },
+        "ComprehendFlywheel": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Comprehend::Flywheel"
+          }
+        },
+        "DataSyncAgent": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::DataSync::Agent"
+          }
+        },
+        "MediaTailorLiveSource": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaTailor::LiveSource"
+          }
+        },
+        "MSKServerlessCluster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MSK::ServerlessCluster"
+          }
+        },
+        "IoTSiteWiseAsset": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoTSiteWise::Asset"
+          }
+        },
+        "B2BICapability": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::B2BI::Capability"
+          }
+        },
+        "CloudFrontKeyValueStore": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CloudFront::KeyValueStore"
+          }
+        },
+        "DeadlineMonitor": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Deadline::Monitor"
+          }
+        },
+        "GuardDutyMalwareProtectionPlan": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GuardDuty::MalwareProtectionPlan"
+          }
+        },
+        "LocationAPIKey": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Location::APIKey"
+          }
+        },
+        "MediaPackageV2OriginEndpoint": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::MediaPackageV2::OriginEndpoint"
+          }
+        },
+        "PCAConnectorADConnector": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::PCAConnectorAD::Connector"
+          }
+        },
+        "S3TablesTableBucketPolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::S3Tables::TableBucketPolicy"
+          }
+        },
+        "SecretsManagerResourcePolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SecretsManager::ResourcePolicy"
+          }
+        },
+        "SSMContactsContact": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SSMContacts::Contact"
+          }
+        },
+        "IoTThingGroup": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::IoT::ThingGroup"
+          }
+        },
+        "ImageBuilderLifecyclePolicy": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ImageBuilder::LifecyclePolicy"
+          }
+        },
+        "GameLiftBuild": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::GameLift::Build"
+          }
+        },
+        "ECRReplicationConfiguration": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ECR::ReplicationConfiguration"
+          }
+        },
+        "EC2SubnetCidrBlock": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::EC2::SubnetCidrBlock"
+          }
+        },
+        "ConnectSecurityProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Connect::SecurityProfile"
+          }
+        },
+        "CleanRoomsMLTrainingDataset": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::CleanRoomsML::TrainingDataset"
+          }
+        },
+        "AppStreamAppBlockBuilder": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::AppStream::AppBlockBuilder"
+          }
+        },
+        "Route53DNSSEC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::Route53::DNSSEC"
+          }
+        },
+        "SageMakerUserProfile": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::SageMaker::UserProfile"
+          }
+        },
+        "ApiGatewayMethod": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWS::ApiGateway::Method"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceTypeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceType"
+      }
+    },
+    "com.amazonaws.configservice#ResourceTypeString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 196
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceTypeValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
+      }
+    },
+    "com.amazonaws.configservice#ResourceTypeValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ResourceTypeValue"
+      }
+    },
+    "com.amazonaws.configservice#ResourceTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit256"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceTypesScope": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit256"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#ResourceValue": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.configservice#ResourceValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The value is a resource ID.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dynamic value of the resource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ResourceValueType": {
+      "type": "enum",
+      "members": {
+        "RESOURCE_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESOURCE_ID"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#Results": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#String"
+      }
+    },
+    "com.amazonaws.configservice#RetentionConfiguration": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.configservice#RetentionConfigurationName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the retention configuration object.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RetentionPeriodInDays": {
+          "target": "com.amazonaws.configservice#RetentionPeriodInDays",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of days Config stores your historical information.</p>\n         <note>\n            <p>Currently, only applicable to the configuration item history.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object with the name of the retention configuration and the retention period in days. The object stores the configuration for data retention in Config.</p>"
+      }
+    },
+    "com.amazonaws.configservice#RetentionConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RetentionConfiguration"
+      }
+    },
+    "com.amazonaws.configservice#RetentionConfigurationName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[\\w\\-]+$"
+      }
+    },
+    "com.amazonaws.configservice#RetentionConfigurationNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#RetentionConfigurationName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.configservice#RetentionPeriodInDays": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 30,
+          "max": 2557
+        }
+      }
+    },
+    "com.amazonaws.configservice#RuleEvaluationVisibility": {
+      "type": "enum",
+      "members": {
+        "EXTERNAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXTERNAL"
+          }
+        },
+        "INTERNAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#RuleLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.configservice#SSMDocumentName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^[a-zA-Z0-9_\\-.:/]{3,200}$"
+      }
+    },
+    "com.amazonaws.configservice#SSMDocumentVersion": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)$"
+      }
+    },
+    "com.amazonaws.configservice#SchemaVersionId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[A-Za-z0-9-]+$"
+      }
+    },
+    "com.amazonaws.configservice#Scope": {
+      "type": "structure",
+      "members": {
+        "ComplianceResourceTypes": {
+          "target": "com.amazonaws.configservice#ComplianceResourceTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource types of only those Amazon Web Services resources that you want to\n\t\t\ttrigger an evaluation for the rule. You can only specify one type if\n\t\t\tyou also specify a resource ID for\n\t\t\t<code>ComplianceResourceId</code>.</p>"
+          }
+        },
+        "TagKey": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit128",
+          "traits": {
+            "smithy.api#documentation": "<p>The tag key that is applied to only those Amazon Web Services resources that\n\t\t\tyou want to trigger an evaluation for the rule.</p>"
+          }
+        },
+        "TagValue": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>The tag value applied to only those Amazon Web Services resources that you want\n\t\t\tto trigger an evaluation for the rule. If you specify a value for\n\t\t\t\t<code>TagValue</code>, you must also specify a value for\n\t\t\t\t<code>TagKey</code>.</p>"
+          }
+        },
+        "ComplianceResourceId": {
+          "target": "com.amazonaws.configservice#BaseResourceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the only Amazon Web Services resource that you want to trigger an\n\t\t\tevaluation for the rule. If you specify a resource ID, you must\n\t\t\tspecify one resource type for\n\t\t\t<code>ComplianceResourceTypes</code>.</p>"
+          }
+        },
+        "ServicePrincipals": {
+          "target": "com.amazonaws.configservice#ServicePrincipals",
+          "traits": {
+            "smithy.api#documentation": "<p>The service principals of the Amazon Web Services services for the rule.</p>\n         <note>\n            <p>The field is populated only if the service-linked rule is created by a service. The field is empty if you create your own rule.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines which resources trigger an evaluation for an Config\n\t\t\trule. The scope can include one or more resource types, a\n\t\t\tcombination of a tag key and value, or a combination of one resource\n\t\t\ttype and one resource ID. Specify a scope to constrain which\n\t\t\tresources trigger an evaluation for a rule. Otherwise, evaluations\n\t\t\tfor the rule are triggered when any resource in your recording group\n\t\t\tchanges in configuration.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ScopeConfiguration": {
+      "type": "structure",
+      "members": {
+        "scopeType": {
+          "target": "com.amazonaws.configservice#ScopeType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of scope for the third-party cloud resources. Valid values include <code>tenant</code> and <code>subscription</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "scopeValues": {
+          "target": "com.amazonaws.configservice#ScopeValues",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of specific scope values for the third-party cloud resources. For example, a list of Azure subscriptions or management groups.</p>"
+          }
+        },
+        "allRegions": {
+          "target": "com.amazonaws.configservice#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether to record resources from all supported regions for the third-party cloud service provider.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "includedRegions": {
+          "target": "com.amazonaws.configservice#IncludedRegions",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of regions from the third-party cloud service provider to include when recording resources. Used when <code>allRegions</code> is set to <code>false</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the scope of resources to record from a third-party cloud service provider.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ScopeType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#ScopeValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#ScopeValues": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ScopeValue"
+      }
+    },
+    "com.amazonaws.configservice#SelectAggregateResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#SelectAggregateResourceConfigRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#SelectAggregateResourceConfigResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidExpressionException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationAggregatorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Accepts a structured query language (SQL) SELECT command and an aggregator to query configuration state of Amazon Web Services resources across multiple accounts and regions, \n\t\t\tperforms the corresponding search, and returns resource configurations matching the properties.</p>\n         <p>For more information about query components, see the \n\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/query-components.html\">\n               <b>Query Components</b>\n            </a> section in the <i>Config Developer Guide</i>.</p>\n         <note>\n            <p>If you run an aggregation query (i.e., using <code>GROUP BY</code> or using aggregate functions such as <code>COUNT</code>; e.g., <code>SELECT resourceId, COUNT(*) WHERE resourceType = 'AWS::IAM::Role' GROUP BY resourceId</code>)\n\t\t\t\tand do not specify the <code>MaxResults</code> or the <code>Limit</code> query parameters, the default page size is set to 500.</p>\n            <p>If you run a non-aggregation query (i.e., not using <code>GROUP BY</code> or aggregate function; e.g., <code>SELECT * WHERE resourceType = 'AWS::IAM::Role'</code>)\n\t\t\t\tand do not specify the <code>MaxResults</code> or the <code>Limit</code> query parameters, the default page size is set to 25.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Results",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#SelectAggregateResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.configservice#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The SQL query SELECT command. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ConfigurationAggregatorName": {
+          "target": "com.amazonaws.configservice#ConfigurationAggregatorName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the configuration aggregator.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of query results returned on each page. </p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of query results returned on each page. Config also allows the Limit request parameter.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned in a previous request that you use to request the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#SelectAggregateResourceConfigResponse": {
+      "type": "structure",
+      "members": {
+        "Results": {
+          "target": "com.amazonaws.configservice#Results",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns the results for the SQL query.</p>"
+          }
+        },
+        "QueryInfo": {
+          "target": "com.amazonaws.configservice#QueryInfo"
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The nextToken string returned in a previous request that you use to request the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#SelectResourceConfig": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#SelectResourceConfigRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#SelectResourceConfigResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidExpressionException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidLimitException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidNextTokenException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Accepts a structured query language (SQL) <code>SELECT</code> command, performs the corresponding search, and returns resource configurations matching the properties.</p>\n         <p>For more information about query components, see the \n\t\t\t<a href=\"https://docs.aws.amazon.com/config/latest/developerguide/query-components.html\">\n               <b>Query Components</b>\n            </a> section in the <i>Config Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Results",
+          "pageSize": "Limit"
+        }
+      }
+    },
+    "com.amazonaws.configservice#SelectResourceConfigRequest": {
+      "type": "structure",
+      "members": {
+        "Expression": {
+          "target": "com.amazonaws.configservice#Expression",
+          "traits": {
+            "smithy.api#documentation": "<p>The SQL query <code>SELECT</code> command.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.configservice#Limit",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of query results returned on each page. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#SelectResourceConfigResponse": {
+      "type": "structure",
+      "members": {
+        "Results": {
+          "target": "com.amazonaws.configservice#Results",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns the results for the SQL query.</p>"
+          }
+        },
+        "QueryInfo": {
+          "target": "com.amazonaws.configservice#QueryInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns the <code>QueryInfo</code> object.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.configservice#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>nextToken</code> string returned in a previous request that you use to request the next page of results in a paginated response. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#ServicePrincipal": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[\\w+=,.@-]+$"
+      }
+    },
+    "com.amazonaws.configservice#ServicePrincipalValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[\\w+=,.@-]+$"
+      }
+    },
+    "com.amazonaws.configservice#ServicePrincipalValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#ServicePrincipalValue"
+      }
+    },
+    "com.amazonaws.configservice#ServicePrincipals": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit128"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.configservice#SortBy": {
+      "type": "enum",
+      "members": {
+        "SCORE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCORE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#SortOrder": {
+      "type": "enum",
+      "members": {
+        "ASCENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASCENDING"
+          }
+        },
+        "DESCENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESCENDING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.configservice#Source": {
+      "type": "structure",
+      "members": {
+        "Owner": {
+          "target": "com.amazonaws.configservice#Owner",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Amazon Web Services or the customer owns and manages the Config rule.</p>\n         <p>Config Managed Rules are predefined rules owned by Amazon Web Services. For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html\">Config Managed Rules</a> in the <i>Config developer guide</i>.</p>\n         <p>Config Custom Rules are rules that you can develop either with Guard (<code>CUSTOM_POLICY</code>) or Lambda (<code>CUSTOM_LAMBDA</code>). For more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules.html\">Config Custom Rules </a> in the <i>Config developer guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceIdentifier": {
+          "target": "com.amazonaws.configservice#StringWithCharLimit256",
+          "traits": {
+            "smithy.api#documentation": "<p>For Config Managed rules, a predefined identifier from a\n\t\t\tlist. For example, <code>IAM_PASSWORD_POLICY</code> is a managed\n\t\t\trule. To reference a managed rule, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html\">List of Config Managed Rules</a>.</p>\n         <p>For Config Custom Lambda rules, the identifier is the Amazon Resource Name\n\t\t\t(ARN) of the rule's Lambda function, such as\n\t\t\t<code>arn:aws:lambda:us-east-2:123456789012:function:custom_rule_name</code>.</p>\n         <p>For Config Custom Policy rules, this field will be ignored.</p>"
+          }
+        },
+        "SourceDetails": {
+          "target": "com.amazonaws.configservice#SourceDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the source and the message types that cause Config to evaluate your Amazon Web Services resources against a rule. It also provides the frequency with which you want Config to run evaluations for the rule if the trigger type is periodic.</p>\n         <p>If the owner is set to <code>CUSTOM_POLICY</code>, the only acceptable values for the Config rule trigger message type are <code>ConfigurationItemChangeNotification</code> and <code>OversizedConfigurationItemChangeNotification</code>.</p>"
+          }
+        },
+        "CustomPolicyDetails": {
+          "target": "com.amazonaws.configservice#CustomPolicyDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the runtime system, policy definition, and whether debug logging is enabled. Required when owner is set to <code>CUSTOM_POLICY</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the CustomPolicyDetails, the rule owner (<code>Amazon Web Services</code> for managed rules, <code>CUSTOM_POLICY</code> for Custom Policy rules, and <code>CUSTOM_LAMBDA</code> for Custom Lambda rules), the rule\n\t\t\tidentifier, and the events that cause the evaluation of your Amazon Web Services\n\t\t\tresources.</p>"
+      }
+    },
+    "com.amazonaws.configservice#SourceDetail": {
+      "type": "structure",
+      "members": {
+        "EventSource": {
+          "target": "com.amazonaws.configservice#EventSource",
+          "traits": {
+            "smithy.api#documentation": "<p>The source of the event, such as an Amazon Web Services service, that triggers\n\t\t\tConfig to evaluate your Amazon Web Services resources.</p>"
+          }
+        },
+        "MessageType": {
+          "target": "com.amazonaws.configservice#MessageType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of notification that triggers Config to run an\n\t\t\tevaluation for a rule. You can specify the following notification\n\t\t\ttypes:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationItemChangeNotification</code> - Triggers\n\t\t\t\t\tan evaluation when Config delivers a configuration item\n\t\t\t\t\tas a result of a resource change.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OversizedConfigurationItemChangeNotification</code>\n\t\t\t\t\t- Triggers an evaluation when Config delivers an\n\t\t\t\t\toversized configuration item. Config may generate this\n\t\t\t\t\tnotification type when a resource changes and the\n\t\t\t\t\tnotification exceeds the maximum size allowed by Amazon\n\t\t\t\t\tSNS.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ScheduledNotification</code> - Triggers a\n\t\t\t\t\tperiodic evaluation at the frequency specified for\n\t\t\t\t\t\t<code>MaximumExecutionFrequency</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigurationSnapshotDeliveryCompleted</code> -\n\t\t\t\t\tTriggers a periodic evaluation when Config delivers a\n\t\t\t\t\tconfiguration snapshot.</p>\n            </li>\n         </ul>\n         <p>If you want your custom rule to be triggered by configuration\n\t\t\tchanges, specify two SourceDetail objects, one for\n\t\t\t\t<code>ConfigurationItemChangeNotification</code> and one for\n\t\t\t\t<code>OversizedConfigurationItemChangeNotification</code>.</p>"
+          }
+        },
+        "MaximumExecutionFrequency": {
+          "target": "com.amazonaws.configservice#MaximumExecutionFrequency",
+          "traits": {
+            "smithy.api#documentation": "<p>The frequency at which you want Config to run evaluations\n\t\t\tfor a custom rule with a periodic trigger. If you specify a value\n\t\t\tfor <code>MaximumExecutionFrequency</code>, then\n\t\t\t\t<code>MessageType</code> must use the\n\t\t\t\t<code>ScheduledNotification</code> value.</p>\n         <note>\n            <p>By default, rules with a periodic trigger are evaluated\n\t\t\t\tevery 24 hours. To change the frequency, specify a valid value\n\t\t\t\tfor the <code>MaximumExecutionFrequency</code>\n\t\t\t\tparameter.</p>\n            <p>Based on the valid value you choose, Config runs\n\t\t\t\tevaluations once for each valid value. For example, if you\n\t\t\t\tchoose <code>Three_Hours</code>, Config runs evaluations\n\t\t\t\tonce every three hours. In this case, <code>Three_Hours</code>\n\t\t\t\tis the frequency of this rule. </p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the source and the message types that trigger Config to evaluate your Amazon Web Services resources against a rule. It also\n\t\t\tprovides the frequency with which you want Config to run\n\t\t\tevaluations for the rule if the trigger type is periodic. You can\n\t\t\tspecify the parameter values for <code>SourceDetail</code> only for\n\t\t\tcustom rules. </p>"
+      }
+    },
+    "com.amazonaws.configservice#SourceDetails": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#SourceDetail"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#SsmControls": {
+      "type": "structure",
+      "members": {
+        "ConcurrentExecutionRatePercentage": {
+          "target": "com.amazonaws.configservice#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum percentage of remediation actions allowed to run in parallel on the non-compliant resources for that specific rule. You can specify a percentage, such as 10%. The default value is 10. </p>"
+          }
+        },
+        "ErrorPercentage": {
+          "target": "com.amazonaws.configservice#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The percentage of errors that are allowed before SSM stops running automations on non-compliant resources for that specific rule.\n\t\t\tYou can specify a percentage of errors, for example 10%. If you do not specifiy a percentage, the default is 50%. \n\t\t\tFor example, if you set the ErrorPercentage to 40% for 10 non-compliant resources, then SSM stops running the automations when the fifth error is received. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Web Services Systems Manager (SSM) specific remediation controls.</p>"
+      }
+    },
+    "com.amazonaws.configservice#StackArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.configservice#StarlingDoveService": {
+      "type": "service",
+      "version": "2014-11-12",
+      "operations": [
+        {
+          "target": "com.amazonaws.configservice#AssociateResourceTypes"
+        },
+        {
+          "target": "com.amazonaws.configservice#BatchGetAggregateResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#BatchGetResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteAggregationAuthorization"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteConfigurationAggregator"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteConformancePack"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteConnector"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteDeliveryChannel"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteEvaluationResults"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteOrganizationConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteOrganizationConformancePack"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeletePendingAggregationRequest"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteRemediationConfiguration"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteRemediationExceptions"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteRetentionConfiguration"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteServiceLinkedConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeleteStoredQuery"
+        },
+        {
+          "target": "com.amazonaws.configservice#DeliverConfigSnapshot"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeAggregateComplianceByConfigRules"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeAggregateComplianceByConformancePacks"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeAggregationAuthorizations"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeComplianceByConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeComplianceByResource"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConfigRuleEvaluationStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConfigRules"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConfigurationAggregators"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConfigurationAggregatorSourcesStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConfigurationRecorders"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConfigurationRecorderStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConformancePackCompliance"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConformancePacks"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeConformancePackStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeDeliveryChannels"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeDeliveryChannelStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeOrganizationConfigRules"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeOrganizationConfigRuleStatuses"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeOrganizationConformancePacks"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeOrganizationConformancePackStatuses"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribePendingAggregationRequests"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeRemediationConfigurations"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeRemediationExceptions"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeRemediationExecutionStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#DescribeRetentionConfigurations"
+        },
+        {
+          "target": "com.amazonaws.configservice#DisassociateResourceTypes"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetAggregateComplianceDetailsByConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetAggregateConfigRuleComplianceSummary"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetAggregateConformancePackComplianceSummary"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetAggregateDiscoveredResourceCounts"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetAggregateResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetComplianceDetailsByConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetComplianceDetailsByResource"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetComplianceSummaryByConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetComplianceSummaryByResourceType"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetConformancePackComplianceDetails"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetConformancePackComplianceSummary"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetConnector"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetCustomRulePolicy"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetDiscoveredResourceCounts"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetOrganizationConfigRuleDetailedStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetOrganizationConformancePackDetailedStatus"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetOrganizationCustomRulePolicy"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetResourceConfigHistory"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetResourceEvaluationSummary"
+        },
+        {
+          "target": "com.amazonaws.configservice#GetStoredQuery"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListAggregateDiscoveredResources"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListConfigurationRecorders"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListConformancePackComplianceScores"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListConnectors"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListDiscoveredResources"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListResourceEvaluations"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListStoredQueries"
+        },
+        {
+          "target": "com.amazonaws.configservice#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutAggregationAuthorization"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutConfigurationAggregator"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutConformancePack"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutConnector"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutDeliveryChannel"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutEvaluations"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutExternalEvaluation"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutOrganizationConfigRule"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutOrganizationConformancePack"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutRemediationConfigurations"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutRemediationExceptions"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutRetentionConfiguration"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutServiceLinkedConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutStoredQuery"
+        },
+        {
+          "target": "com.amazonaws.configservice#PutThirdPartyServiceLinkedConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#SelectAggregateResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#SelectResourceConfig"
+        },
+        {
+          "target": "com.amazonaws.configservice#StartConfigRulesEvaluation"
+        },
+        {
+          "target": "com.amazonaws.configservice#StartConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#StartRemediationExecution"
+        },
+        {
+          "target": "com.amazonaws.configservice#StartResourceEvaluation"
+        },
+        {
+          "target": "com.amazonaws.configservice#StopConfigurationRecorder"
+        },
+        {
+          "target": "com.amazonaws.configservice#TagResource"
+        },
+        {
+          "target": "com.amazonaws.configservice#UntagResource"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Config Service",
+          "arnNamespace": "config",
+          "cloudFormationName": "Config",
+          "cloudTrailEventSource": "configservice.amazonaws.com",
+          "docId": "config-2014-11-12",
+          "endpointPrefix": "config"
+        },
+        "aws.auth#sigv4": {
+          "name": "config"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<fullname>Config</fullname>\n         <p>Config provides a way to keep track of the configurations\n\t\t\tof all the Amazon Web Services resources associated with your Amazon Web Services account. You can\n\t\t\tuse Config to get the current and historical configurations of\n\t\t\teach Amazon Web Services resource and also to get information about the relationship\n\t\t\tbetween the resources. An Amazon Web Services resource can be an Amazon Compute\n\t\t\tCloud (Amazon EC2) instance, an Elastic Block Store (EBS) volume, an\n\t\t\telastic network Interface (ENI), or a security group. For a complete\n\t\t\tlist of resources currently supported by Config, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources\">Supported Amazon Web Services resources</a>.</p>\n         <p>You can access and manage Config through the Amazon Web Services Management\n\t\t\tConsole, the Amazon Web Services Command Line Interface (Amazon Web Services CLI), the Config\n\t\t\tAPI, or the Amazon Web Services SDKs for Config. This reference guide contains\n\t\t\tdocumentation for the Config API and the Amazon Web Services CLI commands that\n\t\t\tyou can use to manage Config. The Config API uses the\n\t\t\tSignature Version 4 protocol for signing requests. For more\n\t\t\tinformation about how to sign a request with this protocol, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature\n\t\t\t\tVersion 4 Signing Process</a>. For detailed information\n\t\t\tabout Config features and their associated actions or commands,\n\t\t\tas well as how to work with Amazon Web Services Management Console, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html\">What Is Config</a> in the <i>Config Developer\n\t\t\t\tGuide</i>.</p>",
+        "smithy.api#title": "AWS Config",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://config.amazonaws.com/doc/2014-11-12/"
+        },
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://config-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://config.{Region}.amazonaws.com",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://config-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://config.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://config.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 14,
+          "nodes": "/////wAAAAH/////AAAAAAAAAA0AAAADAAAAAQAAAAQF9eEMAAAAAgAAAAUF9eEMAAAAAwAAAAgAAAAGAAAABAAAAAcF9eELAAAABQX14QkF9eEKAAAABAAAAAsAAAAJAAAABgAAAAoF9eEIAAAABwX14QYF9eEHAAAABQAAAAwF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAAOAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://config-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws-us-gov"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://config.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://config-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://config.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://config.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.af-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "af-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-northeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ap-southeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.eu-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.me-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "me-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.sa-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "sa-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-iso-west-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://config-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.configservice#StartConfigRulesEvaluation": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#StartConfigRulesEvaluationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#StartConfigRulesEvaluationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigRuleException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ResourceInUseException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Runs an on-demand evaluation for the specified Config rules\n\t\t\tagainst the last known configuration state of the resources. Use\n\t\t\t\t<code>StartConfigRulesEvaluation</code> when you want to test\n\t\t\tthat a rule you updated is working as expected.\n\t\t\t\t<code>StartConfigRulesEvaluation</code> does not re-record the\n\t\t\tlatest configuration state for your resources. It re-runs an\n\t\t\tevaluation against the last known state of your resources. </p>\n         <p>You can specify up to 25 Config rules per request. </p>\n         <p>An existing <code>StartConfigRulesEvaluation</code> call for\n\t\t\tthe specified rules must complete before you can call the API again.\n\t\t\tIf you chose to have Config stream to an Amazon SNS topic, you\n\t\t\twill receive a <code>ConfigRuleEvaluationStarted</code> notification\n\t\t\twhen the evaluation starts.</p>\n         <note>\n            <p>You don't need to call the\n\t\t\t\t\t<code>StartConfigRulesEvaluation</code> API to run an\n\t\t\t\tevaluation for a new rule. When you create a rule, Config\n\t\t\t\tevaluates your resources against the rule automatically.\n\t\t\t</p>\n         </note>\n         <p>The <code>StartConfigRulesEvaluation</code> API is useful if\n\t\t\tyou want to run on-demand evaluations, such as the following\n\t\t\texample:</p>\n         <ol>\n            <li>\n               <p>You have a custom rule that evaluates your IAM\n\t\t\t\t\tresources every 24 hours.</p>\n            </li>\n            <li>\n               <p>You update your Lambda function to add additional\n\t\t\t\t\tconditions to your rule.</p>\n            </li>\n            <li>\n               <p>Instead of waiting for the next periodic evaluation,\n\t\t\t\t\tyou call the <code>StartConfigRulesEvaluation</code>\n\t\t\t\t\tAPI.</p>\n            </li>\n            <li>\n               <p>Config invokes your Lambda function and evaluates\n\t\t\t\t\tyour IAM resources.</p>\n            </li>\n            <li>\n               <p>Your custom rule will still run periodic evaluations\n\t\t\t\t\tevery 24 hours.</p>\n            </li>\n         </ol>"
+      }
+    },
+    "com.amazonaws.configservice#StartConfigRulesEvaluationRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleNames": {
+          "target": "com.amazonaws.configservice#ReevaluateConfigRuleNames",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of names of Config rules that you want to run\n\t\t\tevaluations for.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#StartConfigRulesEvaluationResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>The output when you start the evaluation for the specified Config rule.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#StartConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#StartConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoAvailableDeliveryChannelException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#UnmodifiableEntityException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts the customer managed configuration recorder. The customer managed configuration recorder will begin recording configuration changes for the resource types you specify.</p>\n         <p>You must have created a delivery channel to\n\t\t\tsuccessfully start the customer managed configuration recorder. You can use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutDeliveryChannel.html\">PutDeliveryChannel</a> operation to create a delivery channel.</p>"
+      }
+    },
+    "com.amazonaws.configservice#StartConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderName": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the customer managed configuration recorder that you want to start.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>StartConfigurationRecorder</a>\n\t\t\toperation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#StartRemediationExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#StartRemediationExecutionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#StartRemediationExecutionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#InsufficientPermissionsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.configservice#NoSuchRemediationConfigurationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Runs an on-demand remediation for the specified Config rules against the last known remediation configuration. It runs an execution against the current state of your resources. Remediation execution is asynchronous.</p>\n         <p>You can specify up to 100 resource keys per request. An existing StartRemediationExecution call for the specified resource keys must complete before you can call the API again.</p>"
+      }
+    },
+    "com.amazonaws.configservice#StartRemediationExecutionRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigRuleName": {
+          "target": "com.amazonaws.configservice#ConfigRuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of names of Config rules that you want to run remediation execution for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceKeys": {
+          "target": "com.amazonaws.configservice#ResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of resource keys to be processed with the current request. Each element in the list consists of the resource type and resource ID. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#StartRemediationExecutionResponse": {
+      "type": "structure",
+      "members": {
+        "FailureMessage": {
+          "target": "com.amazonaws.configservice#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a failure message. For example, the resource is already compliant.</p>"
+          }
+        },
+        "FailedItems": {
+          "target": "com.amazonaws.configservice#ResourceKeys",
+          "traits": {
+            "smithy.api#documentation": "<p>For resources that have failed to start execution, the API returns a resource key object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#StartResourceEvaluation": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#StartResourceEvaluationRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.configservice#StartResourceEvaluationResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#IdempotentParameterMismatch"
+        },
+        {
+          "target": "com.amazonaws.configservice#InvalidParameterValueException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Runs an on-demand evaluation for the specified resource to determine whether the resource details will comply with configured Config rules.\n\t\t\tYou can also use it for evaluation purposes. Config recommends using an evaluation context. It runs an execution against the resource details with all\n\t\t\tof the Config rules in your account that match with the specified proactive mode and resource type.</p>\n         <note>\n            <p>Ensure you have the <code>cloudformation:DescribeType</code> role setup to validate the resource type schema.</p>\n            <p>You can find the\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html\">Resource type schema</a> in \"<i>Amazon Web Services public extensions</i>\" within the CloudFormation registry or with the following CLI commmand:\n\t\t\t<code>aws cloudformation describe-type --type-name \"AWS::S3::Bucket\" --type RESOURCE</code>.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html#registry-view\">Managing extensions through the CloudFormation registry</a>\n\t\t\tand <a href=\"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html\">Amazon Web Services resource and property types reference</a> in the CloudFormation User Guide.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.configservice#StartResourceEvaluationRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceDetails": {
+          "target": "com.amazonaws.configservice#ResourceDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a <code>ResourceDetails</code> object.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EvaluationContext": {
+          "target": "com.amazonaws.configservice#EvaluationContext",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns an <code>EvaluationContext</code> object.</p>"
+          }
+        },
+        "EvaluationMode": {
+          "target": "com.amazonaws.configservice#EvaluationMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode of an evaluation.</p>\n         <note>\n            <p>The only valid value for this API is <code>PROACTIVE</code>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "EvaluationTimeout": {
+          "target": "com.amazonaws.configservice#EvaluationTimeout",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The timeout for an evaluation. The default is 900 seconds. You cannot specify a number greater than 3600. If you specify 0, Config uses the default.</p>"
+          }
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.configservice#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A client token is a unique, case-sensitive string of up to 64 ASCII characters. \n\t\t\tTo make an idempotent API request using one of these actions, specify a client token in the request.</p>\n         <note>\n            <p>Avoid reusing the same client token for other API requests. If you retry\n\t\t\t\ta request that completed successfully using the same client token and the same\n\t\t\t\tparameters, the retry succeeds without performing any further actions. If you retry\n\t\t\t\ta successful request using the same client token, but one or more of the parameters\n\t\t\t\tare different, other than the Region or Availability Zone, the retry fails with an\n\t\t\t\tIdempotentParameterMismatch error.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#StartResourceEvaluationResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceEvaluationId": {
+          "target": "com.amazonaws.configservice#ResourceEvaluationId",
+          "traits": {
+            "smithy.api#documentation": "<p>A\n\t\t\tunique ResourceEvaluationId that is associated with a single execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.configservice#StaticParameterValues": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StringWithCharLimit256"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 25
+        }
+      }
+    },
+    "com.amazonaws.configservice#StaticValue": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.configservice#StaticParameterValues",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of values. For example, the ARN of the assumed role. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The static value of the resource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#StatusDetailFilters": {
+      "type": "structure",
+      "members": {
+        "AccountId": {
+          "target": "com.amazonaws.configservice#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit account ID of the member account within an organization.</p>"
+          }
+        },
+        "MemberAccountRuleStatus": {
+          "target": "com.amazonaws.configservice#MemberAccountRuleStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates deployment status for Config rule in the member account.\n\t\t\tWhen management account calls <code>PutOrganizationConfigRule</code> action for the first time, Config rule status is created in the member account. \n\t\t\tWhen management account calls <code>PutOrganizationConfigRule</code> action for the second time, Config rule status is updated in the member account.   \n\t\t\tConfig rule status is deleted when the management account deletes <code>OrganizationConfigRule</code> and disables service access for <code>config-multiaccountsetup.amazonaws.com</code>. \n\t\t\t</p>\n         <p>Config sets the state of the rule to:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATE_SUCCESSFUL</code> when Config rule has been created in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_IN_PROGRESS</code> when Config rule is being created in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CREATE_FAILED</code> when Config rule creation has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_FAILED</code> when Config rule deletion has failed in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_IN_PROGRESS</code> when Config rule is being deleted in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE_SUCCESSFUL</code> when Config rule has been deleted in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_SUCCESSFUL</code> when Config rule has been updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_IN_PROGRESS</code> when Config rule is being updated in the member account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATE_FAILED</code> when Config rule deletion has failed in the member account.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Status filter object to filter results based on specific member account ID or status type for an organization Config rule. </p>"
+      }
+    },
+    "com.amazonaws.configservice#StopConfigurationRecorder": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#StopConfigurationRecorderRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#NoSuchConfigurationRecorderException"
+        },
+        {
+          "target": "com.amazonaws.configservice#UnmodifiableEntityException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops the customer managed configuration recorder. The customer managed configuration recorder will stop recording configuration changes for the resource types you have specified.</p>"
+      }
+    },
+    "com.amazonaws.configservice#StopConfigurationRecorderRequest": {
+      "type": "structure",
+      "members": {
+        "ConfigurationRecorderName": {
+          "target": "com.amazonaws.configservice#RecorderName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the customer managed configuration recorder that you want to stop.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input for the <a>StopConfigurationRecorder</a> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#StoredQuery": {
+      "type": "structure",
+      "members": {
+        "QueryId": {
+          "target": "com.amazonaws.configservice#QueryId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the query.</p>"
+          }
+        },
+        "QueryArn": {
+          "target": "com.amazonaws.configservice#QueryArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the query. For example, arn:partition:service:region:account-id:resource-type/resource-name/resource-id.</p>"
+          }
+        },
+        "QueryName": {
+          "target": "com.amazonaws.configservice#QueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.configservice#QueryDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique description for the query.</p>"
+          }
+        },
+        "Expression": {
+          "target": "com.amazonaws.configservice#QueryExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The expression of the query. For example, <code>SELECT\n\t\t\tresourceId,\n\t\t\tresourceType,\n\t\t\tsupplementaryConfiguration.BucketVersioningConfiguration.status\n\t\t\tWHERE\n\t\t\tresourceType = 'AWS::S3::Bucket'\n\t\t\tAND supplementaryConfiguration.BucketVersioningConfiguration.status = 'Off'.</code>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of a stored query.</p>"
+      }
+    },
+    "com.amazonaws.configservice#StoredQueryMetadata": {
+      "type": "structure",
+      "members": {
+        "QueryId": {
+          "target": "com.amazonaws.configservice#QueryId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the query. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "QueryArn": {
+          "target": "com.amazonaws.configservice#QueryArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Resource Name (ARN) of the query. For example, arn:partition:service:region:account-id:resource-type/resource-name/resource-id.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "QueryName": {
+          "target": "com.amazonaws.configservice#QueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.configservice#QueryDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique description for the query.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details of a specific query. </p>"
+      }
+    },
+    "com.amazonaws.configservice#StoredQueryMetadataList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#StoredQueryMetadata"
+      }
+    },
+    "com.amazonaws.configservice#String": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#StringWithCharLimit1024": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.configservice#StringWithCharLimit128": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#StringWithCharLimit256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#StringWithCharLimit256Min0": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#StringWithCharLimit64": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.configservice#StringWithCharLimit768": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 768
+        }
+      }
+    },
+    "com.amazonaws.configservice#SupplementaryConfiguration": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.configservice#SupplementaryConfigurationName"
+      },
+      "value": {
+        "target": "com.amazonaws.configservice#SupplementaryConfigurationValue"
+      }
+    },
+    "com.amazonaws.configservice#SupplementaryConfigurationName": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#SupplementaryConfigurationValue": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.configservice#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.configservice#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The tags for the resource. The metadata that you apply to a resource to help you categorize and organize them. \n\t\t\tEach tag consists of a key and an optional value, both of which you define. \n\t\t\tTag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.</p>"
+      }
+    },
+    "com.amazonaws.configservice#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.configservice#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.configservice#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#TagResourceRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#TooManyTagsException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associates the specified tags to a resource with the specified <code>ResourceArn</code>. If existing tags on a resource are not specified in the request parameters, they are not changed.\n\t\t\tIf existing tags are specified, however, then their values will be updated. When a resource is deleted, the tags associated with that resource are deleted as well.</p>"
+      }
+    },
+    "com.amazonaws.configservice#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the resource for which to list the tags. The following resources are supported:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationRecorder</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigRule</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>OrganizationConfigRule</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConformancePack</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>OrganizationConformancePack</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigurationAggregator</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>AggregationAuthorization</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>StoredQuery</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>Connector</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.configservice#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tag object.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.configservice#Tags": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.configservice#Name"
+      },
+      "value": {
+        "target": "com.amazonaws.configservice#Value"
+      }
+    },
+    "com.amazonaws.configservice#TagsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.configservice#TemplateBody": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 51200
+        }
+      }
+    },
+    "com.amazonaws.configservice#TemplateS3Uri": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^s3://"
+      }
+    },
+    "com.amazonaws.configservice#TemplateSSMDocumentDetails": {
+      "type": "structure",
+      "members": {
+        "DocumentName": {
+          "target": "com.amazonaws.configservice#SSMDocumentName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name or Amazon Resource Name (ARN) of the SSM document to use to create a conformance pack.\n\t\t\tIf you use the document name, Config checks only your account and Amazon Web Services Region for the SSM document.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DocumentVersion": {
+          "target": "com.amazonaws.configservice#SSMDocumentVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the SSM document to use to create a conformance pack. By default, Config uses the latest version.</p>\n         <note>\n            <p>This field is optional.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This API allows you to create a conformance pack template with an Amazon Web Services Systems Manager document (SSM document). \n\t\t\tTo deploy a conformance pack using an SSM document, first create an SSM document with conformance pack content, and then provide the <code>DocumentName</code> in the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConformancePack.html\">PutConformancePack API</a>. You can also provide the <code>DocumentVersion</code>.</p>\n         <p>The <code>TemplateSSMDocumentDetails</code> object contains the name of the SSM document and the version of the SSM document.</p>"
+      }
+    },
+    "com.amazonaws.configservice#ThirdPartyCloudRegion": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.configservice#TimeWindow": {
+      "type": "structure",
+      "members": {
+        "StartTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The start time of an execution.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.configservice#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The end time of an execution. The end time must be after the start date.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Filters evaluation results based on start and end times.</p>"
+      }
+    },
+    "com.amazonaws.configservice#TooManyTagsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have reached the limit of the number of tags you can use. \n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html\">\n               <b>Service Limits</b>\n            </a> in the <i>Config Developer Guide</i>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#UnmodifiableEntityException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested operation is not valid.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutConfigurationRecorder.html\">PutConfigurationRecorder</a>,\n\t\t\tyou will see this exception because you cannot use this operation to create a service-linked configuration recorder. Use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutServiceLinkedConfigurationRecorder.html\">PutServiceLinkedConfigurationRecorder</a> operation to create a service-linked configuration\n\t\t\trecorder.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteConfigurationRecorder.html\">DeleteConfigurationRecorder</a>, you will see this exception because you cannot use this operation to delete a service-linked configuration recorder. Use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteServiceLinkedConfigurationRecorder.html\">DeleteServiceLinkedConfigurationRecorder</a> operation to delete a service-linked configuration\n\t\t\trecorder.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_StartConfigurationRecorder.html\">StartConfigurationRecorder</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_StopConfigurationRecorder.html\">StopConfigurationRecorder</a>, you will see this exception because these operations do not affect service-linked configuration recorders.\n\t\t\tService-linked configuration recorders are always recording. To stop recording, you must delete the service-linked configuration recorder. Use the <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteServiceLinkedConfigurationRecorder.html\">DeleteServiceLinkedConfigurationRecorder</a> operation to delete a service-linked configuration\n\t\t\trecorder.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#UnprocessedResourceIdentifierList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.configservice#AggregateResourceIdentifier"
+      }
+    },
+    "com.amazonaws.configservice#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.configservice#UntagResourceRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.configservice#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.configservice#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes specified tags from a resource.</p>"
+      }
+    },
+    "com.amazonaws.configservice#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.configservice#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that identifies the resource for which to list the tags. The following resources are supported:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConfigurationRecorder</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigRule</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>OrganizationConfigRule</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConformancePack</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>OrganizationConformancePack</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ConfigurationAggregator</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>AggregationAuthorization</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>StoredQuery</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>Connector</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.configservice#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The keys of the tags to be removed.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.configservice#ValidationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.configservice#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error executing the command</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested operation is not valid. You will see this exception if there are missing required fields or if the input value fails the validation.</p>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_PutStoredQuery.html\">PutStoredQuery</a>, one of the following errors:</p>\n         <ul>\n            <li>\n               <p>There are missing required fields.</p>\n            </li>\n            <li>\n               <p>The input value fails the validation.</p>\n            </li>\n            <li>\n               <p>You are trying to create more than 300 queries.</p>\n            </li>\n         </ul>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeConfigurationRecorders.html\">DescribeConfigurationRecorders</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeConfigurationRecorderStatus.html\">DescribeConfigurationRecorderStatus</a>, one of the following errors:</p>\n         <ul>\n            <li>\n               <p>You have specified more than one configuration recorder.</p>\n            </li>\n            <li>\n               <p>You have provided a service principal for service-linked configuration recorder that is not valid.</p>\n            </li>\n         </ul>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_AssociateResourceTypes.html\">AssociateResourceTypes</a> and <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DisassociateResourceTypes.html\">DisassociateResourceTypes</a>, one of the following errors:</p>\n         <ul>\n            <li>\n               <p>Your configuraiton recorder has a recording strategy that does not allow the association or disassociation of resource types.</p>\n            </li>\n            <li>\n               <p>One or more of the specified resource types are already associated or disassociated with the configuration recorder.</p>\n            </li>\n            <li>\n               <p>For service-linked configuration recorders, the configuration recorder does not record one or more of the specified resource types.</p>\n            </li>\n         </ul>\n         <p>For <a href=\"https://docs.aws.amazon.com/config/latest/APIReference/API_DeleteServiceLinkedConfigurationRecorder.html\">DeleteServiceLinkedConfigurationRecorder</a>, one of the following errors:</p>\n         <ul>\n            <li>\n               <p>You have provided both <code>Arn</code> and <code>ServicePrincipal</code>. Only one of <code>Arn</code> or <code>ServicePrincipal</code> can be specified.</p>\n            </li>\n            <li>\n               <p>You have provided a service principal for service-linked configuration recorder that is not valid.</p>\n            </li>\n         </ul>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.configservice#Value": {
+      "type": "string"
+    },
+    "com.amazonaws.configservice#Version": {
+      "type": "string"
+    }
+  }
+}

--- a/crates/fakecloud-config/src/model_validate.rs
+++ b/crates/fakecloud-config/src/model_validate.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 
 /// The vendored Config Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/config.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 #[derive(Debug, Default)]
 struct MemberConstraint {

--- a/crates/fakecloud-emr/model.json
+++ b/crates/fakecloud-emr/model.json
@@ -1,0 +1,12540 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.emr#ActionOnFailure": {
+      "type": "enum",
+      "members": {
+        "TERMINATE_JOB_FLOW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE_JOB_FLOW"
+          }
+        },
+        "TERMINATE_CLUSTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE_CLUSTER"
+          }
+        },
+        "CANCEL_AND_WAIT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCEL_AND_WAIT"
+          }
+        },
+        "CONTINUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTINUE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#AddInstanceFleet": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#AddInstanceFleetInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#AddInstanceFleetOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds an instance fleet to a running cluster.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#AddInstanceFleetInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceFleet": {
+          "target": "com.amazonaws.emr#InstanceFleetConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the configuration of the instance fleet.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#AddInstanceFleetOutput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the cluster.</p>"
+          }
+        },
+        "InstanceFleetId": {
+          "target": "com.amazonaws.emr#InstanceFleetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the instance fleet.</p>"
+          }
+        },
+        "ClusterArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name of the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#AddInstanceGroups": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#AddInstanceGroupsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#AddInstanceGroupsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds one or more instance groups to a running cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#AddInstanceGroupsInput": {
+      "type": "structure",
+      "members": {
+        "InstanceGroups": {
+          "target": "com.amazonaws.emr#InstanceGroupConfigList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Instance groups to add.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobFlowId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Job flow in which to add the instance groups.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input to an AddInstanceGroups call.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#AddInstanceGroupsOutput": {
+      "type": "structure",
+      "members": {
+        "JobFlowId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The job flow ID in which the instance groups are added.</p>"
+          }
+        },
+        "InstanceGroupIds": {
+          "target": "com.amazonaws.emr#InstanceGroupIdsList",
+          "traits": {
+            "smithy.api#documentation": "<p>Instance group IDs of the newly created instance groups.</p>"
+          }
+        },
+        "ClusterArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name of the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output from an AddInstanceGroups call.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#AddJobFlowSteps": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#AddJobFlowStepsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#AddJobFlowStepsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>AddJobFlowSteps adds new steps to a running cluster. A maximum of 256 steps are allowed\n         in each job flow.</p>\n         <p>If your cluster is long-running (such as a Hive data warehouse) or complex, you may\n         require more than 256 steps to process your data. You can bypass the 256-step limitation in\n         various ways, including using SSH to connect to the master node and submitting queries\n         directly to the software running on the master node, such as Hive and Hadoop.</p>\n         <p>A step specifies the location of a JAR file stored either on the master node of the\n         cluster or in Amazon S3. Each step is performed by the main function of the main\n         class of the JAR file. The main class can be specified either in the manifest of the JAR or\n         by using the MainFunction parameter of the step.</p>\n         <p>Amazon EMR executes each step in the order listed. For a step to be considered\n         complete, the main function must exit with a zero exit code and all Hadoop jobs started\n         while the step was running must have completed and run successfully.</p>\n         <p>You can only add steps to a cluster that is in one of the following states: STARTING,\n         BOOTSTRAPPING, RUNNING, or WAITING.</p>\n         <note>\n            <p>The string values passed into <code>HadoopJarStep</code> object cannot exceed a total\n            of 10240 characters.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#AddJobFlowStepsInput": {
+      "type": "structure",
+      "members": {
+        "JobFlowId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A string that uniquely identifies the job flow. This identifier is returned by <a>RunJobFlow</a> and can also be obtained from <a>ListClusters</a>.\n      </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Steps": {
+          "target": "com.amazonaws.emr#StepConfigList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p> A list of <a>StepConfig</a> to be executed by the job flow. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the runtime role for a step on the cluster. The\n         runtime role can be a cross-account IAM role. The runtime role ARN is a\n         combination of account ID, role name, and role type using the following format:\n            <code>arn:partition:service:region:account:resource</code>. </p>\n         <p>For example, <code>arn:aws:IAM::1234567890:role/ReadOnly</code> is a correctly formatted\n         runtime role ARN.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The input argument to the <a>AddJobFlowSteps</a> operation. </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#AddJobFlowStepsOutput": {
+      "type": "structure",
+      "members": {
+        "StepIds": {
+          "target": "com.amazonaws.emr#StepIdsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifiers of the list of steps added to the job flow.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The output for the <a>AddJobFlowSteps</a> operation. </p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#AddTags": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#AddTagsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#AddTagsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds tags to an Amazon EMR resource, such as a cluster or an Amazon EMR\n         Studio. Tags make it easier to associate resources in various ways, such as grouping\n         clusters to track your Amazon EMR resource allocation costs. For more information,\n         see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html\">Tag\n            Clusters</a>. </p>"
+      }
+    },
+    "com.amazonaws.emr#AddTagsInput": {
+      "type": "structure",
+      "members": {
+        "ResourceId": {
+          "target": "com.amazonaws.emr#ResourceId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EMR resource identifier to which tags will be added. For example, a\n         cluster identifier or an Amazon EMR Studio ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of tags to associate with a resource. Tags are user-defined key-value pairs that\n         consist of a required key string with a maximum of 128 characters, and an optional value\n         string with a maximum of 256 characters.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the cluster that scopes the tag operation. Required when the resource being tagged is a session-scoped resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input identifies an Amazon EMR resource and a list of tags to\n         attach.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#AddTagsOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>This output indicates the result of adding tags to a resource.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#AdjustmentType": {
+      "type": "enum",
+      "members": {
+        "CHANGE_IN_CAPACITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHANGE_IN_CAPACITY"
+          }
+        },
+        "PERCENT_CHANGE_IN_CAPACITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENT_CHANGE_IN_CAPACITY"
+          }
+        },
+        "EXACT_CAPACITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXACT_CAPACITY"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#Application": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the application.</p>"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the application.</p>"
+          }
+        },
+        "Args": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Arguments for Amazon EMR to pass to the application.</p>"
+          }
+        },
+        "AdditionalInfo": {
+          "target": "com.amazonaws.emr#StringMap",
+          "traits": {
+            "smithy.api#documentation": "<p>This option is for advanced users only. This is meta information about third-party\n         applications that third-party vendors use for testing purposes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>With Amazon EMR release version 4.0 and later, the only accepted parameter is\n         the application name. To pass arguments to applications, you use configuration\n         classifications specified using configuration JSON objects. For more information, see\n            <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html\">Configuring Applications</a>.</p>\n         <p>With earlier Amazon EMR releases, the application is any Amazon or third-party\n         software that you can add to the cluster. This structure contains a list of strings that\n         indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation\n         script as bootstrap action argument.</p>"
+      }
+    },
+    "com.amazonaws.emr#ApplicationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#Application"
+      }
+    },
+    "com.amazonaws.emr#ArnType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.emr#AuthMode": {
+      "type": "enum",
+      "members": {
+        "SSO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSO"
+          }
+        },
+        "IAM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IAM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#AutoScalingPolicy": {
+      "type": "structure",
+      "members": {
+        "Constraints": {
+          "target": "com.amazonaws.emr#ScalingConstraints",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The upper and lower Amazon EC2 instance limits for an automatic scaling policy.\n         Automatic scaling activity will not cause an instance group to grow above or below these\n         limits.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Rules": {
+          "target": "com.amazonaws.emr#ScalingRuleList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The scale-in and scale-out rules that comprise the automatic scaling policy.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An automatic scaling policy for a core instance group or task instance group in an\n            Amazon EMR cluster. An automatic scaling policy defines how an instance group\n         dynamically adds and terminates Amazon EC2 instances in response to the value of a\n         CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>"
+      }
+    },
+    "com.amazonaws.emr#AutoScalingPolicyDescription": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.emr#AutoScalingPolicyStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of an automatic scaling policy. </p>"
+          }
+        },
+        "Constraints": {
+          "target": "com.amazonaws.emr#ScalingConstraints",
+          "traits": {
+            "smithy.api#documentation": "<p>The upper and lower Amazon EC2 instance limits for an automatic scaling policy.\n         Automatic scaling activity will not cause an instance group to grow above or below these\n         limits.</p>"
+          }
+        },
+        "Rules": {
+          "target": "com.amazonaws.emr#ScalingRuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>The scale-in and scale-out rules that comprise the automatic scaling policy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An automatic scaling policy for a core instance group or task instance group in an\n            Amazon EMR cluster. The automatic scaling policy defines how an instance group\n         dynamically adds and terminates Amazon EC2 instances in response to the value of a\n         CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>"
+      }
+    },
+    "com.amazonaws.emr#AutoScalingPolicyState": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "ATTACHING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ATTACHING"
+          }
+        },
+        "ATTACHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ATTACHED"
+          }
+        },
+        "DETACHING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DETACHING"
+          }
+        },
+        "DETACHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DETACHED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#AutoScalingPolicyStateChangeReason": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.emr#AutoScalingPolicyStateChangeReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The code indicating the reason for the change in status.<code>USER_REQUEST</code>\n         indicates that the scaling policy status was changed by a user.\n            <code>PROVISION_FAILURE</code> indicates that the status change was because the policy\n         failed to provision. <code>CLEANUP_FAILURE</code> indicates an error.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A friendly, more verbose message that accompanies an automatic scaling policy state\n         change.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The reason for an <a>AutoScalingPolicyStatus</a> change.</p>"
+      }
+    },
+    "com.amazonaws.emr#AutoScalingPolicyStateChangeReasonCode": {
+      "type": "enum",
+      "members": {
+        "USER_REQUEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "USER_REQUEST"
+          }
+        },
+        "PROVISION_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROVISION_FAILURE"
+          }
+        },
+        "CLEANUP_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLEANUP_FAILURE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#AutoScalingPolicyStatus": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#AutoScalingPolicyState",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the status of the automatic scaling policy.</p>"
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#AutoScalingPolicyStateChangeReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for a change in status.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of an automatic scaling policy.\n         </p>"
+      }
+    },
+    "com.amazonaws.emr#AutoTerminationPolicy": {
+      "type": "structure",
+      "members": {
+        "IdleTimeout": {
+          "target": "com.amazonaws.emr#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the amount of idle time in seconds after which the cluster automatically\n         terminates. You can specify a minimum of 60 seconds and a maximum of 604800 seconds (seven\n         days).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An auto-termination policy for an Amazon EMR cluster. An auto-termination policy\n         defines the amount of idle time in seconds after which a cluster automatically terminates.\n         For alternative cluster termination options, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-termination.html\">Control cluster\n            termination</a>.</p>"
+      }
+    },
+    "com.amazonaws.emr#BlockPublicAccessConfiguration": {
+      "type": "structure",
+      "members": {
+        "BlockPublicSecurityGroupRules": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Indicates whether Amazon EMR block public access is enabled (<code>true</code>)\n         or disabled (<code>false</code>). By default, the value is <code>false</code> for accounts\n         that have created Amazon EMR clusters before July 2019. For accounts created after\n         this, the default is <code>true</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PermittedPublicSecurityGroupRuleRanges": {
+          "target": "com.amazonaws.emr#PortRanges",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies ports and port ranges that are permitted to have security group rules that\n         allow inbound traffic from all public sources. For example, if Port 23 (Telnet) is\n         specified for <code>PermittedPublicSecurityGroupRuleRanges</code>, Amazon EMR\n         allows cluster creation if a security group associated with the cluster has a rule that\n         allows inbound traffic on Port 23 from IPv4 0.0.0.0/0 or IPv6 port ::/0 as the\n         source.</p>\n         <p>By default, Port 22, which is used for SSH access to the cluster Amazon EC2\n         instances, is in the list of <code>PermittedPublicSecurityGroupRuleRanges</code>.</p>"
+          }
+        },
+        "Classification": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The classification within a configuration.</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of additional configurations to apply within a configuration object.</p>"
+          }
+        },
+        "Properties": {
+          "target": "com.amazonaws.emr#StringMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of properties specified within a configuration classification.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A configuration for Amazon EMR block public access. When\n            <code>BlockPublicSecurityGroupRules</code> is set to <code>true</code>, Amazon EMR prevents cluster creation if one of the cluster's security groups has a rule that allows\n         inbound traffic from 0.0.0.0/0 or ::/0 on a port, unless the port is specified as an\n         exception using <code>PermittedPublicSecurityGroupRuleRanges</code>.</p>"
+      }
+    },
+    "com.amazonaws.emr#BlockPublicAccessConfigurationMetadata": {
+      "type": "structure",
+      "members": {
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The date and time that the configuration was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CreatedByArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name that created or last modified the configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Properties that describe the Amazon Web Services principal that created the\n            <code>BlockPublicAccessConfiguration</code> using the\n            <code>PutBlockPublicAccessConfiguration</code> action as well as the date and time that\n         the configuration was created. Each time a configuration for block public access is\n         updated, Amazon EMR updates this metadata.</p>"
+      }
+    },
+    "com.amazonaws.emr#Boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.emr#BooleanObject": {
+      "type": "boolean"
+    },
+    "com.amazonaws.emr#BootstrapActionConfig": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the bootstrap action.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ScriptBootstrapAction": {
+          "target": "com.amazonaws.emr#ScriptBootstrapActionConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The script run by the bootstrap action.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration of a bootstrap action.</p>"
+      }
+    },
+    "com.amazonaws.emr#BootstrapActionConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#BootstrapActionConfig"
+      }
+    },
+    "com.amazonaws.emr#BootstrapActionDetail": {
+      "type": "structure",
+      "members": {
+        "BootstrapActionConfig": {
+          "target": "com.amazonaws.emr#BootstrapActionConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the bootstrap action.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Reports the configuration of a bootstrap action in a cluster (job flow).</p>"
+      }
+    },
+    "com.amazonaws.emr#BootstrapActionDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#BootstrapActionDetail"
+      }
+    },
+    "com.amazonaws.emr#CancelSteps": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#CancelStepsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#CancelStepsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Cancels a pending step or steps in a running cluster. Available only in Amazon EMR versions 4.8.0 and later, excluding version 5.0.0. A maximum of 256 steps are allowed in\n         each CancelSteps request. CancelSteps is idempotent but asynchronous; it does not guarantee\n         that a step will be canceled, even if the request is successfully submitted. When you use\n            Amazon EMR releases 5.28.0 and later, you can cancel steps that are in a\n            <code>PENDING</code> or <code>RUNNING</code> state. In earlier versions of Amazon EMR, you can only cancel steps that are in a <code>PENDING</code> state. </p>"
+      }
+    },
+    "com.amazonaws.emr#CancelStepsInfo": {
+      "type": "structure",
+      "members": {
+        "StepId": {
+          "target": "com.amazonaws.emr#StepId",
+          "traits": {
+            "smithy.api#documentation": "<p>The encrypted StepId of a step.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#CancelStepsRequestStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of a CancelSteps Request. The value may be SUBMITTED or FAILED.</p>"
+          }
+        },
+        "Reason": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for the failure if the CancelSteps request fails.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specification of the status of a CancelSteps request. Available only in Amazon EMR version 4.8.0 and later, excluding version 5.0.0.</p>"
+      }
+    },
+    "com.amazonaws.emr#CancelStepsInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#CancelStepsInfo"
+      }
+    },
+    "com.amazonaws.emr#CancelStepsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The <code>ClusterID</code> for the specified steps that will be canceled. Use <a>RunJobFlow</a> and <a>ListClusters</a> to get ClusterIDs. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepIds": {
+          "target": "com.amazonaws.emr#StepIdsList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The list of <code>StepIDs</code> to cancel. Use <a>ListSteps</a> to get steps\n         and their states for the specified cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepCancellationOption": {
+          "target": "com.amazonaws.emr#StepCancellationOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The option to choose to cancel <code>RUNNING</code> steps. By default, the value is\n            <code>SEND_INTERRUPT</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input argument to the <a>CancelSteps</a> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#CancelStepsOutput": {
+      "type": "structure",
+      "members": {
+        "CancelStepsInfoList": {
+          "target": "com.amazonaws.emr#CancelStepsInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of <a>CancelStepsInfo</a>, which shows the status of specified cancel\n         requests for each <code>StepID</code> specified.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The output for the <a>CancelSteps</a> operation. </p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#CancelStepsRequestStatus": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#CertificateAuthority": {
+      "type": "structure",
+      "members": {
+        "CertificateArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the certificate authority in Amazon Web Services Private CA that issued the Spark Connect server certificate.</p>"
+          }
+        },
+        "CertificateData": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The PEM-encoded root CA certificate data. Provide this certificate to your client's trust store when connecting directly to the Spark Connect server over VPC peering.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the certificate authority used to establish an mTLS connection to the Spark Connect server when connecting directly over VPC peering.</p>"
+      }
+    },
+    "com.amazonaws.emr#ClientRequestToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 36
+        }
+      }
+    },
+    "com.amazonaws.emr#CloudWatchAlarmDefinition": {
+      "type": "structure",
+      "members": {
+        "ComparisonOperator": {
+          "target": "com.amazonaws.emr#ComparisonOperator",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Determines how the metric specified by <code>MetricName</code> is compared to the value\n         specified by <code>Threshold</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EvaluationPeriods": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of periods, in five-minute increments, during which the alarm condition must\n         exist before the alarm triggers automatic scaling activity. The default value is\n            <code>1</code>.</p>"
+          }
+        },
+        "MetricName": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the CloudWatch metric that is watched to determine an alarm\n         condition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Namespace": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The namespace for the CloudWatch metric. The default is\n            <code>AWS/ElasticMapReduce</code>.</p>"
+          }
+        },
+        "Period": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The period, in seconds, over which the statistic is applied. CloudWatch metrics for\n            Amazon EMR are emitted every five minutes (300 seconds), so if you specify a\n         CloudWatch metric, specify <code>300</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Statistic": {
+          "target": "com.amazonaws.emr#Statistic",
+          "traits": {
+            "smithy.api#documentation": "<p>The statistic to apply to the metric associated with the alarm. The default is\n            <code>AVERAGE</code>.</p>"
+          }
+        },
+        "Threshold": {
+          "target": "com.amazonaws.emr#NonNegativeDouble",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The value against which the specified statistic is compared.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Unit": {
+          "target": "com.amazonaws.emr#Unit",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of measure associated with the CloudWatch metric being watched. The value\n         specified for <code>Unit</code> must correspond to the units specified in the CloudWatch\n         metric.</p>"
+          }
+        },
+        "Dimensions": {
+          "target": "com.amazonaws.emr#MetricDimensionList",
+          "traits": {
+            "smithy.api#documentation": "<p>A CloudWatch metric dimension.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The definition of a CloudWatch metric alarm, which determines when an automatic scaling\n         activity is triggered. When the defined alarm conditions are satisfied, scaling activity\n         begins.</p>"
+      }
+    },
+    "com.amazonaws.emr#CloudWatchLogConfiguration": {
+      "type": "structure",
+      "members": {
+        "Enabled": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies if CloudWatch logging is enabled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LogGroupName": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the CloudWatch log group where logs are published.</p>"
+          }
+        },
+        "LogStreamNamePrefix": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix of the log stream name.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the encryption key used to encrypt the logs.</p>"
+          }
+        },
+        "LogTypes": {
+          "target": "com.amazonaws.emr#LogTypesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of log types to file names for publishing logs to the standard output or standard error streams for CloudWatch. Valid log types include STEP_LOGS, SPARK_DRIVER, and SPARK_EXECUTOR. Valid file names for each type include STDOUT and STDERR.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Holds CloudWatch log configuration settings and metadata that specify settings like log files to monitor and where to send them.</p>"
+      }
+    },
+    "com.amazonaws.emr#Cluster": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the cluster.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the cluster. This parameter can't contain the characters <, >, $, |, or ` (backtick).</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#ClusterStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status details about the cluster.</p>"
+          }
+        },
+        "Ec2InstanceAttributes": {
+          "target": "com.amazonaws.emr#Ec2InstanceAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the Amazon EC2 instances in a cluster grouped by\n         category. For example, key name, subnet ID, IAM instance profile, and so\n         on.</p>"
+          }
+        },
+        "InstanceCollectionType": {
+          "target": "com.amazonaws.emr#InstanceCollectionType",
+          "traits": {
+            "smithy.api#documentation": "<note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>\n         <p>The instance group configuration of the cluster. A value of <code>INSTANCE_GROUP</code>\n         indicates a uniform instance group configuration. A value of <code>INSTANCE_FLEET</code>\n         indicates an instance fleets configuration.</p>"
+          }
+        },
+        "LogUri": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path to the Amazon S3 location where logs for this cluster are\n         stored.</p>"
+          }
+        },
+        "LogEncryptionKmsKeyId": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p> The KMS key used for encrypting log files. This attribute is only\n         available with Amazon EMR 5.30.0 and later, excluding Amazon EMR 6.0.0.\n      </p>"
+          }
+        },
+        "RequestedAmiVersion": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The AMI version requested for this cluster.</p>"
+          }
+        },
+        "RunningAmiVersion": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The AMI version running on this cluster.</p>"
+          }
+        },
+        "ReleaseLabel": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EMR release label, which determines the version of open-source\n         application packages installed on the cluster. Release labels are in the form\n            <code>emr-x.x.x</code>, where x.x.x is an Amazon EMR release version such as\n            <code>emr-5.14.0</code>. For more information about Amazon EMR release versions\n         and included application versions and features, see <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/\">https://docs.aws.amazon.com/emr/latest/ReleaseGuide/</a>. The release label applies only to Amazon EMR\n         releases version 4.0 and later. Earlier versions use <code>AmiVersion</code>.</p>"
+          }
+        },
+        "AutoTerminate": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the cluster should terminate after completing all steps.</p>"
+          }
+        },
+        "TerminationProtected": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Amazon EMR will lock the cluster to prevent the Amazon EC2 instances from being terminated by an API call or user intervention, or in\n         the event of a cluster error.</p>"
+          }
+        },
+        "UnhealthyNodeReplacement": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Amazon EMR should gracefully replace Amazon EC2\n         core instances that have degraded within the cluster.</p>"
+          }
+        },
+        "VisibleToAllUsers": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the cluster is visible to IAM principals in the Amazon Web Services account associated with the cluster. When <code>true</code>, IAM principals in the Amazon Web Services account can perform Amazon EMR cluster\n         actions on the cluster that their IAM policies allow. When\n            <code>false</code>, only the IAM principal that created the cluster and\n         the Amazon Web Services account root user can perform Amazon EMR actions, regardless\n         of IAM permissions policies attached to other IAM\n         principals.</p>\n         <p>The default value is <code>true</code> if a value is not provided when creating a\n         cluster using the Amazon EMR API <a>RunJobFlow</a> command, the CLI\n         <a href=\"https://docs.aws.amazon.com/cli/latest/reference/emr/create-cluster.html\">create-cluster</a> command, or the Amazon Web Services Management Console.</p>"
+          }
+        },
+        "Applications": {
+          "target": "com.amazonaws.emr#ApplicationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The applications installed on this cluster.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags associated with a cluster.</p>"
+          }
+        },
+        "ServiceRole": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role that Amazon EMR assumes in order to access Amazon Web Services resources on your behalf.</p>"
+          }
+        },
+        "NormalizedInstanceHours": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>An approximation of the cost of the cluster, represented in m1.small/hours. This value\n         is incremented one time for every hour an m1.small instance runs. Larger instances are\n         weighted more, so an Amazon EC2 instance that is roughly four times more expensive\n         would result in the normalized instance hours being incremented by four. This result is\n         only an approximation and does not reflect the actual billing rate.</p>"
+          }
+        },
+        "MasterPublicDnsName": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The DNS name of the master node. If the cluster is on a private subnet, this is the\n         private DNS name. On a public subnet, this is the public DNS name.</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies only to Amazon EMR releases 4.x and later. The list of configurations\n         that are supplied to the Amazon EMR cluster.</p>"
+          }
+        },
+        "SecurityConfiguration": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the security configuration applied to the cluster.</p>"
+          }
+        },
+        "AutoScalingRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>An IAM role for automatic scaling policies. The default role is\n            <code>EMR_AutoScaling_DefaultRole</code>. The IAM role provides\n         permissions that the automatic scaling feature requires to launch and terminate Amazon EC2 instances in an instance group.</p>"
+          }
+        },
+        "ScaleDownBehavior": {
+          "target": "com.amazonaws.emr#ScaleDownBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>The way that individual Amazon EC2 instances terminate when an automatic\n         scale-in activity occurs or an instance group is resized.\n            <code>TERMINATE_AT_INSTANCE_HOUR</code> indicates that Amazon EMR terminates\n         nodes at the instance-hour boundary, regardless of when the request to terminate the\n         instance was submitted. This option is only available with Amazon EMR 5.1.0 and\n         later and is the default for clusters created using that version.\n            <code>TERMINATE_AT_TASK_COMPLETION</code> indicates that Amazon EMR adds nodes\n         to a deny list and drains tasks from nodes before terminating the Amazon EC2\n         instances, regardless of the instance-hour boundary. With either behavior, Amazon EMR removes the least active nodes first and blocks instance termination if it could lead to\n         HDFS corruption. <code>TERMINATE_AT_TASK_COMPLETION</code> is available only in Amazon EMR releases 4.1.0 and later, and is the default for versions of Amazon EMR earlier than 5.1.0.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Available only in Amazon EMR releases 5.7.0 and later. The ID of a custom Amazon\n         EBS-backed Linux AMI if the cluster uses a custom AMI.</p>"
+          }
+        },
+        "EbsRootVolumeSize": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size, in GiB, of the Amazon EBS root device volume of the Linux AMI that is\n         used for each Amazon EC2 instance. Available in Amazon EMR releases 4.x and\n         later.</p>"
+          }
+        },
+        "RepoUpgradeOnBoot": {
+          "target": "com.amazonaws.emr#RepoUpgradeOnBoot",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies only when <code>CustomAmiID</code> is used. Specifies the type of updates that\n         the Amazon Linux AMI package repositories apply when an instance boots using the\n         AMI.</p>"
+          }
+        },
+        "KerberosAttributes": {
+          "target": "com.amazonaws.emr#KerberosAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Attributes for Kerberos configuration when Kerberos authentication is enabled using a\n         security configuration. For more information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos.html\">Use Kerberos Authentication</a>\n         in the <i>Amazon EMR Management Guide</i>.</p>"
+          }
+        },
+        "ClusterArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name of the cluster.</p>"
+          }
+        },
+        "OutpostArn": {
+          "target": "com.amazonaws.emr#OptionalArnType",
+          "traits": {
+            "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the Outpost where the cluster is launched. </p>"
+          }
+        },
+        "StepConcurrencyLevel": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the number of steps that can be executed concurrently.</p>"
+          }
+        },
+        "PlacementGroups": {
+          "target": "com.amazonaws.emr#PlacementGroupConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>Placement group configured for an Amazon EMR cluster.</p>"
+          }
+        },
+        "OSReleaseLabel": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Linux release specified in a cluster launch RunJobFlow request. If no Amazon\n         Linux release was specified, the default Amazon Linux release is shown in the\n         response.</p>"
+          }
+        },
+        "EbsRootVolumeIops": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The IOPS, of the Amazon EBS root device volume of the Linux AMI that is\n         used for each Amazon EC2 instance. Available in Amazon EMR releases 6.15.0 and\n         later.</p>"
+          }
+        },
+        "EbsRootVolumeThroughput": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The throughput, in MiB/s, of the Amazon EBS root device volume of the Linux AMI that is\n         used for each Amazon EC2 instance. Available in Amazon EMR releases 6.15.0 and\n         later.</p>"
+          }
+        },
+        "ExtendedSupport": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        },
+        "MonitoringConfiguration": {
+          "target": "com.amazonaws.emr#MonitoringConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains Cloudwatch log configuration metadata and settings.</p>"
+          }
+        },
+        "SessionEnabled": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Spark Connect sessions are enabled on the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The detailed description of the cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#ClusterId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.emr#ClusterState": {
+      "type": "enum",
+      "members": {
+        "STARTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTING"
+          }
+        },
+        "BOOTSTRAPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAPPING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "WAITING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WAITING"
+          }
+        },
+        "TERMINATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATING"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        },
+        "TERMINATED_WITH_ERRORS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED_WITH_ERRORS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ClusterStateChangeReason": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.emr#ClusterStateChangeReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The programmatic code for the state change reason.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The descriptive message for the state change reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The reason that the cluster changed to its current state.</p>"
+      }
+    },
+    "com.amazonaws.emr#ClusterStateChangeReasonCode": {
+      "type": "enum",
+      "members": {
+        "INTERNAL_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_ERROR"
+          }
+        },
+        "VALIDATION_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALIDATION_ERROR"
+          }
+        },
+        "INSTANCE_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_FAILURE"
+          }
+        },
+        "INSTANCE_FLEET_TIMEOUT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_FLEET_TIMEOUT"
+          }
+        },
+        "BOOTSTRAP_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAP_FAILURE"
+          }
+        },
+        "USER_REQUEST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "USER_REQUEST"
+          }
+        },
+        "STEP_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STEP_FAILURE"
+          }
+        },
+        "ALL_STEPS_COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL_STEPS_COMPLETED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ClusterStateList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#ClusterState"
+      }
+    },
+    "com.amazonaws.emr#ClusterStatus": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#ClusterState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current state of the cluster.</p>"
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#ClusterStateChangeReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for the cluster status change.</p>"
+          }
+        },
+        "Timeline": {
+          "target": "com.amazonaws.emr#ClusterTimeline",
+          "traits": {
+            "smithy.api#documentation": "<p>A timeline that represents the status of a cluster over the lifetime of the\n         cluster.</p>"
+          }
+        },
+        "ErrorDetails": {
+          "target": "com.amazonaws.emr#ErrorDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tuples that provides information about the errors that caused a cluster to\n         terminate. This structure can contain up to 10 different <code>ErrorDetail</code>\n         tuples.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The detailed status of the cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#ClusterSummary": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the cluster.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the cluster.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#ClusterStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The details about the current status of the cluster.</p>"
+          }
+        },
+        "NormalizedInstanceHours": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>An approximation of the cost of the cluster, represented in m1.small/hours. This value\n         is incremented one time for every hour an m1.small instance runs. Larger instances are\n         weighted more, so an Amazon EC2 instance that is roughly four times more expensive\n         would result in the normalized instance hours being incremented by four. This result is\n         only an approximation and does not reflect the actual billing rate.</p>"
+          }
+        },
+        "ClusterArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name of the cluster.</p>"
+          }
+        },
+        "OutpostArn": {
+          "target": "com.amazonaws.emr#OptionalArnType",
+          "traits": {
+            "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the Outpost where the cluster is launched. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The summary description of the cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#ClusterSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#ClusterSummary"
+      }
+    },
+    "com.amazonaws.emr#ClusterTimeline": {
+      "type": "structure",
+      "members": {
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time of the cluster.</p>"
+          }
+        },
+        "ReadyDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the cluster was ready to run steps.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the cluster was terminated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the timeline of the cluster's lifecycle.</p>"
+      }
+    },
+    "com.amazonaws.emr#Command": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the command.</p>"
+          }
+        },
+        "ScriptPath": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the command script.</p>"
+          }
+        },
+        "Args": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Arguments for Amazon EMR to pass to the command for execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An entity describing an executable that runs on a cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#CommandList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#Command"
+      }
+    },
+    "com.amazonaws.emr#ComparisonOperator": {
+      "type": "enum",
+      "members": {
+        "GREATER_THAN_OR_EQUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GREATER_THAN_OR_EQUAL"
+          }
+        },
+        "GREATER_THAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GREATER_THAN"
+          }
+        },
+        "LESS_THAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LESS_THAN"
+          }
+        },
+        "LESS_THAN_OR_EQUAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LESS_THAN_OR_EQUAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ComputeLimits": {
+      "type": "structure",
+      "members": {
+        "UnitType": {
+          "target": "com.amazonaws.emr#ComputeLimitsUnitType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p> The unit type used for specifying a managed scaling policy. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MinimumCapacityUnits": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p> The lower boundary of Amazon EC2 units. It is measured through vCPU cores or\n         instances for instance groups and measured through units for instance fleets. Managed\n         scaling activities are not allowed beyond this boundary. The limit only applies to the core\n         and task nodes. The master node cannot be scaled after initial configuration. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaximumCapacityUnits": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p> The upper boundary of Amazon EC2 units. It is measured through vCPU cores or\n         instances for instance groups and measured through units for instance fleets. Managed\n         scaling activities are not allowed beyond this boundary. The limit only applies to the core\n         and task nodes. The master node cannot be scaled after initial configuration. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaximumOnDemandCapacityUnits": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p> The upper boundary of On-Demand Amazon EC2 units. It is measured through vCPU\n         cores or instances for instance groups and measured through units for instance fleets. The\n         On-Demand units are not allowed to scale beyond this boundary. The parameter is used to\n         split capacity allocation between On-Demand and Spot Instances. </p>"
+          }
+        },
+        "MaximumCoreCapacityUnits": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p> The upper boundary of Amazon EC2 units for core node type in a cluster. It is\n         measured through vCPU cores or instances for instance groups and measured through units for\n         instance fleets. The core units are not allowed to scale beyond this boundary. The\n         parameter is used to split capacity allocation between core and task nodes. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The Amazon EC2 unit limits for a managed scaling policy. The managed scaling\n         activity of a cluster can not be above or below these limits. The limit only applies to the\n         core and task nodes. The master node cannot be scaled after initial configuration. </p>"
+      }
+    },
+    "com.amazonaws.emr#ComputeLimitsUnitType": {
+      "type": "enum",
+      "members": {
+        "InstanceFleetUnits": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "InstanceFleetUnits"
+          }
+        },
+        "Instances": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Instances"
+          }
+        },
+        "VCPU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VCPU"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#Configuration": {
+      "type": "structure",
+      "members": {
+        "Classification": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The classification within a configuration.</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of additional configurations to apply within a configuration object.</p>"
+          }
+        },
+        "Properties": {
+          "target": "com.amazonaws.emr#StringMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of properties specified within a configuration classification.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<note>\n            <p>Amazon EMR releases 4.x or later.</p>\n         </note>\n         <p>An optional configuration specification to be used when provisioning cluster instances,\n         which can include configurations for applications and software bundled with Amazon EMR. A configuration consists of a classification, properties, and optional\n         nested configurations. A classification refers to an application-specific configuration\n         file. Properties are the settings you want to change in that file. For more information,\n         see <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html\">Configuring Applications</a>.</p>"
+      }
+    },
+    "com.amazonaws.emr#ConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#Configuration"
+      }
+    },
+    "com.amazonaws.emr#CreatePersistentAppUI": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#CreatePersistentAppUIInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#CreatePersistentAppUIOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a persistent application user interface.</p>"
+      }
+    },
+    "com.amazonaws.emr#CreatePersistentAppUIInput": {
+      "type": "structure",
+      "members": {
+        "TargetResourceArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique Amazon Resource Name (ARN) of the target resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EMRContainersConfig": {
+          "target": "com.amazonaws.emr#EMRContainersConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The EMR containers configuration.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags for the persistent application user interface.</p>"
+          }
+        },
+        "XReferer": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The cross reference for the persistent application user interface.</p>"
+          }
+        },
+        "ProfilerType": {
+          "target": "com.amazonaws.emr#ProfilerType",
+          "traits": {
+            "smithy.api#documentation": "<p>The profiler type for the persistent application user interface.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#CreatePersistentAppUIOutput": {
+      "type": "structure",
+      "members": {
+        "PersistentAppUIId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The persistent application user interface identifier.</p>"
+          }
+        },
+        "RuntimeRoleEnabledCluster": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Represents if the EMR on EC2 cluster that the persisent application user interface is created for is a runtime role \n         enabled cluster or not.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#CreateSecurityConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#CreateSecurityConfigurationInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#CreateSecurityConfigurationOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a security configuration, which is stored in the service and can be specified\n         when a cluster is created.</p>"
+      }
+    },
+    "com.amazonaws.emr#CreateSecurityConfigurationInput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the security configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SecurityConfiguration": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The security configuration details in JSON format. For JSON parameters and examples, see\n            <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-security-configurations.html\">Use Security\n            Configurations to Set Up Cluster Security</a> in the <i>Amazon EMR\n            Management Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#CreateSecurityConfigurationOutput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the security configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The date and time the security configuration was created.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#CreateStudio": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#CreateStudioInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#CreateStudioOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Amazon EMR Studio.</p>"
+      }
+    },
+    "com.amazonaws.emr#CreateStudioInput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A descriptive name for the Amazon EMR Studio.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>A detailed description of the Amazon EMR Studio.</p>"
+          }
+        },
+        "AuthMode": {
+          "target": "com.amazonaws.emr#AuthMode",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether the Studio authenticates users using IAM or IAM Identity Center.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VpcId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon Virtual Private Cloud (Amazon VPC) to associate with the\n         Studio.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.emr#SubnetIdList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of subnet IDs to associate with the Amazon EMR Studio. A Studio can have\n         a maximum of 5 subnets. The subnets must belong to the VPC specified by <code>VpcId</code>.\n         Studio users can create a Workspace in any of the specified subnets.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ServiceRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The IAM role that the Amazon EMR Studio assumes. The service role\n         provides a way for Amazon EMR Studio to interoperate with other Amazon Web Services\n         services.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "UserRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM user role that users and groups assume when logged in to an\n            Amazon EMR Studio. Only specify a <code>UserRole</code> when you use IAM Identity Center authentication. The permissions attached to the <code>UserRole</code> can be\n         scoped down for each user or group using session policies.</p>"
+          }
+        },
+        "WorkspaceSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio Workspace security group. The Workspace security\n         group allows outbound network traffic to resources in the Engine security group, and it\n         must be in the same VPC specified by <code>VpcId</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EngineSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio Engine security group. The Engine security group\n         allows inbound network traffic from the Workspace security group, and it must be in the\n         same VPC specified by <code>VpcId</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DefaultS3Location": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon S3 location to back up Amazon EMR Studio Workspaces and\n         notebook files.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IdpAuthUrl": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The authentication endpoint of your identity provider (IdP). Specify this value when you\n         use IAM authentication and want to let federated users log in to a Studio\n         with the Studio URL and credentials from your IdP. Amazon EMR Studio redirects\n         users to this endpoint to enter credentials.</p>"
+          }
+        },
+        "IdpRelayStateParameterName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name that your identity provider (IdP) uses for its <code>RelayState</code>\n         parameter. For example, <code>RelayState</code> or <code>TargetSource</code>. Specify this\n         value when you use IAM authentication and want to let federated users log in\n         to a Studio using the Studio URL. The <code>RelayState</code> parameter differs by\n         IdP.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags to associate with the Amazon EMR Studio. Tags are user-defined\n         key-value pairs that consist of a required key string with a maximum of 128 characters, and\n         an optional value string with a maximum of 256 characters.</p>"
+          }
+        },
+        "TrustedIdentityPropagationEnabled": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         A Boolean indicating whether to enable Trusted identity propagation for the Studio. The default value is <code>false</code>.\n      </p>"
+          }
+        },
+        "IdcUserAssignment": {
+          "target": "com.amazonaws.emr#IdcUserAssignment",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Specifies whether IAM Identity Center user assignment is <code>REQUIRED</code> or <code>OPTIONAL</code>. If the value is set to <code>REQUIRED</code>, users must be explicitly assigned to the Studio application to access the Studio.\n      </p>"
+          }
+        },
+        "IdcInstanceArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The ARN of the IAM Identity Center instance to create the Studio application.\n      </p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key identifier (ARN) used to encrypt Amazon EMR Studio workspace and notebook files when backed up to Amazon S3.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#CreateStudioOutput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>"
+          }
+        },
+        "Url": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique Studio access URL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#CreateStudioSessionMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#CreateStudioSessionMappingInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Maps a user or group to the Amazon EMR Studio specified by\n         <code>StudioId</code>, and applies a session policy to refine Studio permissions for that\n         user or group. Use <code>CreateStudioSessionMapping</code> to assign users to a Studio when\n         you use IAM Identity Center authentication. For instructions on how to assign users to a\n         Studio when you use IAM authentication, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-manage-users.html#emr-studio-assign-users-groups\">Assign a user or group to your EMR Studio</a>.</p>"
+      }
+    },
+    "com.amazonaws.emr#CreateStudioSessionMappingInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio to which the user or group will be\n         mapped.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IdentityId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The globally unique identifier (GUID) of the user or group from the IAM Identity Center\n         Identity Store. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserId\">UserId</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-GroupId\">GroupId</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified, but not both.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the user or group. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserName\">UserName</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-DisplayName\">DisplayName</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified, but not both.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether the identity to map to the Amazon EMR Studio is a user or a\n         group.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionPolicyArn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the session policy that will be applied to the user\n         or group. You should specify the ARN for the session policy that you want to apply, not the\n         ARN of your user role. For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-user-role.html\">Create an Amazon EMR\n            Studio User Role with Session Policies</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#Credentials": {
+      "type": "union",
+      "members": {
+        "UsernamePassword": {
+          "target": "com.amazonaws.emr#UsernamePassword",
+          "traits": {
+            "smithy.api#documentation": "<p>The username and password that you use to connect to cluster endpoints.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The credentials that you can use to connect to cluster endpoints. Credentials consist of\n         a username and a password.</p>"
+      }
+    },
+    "com.amazonaws.emr#Date": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.emr#DeleteSecurityConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DeleteSecurityConfigurationInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DeleteSecurityConfigurationOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a security configuration.</p>"
+      }
+    },
+    "com.amazonaws.emr#DeleteSecurityConfigurationInput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the security configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DeleteSecurityConfigurationOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DeleteStudio": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DeleteStudioInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes an Amazon EMR Studio from the Studio metadata store.</p>"
+      }
+    },
+    "com.amazonaws.emr#DeleteStudioInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DeleteStudioSessionMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DeleteStudioSessionMappingInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes a user or group from an Amazon EMR Studio.</p>"
+      }
+    },
+    "com.amazonaws.emr#DeleteStudioSessionMappingInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IdentityId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The globally unique identifier (GUID) of the user or group to remove from the Amazon EMR Studio. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserId\">UserId</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-GroupId\">GroupId</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the user name or group to remove from the Amazon EMR Studio. For\n         more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserName\">UserName</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-DisplayName\">DisplayName</a> in the <i>IAM Identity Center Store API Reference</i>.\n         Either <code>IdentityName</code> or <code>IdentityId</code> must be specified.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether the identity to delete from the Amazon EMR Studio is a user or\n         a group.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeCluster": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeClusterInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeClusterOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides cluster-level details including status, hardware and software configuration,\n         VPC settings, and so on.</p>",
+        "smithy.test#smokeTests": [
+          {
+            "id": "DescribeClusterFailure",
+            "params": {
+              "ClusterId": "fake_cluster"
+            },
+            "vendorParams": {
+              "region": "us-west-2"
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "expect": {
+              "failure": {}
+            }
+          }
+        ],
+        "smithy.waiters#waitable": {
+          "ClusterRunning": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "RUNNING",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "WAITING",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "TERMINATING",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "TERMINATED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "TERMINATED_WITH_ERRORS",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 30
+          },
+          "ClusterTerminated": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "TERMINATED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "Cluster.Status.State",
+                    "expected": "TERMINATED_WITH_ERRORS",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 30
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#DescribeClusterInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier of the cluster to describe.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which cluster to describe.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeClusterOutput": {
+      "type": "structure",
+      "members": {
+        "Cluster": {
+          "target": "com.amazonaws.emr#Cluster",
+          "traits": {
+            "smithy.api#documentation": "<p>This output contains the details for the requested cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This output contains the description of the cluster.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeJobFlows": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeJobFlowsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeJobFlowsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#deprecated": {},
+        "smithy.api#documentation": "<p>This API is no longer supported and will eventually be removed. We recommend you use\n            <a>ListClusters</a>, <a>DescribeCluster</a>, <a>ListSteps</a>, <a>ListInstanceGroups</a> and <a>ListBootstrapActions</a> instead.</p>\n         <p>DescribeJobFlows returns a list of job flows that match all of the supplied parameters.\n         The parameters can include a list of job flow IDs, job flow states, and restrictions on job\n         flow creation date and time.</p>\n         <p>Regardless of supplied parameters, only job flows created within the last two months are\n         returned.</p>\n         <p>If no parameters are supplied, then job flows matching either of the following criteria\n         are returned:</p>\n         <ul>\n            <li>\n               <p>Job flows created and completed in the last two weeks</p>\n            </li>\n            <li>\n               <p> Job flows created within the last two months that are in one of the following\n               states: <code>RUNNING</code>, <code>WAITING</code>, <code>SHUTTING_DOWN</code>,\n                  <code>STARTING</code>\n               </p>\n            </li>\n         </ul>\n         <p>Amazon EMR can return a maximum of 512 job flow descriptions.</p>"
+      }
+    },
+    "com.amazonaws.emr#DescribeJobFlowsInput": {
+      "type": "structure",
+      "members": {
+        "CreatedAfter": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>Return only job flows created after this date and time.</p>"
+          }
+        },
+        "CreatedBefore": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>Return only job flows created before this date and time.</p>"
+          }
+        },
+        "JobFlowIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Return only job flows whose job flow ID is contained in this list.</p>"
+          }
+        },
+        "JobFlowStates": {
+          "target": "com.amazonaws.emr#JobFlowExecutionStateList",
+          "traits": {
+            "smithy.api#documentation": "<p>Return only job flows whose state is contained in this list.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The input for the <a>DescribeJobFlows</a> operation. </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeJobFlowsOutput": {
+      "type": "structure",
+      "members": {
+        "JobFlows": {
+          "target": "com.amazonaws.emr#JobFlowDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of job flows matching the parameters supplied.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The output for the <a>DescribeJobFlows</a> operation. </p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeNotebookExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeNotebookExecutionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeNotebookExecutionOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details of a notebook execution.</p>"
+      }
+    },
+    "com.amazonaws.emr#DescribeNotebookExecutionInput": {
+      "type": "structure",
+      "members": {
+        "NotebookExecutionId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the notebook execution.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeNotebookExecutionOutput": {
+      "type": "structure",
+      "members": {
+        "NotebookExecution": {
+          "target": "com.amazonaws.emr#NotebookExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>Properties of the notebook execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribePersistentAppUI": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribePersistentAppUIInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribePersistentAppUIOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes a persistent application user interface.</p>"
+      }
+    },
+    "com.amazonaws.emr#DescribePersistentAppUIInput": {
+      "type": "structure",
+      "members": {
+        "PersistentAppUIId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier for the persistent application user interface.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribePersistentAppUIOutput": {
+      "type": "structure",
+      "members": {
+        "PersistentAppUI": {
+          "target": "com.amazonaws.emr#PersistentAppUI",
+          "traits": {
+            "smithy.api#documentation": "<p>The persistent application user interface.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeReleaseLabel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeReleaseLabelInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeReleaseLabelOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides Amazon EMR release label details, such as the releases available the\n         Region where the API request is run, and the available applications for a specific Amazon EMR release label. Can also list Amazon EMR releases that support a\n         specified version of Spark.</p>"
+      }
+    },
+    "com.amazonaws.emr#DescribeReleaseLabelInput": {
+      "type": "structure",
+      "members": {
+        "ReleaseLabel": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The target release label to be described.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token. Reserved for future use. Currently set to null.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.emr#MaxResultsNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved for future use. Currently set to null.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeReleaseLabelOutput": {
+      "type": "structure",
+      "members": {
+        "ReleaseLabel": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The target release label described in the response.</p>"
+          }
+        },
+        "Applications": {
+          "target": "com.amazonaws.emr#SimplifiedApplicationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of applications available for the target release label. <code>Name</code> is\n         the name of the application. <code>Version</code> is the concise version of the\n         application.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token. Reserved for future use. Currently set to null.</p>"
+          }
+        },
+        "AvailableOSReleases": {
+          "target": "com.amazonaws.emr#OSReleaseList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of available Amazon Linux release versions for an Amazon EMR release.\n         Contains a Label field that is formatted as shown in <a href=\"https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html\">\n               <i>Amazon Linux 2 Release\n               Notes</i>\n            </a>. For example, <a href=\"https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20220218.html\">2.0.20220218.1</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeSecurityConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeSecurityConfigurationInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeSecurityConfigurationOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of a security configuration by returning the configuration\n         JSON.</p>"
+      }
+    },
+    "com.amazonaws.emr#DescribeSecurityConfigurationInput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the security configuration.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeSecurityConfigurationOutput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the security configuration.</p>"
+          }
+        },
+        "SecurityConfiguration": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The security configuration details in JSON format.</p>"
+          }
+        },
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the security configuration was created</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeStep": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeStepInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeStepOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides more detail about the cluster step.</p>",
+        "smithy.waiters#waitable": {
+          "StepComplete": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "Step.Status.State",
+                    "expected": "COMPLETED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "Step.Status.State",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "Step.Status.State",
+                    "expected": "CANCELLED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 30
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#DescribeStepInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier of the cluster with steps to describe.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepId": {
+          "target": "com.amazonaws.emr#StepId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier of the step to describe.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which step to describe.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeStepOutput": {
+      "type": "structure",
+      "members": {
+        "Step": {
+          "target": "com.amazonaws.emr#Step",
+          "traits": {
+            "smithy.api#documentation": "<p>The step details for the requested step identifier.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This output contains the description of the cluster step.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeStudio": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#DescribeStudioInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#DescribeStudioOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns details for the specified Amazon EMR Studio including ID, Name, VPC,\n         Studio access URL, and so on.</p>"
+      }
+    },
+    "com.amazonaws.emr#DescribeStudioInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EMR Studio ID.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#DescribeStudioOutput": {
+      "type": "structure",
+      "members": {
+        "Studio": {
+          "target": "com.amazonaws.emr#Studio",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EMR Studio details.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#EC2InstanceIdsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceId"
+      }
+    },
+    "com.amazonaws.emr#EC2InstanceIdsToTerminateList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceId"
+      }
+    },
+    "com.amazonaws.emr#EMRContainersConfig": {
+      "type": "structure",
+      "members": {
+        "JobRunId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Job run ID for the container configuration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The EMR container configuration.</p>"
+      }
+    },
+    "com.amazonaws.emr#EbsBlockDevice": {
+      "type": "structure",
+      "members": {
+        "VolumeSpecification": {
+          "target": "com.amazonaws.emr#VolumeSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p>EBS volume specifications such as volume type, IOPS, size (GiB) and throughput (MiB/s)\n         that are requested for the EBS volume attached to an Amazon EC2 instance in the\n         cluster.</p>"
+          }
+        },
+        "Device": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The device name that is exposed to the instance, such as /dev/sdh.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration of requested EBS block device associated with the instance group.</p>"
+      }
+    },
+    "com.amazonaws.emr#EbsBlockDeviceConfig": {
+      "type": "structure",
+      "members": {
+        "VolumeSpecification": {
+          "target": "com.amazonaws.emr#VolumeSpecification",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>EBS volume specifications such as volume type, IOPS, size (GiB) and throughput (MiB/s)\n         that are requested for the EBS volume attached to an Amazon EC2 instance in the\n         cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VolumesPerInstance": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of EBS volumes with a specific volume configuration that are associated with\n         every instance in the instance group</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration of requested EBS block device associated with the instance group with\n         count of volumes that are associated to every instance.</p>"
+      }
+    },
+    "com.amazonaws.emr#EbsBlockDeviceConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#EbsBlockDeviceConfig"
+      }
+    },
+    "com.amazonaws.emr#EbsBlockDeviceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#EbsBlockDevice"
+      }
+    },
+    "com.amazonaws.emr#EbsConfiguration": {
+      "type": "structure",
+      "members": {
+        "EbsBlockDeviceConfigs": {
+          "target": "com.amazonaws.emr#EbsBlockDeviceConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of Amazon EBS volume specifications attached to a cluster\n         instance.</p>"
+          }
+        },
+        "EbsOptimized": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether an Amazon EBS volume is EBS-optimized. The default is false. You should explicitly set this value to true to enable the Amazon EBS-optimized setting \n         for an EC2 instance.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon EBS configuration of a cluster instance.</p>"
+      }
+    },
+    "com.amazonaws.emr#EbsVolume": {
+      "type": "structure",
+      "members": {
+        "Device": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The device name that is exposed to the instance, such as /dev/sdh.</p>"
+          }
+        },
+        "VolumeId": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The volume identifier of the EBS volume.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>EBS block device that's attached to an Amazon EC2 instance.</p>"
+      }
+    },
+    "com.amazonaws.emr#EbsVolumeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#EbsVolume"
+      }
+    },
+    "com.amazonaws.emr#Ec2InstanceAttributes": {
+      "type": "structure",
+      "members": {
+        "Ec2KeyName": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon EC2 key pair to use when connecting with SSH into the\n         master node as a user named \"hadoop\".</p>"
+          }
+        },
+        "Ec2SubnetId": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Set this parameter to the identifier of the Amazon VPC subnet where you want the\n         cluster to launch. If you do not specify this value, and your account supports EC2-Classic,\n         the cluster launches in EC2-Classic.</p>"
+          }
+        },
+        "RequestedEc2SubnetIds": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256List",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies to clusters configured with the instance fleets option. Specifies the unique\n         identifier of one or more Amazon EC2 subnets in which to launch Amazon EC2\n         cluster instances. Subnets must exist within the same VPC. Amazon EMR chooses the\n            Amazon EC2 subnet with the best fit from among the list of\n            <code>RequestedEc2SubnetIds</code>, and then launches all cluster instances within that\n         Subnet. If this value is not specified, and the account and Region support EC2-Classic\n         networks, the cluster launches instances in the EC2-Classic network and uses\n            <code>RequestedEc2AvailabilityZones</code> instead of this setting. If EC2-Classic is\n         not supported, and no Subnet is specified, Amazon EMR chooses the subnet for you.\n            <code>RequestedEc2SubnetIDs</code> and <code>RequestedEc2AvailabilityZones</code> cannot\n         be specified together.</p>"
+          }
+        },
+        "Ec2AvailabilityZone": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone in which the cluster will run. </p>"
+          }
+        },
+        "RequestedEc2AvailabilityZones": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256List",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies to clusters configured with the instance fleets option. Specifies one or more\n         Availability Zones in which to launch Amazon EC2 cluster instances when the\n         EC2-Classic network configuration is supported. Amazon EMR chooses the Availability\n         Zone with the best fit from among the list of <code>RequestedEc2AvailabilityZones</code>,\n         and then launches all cluster instances within that Availability Zone. If you do not\n         specify this value, Amazon EMR chooses the Availability Zone for you.\n            <code>RequestedEc2SubnetIDs</code> and <code>RequestedEc2AvailabilityZones</code> cannot\n         be specified together.</p>"
+          }
+        },
+        "IamInstanceProfile": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role that was specified when the cluster was launched. The\n            Amazon EC2 instances of the cluster assume this role.</p>"
+          }
+        },
+        "EmrManagedMasterSecurityGroup": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Amazon EC2 security group for the master node.</p>"
+          }
+        },
+        "EmrManagedSlaveSecurityGroup": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Amazon EC2 security group for the core and task\n         nodes.</p>"
+          }
+        },
+        "ServiceAccessSecurityGroup": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Amazon EC2 security group for the Amazon EMR\n         service to access clusters in VPC private subnets.</p>"
+          }
+        },
+        "AdditionalMasterSecurityGroups": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of additional Amazon EC2 security group IDs for the master node.</p>"
+          }
+        },
+        "AdditionalSlaveSecurityGroups": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of additional Amazon EC2 security group IDs for the core and task\n         nodes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the Amazon EC2 instances in a cluster grouped by\n         category. For example, key name, subnet ID, IAM instance profile, and so\n         on.</p>"
+      }
+    },
+    "com.amazonaws.emr#ElasticMapReduce": {
+      "type": "service",
+      "version": "2009-03-31",
+      "operations": [
+        {
+          "target": "com.amazonaws.emr#AddInstanceFleet"
+        },
+        {
+          "target": "com.amazonaws.emr#AddInstanceGroups"
+        },
+        {
+          "target": "com.amazonaws.emr#AddJobFlowSteps"
+        },
+        {
+          "target": "com.amazonaws.emr#AddTags"
+        },
+        {
+          "target": "com.amazonaws.emr#CancelSteps"
+        },
+        {
+          "target": "com.amazonaws.emr#CreatePersistentAppUI"
+        },
+        {
+          "target": "com.amazonaws.emr#CreateSecurityConfiguration"
+        },
+        {
+          "target": "com.amazonaws.emr#CreateStudio"
+        },
+        {
+          "target": "com.amazonaws.emr#CreateStudioSessionMapping"
+        },
+        {
+          "target": "com.amazonaws.emr#DeleteSecurityConfiguration"
+        },
+        {
+          "target": "com.amazonaws.emr#DeleteStudio"
+        },
+        {
+          "target": "com.amazonaws.emr#DeleteStudioSessionMapping"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeCluster"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeJobFlows"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeNotebookExecution"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribePersistentAppUI"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeReleaseLabel"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeSecurityConfiguration"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeStep"
+        },
+        {
+          "target": "com.amazonaws.emr#DescribeStudio"
+        },
+        {
+          "target": "com.amazonaws.emr#GetAutoTerminationPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#GetBlockPublicAccessConfiguration"
+        },
+        {
+          "target": "com.amazonaws.emr#GetClusterSessionCredentials"
+        },
+        {
+          "target": "com.amazonaws.emr#GetManagedScalingPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#GetOnClusterAppUIPresignedURL"
+        },
+        {
+          "target": "com.amazonaws.emr#GetPersistentAppUIPresignedURL"
+        },
+        {
+          "target": "com.amazonaws.emr#GetSession"
+        },
+        {
+          "target": "com.amazonaws.emr#GetSessionEndpoint"
+        },
+        {
+          "target": "com.amazonaws.emr#GetStudioSessionMapping"
+        },
+        {
+          "target": "com.amazonaws.emr#ListBootstrapActions"
+        },
+        {
+          "target": "com.amazonaws.emr#ListClusters"
+        },
+        {
+          "target": "com.amazonaws.emr#ListInstanceFleets"
+        },
+        {
+          "target": "com.amazonaws.emr#ListInstanceGroups"
+        },
+        {
+          "target": "com.amazonaws.emr#ListInstances"
+        },
+        {
+          "target": "com.amazonaws.emr#ListNotebookExecutions"
+        },
+        {
+          "target": "com.amazonaws.emr#ListReleaseLabels"
+        },
+        {
+          "target": "com.amazonaws.emr#ListSecurityConfigurations"
+        },
+        {
+          "target": "com.amazonaws.emr#ListSessions"
+        },
+        {
+          "target": "com.amazonaws.emr#ListSteps"
+        },
+        {
+          "target": "com.amazonaws.emr#ListStudios"
+        },
+        {
+          "target": "com.amazonaws.emr#ListStudioSessionMappings"
+        },
+        {
+          "target": "com.amazonaws.emr#ListSupportedInstanceTypes"
+        },
+        {
+          "target": "com.amazonaws.emr#ModifyCluster"
+        },
+        {
+          "target": "com.amazonaws.emr#ModifyInstanceFleet"
+        },
+        {
+          "target": "com.amazonaws.emr#ModifyInstanceGroups"
+        },
+        {
+          "target": "com.amazonaws.emr#PutAutoScalingPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#PutAutoTerminationPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#PutBlockPublicAccessConfiguration"
+        },
+        {
+          "target": "com.amazonaws.emr#PutManagedScalingPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#RemoveAutoScalingPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#RemoveAutoTerminationPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#RemoveManagedScalingPolicy"
+        },
+        {
+          "target": "com.amazonaws.emr#RemoveTags"
+        },
+        {
+          "target": "com.amazonaws.emr#RunJobFlow"
+        },
+        {
+          "target": "com.amazonaws.emr#SetKeepJobFlowAliveWhenNoSteps"
+        },
+        {
+          "target": "com.amazonaws.emr#SetTerminationProtection"
+        },
+        {
+          "target": "com.amazonaws.emr#SetUnhealthyNodeReplacement"
+        },
+        {
+          "target": "com.amazonaws.emr#SetVisibleToAllUsers"
+        },
+        {
+          "target": "com.amazonaws.emr#StartNotebookExecution"
+        },
+        {
+          "target": "com.amazonaws.emr#StartSession"
+        },
+        {
+          "target": "com.amazonaws.emr#StopNotebookExecution"
+        },
+        {
+          "target": "com.amazonaws.emr#TerminateJobFlows"
+        },
+        {
+          "target": "com.amazonaws.emr#TerminateSession"
+        },
+        {
+          "target": "com.amazonaws.emr#UpdateStudio"
+        },
+        {
+          "target": "com.amazonaws.emr#UpdateStudioSessionMapping"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "EMR",
+          "arnNamespace": "elasticmapreduce",
+          "cloudFormationName": "EMR",
+          "cloudTrailEventSource": "elasticmapreduce.amazonaws.com",
+          "docId": "elasticmapreduce-2009-03-31",
+          "endpointPrefix": "elasticmapreduce"
+        },
+        "aws.auth#sigv4": {
+          "name": "elasticmapreduce"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<p>Amazon EMR is a web service that makes it easier to process large amounts of\n         data efficiently. Amazon EMR uses Hadoop processing combined with several Amazon Web Services services to do tasks such as web indexing, data mining, log file analysis,\n         machine learning, scientific simulation, and data warehouse management.</p>",
+        "smithy.api#title": "Amazon EMR",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://elasticmapreduce.amazonaws.com/doc/2009-03-31"
+        },
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://elasticmapreduce-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://elasticmapreduce.{Region}.amazonaws.com",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://elasticmapreduce-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://elasticmapreduce.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://elasticmapreduce.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 14,
+          "nodes": "/////wAAAAH/////AAAAAAAAAA0AAAADAAAAAQAAAAQF9eEMAAAAAgAAAAUF9eEMAAAAAwAAAAgAAAAGAAAABAAAAAcF9eELAAAABQX14QkF9eEKAAAABAAAAAsAAAAJAAAABgAAAAoF9eEIAAAABwX14QYF9eEHAAAABQAAAAwF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAAOAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://elasticmapreduce-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws-us-gov"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://elasticmapreduce.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://elasticmapreduce-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://elasticmapreduce.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://elasticmapreduce.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.af-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "af-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-northeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ap-southeast-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.eu-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.me-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "me-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.sa-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "sa-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-iso-west-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://elasticmapreduce-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.emr#EnvironmentVariablesMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.emr#XmlStringMaxLen256"
+      },
+      "value": {
+        "target": "com.amazonaws.emr#XmlString"
+      }
+    },
+    "com.amazonaws.emr#ErrorCode": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.emr#ErrorData": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#StringMap"
+      }
+    },
+    "com.amazonaws.emr#ErrorDetail": {
+      "type": "structure",
+      "members": {
+        "ErrorCode": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name or code associated with the error.</p>"
+          }
+        },
+        "ErrorData": {
+          "target": "com.amazonaws.emr#ErrorData",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of key value pairs that provides contextual information about why an error\n         occured.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A message that describes the error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A tuple that provides information about an error that caused a cluster to\n         terminate.</p>"
+      }
+    },
+    "com.amazonaws.emr#ErrorDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#ErrorDetail"
+      }
+    },
+    "com.amazonaws.emr#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.emr#ExecutionEngineConfig": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the execution engine. For an Amazon EMR cluster, this\n         is the cluster ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.emr#ExecutionEngineType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of execution engine. A value of <code>EMR</code> specifies an Amazon EMR cluster.</p>"
+          }
+        },
+        "MasterInstanceSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional unique ID of an Amazon EC2 security group to associate with the\n         master instance of the Amazon EMR cluster for this notebook execution. For more\n         information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-security-groups.html\">Specifying\n               Amazon EC2 Security Groups for Amazon EMR Notebooks</a> in the\n            <i>EMR Management Guide</i>.</p>"
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#IAMRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution role ARN required for the notebook execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the execution engine (cluster) to run the notebook and perform the notebook\n         execution, for example, an Amazon EMR cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#ExecutionEngineType": {
+      "type": "enum",
+      "members": {
+        "EMR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMR"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#FailureDetails": {
+      "type": "structure",
+      "members": {
+        "Reason": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for the step failure. In the case where the service cannot successfully\n         determine the root cause of the failure, it returns \"Unknown Error\" as a reason.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The descriptive message including the error the Amazon EMR service has\n         identified as the cause of step failure. This is text from an error log that describes the\n         root cause of the failure.</p>"
+          }
+        },
+        "LogFile": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path to the log file where the step failure root cause was originally\n         recorded.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of the step failure. The service attempts to detect the root cause for many\n         common failures.</p>"
+      }
+    },
+    "com.amazonaws.emr#Float": {
+      "type": "float"
+    },
+    "com.amazonaws.emr#GetAutoTerminationPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetAutoTerminationPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetAutoTerminationPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the auto-termination policy for an Amazon EMR cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetAutoTerminationPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of the Amazon EMR cluster for which the auto-termination policy\n         will be fetched.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetAutoTerminationPolicyOutput": {
+      "type": "structure",
+      "members": {
+        "AutoTerminationPolicy": {
+          "target": "com.amazonaws.emr#AutoTerminationPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the auto-termination policy that is attached to an Amazon EMR cluster.\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetBlockPublicAccessConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetBlockPublicAccessConfigurationInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetBlockPublicAccessConfigurationOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the Amazon EMR block public access configuration for your Amazon Web Services account in the current Region. For more information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/configure-block-public-access.html\">Configure Block\n            Public Access for Amazon EMR</a> in the <i>Amazon EMR\n            Management Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetBlockPublicAccessConfigurationInput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetBlockPublicAccessConfigurationOutput": {
+      "type": "structure",
+      "members": {
+        "BlockPublicAccessConfiguration": {
+          "target": "com.amazonaws.emr#BlockPublicAccessConfiguration",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A configuration for Amazon EMR block public access. The configuration applies to\n         all clusters created in your account for the current Region. The configuration specifies\n         whether block public access is enabled. If block public access is enabled, security groups\n         associated with the cluster cannot have rules that allow inbound traffic from 0.0.0.0/0 or\n         ::/0 on a port, unless the port is specified as an exception using\n            <code>PermittedPublicSecurityGroupRuleRanges</code> in the\n            <code>BlockPublicAccessConfiguration</code>. By default, Port 22 (SSH) is an exception,\n         and public access is allowed on this port. You can change this by updating the block public\n         access configuration to remove the exception.</p>\n         <note>\n            <p>For accounts that created clusters in a Region before November 25, 2019, block public\n            access is disabled by default in that Region. To use this feature, you must manually\n            enable and configure it. For accounts that did not create an Amazon EMR cluster\n            in a Region before this date, block public access is enabled by default in that\n            Region.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "BlockPublicAccessConfigurationMetadata": {
+          "target": "com.amazonaws.emr#BlockPublicAccessConfigurationMetadata",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Properties that describe the Amazon Web Services principal that created the\n            <code>BlockPublicAccessConfiguration</code> using the\n            <code>PutBlockPublicAccessConfiguration</code> action as well as the date and time that\n         the configuration was created. Each time a configuration for block public access is\n         updated, Amazon EMR updates this metadata.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetClusterSessionCredentials": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetClusterSessionCredentialsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetClusterSessionCredentialsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides temporary, HTTP basic credentials that are associated with a given runtime\n            IAM role and used by a cluster with fine-grained access control\n         activated. You can use these credentials to connect to cluster endpoints that support\n         username and password authentication.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetClusterSessionCredentialsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the runtime role for interactive workload submission\n         on the cluster. The runtime role can be a cross-account IAM role. The\n         runtime role ARN is a combination of account ID, role name, and role type using the\n         following format: <code>arn:partition:service:region:account:resource</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetClusterSessionCredentialsOutput": {
+      "type": "structure",
+      "members": {
+        "Credentials": {
+          "target": "com.amazonaws.emr#Credentials",
+          "traits": {
+            "smithy.api#documentation": "<p>The credentials that you can use to connect to cluster endpoints that support username\n         and password authentication.</p>"
+          }
+        },
+        "ExpiresAt": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the credentials that are returned by the\n            <code>GetClusterSessionCredentials</code> API expire.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetManagedScalingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetManagedScalingPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetManagedScalingPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Fetches the attached managed scaling policy for an Amazon EMR cluster. </p>"
+      }
+    },
+    "com.amazonaws.emr#GetManagedScalingPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of the cluster for which the managed scaling policy will be fetched.\n      </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetManagedScalingPolicyOutput": {
+      "type": "structure",
+      "members": {
+        "ManagedScalingPolicy": {
+          "target": "com.amazonaws.emr#ManagedScalingPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the managed scaling policy that is attached to an Amazon EMR cluster.\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetOnClusterAppUIPresignedURL": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetOnClusterAppUIPresignedURLInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetOnClusterAppUIPresignedURLOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>The presigned URL properties for the cluster's application user interface.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetOnClusterAppUIPresignedURLInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The cluster ID associated with the cluster's application user interface presigned URL.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OnClusterAppUIType": {
+          "target": "com.amazonaws.emr#OnClusterAppUIType",
+          "traits": {
+            "smithy.api#documentation": "<p>The application UI type associated with the cluster's application user interface presigned URL.</p>"
+          }
+        },
+        "ApplicationId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The application ID associated with the cluster's application user interface presigned URL.</p>"
+          }
+        },
+        "DryRun": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines if the user interface presigned URL is for a dry run.</p>"
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution role ARN associated with the cluster's application user interface \n         presigned URL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetOnClusterAppUIPresignedURLOutput": {
+      "type": "structure",
+      "members": {
+        "PresignedURLReady": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Used to determine if the presigned URL is ready.</p>"
+          }
+        },
+        "PresignedURL": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The cluster's generated presigned URL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetPersistentAppUIPresignedURL": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetPersistentAppUIPresignedURLInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetPersistentAppUIPresignedURLOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>The presigned URL properties for the cluster's application user interface.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetPersistentAppUIPresignedURLInput": {
+      "type": "structure",
+      "members": {
+        "PersistentAppUIId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The persistent application user interface ID associated with the presigned URL.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PersistentAppUIType": {
+          "target": "com.amazonaws.emr#PersistentAppUIType",
+          "traits": {
+            "smithy.api#documentation": "<p>The persistent application user interface type associated with the presigned URL.</p>"
+          }
+        },
+        "ApplicationId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The application ID associated with the presigned URL.</p>"
+          }
+        },
+        "AuthProxyCall": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>A boolean that represents if the caller is an authentication proxy call.</p>"
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution role ARN associated with the presigned URL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetPersistentAppUIPresignedURLOutput": {
+      "type": "structure",
+      "members": {
+        "PresignedURLReady": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Used to determine if the presigned URL is ready.</p>"
+          }
+        },
+        "PresignedURL": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The returned presigned URL.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetSession": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetSessionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetSessionOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns detailed information about a session.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetSessionEndpoint": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetSessionEndpointInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetSessionEndpointOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the Spark Connect endpoint URL and a time-limited authentication token for the specified session. Use the endpoint and token to connect a PySpark client to the session. Call this operation again when the token expires to obtain a new one.</p>"
+      }
+    },
+    "com.amazonaws.emr#GetSessionEndpointInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster that the session belongs to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionId": {
+          "target": "com.amazonaws.emr#SessionId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the session.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input to the <code>GetSessionEndpoint</code> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetSessionEndpointOutput": {
+      "type": "structure",
+      "members": {
+        "Endpoint": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Spark Connect endpoint URL to use in the PySpark client.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AuthToken": {
+          "target": "com.amazonaws.emr#SensitiveString",
+          "traits": {
+            "smithy.api#documentation": "<p>A time-limited authentication token used to connect to the Spark Connect endpoint.</p>"
+          }
+        },
+        "AuthTokenExpirationTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the authentication token expires. After this time, call <code>GetSessionEndpoint</code> again to obtain a new token.</p>"
+          }
+        },
+        "Credentials": {
+          "target": "com.amazonaws.emr#Credentials",
+          "traits": {
+            "smithy.api#documentation": "<p>Username and password used to authenticate with the Spark Connect server when connecting directly over VPC peering.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output of the <code>GetSessionEndpoint</code> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetSessionInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster that the session belongs to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionId": {
+          "target": "com.amazonaws.emr#SessionId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the session.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input to the <code>GetSession</code> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetSessionOutput": {
+      "type": "structure",
+      "members": {
+        "Session": {
+          "target": "com.amazonaws.emr#Session",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The output displays information about the session.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output of the <code>GetSession</code> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#GetStudioSessionMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#GetStudioSessionMappingInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#GetStudioSessionMappingOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Fetches mapping details for the specified Amazon EMR Studio and identity (user\n         or group).</p>"
+      }
+    },
+    "com.amazonaws.emr#GetStudioSessionMappingInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IdentityId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The globally unique identifier (GUID) of the user or group. For more information, see\n            <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserId\">UserId</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-GroupId\">GroupId</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the user or group to fetch. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserName\">UserName</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-DisplayName\">DisplayName</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether the identity to fetch is a user or a group.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#GetStudioSessionMappingOutput": {
+      "type": "structure",
+      "members": {
+        "SessionMapping": {
+          "target": "com.amazonaws.emr#SessionMappingDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The session mapping details for the specified Amazon EMR Studio and identity,\n         including session policy ARN and creation time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#HadoopJarStepConfig": {
+      "type": "structure",
+      "members": {
+        "Properties": {
+          "target": "com.amazonaws.emr#KeyValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of Java properties that are set when the step runs. You can use these properties\n         to pass key-value pairs to your main function.</p>"
+          }
+        },
+        "Jar": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A path to a JAR file run during the step.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MainClass": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the main class in the specified Java file. If not specified, the JAR file\n         should specify a Main-Class in its manifest file.</p>"
+          }
+        },
+        "Args": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of command line arguments passed to the JAR file's main function when\n         executed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A job flow step consisting of a JAR file whose main function will be executed. The main\n         function submits a job for Hadoop to execute and waits for the job to finish or\n         fail.</p>"
+      }
+    },
+    "com.amazonaws.emr#HadoopStepConfig": {
+      "type": "structure",
+      "members": {
+        "Jar": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The path to the JAR file that runs during the step.</p>"
+          }
+        },
+        "Properties": {
+          "target": "com.amazonaws.emr#StringMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of Java properties that are set when the step runs. You can use these\n         properties to pass key-value pairs to your main function.</p>"
+          }
+        },
+        "MainClass": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the main class in the specified Java file. If not specified, the JAR file\n         should specify a main class in its manifest file.</p>"
+          }
+        },
+        "Args": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of command line arguments to pass to the JAR file's main function for\n         execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A cluster step consisting of a JAR file whose main function will be executed. The main\n         function submits a job for Hadoop to execute and waits for the job to finish or\n         fail.</p>"
+      }
+    },
+    "com.amazonaws.emr#IAMRoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:(aws[a-zA-Z0-9-]*):iam::(\\d{12})?:(role((\\u002F)|(\\u002F[\\u0021-\\u007F]+\\u002F))[\\w+=,.@-]+)$"
+      }
+    },
+    "com.amazonaws.emr#IdcUserAssignment": {
+      "type": "enum",
+      "members": {
+        "REQUIRED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUIRED"
+          }
+        },
+        "OPTIONAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPTIONAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#IdentityType": {
+      "type": "enum",
+      "members": {
+        "USER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "USER"
+          }
+        },
+        "GROUP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GROUP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#Instance": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#InstanceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the instance in Amazon EMR.</p>"
+          }
+        },
+        "Ec2InstanceId": {
+          "target": "com.amazonaws.emr#InstanceId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the instance in Amazon EC2.</p>"
+          }
+        },
+        "PublicDnsName": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The public DNS name of the instance.</p>"
+          }
+        },
+        "PublicIpAddress": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The public IP address of the instance.</p>"
+          }
+        },
+        "PrivateDnsName": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The private DNS name of the instance.</p>"
+          }
+        },
+        "PrivateIpAddress": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The private IP address of the instance.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#InstanceStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the instance.</p>"
+          }
+        },
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the instance group to which this instance belongs.</p>"
+          }
+        },
+        "InstanceFleetId": {
+          "target": "com.amazonaws.emr#InstanceFleetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the instance fleet to which an Amazon EC2 instance\n         belongs.</p>"
+          }
+        },
+        "Market": {
+          "target": "com.amazonaws.emr#MarketType",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance purchasing option. Valid values are <code>ON_DEMAND</code> or\n            <code>SPOT</code>. </p>"
+          }
+        },
+        "InstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 instance type, for example <code>m3.xlarge</code>.</p>"
+          }
+        },
+        "EbsVolumes": {
+          "target": "com.amazonaws.emr#EbsVolumeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of Amazon EBS volumes that are attached to this instance.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an Amazon EC2 instance provisioned as part of cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceCollectionType": {
+      "type": "enum",
+      "members": {
+        "INSTANCE_FLEET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_FLEET"
+          }
+        },
+        "INSTANCE_GROUP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_GROUP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceFleet": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#InstanceFleetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the instance fleet.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>A friendly name for the instance fleet.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#InstanceFleetStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the instance fleet. </p>"
+          }
+        },
+        "InstanceFleetType": {
+          "target": "com.amazonaws.emr#InstanceFleetType",
+          "traits": {
+            "smithy.api#documentation": "<p>The node type that the instance fleet hosts. Valid values are MASTER, CORE, or TASK.\n      </p>"
+          }
+        },
+        "TargetOnDemandCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The target capacity of On-Demand units for the instance fleet, which determines how many\n         On-Demand Instances to provision. When the instance fleet launches, Amazon EMR\n         tries to provision On-Demand Instances as specified by <a>InstanceTypeConfig</a>. Each instance configuration has a specified <code>WeightedCapacity</code>. When an\n         On-Demand Instance is provisioned, the <code>WeightedCapacity</code> units count toward the\n         target capacity. Amazon EMR provisions instances until the target capacity is\n         totally fulfilled, even if this results in an overage. For example, if there are 2 units\n         remaining to fulfill capacity, and Amazon EMR can only provision an instance with a\n            <code>WeightedCapacity</code> of 5 units, the instance is provisioned, and the target\n         capacity is exceeded by 3 units. You can use <a>InstanceFleet$ProvisionedOnDemandCapacity</a> to determine the Spot capacity\n         units that have been provisioned for the instance fleet.</p>\n         <note>\n            <p>If not specified or set to 0, only Spot Instances are provisioned for the instance\n            fleet using <code>TargetSpotCapacity</code>. At least one of\n               <code>TargetSpotCapacity</code> and <code>TargetOnDemandCapacity</code> should be\n            greater than 0. For a master instance fleet, only one of <code>TargetSpotCapacity</code>\n            and <code>TargetOnDemandCapacity</code> can be specified, and its value must be\n            1.</p>\n         </note>"
+          }
+        },
+        "TargetSpotCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The target capacity of Spot units for the instance fleet, which determines how many Spot\n         Instances to provision. When the instance fleet launches, Amazon EMR tries to\n         provision Spot Instances as specified by <a>InstanceTypeConfig</a>. Each\n         instance configuration has a specified <code>WeightedCapacity</code>. When a Spot instance\n         is provisioned, the <code>WeightedCapacity</code> units count toward the target capacity.\n            Amazon EMR provisions instances until the target capacity is totally fulfilled,\n         even if this results in an overage. For example, if there are 2 units remaining to fulfill\n         capacity, and Amazon EMR can only provision an instance with a\n            <code>WeightedCapacity</code> of 5 units, the instance is provisioned, and the target\n         capacity is exceeded by 3 units. You can use <a>InstanceFleet$ProvisionedSpotCapacity</a> to determine the Spot capacity units\n         that have been provisioned for the instance fleet.</p>\n         <note>\n            <p>If not specified or set to 0, only On-Demand Instances are provisioned for the\n            instance fleet. At least one of <code>TargetSpotCapacity</code> and\n               <code>TargetOnDemandCapacity</code> should be greater than 0. For a master instance\n            fleet, only one of <code>TargetSpotCapacity</code> and\n               <code>TargetOnDemandCapacity</code> can be specified, and its value must be 1.</p>\n         </note>"
+          }
+        },
+        "ProvisionedOnDemandCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of On-Demand units that have been provisioned for the instance fleet to\n         fulfill <code>TargetOnDemandCapacity</code>. This provisioned capacity might be less than\n         or greater than <code>TargetOnDemandCapacity</code>.</p>"
+          }
+        },
+        "ProvisionedSpotCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Spot units that have been provisioned for this instance fleet to fulfill\n            <code>TargetSpotCapacity</code>. This provisioned capacity might be less than or greater\n         than <code>TargetSpotCapacity</code>.</p>"
+          }
+        },
+        "InstanceTypeSpecifications": {
+          "target": "com.amazonaws.emr#InstanceTypeSpecificationList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of specifications for the instance types that comprise an instance\n         fleet.</p>"
+          }
+        },
+        "LaunchSpecifications": {
+          "target": "com.amazonaws.emr#InstanceFleetProvisioningSpecifications",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the launch specification for an instance fleet. </p>"
+          }
+        },
+        "ResizeSpecifications": {
+          "target": "com.amazonaws.emr#InstanceFleetResizingSpecifications",
+          "traits": {
+            "smithy.api#documentation": "<p>The resize specification for the instance fleet.</p>"
+          }
+        },
+        "Context": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes an instance fleet, which is a group of Amazon EC2 instances that host\n         a particular node type (master, core, or task) in an Amazon EMR cluster. Instance\n         fleets can consist of a mix of instance types and On-Demand and Spot Instances, which are\n         provisioned to meet a defined target capacity. </p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetConfig": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The friendly name of the instance fleet.</p>"
+          }
+        },
+        "InstanceFleetType": {
+          "target": "com.amazonaws.emr#InstanceFleetType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The node type that the instance fleet hosts. Valid values are MASTER, CORE, and\n         TASK.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetOnDemandCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The target capacity of On-Demand units for the instance fleet, which determines how many\n         On-Demand Instances to provision. When the instance fleet launches, Amazon EMR\n         tries to provision On-Demand Instances as specified by <a>InstanceTypeConfig</a>. Each instance configuration has a specified <code>WeightedCapacity</code>. When an\n         On-Demand Instance is provisioned, the <code>WeightedCapacity</code> units count toward the\n         target capacity. Amazon EMR provisions instances until the target capacity is\n         totally fulfilled, even if this results in an overage. For example, if there are 2 units\n         remaining to fulfill capacity, and Amazon EMR can only provision an instance with a\n            <code>WeightedCapacity</code> of 5 units, the instance is provisioned, and the target\n         capacity is exceeded by 3 units.</p>\n         <note>\n            <p>If not specified or set to 0, only Spot Instances are provisioned for the instance\n            fleet using <code>TargetSpotCapacity</code>. At least one of\n               <code>TargetSpotCapacity</code> and <code>TargetOnDemandCapacity</code> should be\n            greater than 0. For a master instance fleet, only one of <code>TargetSpotCapacity</code>\n            and <code>TargetOnDemandCapacity</code> can be specified, and its value must be\n            1.</p>\n         </note>"
+          }
+        },
+        "TargetSpotCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The target capacity of Spot units for the instance fleet, which determines how many Spot\n         Instances to provision. When the instance fleet launches, Amazon EMR tries to\n         provision Spot Instances as specified by <a>InstanceTypeConfig</a>. Each\n         instance configuration has a specified <code>WeightedCapacity</code>. When a Spot Instance\n         is provisioned, the <code>WeightedCapacity</code> units count toward the target capacity.\n            Amazon EMR provisions instances until the target capacity is totally fulfilled,\n         even if this results in an overage. For example, if there are 2 units remaining to fulfill\n         capacity, and Amazon EMR can only provision an instance with a\n            <code>WeightedCapacity</code> of 5 units, the instance is provisioned, and the target\n         capacity is exceeded by 3 units.</p>\n         <note>\n            <p>If not specified or set to 0, only On-Demand Instances are provisioned for the\n            instance fleet. At least one of <code>TargetSpotCapacity</code> and\n               <code>TargetOnDemandCapacity</code> should be greater than 0. For a master instance\n            fleet, only one of <code>TargetSpotCapacity</code> and\n               <code>TargetOnDemandCapacity</code> can be specified, and its value must be 1.</p>\n         </note>"
+          }
+        },
+        "InstanceTypeConfigs": {
+          "target": "com.amazonaws.emr#InstanceTypeConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>The instance type configurations that define the Amazon EC2 instances in the\n         instance fleet.</p>"
+          }
+        },
+        "LaunchSpecifications": {
+          "target": "com.amazonaws.emr#InstanceFleetProvisioningSpecifications",
+          "traits": {
+            "smithy.api#documentation": "<p>The launch specification for the instance fleet.</p>"
+          }
+        },
+        "ResizeSpecifications": {
+          "target": "com.amazonaws.emr#InstanceFleetResizingSpecifications",
+          "traits": {
+            "smithy.api#documentation": "<p>The resize specification for the instance fleet.</p>"
+          }
+        },
+        "Context": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that defines an instance fleet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceFleetConfig"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceFleet"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetModifyConfig": {
+      "type": "structure",
+      "members": {
+        "InstanceFleetId": {
+          "target": "com.amazonaws.emr#InstanceFleetId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A unique identifier for the instance fleet.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetOnDemandCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The target capacity of On-Demand units for the instance fleet. For more information see\n            <a>InstanceFleetConfig$TargetOnDemandCapacity</a>.</p>"
+          }
+        },
+        "TargetSpotCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The target capacity of Spot units for the instance fleet. For more information, see\n            <a>InstanceFleetConfig$TargetSpotCapacity</a>.</p>"
+          }
+        },
+        "ResizeSpecifications": {
+          "target": "com.amazonaws.emr#InstanceFleetResizingSpecifications",
+          "traits": {
+            "smithy.api#documentation": "<p>The resize specification for the instance fleet.</p>"
+          }
+        },
+        "InstanceTypeConfigs": {
+          "target": "com.amazonaws.emr#InstanceTypeConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of InstanceTypeConfig objects that specify how Amazon EMR provisions Amazon EC2 instances\n         when it fulfills On-Demand and Spot capacities. For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/APIReference/API_InstanceTypeConfig.html\">InstanceTypeConfig</a>.</p>"
+          }
+        },
+        "Context": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration parameters for an instance fleet modification request.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetProvisioningSpecifications": {
+      "type": "structure",
+      "members": {
+        "SpotSpecification": {
+          "target": "com.amazonaws.emr#SpotProvisioningSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p>The launch specification for Spot instances in the fleet, which determines the allocation strategy, defined\n         duration, and provisioning timeout behavior.</p>"
+          }
+        },
+        "OnDemandSpecification": {
+          "target": "com.amazonaws.emr#OnDemandProvisioningSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p> The launch specification for On-Demand Instances in the instance fleet, which\n         determines the allocation strategy and capacity reservation options.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions. On-Demand Instances allocation strategy is\n            available in Amazon EMR releases 5.12.1 and later.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The launch specification for On-Demand and Spot Instances in the fleet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions. On-Demand and Spot instance allocation\n            strategies are available in Amazon EMR releases 5.12.1 and later.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetResizingSpecifications": {
+      "type": "structure",
+      "members": {
+        "SpotResizeSpecification": {
+          "target": "com.amazonaws.emr#SpotResizingSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p>The resize specification for Spot Instances in the instance fleet, which contains the\n         allocation strategy and the resize timeout period. </p>"
+          }
+        },
+        "OnDemandResizeSpecification": {
+          "target": "com.amazonaws.emr#OnDemandResizingSpecification",
+          "traits": {
+            "smithy.api#documentation": "<p>The resize specification for On-Demand Instances in the instance fleet, which contains\n         the allocation strategy, capacity reservation options, and the resize timeout period. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resize specification for On-Demand and Spot Instances in the fleet.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetState": {
+      "type": "enum",
+      "members": {
+        "PROVISIONING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROVISIONING"
+          }
+        },
+        "BOOTSTRAPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAPPING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "RESIZING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESIZING"
+          }
+        },
+        "RECONFIGURING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RECONFIGURING"
+          }
+        },
+        "SUSPENDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUSPENDED"
+          }
+        },
+        "TERMINATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATING"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetStateChangeReason": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.emr#InstanceFleetStateChangeReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>A code corresponding to the reason the state change occurred.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An explanatory message.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides status change reason details for the instance fleet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetStateChangeReasonCode": {
+      "type": "enum",
+      "members": {
+        "INTERNAL_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_ERROR"
+          }
+        },
+        "VALIDATION_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALIDATION_ERROR"
+          }
+        },
+        "INSTANCE_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_FAILURE"
+          }
+        },
+        "CLUSTER_TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLUSTER_TERMINATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetStatus": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#InstanceFleetState",
+          "traits": {
+            "smithy.api#documentation": "<p>A code representing the instance fleet status.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONING</code>\u2014The instance fleet is provisioning Amazon EC2\n               resources and is not yet ready to run jobs.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BOOTSTRAPPING</code>\u2014Amazon EC2 instances and other resources have\n               been provisioned and the bootstrap actions specified for the instances are\n               underway.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RUNNING</code>\u2014Amazon EC2 instances and other resources are running.\n               They are either executing jobs or waiting to execute jobs.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RESIZING</code>\u2014A resize operation is underway. Amazon EC2 instances\n               are either being added or removed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUSPENDED</code>\u2014A resize operation could not complete. Existing Amazon EC2 instances are running, but instances can't be added or removed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TERMINATING</code>\u2014The instance fleet is terminating Amazon EC2\n               instances.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TERMINATED</code>\u2014The instance fleet is no longer active, and all Amazon EC2 instances have been terminated.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#InstanceFleetStateChangeReason",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides status change reason details for the instance fleet.</p>"
+          }
+        },
+        "Timeline": {
+          "target": "com.amazonaws.emr#InstanceFleetTimeline",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides historical timestamps for the instance fleet, including the time of creation,\n         the time it became ready to run jobs, and the time of termination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of the instance fleet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetTimeline": {
+      "type": "structure",
+      "members": {
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time and date the instance fleet was created.</p>"
+          }
+        },
+        "ReadyDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time and date the instance fleet was ready to run jobs.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time and date the instance fleet terminated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides historical timestamps for the instance fleet, including the time of creation,\n         the time it became ready to run jobs, and the time of termination.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceFleetType": {
+      "type": "enum",
+      "members": {
+        "MASTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MASTER"
+          }
+        },
+        "CORE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CORE"
+          }
+        },
+        "TASK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TASK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceGroup": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#InstanceGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the instance group.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the instance group.</p>"
+          }
+        },
+        "Market": {
+          "target": "com.amazonaws.emr#MarketType",
+          "traits": {
+            "smithy.api#documentation": "<p>The marketplace to provision instances for this group. Valid values are ON_DEMAND or\n         SPOT.</p>"
+          }
+        },
+        "InstanceGroupType": {
+          "target": "com.amazonaws.emr#InstanceGroupType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the instance group. Valid values are MASTER, CORE or TASK.</p>"
+          }
+        },
+        "BidPrice": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price for each Amazon EC2 Spot Instance type as defined by\n         <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided,\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%.</p>"
+          }
+        },
+        "InstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 instance type for all instances in the instance group.</p>"
+          }
+        },
+        "RequestedInstanceCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The target number of instances for the instance group.</p>"
+          }
+        },
+        "RunningInstanceCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of instances currently running in this instance group.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#InstanceGroupStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the instance group.</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<note>\n            <p>Amazon EMR releases 4.x or later.</p>\n         </note>\n         <p>The list of configurations supplied for an Amazon EMR cluster instance group.\n         You can specify a separate configuration for each instance group (master, core, and\n         task).</p>"
+          }
+        },
+        "ConfigurationsVersion": {
+          "target": "com.amazonaws.emr#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of the requested configuration specification for this instance\n         group.</p>"
+          }
+        },
+        "LastSuccessfullyAppliedConfigurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of configurations that were successfully applied for an instance group last\n         time.</p>"
+          }
+        },
+        "LastSuccessfullyAppliedConfigurationsVersion": {
+          "target": "com.amazonaws.emr#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The version number of a configuration specification that was successfully applied for an\n         instance group last time. </p>"
+          }
+        },
+        "EbsBlockDevices": {
+          "target": "com.amazonaws.emr#EbsBlockDeviceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The EBS block devices that are mapped to this instance group.</p>"
+          }
+        },
+        "EbsOptimized": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>If the instance group is EBS-optimized. An Amazon EBS-optimized instance uses an\n         optimized configuration stack and provides additional, dedicated capacity for Amazon EBS I/O.</p>"
+          }
+        },
+        "ShrinkPolicy": {
+          "target": "com.amazonaws.emr#ShrinkPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Policy for customizing shrink operations.</p>"
+          }
+        },
+        "AutoScalingPolicy": {
+          "target": "com.amazonaws.emr#AutoScalingPolicyDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>An automatic scaling policy for a core instance group or task instance group in an\n            Amazon EMR cluster. The automatic scaling policy defines how an instance group\n         dynamically adds and terminates Amazon EC2 instances in response to the value of a\n         CloudWatch metric. See PutAutoScalingPolicy.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom AMI ID to use for the provisioned instance group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This entity represents an instance group, which is a group of instances that have common\n         purpose. For example, CORE instance group is used for HDFS.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupConfig": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Friendly name given to the instance group.</p>"
+          }
+        },
+        "Market": {
+          "target": "com.amazonaws.emr#MarketType",
+          "traits": {
+            "smithy.api#documentation": "<p>Market type of the Amazon EC2 instances used to create a cluster node.</p>"
+          }
+        },
+        "InstanceRole": {
+          "target": "com.amazonaws.emr#InstanceRoleType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The role of the instance group in the cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BidPrice": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price for each Amazon EC2 Spot Instance type as defined by\n         <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided,\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%.</p>"
+          }
+        },
+        "InstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EC2 instance type for all instances in the instance group.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Target number of instances for the instance group.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<note>\n            <p>Amazon EMR releases 4.x or later.</p>\n         </note>\n         <p>The list of configurations supplied for an Amazon EMR cluster instance group.\n         You can specify a separate configuration for each instance group (master, core, and\n         task).</p>"
+          }
+        },
+        "EbsConfiguration": {
+          "target": "com.amazonaws.emr#EbsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>EBS configurations that will be attached to each Amazon EC2 instance in the\n         instance group.</p>"
+          }
+        },
+        "AutoScalingPolicy": {
+          "target": "com.amazonaws.emr#AutoScalingPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>An automatic scaling policy for a core instance group or task instance group in an\n            Amazon EMR cluster. The automatic scaling policy defines how an instance group\n         dynamically adds and terminates Amazon EC2 instances in response to the value of a\n         CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom AMI ID to use for the provisioned instance group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration defining a new instance group.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceGroupConfig"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupDetail": {
+      "type": "structure",
+      "members": {
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Unique identifier for the instance group.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Friendly name for the instance group.</p>"
+          }
+        },
+        "Market": {
+          "target": "com.amazonaws.emr#MarketType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Market type of the Amazon EC2 instances used to create a cluster node.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceRole": {
+          "target": "com.amazonaws.emr#InstanceRoleType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Instance group role in the cluster</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BidPrice": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price for each Amazon EC2 Spot Instance type as defined by\n         <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided,\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%.</p>"
+          }
+        },
+        "InstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Amazon EC2 instance type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceRequestCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Target number of instances to run in the instance group.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceRunningCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Actual count of running instances.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.emr#InstanceGroupState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>State of instance group. The following values are no longer supported: STARTING,\n         TERMINATED, and FAILED.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LastStateChangeReason": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>Details regarding the state of the instance group.</p>"
+          }
+        },
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The date/time the instance group was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StartDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date/time the instance group was started.</p>"
+          }
+        },
+        "ReadyDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date/time the instance group was available to the cluster.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date/time the instance group was terminated.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom AMI ID to use for the provisioned instance group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about an instance group.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceGroupDetail"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupIdsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#XmlStringMaxLen256"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceGroup"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupModifyConfig": {
+      "type": "structure",
+      "members": {
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Unique ID of the instance group to modify.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Target size for the instance group.</p>"
+          }
+        },
+        "EC2InstanceIdsToTerminate": {
+          "target": "com.amazonaws.emr#EC2InstanceIdsToTerminateList",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 InstanceIds to terminate. After you terminate the instances, the\n         instance group will not return to its original requested size.</p>"
+          }
+        },
+        "ShrinkPolicy": {
+          "target": "com.amazonaws.emr#ShrinkPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Policy for customizing shrink operations.</p>"
+          }
+        },
+        "ReconfigurationType": {
+          "target": "com.amazonaws.emr#ReconfigurationType",
+          "traits": {
+            "smithy.api#documentation": "<p>Type of reconfiguration requested. Valid values are MERGE and OVERWRITE.</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of new or modified configurations to apply for an instance group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Modify the size or configurations of an instance group.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupModifyConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceGroupModifyConfig"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupState": {
+      "type": "enum",
+      "members": {
+        "PROVISIONING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROVISIONING"
+          }
+        },
+        "BOOTSTRAPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAPPING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "RECONFIGURING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RECONFIGURING"
+          }
+        },
+        "RESIZING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESIZING"
+          }
+        },
+        "SUSPENDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUSPENDED"
+          }
+        },
+        "TERMINATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATING"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        },
+        "ARRESTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARRESTED"
+          }
+        },
+        "SHUTTING_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHUTTING_DOWN"
+          }
+        },
+        "ENDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENDED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupStateChangeReason": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.emr#InstanceGroupStateChangeReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The programmable code for the state change reason.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status change reason description.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status change reason details for the instance group.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupStateChangeReasonCode": {
+      "type": "enum",
+      "members": {
+        "INTERNAL_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_ERROR"
+          }
+        },
+        "VALIDATION_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALIDATION_ERROR"
+          }
+        },
+        "INSTANCE_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_FAILURE"
+          }
+        },
+        "CLUSTER_TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLUSTER_TERMINATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupStatus": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#InstanceGroupState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current state of the instance group.</p>"
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#InstanceGroupStateChangeReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The status change reason details for the instance group.</p>"
+          }
+        },
+        "Timeline": {
+          "target": "com.amazonaws.emr#InstanceGroupTimeline",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeline of the instance group status over time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of the instance group status.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupTimeline": {
+      "type": "structure",
+      "members": {
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time of the instance group.</p>"
+          }
+        },
+        "ReadyDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the instance group became ready to perform tasks.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the instance group terminated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The timeline of the instance group lifecycle.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupType": {
+      "type": "enum",
+      "members": {
+        "MASTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MASTER"
+          }
+        },
+        "CORE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CORE"
+          }
+        },
+        "TASK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TASK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceGroupTypeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceGroupType"
+      }
+    },
+    "com.amazonaws.emr#InstanceId": {
+      "type": "string"
+    },
+    "com.amazonaws.emr#InstanceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#Instance"
+      }
+    },
+    "com.amazonaws.emr#InstanceResizePolicy": {
+      "type": "structure",
+      "members": {
+        "InstancesToTerminate": {
+          "target": "com.amazonaws.emr#EC2InstanceIdsList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specific list of instances to be terminated when shrinking an instance group.</p>"
+          }
+        },
+        "InstancesToProtect": {
+          "target": "com.amazonaws.emr#EC2InstanceIdsList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specific list of instances to be protected when shrinking an instance group.</p>"
+          }
+        },
+        "InstanceTerminationTimeout": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Decommissioning timeout override for the specific list of instances to be\n         terminated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Custom policy for requesting termination protection or termination of specific instances\n         when shrinking an instance group.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceRoleType": {
+      "type": "enum",
+      "members": {
+        "MASTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MASTER"
+          }
+        },
+        "CORE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CORE"
+          }
+        },
+        "TASK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TASK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceState": {
+      "type": "enum",
+      "members": {
+        "AWAITING_FULFILLMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AWAITING_FULFILLMENT"
+          }
+        },
+        "PROVISIONING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROVISIONING"
+          }
+        },
+        "BOOTSTRAPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAPPING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceStateChangeReason": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.emr#InstanceStateChangeReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The programmable code for the state change reason.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status change reason description.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of the status change reason for the instance.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceStateChangeReasonCode": {
+      "type": "enum",
+      "members": {
+        "INTERNAL_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERNAL_ERROR"
+          }
+        },
+        "VALIDATION_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALIDATION_ERROR"
+          }
+        },
+        "INSTANCE_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSTANCE_FAILURE"
+          }
+        },
+        "BOOTSTRAP_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAP_FAILURE"
+          }
+        },
+        "CLUSTER_TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLUSTER_TERMINATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#InstanceStateList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceState"
+      }
+    },
+    "com.amazonaws.emr#InstanceStatus": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#InstanceState",
+          "traits": {
+            "smithy.api#documentation": "<p>The current state of the instance.</p>"
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#InstanceStateChangeReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the status change reason for the instance.</p>"
+          }
+        },
+        "Timeline": {
+          "target": "com.amazonaws.emr#InstanceTimeline",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeline of the instance status over time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The instance status details.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceTimeline": {
+      "type": "structure",
+      "members": {
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time of the instance.</p>"
+          }
+        },
+        "ReadyDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the instance was ready to perform tasks.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the instance was terminated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The timeline of the instance lifecycle.</p>"
+      }
+    },
+    "com.amazonaws.emr#InstanceType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*$"
+      }
+    },
+    "com.amazonaws.emr#InstanceTypeConfig": {
+      "type": "structure",
+      "members": {
+        "InstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>An Amazon EC2 instance type, such as <code>m3.xlarge</code>. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "WeightedCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of units that a provisioned instance of this type provides toward fulfilling\n         the target capacities defined in <a>InstanceFleetConfig</a>. This value is 1 for\n         a master instance fleet, and must be 1 or greater for core and task instance fleets.\n         Defaults to 1 if not specified. </p>"
+          }
+        },
+        "BidPrice": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price for each Amazon EC2 Spot Instance type as defined by\n            <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor\n            <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided,\n            <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%. </p>"
+          }
+        },
+        "BidPriceAsPercentageOfOnDemandPrice": {
+          "target": "com.amazonaws.emr#NonNegativeDouble",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price, as a percentage of On-Demand price, for each Amazon EC2 Spot\n         Instance as defined by <code>InstanceType</code>. Expressed as a number (for example, 20\n         specifies 20%). If neither <code>BidPrice</code> nor\n            <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided,\n            <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%.</p>"
+          }
+        },
+        "EbsConfiguration": {
+          "target": "com.amazonaws.emr#EbsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of Amazon Elastic Block Store (Amazon EBS) attached to each\n         instance as defined by <code>InstanceType</code>. </p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A configuration classification that applies when provisioning cluster instances, which\n         can include configurations for applications and software that run on the cluster.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom AMI ID to use for the instance type.</p>"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.emr#NonNegativeDouble",
+          "traits": {
+            "smithy.api#documentation": "<p>The priority at which Amazon EMR launches the Amazon EC2 instances with this instance type. \n         Priority starts at 0, which is the highest priority. Amazon EMR considers the highest priority first.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An instance type configuration for each instance type in an instance fleet, which\n         determines the Amazon EC2 instances Amazon EMR attempts to provision to\n         fulfill On-Demand and Spot target capacities. When you use an allocation strategy, you can\n         include a maximum of 30 instance type configurations for a fleet. For more information\n         about how to use an allocation strategy, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html\">Configure Instance\n            Fleets</a>. Without an allocation strategy, you may specify a maximum of five\n         instance type configurations for a fleet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceTypeConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceTypeConfig"
+      }
+    },
+    "com.amazonaws.emr#InstanceTypeSpecification": {
+      "type": "structure",
+      "members": {
+        "InstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 instance type, for example <code>m3.xlarge</code>.</p>"
+          }
+        },
+        "WeightedCapacity": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of units that a provisioned instance of this type provides toward fulfilling\n         the target capacities defined in <a>InstanceFleetConfig</a>. Capacity values\n         represent performance characteristics such as vCPUs, memory, or I/O. If not specified, the\n         default value is 1.</p>"
+          }
+        },
+        "BidPrice": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price for each Amazon EC2 Spot Instance type as defined by\n         <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided,\n         <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%.</p>"
+          }
+        },
+        "BidPriceAsPercentageOfOnDemandPrice": {
+          "target": "com.amazonaws.emr#NonNegativeDouble",
+          "traits": {
+            "smithy.api#documentation": "<p>The bid price, as a percentage of On-Demand price, for each Amazon EC2 Spot\n         Instance as defined by <code>InstanceType</code>. Expressed as a number (for example, 20\n         specifies 20%).</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>A configuration classification that applies when provisioning cluster instances, which\n         can include configurations for applications and software bundled with Amazon EMR.</p>"
+          }
+        },
+        "EbsBlockDevices": {
+          "target": "com.amazonaws.emr#EbsBlockDeviceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration of Amazon Elastic Block Store (Amazon EBS) attached to each\n         instance as defined by <code>InstanceType</code>.</p>"
+          }
+        },
+        "EbsOptimized": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Evaluates to <code>TRUE</code> when the specified <code>InstanceType</code> is\n         EBS-optimized.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom AMI ID to use for the instance type.</p>"
+          }
+        },
+        "Priority": {
+          "target": "com.amazonaws.emr#NonNegativeDouble",
+          "traits": {
+            "smithy.api#documentation": "<p>The priority at which Amazon EMR launches the Amazon EC2 instances with this instance type. \n         Priority starts at 0, which is the highest priority. Amazon EMR considers the highest priority first.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration specification for each instance type in an instance fleet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#InstanceTypeSpecificationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#InstanceTypeSpecification"
+      }
+    },
+    "com.amazonaws.emr#Integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.emr#InternalServerError": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "aws.protocols#awsQueryError": {
+          "code": "InternalFailure",
+          "httpResponseCode": 500
+        },
+        "smithy.api#documentation": "<p>Indicates that an error occurred while processing the request and that the request was\n         not completed.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.emr#InternalServerException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.emr#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The message associated with the exception.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This exception occurs when there is an internal failure in the Amazon EMR\n         service.</p>",
+        "smithy.api#error": "server"
+      }
+    },
+    "com.amazonaws.emr#InvalidRequestException": {
+      "type": "structure",
+      "members": {
+        "ErrorCode": {
+          "target": "com.amazonaws.emr#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code associated with the exception.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The message associated with the exception.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This exception occurs when there is something wrong with user input.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.emr#JobFlowDetail": {
+      "type": "structure",
+      "members": {
+        "JobFlowId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The job flow identifier.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job flow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LogUri": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The location in Amazon S3 where log files for the job are stored.</p>"
+          }
+        },
+        "LogEncryptionKmsKeyId": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key used for encrypting log files. This attribute is only\n         available with Amazon EMR 5.30.0 and later, excluding 6.0.0.</p>"
+          }
+        },
+        "AmiVersion": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies only to Amazon EMR AMI versions 3.x and 2.x. For Amazon EMR\n         releases 4.0 and later, <code>ReleaseLabel</code> is used. To specify a custom AMI, use\n            <code>CustomAmiID</code>.</p>"
+          }
+        },
+        "ExecutionStatusDetail": {
+          "target": "com.amazonaws.emr#JobFlowExecutionStatusDetail",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Describes the execution status of the job flow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Instances": {
+          "target": "com.amazonaws.emr#JobFlowInstancesDetail",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Describes the Amazon EC2 instances of the job flow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Steps": {
+          "target": "com.amazonaws.emr#StepDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of steps run by the job flow.</p>"
+          }
+        },
+        "BootstrapActions": {
+          "target": "com.amazonaws.emr#BootstrapActionDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the bootstrap actions run by the job flow.</p>"
+          }
+        },
+        "SupportedProducts": {
+          "target": "com.amazonaws.emr#SupportedProductsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of strings set by third-party software when the job flow is launched. If you are\n         not using third-party software to manage the job flow, this value is empty.</p>"
+          }
+        },
+        "VisibleToAllUsers": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the cluster is visible to IAM principals in the Amazon Web Services account associated with the cluster. When <code>true</code>, IAM principals in the Amazon Web Services account can perform Amazon EMR cluster\n         actions that their IAM policies allow. When <code>false</code>, only the\n            IAM principal that created the cluster and the Amazon Web Services account\n         root user can perform Amazon EMR actions, regardless of IAM\n         permissions policies attached to other IAM principals.</p>\n         <p>The default value is <code>true</code> if a value is not provided when creating a\n         cluster using the Amazon EMR API <a>RunJobFlow</a> command, the CLI\n         <a href=\"https://docs.aws.amazon.com/cli/latest/reference/emr/create-cluster.html\">create-cluster</a> command, or the Amazon Web Services Management Console.</p>"
+          }
+        },
+        "JobFlowRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role that was specified when the job flow was launched. The\n            Amazon EC2 instances of the job flow assume this role.</p>"
+          }
+        },
+        "ServiceRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role that is assumed by the Amazon EMR service to access\n            Amazon Web Services resources on your behalf.</p>"
+          }
+        },
+        "AutoScalingRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>An IAM role for automatic scaling policies. The default role is\n            <code>EMR_AutoScaling_DefaultRole</code>. The IAM role provides a way for\n         the automatic scaling feature to get the required permissions it needs to launch and\n         terminate Amazon EC2 instances in an instance group.</p>"
+          }
+        },
+        "ScaleDownBehavior": {
+          "target": "com.amazonaws.emr#ScaleDownBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>The way that individual Amazon EC2 instances terminate when an automatic\n         scale-in activity occurs or an instance group is resized.\n            <code>TERMINATE_AT_INSTANCE_HOUR</code> indicates that Amazon EMR terminates\n         nodes at the instance-hour boundary, regardless of when the request to terminate the\n         instance was submitted. This option is only available with Amazon EMR 5.1.0 and\n         later and is the default for clusters created using that version.\n            <code>TERMINATE_AT_TASK_COMPLETION</code> indicates that Amazon EMR adds nodes\n         to a deny list and drains tasks from nodes before terminating the Amazon EC2\n         instances, regardless of the instance-hour boundary. With either behavior, Amazon EMR removes the least active nodes first and blocks instance termination if it could lead to\n         HDFS corruption. <code>TERMINATE_AT_TASK_COMPLETION</code> available only in Amazon EMR releases 4.1.0 and later, and is the default for releases of Amazon EMR earlier than 5.1.0.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A description of a cluster (job flow).</p>"
+      }
+    },
+    "com.amazonaws.emr#JobFlowDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#JobFlowDetail"
+      }
+    },
+    "com.amazonaws.emr#JobFlowExecutionState": {
+      "type": "enum",
+      "members": {
+        "STARTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTING"
+          }
+        },
+        "BOOTSTRAPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOTSTRAPPING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "WAITING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WAITING"
+          }
+        },
+        "SHUTTING_DOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHUTTING_DOWN"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of instance.</p>"
+      }
+    },
+    "com.amazonaws.emr#JobFlowExecutionStateList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#JobFlowExecutionState"
+      }
+    },
+    "com.amazonaws.emr#JobFlowExecutionStatusDetail": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#JobFlowExecutionState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The state of the job flow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The creation date and time of the job flow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StartDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The start date and time of the job flow.</p>"
+          }
+        },
+        "ReadyDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the job flow was ready to start running bootstrap actions.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The completion date and time of the job flow.</p>"
+          }
+        },
+        "LastStateChangeReason": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>Description of the job flow last changed state.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the status of the cluster (job flow).</p>"
+      }
+    },
+    "com.amazonaws.emr#JobFlowInstancesConfig": {
+      "type": "structure",
+      "members": {
+        "MasterInstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 instance type of the master node.</p>"
+          }
+        },
+        "SlaveInstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 instance type of the core and task nodes.</p>"
+          }
+        },
+        "InstanceCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Amazon EC2 instances in the cluster.</p>"
+          }
+        },
+        "InstanceGroups": {
+          "target": "com.amazonaws.emr#InstanceGroupConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration for the instance groups in a cluster.</p>"
+          }
+        },
+        "InstanceFleets": {
+          "target": "com.amazonaws.emr#InstanceFleetConfigList",
+          "traits": {
+            "smithy.api#documentation": "<note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>\n         <p>Describes the Amazon EC2 instances and instance configurations for clusters that\n         use the instance fleet configuration.</p>"
+          }
+        },
+        "Ec2KeyName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon EC2 key pair that can be used to connect to the master\n         node using SSH as the user called \"hadoop.\"</p>"
+          }
+        },
+        "Placement": {
+          "target": "com.amazonaws.emr#PlacementType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Availability Zone in which the cluster runs.</p>"
+          }
+        },
+        "KeepJobFlowAliveWhenNoSteps": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the cluster should remain available after completing all steps.\n         Defaults to <code>false</code>. For more information about configuring cluster termination,\n         see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-termination.html\">Control Cluster Termination</a> in the <i>EMR Management\n         Guide</i>.</p>"
+          }
+        },
+        "TerminationProtected": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to lock the cluster to prevent the Amazon EC2 instances from\n         being terminated by API call, user intervention, or in the event of a job-flow\n         error.</p>"
+          }
+        },
+        "UnhealthyNodeReplacement": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Amazon EMR should gracefully replace core nodes\n         that have degraded within the cluster.</p>"
+          }
+        },
+        "HadoopVersion": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies only to Amazon EMR release versions earlier than 4.0. The Hadoop version\n         for the cluster. Valid inputs are \"0.18\" (no longer maintained), \"0.20\" (no longer\n         maintained), \"0.20.205\" (no longer maintained), \"1.0.3\", \"2.2.0\", or \"2.4.0\". If you do not\n         set this value, the default of 0.18 is used, unless the <code>AmiVersion</code> parameter\n         is set in the RunJobFlow call, in which case the default version of Hadoop for that AMI\n         version is used.</p>"
+          }
+        },
+        "Ec2SubnetId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies to clusters that use the uniform instance group configuration. To launch the\n         cluster in Amazon Virtual Private Cloud (Amazon VPC), set this parameter to the\n         identifier of the Amazon VPC subnet where you want the cluster to launch. If you do\n         not specify this value and your account supports EC2-Classic, the cluster launches in\n         EC2-Classic.</p>"
+          }
+        },
+        "Ec2SubnetIds": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256List",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies to clusters that use the instance fleet configuration. When multiple Amazon EC2 subnet IDs are specified, Amazon EMR evaluates them and launches\n         instances in the optimal subnet.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+          }
+        },
+        "EmrManagedMasterSecurityGroup": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Amazon EC2 security group for the master node. If you\n         specify <code>EmrManagedMasterSecurityGroup</code>, you must also specify\n            <code>EmrManagedSlaveSecurityGroup</code>.</p>"
+          }
+        },
+        "EmrManagedSlaveSecurityGroup": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Amazon EC2 security group for the core and task nodes. If\n         you specify <code>EmrManagedSlaveSecurityGroup</code>, you must also specify\n            <code>EmrManagedMasterSecurityGroup</code>.</p>"
+          }
+        },
+        "ServiceAccessSecurityGroup": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the Amazon EC2 security group for the Amazon EMR\n         service to access clusters in VPC private subnets.</p>"
+          }
+        },
+        "AdditionalMasterSecurityGroups": {
+          "target": "com.amazonaws.emr#SecurityGroupsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of additional Amazon EC2 security group IDs for the master node.</p>"
+          }
+        },
+        "AdditionalSlaveSecurityGroups": {
+          "target": "com.amazonaws.emr#SecurityGroupsList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of additional Amazon EC2 security group IDs for the core and task\n         nodes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A description of the Amazon EC2 instance on which the cluster (job flow) runs. A\n         valid JobFlowInstancesConfig must contain either InstanceGroups or InstanceFleets. They\n         cannot be used together. You may also have MasterInstanceType, SlaveInstanceType, and\n         InstanceCount (all three must be present), but we don't recommend this\n         configuration.</p>"
+      }
+    },
+    "com.amazonaws.emr#JobFlowInstancesDetail": {
+      "type": "structure",
+      "members": {
+        "MasterInstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EC2 master node instance type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MasterPublicDnsName": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The DNS name of the master node. If the cluster is on a private subnet, this is the\n         private DNS name. On a public subnet, this is the public DNS name.</p>"
+          }
+        },
+        "MasterInstanceId": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 instance identifier of the master node.</p>"
+          }
+        },
+        "SlaveInstanceType": {
+          "target": "com.amazonaws.emr#InstanceType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EC2 core and task node instance type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceCount": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The number of Amazon EC2 instances in the cluster. If the value is 1, the same\n         instance serves as both the master and core and task node. If the value is greater than 1,\n         one instance is the master node and all others are core and task nodes.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceGroups": {
+          "target": "com.amazonaws.emr#InstanceGroupDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>Details about the instance groups in a cluster.</p>"
+          }
+        },
+        "NormalizedInstanceHours": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>An approximation of the cost of the cluster, represented in m1.small/hours. This value\n         is increased one time for every hour that an m1.small instance runs. Larger instances are\n         weighted more heavily, so an Amazon EC2 instance that is roughly four times more\n         expensive would result in the normalized instance hours being increased incrementally four\n         times. This result is only an approximation and does not reflect the actual billing\n         rate.</p>"
+          }
+        },
+        "Ec2KeyName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of an Amazon EC2 key pair that can be used to connect to the master\n         node using SSH.</p>"
+          }
+        },
+        "Ec2SubnetId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>For clusters launched within Amazon Virtual Private Cloud, this is the identifier of the\n         subnet where the cluster was launched.</p>"
+          }
+        },
+        "Placement": {
+          "target": "com.amazonaws.emr#PlacementType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 Availability Zone for the cluster.</p>"
+          }
+        },
+        "KeepJobFlowAliveWhenNoSteps": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the cluster should remain available after completing all steps.</p>"
+          }
+        },
+        "TerminationProtected": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the Amazon EC2 instances in the cluster are protected from\n         termination by API calls, user intervention, or in the event of a job-flow error.</p>"
+          }
+        },
+        "UnhealthyNodeReplacement": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Amazon EMR should gracefully replace core nodes\n         that have degraded within the cluster.</p>"
+          }
+        },
+        "HadoopVersion": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Hadoop version for the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specify the type of Amazon EC2 instances that the cluster (job flow) runs\n         on.</p>"
+      }
+    },
+    "com.amazonaws.emr#KerberosAttributes": {
+      "type": "structure",
+      "members": {
+        "Realm": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the Kerberos realm to which all nodes in a cluster belong. For example,\n            <code>EC2.INTERNAL</code>. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KdcAdminPassword": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The password used within the cluster for the kadmin service on the cluster-dedicated\n         KDC, which maintains Kerberos principals, password policies, and keytabs for the\n         cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CrossRealmTrustPrincipalPassword": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Required only when establishing a cross-realm trust with a KDC in a different realm. The\n         cross-realm principal password, which must be identical across realms.</p>"
+          }
+        },
+        "ADDomainJoinUser": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Required only when establishing a cross-realm trust with an Active Directory domain. A\n         user with sufficient privileges to join resources to the domain.</p>"
+          }
+        },
+        "ADDomainJoinPassword": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Active Directory password for <code>ADDomainJoinUser</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Attributes for Kerberos configuration when Kerberos authentication is enabled using a\n         security configuration. For more information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos.html\">Use Kerberos Authentication</a>\n         in the <i>Amazon EMR Management Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.emr#KeyValue": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a key-value pair.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The value part of the identified key.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair.</p>"
+      }
+    },
+    "com.amazonaws.emr#KeyValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#KeyValue"
+      }
+    },
+    "com.amazonaws.emr#ListBootstrapActions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListBootstrapActionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListBootstrapActionsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the bootstrap actions associated with a cluster.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "BootstrapActions"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListBootstrapActionsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The cluster identifier for the bootstrap actions to list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which bootstrap actions to retrieve.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListBootstrapActionsOutput": {
+      "type": "structure",
+      "members": {
+        "BootstrapActions": {
+          "target": "com.amazonaws.emr#CommandList",
+          "traits": {
+            "smithy.api#documentation": "<p>The bootstrap actions associated with the cluster.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This output contains the bootstrap actions detail.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListClusters": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListClustersInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListClustersOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the status of all clusters visible to this Amazon Web Services account. Allows\n         you to filter the list of clusters based on certain criteria; for example, filtering by\n         cluster creation date and time or by status. This call returns a maximum of 50 clusters in\n         unsorted order per call, but returns a marker to track the paging of the cluster list\n         across multiple ListClusters calls.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "Clusters"
+        },
+        "smithy.test#smokeTests": [
+          {
+            "id": "ListClustersSuccess",
+            "params": {},
+            "vendorParams": {
+              "region": "us-west-2"
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "expect": {
+              "success": {}
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.emr#ListClustersInput": {
+      "type": "structure",
+      "members": {
+        "CreatedAfter": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time beginning value filter for listing clusters.</p>"
+          }
+        },
+        "CreatedBefore": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time end value filter for listing clusters.</p>"
+          }
+        },
+        "ClusterStates": {
+          "target": "com.amazonaws.emr#ClusterStateList",
+          "traits": {
+            "smithy.api#documentation": "<p>The cluster state filters to apply when listing clusters. Clusters that change state\n         while this action runs may be not be returned as expected in the list of clusters.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines how the ListClusters action filters the list of clusters that it\n         returns.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListClustersOutput": {
+      "type": "structure",
+      "members": {
+        "Clusters": {
+          "target": "com.amazonaws.emr#ClusterSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of clusters for the account based on the given filters.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This contains a ClusterSummaryList with the cluster details; for example, the cluster\n         IDs, names, and status.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListInstanceFleets": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListInstanceFleetsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListInstanceFleetsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all available details about the instance fleets in a cluster.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "InstanceFleets"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListInstanceFleetsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListInstanceFleetsOutput": {
+      "type": "structure",
+      "members": {
+        "InstanceFleets": {
+          "target": "com.amazonaws.emr#InstanceFleetList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of instance fleets for the cluster and given filters.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListInstanceGroups": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListInstanceGroupsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListInstanceGroupsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides all available details about the instance groups in a cluster.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "InstanceGroups"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListInstanceGroupsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier of the cluster for which to list the instance groups.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which instance groups to retrieve.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListInstanceGroupsOutput": {
+      "type": "structure",
+      "members": {
+        "InstanceGroups": {
+          "target": "com.amazonaws.emr#InstanceGroupList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of instance groups for the cluster and given filters.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which instance groups to retrieve.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListInstances": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListInstancesInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListInstancesOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for all active Amazon EC2 instances and Amazon EC2\n         instances terminated in the last 30 days, up to a maximum of 2,000. Amazon EC2\n         instances in any of the following states are considered active: AWAITING_FULFILLMENT,\n         PROVISIONING, BOOTSTRAPPING, RUNNING.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "Instances"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListInstancesInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier of the cluster for which to list the instances.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#InstanceGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the instance group for which to list the instances.</p>"
+          }
+        },
+        "InstanceGroupTypes": {
+          "target": "com.amazonaws.emr#InstanceGroupTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of instance group for which to list the instances.</p>"
+          }
+        },
+        "InstanceFleetId": {
+          "target": "com.amazonaws.emr#InstanceFleetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the instance fleet.</p>"
+          }
+        },
+        "InstanceFleetType": {
+          "target": "com.amazonaws.emr#InstanceFleetType",
+          "traits": {
+            "smithy.api#documentation": "<p>The node type of the instance fleet. For example MASTER, CORE, or TASK.</p>"
+          }
+        },
+        "InstanceStates": {
+          "target": "com.amazonaws.emr#InstanceStateList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of instance states that will filter the instances returned with this\n         request.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which instances to list.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListInstancesOutput": {
+      "type": "structure",
+      "members": {
+        "Instances": {
+          "target": "com.amazonaws.emr#InstanceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of instances for the cluster and given filters.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This output contains the list of instances.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListNotebookExecutions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListNotebookExecutionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListNotebookExecutionsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides summaries of all notebook executions. You can filter the list based on multiple\n         criteria such as status, time range, and editor id. Returns a maximum of 50 notebook\n         executions and a marker to track the paging of a longer notebook execution list across\n         multiple <code>ListNotebookExecutions</code> calls.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "NotebookExecutions"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListNotebookExecutionsInput": {
+      "type": "structure",
+      "members": {
+        "EditorId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the editor associated with the notebook execution.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#NotebookExecutionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status filter for listing notebook executions.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>START_PENDING</code> indicates that the cluster has received the execution\n               request but execution has not begun.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STARTING</code> indicates that the execution is starting on the\n               cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RUNNING</code> indicates that the execution is being processed by the\n               cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FINISHING</code> indicates that execution processing is in the final\n               stages.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FINISHED</code> indicates that the execution has completed without\n               error.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILING</code> indicates that the execution is failing and will not finish\n               successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> indicates that the execution failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOP_PENDING</code> indicates that the cluster has received a\n                  <code>StopNotebookExecution</code> request and the stop is pending.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPING</code> indicates that the cluster is in the process of stopping the\n               execution as a result of a <code>StopNotebookExecution</code> request.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPED</code> indicates that the execution stopped because of a\n                  <code>StopNotebookExecution</code> request.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "From": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The beginning of time range filter for listing notebook executions. The default is the\n         timestamp of 30 days ago.</p>"
+          }
+        },
+        "To": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The end of time range filter for listing notebook executions. The default is the current\n         timestamp.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token, returned by a previous <code>ListNotebookExecutions</code> call,\n         that indicates the start of the list for this <code>ListNotebookExecutions</code>\n         call.</p>"
+          }
+        },
+        "ExecutionEngineId": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the execution engine.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListNotebookExecutionsOutput": {
+      "type": "structure",
+      "members": {
+        "NotebookExecutions": {
+          "target": "com.amazonaws.emr#NotebookExecutionSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of notebook executions.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token that a subsequent <code>ListNotebookExecutions</code> can use to\n         determine the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListReleaseLabels": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListReleaseLabelsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListReleaseLabelsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves release labels of Amazon EMR services in the Region where the API is\n         called.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListReleaseLabelsInput": {
+      "type": "structure",
+      "members": {
+        "Filters": {
+          "target": "com.amazonaws.emr#ReleaseLabelFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the results of the request. <code>Prefix</code> specifies the prefix of release\n         labels to return. <code>Application</code> specifies the application (with/without version)\n         of release labels to return.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the next page of results. If <code>NextToken</code> is not specified, which is\n         usually the case for the first request of ListReleaseLabels, the first page of results are\n         determined by other filtering parameters or by the latest version. The\n            <code>ListReleaseLabels</code> request fails if the identity (Amazon Web Services account\n         ID) and all filtering parameters are different from the original request, or if the\n            <code>NextToken</code> is expired or tampered with.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.emr#MaxResultsNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the maximum number of release labels to return in a single response. The default\n         is <code>100</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListReleaseLabelsOutput": {
+      "type": "structure",
+      "members": {
+        "ReleaseLabels": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The returned release labels.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Used to paginate the next page of results if specified in the next\n            <code>ListReleaseLabels</code> request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListSecurityConfigurations": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListSecurityConfigurationsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListSecurityConfigurationsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all the security configurations visible to this account, providing their creation\n         dates and times, and their names. This call returns a maximum of 50 clusters per call, but\n         returns a marker to track the paging of the cluster list across multiple\n         ListSecurityConfigurations calls.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "SecurityConfigurations"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListSecurityConfigurationsInput": {
+      "type": "structure",
+      "members": {
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListSecurityConfigurationsOutput": {
+      "type": "structure",
+      "members": {
+        "SecurityConfigurations": {
+          "target": "com.amazonaws.emr#SecurityConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time, and name, of each security configuration.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token that indicates the next set of results to retrieve. Include the\n         marker in the next ListSecurityConfiguration call to retrieve the next page of results, if\n         required.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListSessions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListSessionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListSessionsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the sessions on a cluster. You can filter the results by session state. Newer sessions are returned first.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Sessions"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListSessionsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster to list sessions for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionStates": {
+          "target": "com.amazonaws.emr#SessionStateList",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional filter that limits the results to sessions in the specified states.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token returned by a previous <code>ListSessions</code> call. Use it to retrieve the next page of results.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.emr#MaxResultsNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of sessions to return in each page of results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input to the <code>ListSessions</code> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListSessionsOutput": {
+      "type": "structure",
+      "members": {
+        "Sessions": {
+          "target": "com.amazonaws.emr#SessionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The sessions that match the request.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token to use in a subsequent <code>ListSessions</code> call to retrieve the next page of results. This field is absent when there are no more results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output of the <code>ListSessions</code> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListSteps": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListStepsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListStepsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of steps for the cluster in reverse order unless you specify\n            <code>stepIds</code> with the request or filter by <code>StepStates</code>. You can\n         specify a maximum of 10 <code>stepIDs</code>. The CLI automatically\n         paginates results to return a list greater than 50 steps. To return more than 50 steps\n         using the CLI, specify a <code>Marker</code>, which is a pagination token\n         that indicates the next set of steps to retrieve.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "Steps"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListStepsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The identifier of the cluster for which to list the steps.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepStates": {
+          "target": "com.amazonaws.emr#StepStateList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter to limit the step list based on certain states.</p>"
+          }
+        },
+        "StepIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filter to limit the step list based on the identifier of the steps. You can specify\n         a maximum of ten Step IDs. The character constraint applies to the overall length of the\n         array.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of steps that a single <code>ListSteps</code> action returns is 50.\n         To return a longer list of steps, use multiple <code>ListSteps</code> actions along with\n         the <code>Marker</code> parameter, which is a pagination token that indicates the next set\n         of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input determines which steps to list.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListStepsOutput": {
+      "type": "structure",
+      "members": {
+        "Steps": {
+          "target": "com.amazonaws.emr#StepSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The filtered list of steps for the cluster.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of steps that a single <code>ListSteps</code> action returns is 50.\n         To return a longer list of steps, use multiple <code>ListSteps</code> actions along with\n         the <code>Marker</code> parameter, which is a pagination token that indicates the next set\n         of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This output contains the list of steps returned in reverse order. This means that the\n         last step is the first element in the list.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListStudioSessionMappings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListStudioSessionMappingsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListStudioSessionMappingsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of all user or group session mappings for the Amazon EMR Studio\n         specified by <code>StudioId</code>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "SessionMappings"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListStudioSessionMappingsInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to return session mappings for users or groups. If not specified, the\n         results include session mapping details for both users and groups.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListStudioSessionMappingsOutput": {
+      "type": "structure",
+      "members": {
+        "SessionMappings": {
+          "target": "com.amazonaws.emr#SessionMappingSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of session mapping summary objects. Each object includes session mapping details\n         such as creation time, identity type (user or group), and Amazon EMR Studio\n         ID.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListStudios": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListStudiosInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListStudiosOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of all Amazon EMR Studios associated with the Amazon Web Services account. The list includes details such as ID, Studio Access URL, and\n         creation time for each Studio.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker",
+          "items": "Studios"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListStudiosInput": {
+      "type": "structure",
+      "members": {
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListStudiosOutput": {
+      "type": "structure",
+      "members": {
+        "Studios": {
+          "target": "com.amazonaws.emr#StudioSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of Studio summary objects.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#Marker",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that indicates the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ListSupportedInstanceTypes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ListSupportedInstanceTypesInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ListSupportedInstanceTypesOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>A list of the instance types that Amazon EMR supports. You can filter the\n         list by Amazon Web Services Region and Amazon EMR release. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "Marker",
+          "outputToken": "Marker"
+        }
+      }
+    },
+    "com.amazonaws.emr#ListSupportedInstanceTypesInput": {
+      "type": "structure",
+      "members": {
+        "ReleaseLabel": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EMR release label determines the <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-app-versions-6.x.html\">versions of open-source\n            application packages</a> that Amazon EMR has installed on the cluster.\n         Release labels are in the format <code>emr-x.x.x</code>, where x.x.x is an Amazon EMR release number such as <code>emr-6.10.0</code>. For more information about Amazon EMR releases and their included application versions and features, see the\n               <i>\n               <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-components.html\">Amazon EMR Release\n               Guide</a>\n            </i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that marks the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ListSupportedInstanceTypesOutput": {
+      "type": "structure",
+      "members": {
+        "SupportedInstanceTypes": {
+          "target": "com.amazonaws.emr#SupportedInstanceTypesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of instance types that the release specified in\n            <code>ListSupportedInstanceTypesInput$ReleaseLabel</code> supports, filtered by Amazon Web Services Region.</p>"
+          }
+        },
+        "Marker": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token that marks the next set of results to retrieve.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#LogType": {
+      "type": "enum",
+      "members": {
+        "SYSTEM_LOGS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "system-logs"
+          }
+        },
+        "APPLICATION_LOGS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "application-logs"
+          }
+        },
+        "PERSISTENT_UI_LOGS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "persistent-ui-logs"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#LogTypeMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.emr#LogType"
+      },
+      "value": {
+        "target": "com.amazonaws.emr#LogUploadPolicyValue"
+      }
+    },
+    "com.amazonaws.emr#LogTypesMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.emr#XmlString"
+      },
+      "value": {
+        "target": "com.amazonaws.emr#XmlStringList"
+      }
+    },
+    "com.amazonaws.emr#LogUploadPolicyValue": {
+      "type": "enum",
+      "members": {
+        "EMR_MANAGED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "emr-managed"
+          }
+        },
+        "ON_CUSTOMER_S3ONLY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "on-customer-s3only"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "disabled"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#Long": {
+      "type": "long"
+    },
+    "com.amazonaws.emr#ManagedScalingPolicy": {
+      "type": "structure",
+      "members": {
+        "ComputeLimits": {
+          "target": "com.amazonaws.emr#ComputeLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 unit limits for a managed scaling policy. The managed scaling\n         activity of a cluster is not allowed to go above or below these limits. The limit only\n         applies to the core and task nodes. The master node cannot be scaled after initial\n         configuration.</p>"
+          }
+        },
+        "UtilizationPerformanceIndex": {
+          "target": "com.amazonaws.emr#UtilizationPerformanceIndexInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>An integer value that represents an advanced scaling strategy. Setting a higher value optimizes for performance. Setting a lower value optimizes for resource conservation. Setting the value \n         to 50 balances performance and resource conservation. Possible values are 1, 25, 50, 75, and 100.</p>"
+          }
+        },
+        "ScalingStrategy": {
+          "target": "com.amazonaws.emr#ScalingStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Determines whether a custom scaling utilization performance index can be set. Possible values include <i>ADVANCED</i> or <i>DEFAULT</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Managed scaling policy for an Amazon EMR cluster. The policy specifies the\n         limits for resources that can be added or terminated from a cluster. The policy only\n         applies to the core and task nodes. The master node cannot be scaled after initial\n         configuration. </p>"
+      }
+    },
+    "com.amazonaws.emr#Marker": {
+      "type": "string"
+    },
+    "com.amazonaws.emr#MarketType": {
+      "type": "enum",
+      "members": {
+        "ON_DEMAND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ON_DEMAND"
+          }
+        },
+        "SPOT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPOT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#MaxResultsNumber": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.emr#MetricDimension": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The dimension name.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The dimension value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A CloudWatch dimension, which is specified using a <code>Key</code> (known as a\n            <code>Name</code> in CloudWatch), <code>Value</code> pair. By default, Amazon EMR uses one dimension whose <code>Key</code> is <code>JobFlowID</code> and\n            <code>Value</code> is a variable representing the cluster ID, which is\n            <code>${emr.clusterId}</code>. This enables the rule to bootstrap when the cluster ID\n         becomes available.</p>"
+      }
+    },
+    "com.amazonaws.emr#MetricDimensionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#MetricDimension"
+      }
+    },
+    "com.amazonaws.emr#ModifyCluster": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ModifyClusterInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#ModifyClusterOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Modifies the number of steps that can be executed concurrently for the cluster specified\n         using ClusterID.</p>"
+      }
+    },
+    "com.amazonaws.emr#ModifyClusterInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepConcurrencyLevel": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of steps that can be executed concurrently. You can specify a minimum of 1\n         step and a maximum of 256 steps. We recommend that you do not change this parameter while\n         steps are running or the <code>ActionOnFailure</code> setting may not behave as expected.\n         For more information see <a>Step$ActionOnFailure</a>.</p>"
+          }
+        },
+        "ExtendedSupport": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ModifyClusterOutput": {
+      "type": "structure",
+      "members": {
+        "StepConcurrencyLevel": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of steps that can be executed concurrently.</p>"
+          }
+        },
+        "ExtendedSupport": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ModifyInstanceFleet": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ModifyInstanceFleetInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Modifies the target On-Demand and target Spot capacities for the instance fleet with the\n         specified InstanceFleetID within the cluster specified using ClusterID. The call either\n         succeeds or fails atomically.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#ModifyInstanceFleetInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceFleet": {
+          "target": "com.amazonaws.emr#InstanceFleetModifyConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The configuration parameters of the instance fleet.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ModifyInstanceGroups": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#ModifyInstanceGroupsInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>ModifyInstanceGroups modifies the number of nodes and configuration settings of an\n         instance group. The input parameters include the new target instance count for the group\n         and the instance group ID. The call will either succeed or fail atomically.</p>"
+      }
+    },
+    "com.amazonaws.emr#ModifyInstanceGroupsInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the cluster to which the instance group belongs.</p>"
+          }
+        },
+        "InstanceGroups": {
+          "target": "com.amazonaws.emr#InstanceGroupModifyConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>Instance groups to change.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Change the size of some instance groups.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#MonitoringConfiguration": {
+      "type": "structure",
+      "members": {
+        "CloudWatchLogConfiguration": {
+          "target": "com.amazonaws.emr#CloudWatchLogConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>CloudWatch log configuration settings and metadata that specify settings like log files to monitor and where to send them.</p>"
+          }
+        },
+        "S3LoggingConfiguration": {
+          "target": "com.amazonaws.emr#S3LoggingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>S3 logging configuration that controls how different types of logs (system logs, application logs, and persistent UI logs) are uploaded to S3. Each log type can be configured with a specific upload policy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains CloudWatch log configuration and S3 logging configuration metadata and settings.</p>"
+      }
+    },
+    "com.amazonaws.emr#NewSupportedProductsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#SupportedProductConfig"
+      }
+    },
+    "com.amazonaws.emr#NonNegativeDouble": {
+      "type": "double",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0.0
+        }
+      }
+    },
+    "com.amazonaws.emr#NotebookExecution": {
+      "type": "structure",
+      "members": {
+        "NotebookExecutionId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of a notebook execution.</p>"
+          }
+        },
+        "EditorId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the Amazon EMR Notebook that is used for the notebook\n         execution.</p>"
+          }
+        },
+        "ExecutionEngine": {
+          "target": "com.amazonaws.emr#ExecutionEngineConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution engine, such as an Amazon EMR cluster, used to run the Amazon EMR notebook and perform the notebook execution.</p>"
+          }
+        },
+        "NotebookExecutionName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>A name for the notebook execution.</p>"
+          }
+        },
+        "NotebookParams": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>Input parameters in JSON format passed to the Amazon EMR Notebook at runtime for\n         execution.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#NotebookExecutionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the notebook execution.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>START_PENDING</code> indicates that the cluster has received the execution\n               request but execution has not begun.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STARTING</code> indicates that the execution is starting on the\n               cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RUNNING</code> indicates that the execution is being processed by the\n               cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FINISHING</code> indicates that execution processing is in the final\n               stages.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FINISHED</code> indicates that the execution has completed without\n               error.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILING</code> indicates that the execution is failing and will not finish\n               successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> indicates that the execution failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOP_PENDING</code> indicates that the cluster has received a\n                  <code>StopNotebookExecution</code> request and the stop is pending.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPING</code> indicates that the cluster is in the process of stopping the\n               execution as a result of a <code>StopNotebookExecution</code> request.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPED</code> indicates that the execution stopped because of a\n                  <code>StopNotebookExecution</code> request.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when notebook execution started.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when notebook execution ended.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the notebook execution.</p>"
+          }
+        },
+        "OutputNotebookURI": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the notebook execution's output file in Amazon S3.</p>"
+          }
+        },
+        "LastStateChangeReason": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for the latest status change of the notebook execution.</p>"
+          }
+        },
+        "NotebookInstanceSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the Amazon EC2 security group associated with the\n            Amazon EMR Notebook instance. For more information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-security-groups.html\">Specifying\n               Amazon EC2 Security Groups for Amazon EMR Notebooks</a> in the\n               <i>Amazon EMR Management Guide</i>.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags associated with a notebook execution. Tags are user-defined key-value\n         pairs that consist of a required key string with a maximum of 128 characters and an\n         optional value string with a maximum of 256 characters.</p>"
+          }
+        },
+        "NotebookS3Location": {
+          "target": "com.amazonaws.emr#NotebookS3LocationForOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location that stores the notebook execution input.</p>"
+          }
+        },
+        "OutputNotebookS3Location": {
+          "target": "com.amazonaws.emr#OutputNotebookS3LocationForOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location for the notebook execution output.</p>"
+          }
+        },
+        "OutputNotebookFormat": {
+          "target": "com.amazonaws.emr#OutputNotebookFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The output format for the notebook execution.</p>"
+          }
+        },
+        "EnvironmentVariables": {
+          "target": "com.amazonaws.emr#EnvironmentVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables associated with the notebook execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A notebook execution. An execution is a specific instance that an Amazon EMR\n         Notebook is run using the <code>StartNotebookExecution</code> action.</p>"
+      }
+    },
+    "com.amazonaws.emr#NotebookExecutionStatus": {
+      "type": "enum",
+      "members": {
+        "START_PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "START_PENDING"
+          }
+        },
+        "STARTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "FINISHING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FINISHING"
+          }
+        },
+        "FINISHED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FINISHED"
+          }
+        },
+        "FAILING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "STOP_PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOP_PENDING"
+          }
+        },
+        "STOPPING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOPPING"
+          }
+        },
+        "STOPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOPPED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#NotebookExecutionSummary": {
+      "type": "structure",
+      "members": {
+        "NotebookExecutionId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the notebook execution.</p>"
+          }
+        },
+        "EditorId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the editor associated with the notebook execution.</p>"
+          }
+        },
+        "NotebookExecutionName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the notebook execution.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#NotebookExecutionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the notebook execution.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>START_PENDING</code> indicates that the cluster has received the execution\n               request but execution has not begun.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STARTING</code> indicates that the execution is starting on the\n               cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RUNNING</code> indicates that the execution is being processed by the\n               cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FINISHING</code> indicates that execution processing is in the final\n               stages.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FINISHED</code> indicates that the execution has completed without\n               error.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILING</code> indicates that the execution is failing and will not finish\n               successfully.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> indicates that the execution failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOP_PENDING</code> indicates that the cluster has received a\n                  <code>StopNotebookExecution</code> request and the stop is pending.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPING</code> indicates that the cluster is in the process of stopping the\n               execution as a result of a <code>StopNotebookExecution</code> request.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPED</code> indicates that the execution stopped because of a\n                  <code>StopNotebookExecution</code> request.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when notebook execution started.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when notebook execution started.</p>"
+          }
+        },
+        "NotebookS3Location": {
+          "target": "com.amazonaws.emr#NotebookS3LocationForOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location that stores the notebook execution input.</p>"
+          }
+        },
+        "ExecutionEngineId": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the execution engine for the notebook execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details for a notebook execution. The details include information such as the unique ID\n         and status of the notebook execution.</p>"
+      }
+    },
+    "com.amazonaws.emr#NotebookExecutionSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#NotebookExecutionSummary"
+      }
+    },
+    "com.amazonaws.emr#NotebookS3LocationForOutput": {
+      "type": "structure",
+      "members": {
+        "Bucket": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that stores the notebook execution input.</p>"
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.emr#UriString",
+          "traits": {
+            "smithy.api#documentation": "<p>The key to the Amazon S3 location that stores the notebook execution\n         input.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 location that stores the notebook execution input.</p>"
+      }
+    },
+    "com.amazonaws.emr#NotebookS3LocationFromInput": {
+      "type": "structure",
+      "members": {
+        "Bucket": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that stores the notebook execution input.</p>"
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.emr#UriString",
+          "traits": {
+            "smithy.api#documentation": "<p>The key to the Amazon S3 location that stores the notebook execution\n         input.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 location that stores the notebook execution input.</p>"
+      }
+    },
+    "com.amazonaws.emr#OSRelease": {
+      "type": "structure",
+      "members": {
+        "Label": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Linux release specified for a cluster in the RunJobFlow request. The format\n         is as shown in <a href=\"https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20220218.html\">\n               <i>Amazon Linux 2 Release Notes</i>\n            </a>. For example,\n         2.0.20220218.1.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon Linux release specified for a cluster in the RunJobFlow request.</p>"
+      }
+    },
+    "com.amazonaws.emr#OSReleaseList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#OSRelease"
+      }
+    },
+    "com.amazonaws.emr#OnClusterAppUIType": {
+      "type": "enum",
+      "members": {
+        "SparkHistoryServer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SparkHistoryServer"
+          }
+        },
+        "YarnTimelineService": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "YarnTimelineService"
+          }
+        },
+        "TezUI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TezUI"
+          }
+        },
+        "ApplicationMaster": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ApplicationMaster"
+          }
+        },
+        "JobHistoryServer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "JobHistoryServer"
+          }
+        },
+        "ResourceManager": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ResourceManager"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#OnDemandCapacityReservationOptions": {
+      "type": "structure",
+      "members": {
+        "UsageStrategy": {
+          "target": "com.amazonaws.emr#OnDemandCapacityReservationUsageStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether to use unused Capacity Reservations for fulfilling On-Demand\n         capacity.</p>\n         <p>If you specify <code>use-capacity-reservations-first</code>, the fleet uses unused\n         Capacity Reservations to fulfill On-Demand capacity up to the target On-Demand capacity. If\n         multiple instance pools have unused Capacity Reservations, the On-Demand allocation\n         strategy (<code>lowest-price</code>) is applied. If the number of unused Capacity\n         Reservations is less than the On-Demand target capacity, the remaining On-Demand target\n         capacity is launched according to the On-Demand allocation strategy\n            (<code>lowest-price</code>).</p>\n         <p>If you do not specify a value, the fleet fulfills the On-Demand capacity according to\n         the chosen On-Demand allocation strategy.</p>"
+          }
+        },
+        "CapacityReservationPreference": {
+          "target": "com.amazonaws.emr#OnDemandCapacityReservationPreference",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the instance's Capacity Reservation preferences. Possible preferences\n         include:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>open</code> - The instance can run in any open Capacity Reservation that has\n               matching attributes (instance type, platform, Availability Zone).</p>\n            </li>\n            <li>\n               <p>\n                  <code>none</code> - The instance avoids running in a Capacity Reservation even if\n               one is available. The instance runs as an On-Demand Instance.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "CapacityReservationResourceGroupArn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the Capacity Reservation resource group in which to run the instance.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the strategy for using unused Capacity Reservations for fulfilling On-Demand\n         capacity.</p>"
+      }
+    },
+    "com.amazonaws.emr#OnDemandCapacityReservationPreference": {
+      "type": "enum",
+      "members": {
+        "OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "open"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "none"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#OnDemandCapacityReservationUsageStrategy": {
+      "type": "enum",
+      "members": {
+        "USE_CAPACITY_RESERVATIONS_FIRST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "use-capacity-reservations-first"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#OnDemandProvisioningAllocationStrategy": {
+      "type": "enum",
+      "members": {
+        "LOWEST_PRICE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "lowest-price"
+          }
+        },
+        "PRIORITIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "prioritized"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#OnDemandProvisioningSpecification": {
+      "type": "structure",
+      "members": {
+        "AllocationStrategy": {
+          "target": "com.amazonaws.emr#OnDemandProvisioningAllocationStrategy",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the strategy to use in launching On-Demand instance fleets. Available\n         options are <code>lowest-price</code> and <code>prioritized</code>. <code>lowest-price</code>\n      specifies to launch the instances with the lowest price first, and <code>prioritized</code> specifies\n      that Amazon EMR should launch the instances with the highest priority first. The default is\n      <code>lowest-price</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CapacityReservationOptions": {
+          "target": "com.amazonaws.emr#OnDemandCapacityReservationOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>The launch specification for On-Demand instances in the instance fleet, which determines\n         the allocation strategy.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The launch specification for On-Demand Instances in the instance fleet, which\n         determines the allocation strategy. </p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions. On-Demand Instances allocation strategy is\n            available in Amazon EMR releases 5.12.1 and later.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#OnDemandResizingSpecification": {
+      "type": "structure",
+      "members": {
+        "TimeoutDurationMinutes": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>On-Demand resize timeout in minutes. If On-Demand Instances are not provisioned within\n         this time, the resize workflow stops. The minimum value is 5 minutes, and the maximum value\n         is 10,080 minutes (7 days). The timeout applies to all resize workflows on the Instance\n         Fleet. The resize could be triggered by Amazon EMR Managed Scaling or by the\n         customer (via Amazon EMR Console, Amazon EMR CLI modify-instance-fleet or\n            Amazon EMR SDK ModifyInstanceFleet API) or by Amazon EMR due to Amazon EC2 Spot Reclamation.</p>"
+          }
+        },
+        "AllocationStrategy": {
+          "target": "com.amazonaws.emr#OnDemandProvisioningAllocationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the allocation strategy to use to launch On-Demand instances during a resize. The default is <code>lowest-price</code>.</p>"
+          }
+        },
+        "CapacityReservationOptions": {
+          "target": "com.amazonaws.emr#OnDemandCapacityReservationOptions"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resize specification for On-Demand Instances in the instance fleet, which contains\n         the resize timeout period. </p>"
+      }
+    },
+    "com.amazonaws.emr#OptionalArnType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.emr#OutputNotebookFormat": {
+      "type": "enum",
+      "members": {
+        "HTML": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HTML"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#OutputNotebookS3LocationForOutput": {
+      "type": "structure",
+      "members": {
+        "Bucket": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that stores the notebook execution output.</p>"
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.emr#UriString",
+          "traits": {
+            "smithy.api#documentation": "<p>The key to the Amazon S3 location that stores the notebook execution\n         output.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 location that stores the notebook execution output.</p>"
+      }
+    },
+    "com.amazonaws.emr#OutputNotebookS3LocationFromInput": {
+      "type": "structure",
+      "members": {
+        "Bucket": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that stores the notebook execution output.</p>"
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.emr#UriString",
+          "traits": {
+            "smithy.api#documentation": "<p>The key to the Amazon S3 location that stores the notebook execution\n         output.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 location that stores the notebook execution output.</p>"
+      }
+    },
+    "com.amazonaws.emr#PersistentAppUI": {
+      "type": "structure",
+      "members": {
+        "PersistentAppUIId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the persistent application user interface object.</p>"
+          }
+        },
+        "PersistentAppUITypeList": {
+          "target": "com.amazonaws.emr#PersistentAppUITypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The type list for the persistent application user interface object. Valid values \n         include SHS, YTS, or TEZ.</p>"
+          }
+        },
+        "PersistentAppUIStatus": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The status for the persistent application user interface object.</p>"
+          }
+        },
+        "AuthorId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The author ID for the persistent application user interface object.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation date and time for the persistent application user interface object.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the persistent application user interface object was last changed.</p>"
+          }
+        },
+        "LastStateChangeReason": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason the persistent application user interface object was last changed.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A collection of tags for the persistent application user interface object.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Holds persistent application user interface information. Applications installed on the Amazon EMR cluster publish user interfaces as \n         web sites to monitor cluster activity.</p>"
+      }
+    },
+    "com.amazonaws.emr#PersistentAppUIType": {
+      "type": "enum",
+      "members": {
+        "SHS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHS"
+          }
+        },
+        "TEZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEZ"
+          }
+        },
+        "YTS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "YTS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#PersistentAppUITypeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#PersistentAppUIType"
+      }
+    },
+    "com.amazonaws.emr#PlacementGroupConfig": {
+      "type": "structure",
+      "members": {
+        "InstanceRole": {
+          "target": "com.amazonaws.emr#InstanceRoleType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Role of the instance in the cluster.</p>\n         <p>Starting with Amazon EMR release 5.23.0, the only supported instance role is\n            <code>MASTER</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PlacementStrategy": {
+          "target": "com.amazonaws.emr#PlacementGroupStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon EC2 Placement Group strategy associated with instance role.</p>\n         <p>Starting with Amazon EMR release 5.23.0, the only supported placement strategy\n         is <code>SPREAD</code> for the <code>MASTER</code> instance role.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Placement group configuration for an Amazon EMR cluster. The configuration\n         specifies the placement strategy that can be applied to instance roles during cluster\n         creation.</p>\n         <p>To use this configuration, consider attaching managed policy\n         AmazonElasticMapReducePlacementGroupPolicy to the Amazon EMR role.</p>"
+      }
+    },
+    "com.amazonaws.emr#PlacementGroupConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#PlacementGroupConfig"
+      }
+    },
+    "com.amazonaws.emr#PlacementGroupStrategy": {
+      "type": "enum",
+      "members": {
+        "SPREAD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SPREAD"
+          }
+        },
+        "PARTITION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PARTITION"
+          }
+        },
+        "CLUSTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLUSTER"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#PlacementType": {
+      "type": "structure",
+      "members": {
+        "AvailabilityZone": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 Availability Zone for the cluster. <code>AvailabilityZone</code>\n         is used for uniform instance groups, while <code>AvailabilityZones</code> (plural) is used\n         for instance fleets.</p>"
+          }
+        },
+        "AvailabilityZones": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256List",
+          "traits": {
+            "smithy.api#documentation": "<p>When multiple Availability Zones are specified, Amazon EMR evaluates them and\n         launches instances in the optimal Availability Zone. <code>AvailabilityZones</code> is used\n         for instance fleets, while <code>AvailabilityZone</code> (singular) is used for uniform\n         instance groups.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon EC2 Availability Zone configuration of the cluster (job flow).</p>"
+      }
+    },
+    "com.amazonaws.emr#Port": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": -1,
+          "max": 65535
+        }
+      }
+    },
+    "com.amazonaws.emr#PortRange": {
+      "type": "structure",
+      "members": {
+        "MinRange": {
+          "target": "com.amazonaws.emr#Port",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The smallest port number in a specified range of port numbers.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxRange": {
+          "target": "com.amazonaws.emr#Port",
+          "traits": {
+            "smithy.api#documentation": "<p>The smallest port number in a specified range of port numbers.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A list of port ranges that are permitted to allow inbound traffic from all public IP\n         addresses. To specify a single port, use the same value for <code>MinRange</code> and\n            <code>MaxRange</code>.</p>"
+      }
+    },
+    "com.amazonaws.emr#PortRanges": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#PortRange"
+      }
+    },
+    "com.amazonaws.emr#ProfilerType": {
+      "type": "enum",
+      "members": {
+        "SHS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHS"
+          }
+        },
+        "TEZUI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TEZUI"
+          }
+        },
+        "YTS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "YTS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#PutAutoScalingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#PutAutoScalingPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#PutAutoScalingPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates an automatic scaling policy for a core instance group or task\n         instance group in an Amazon EMR cluster. The automatic scaling policy defines how\n         an instance group dynamically adds and terminates Amazon EC2 instances in response\n         to the value of a CloudWatch metric.</p>"
+      }
+    },
+    "com.amazonaws.emr#PutAutoScalingPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of a cluster. The instance group to which the automatic scaling policy\n         is applied is within this cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#InstanceGroupId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of the instance group to which the automatic scaling policy is\n         applied.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AutoScalingPolicy": {
+          "target": "com.amazonaws.emr#AutoScalingPolicy",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the definition of the automatic scaling policy.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#PutAutoScalingPolicyOutput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the ID of a cluster. The instance group to which the automatic scaling policy\n         is applied is within this cluster.</p>"
+          }
+        },
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#InstanceGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the ID of the instance group to which the scaling policy is applied.</p>"
+          }
+        },
+        "AutoScalingPolicy": {
+          "target": "com.amazonaws.emr#AutoScalingPolicyDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The automatic scaling policy definition.</p>"
+          }
+        },
+        "ClusterArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#PutAutoTerminationPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#PutAutoTerminationPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#PutAutoTerminationPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<note>\n            <p>Auto-termination is supported in Amazon EMR releases 5.30.0 and 6.1.0 and\n            later. For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-auto-termination-policy.html\">Using an\n               auto-termination policy</a>.</p>\n         </note>\n         <p>Creates or updates an auto-termination policy for an Amazon EMR cluster. An\n         auto-termination policy defines the amount of idle time in seconds after which a cluster\n         automatically terminates. For alternative cluster termination options, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-termination.html\">Control\n            cluster termination</a>.</p>"
+      }
+    },
+    "com.amazonaws.emr#PutAutoTerminationPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of the Amazon EMR cluster to which the auto-termination policy\n         will be attached.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AutoTerminationPolicy": {
+          "target": "com.amazonaws.emr#AutoTerminationPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the auto-termination policy to attach to the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#PutAutoTerminationPolicyOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#PutBlockPublicAccessConfiguration": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#PutBlockPublicAccessConfigurationInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#PutBlockPublicAccessConfigurationOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates an Amazon EMR block public access configuration for your\n            Amazon Web Services account in the current Region. For more information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/configure-block-public-access.html\">Configure Block\n            Public Access for Amazon EMR</a> in the <i>Amazon EMR\n            Management Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.emr#PutBlockPublicAccessConfigurationInput": {
+      "type": "structure",
+      "members": {
+        "BlockPublicAccessConfiguration": {
+          "target": "com.amazonaws.emr#BlockPublicAccessConfiguration",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A configuration for Amazon EMR block public access. The configuration applies to\n         all clusters created in your account for the current Region. The configuration specifies\n         whether block public access is enabled. If block public access is enabled, security groups\n         associated with the cluster cannot have rules that allow inbound traffic from 0.0.0.0/0 or\n         ::/0 on a port, unless the port is specified as an exception using\n            <code>PermittedPublicSecurityGroupRuleRanges</code> in the\n            <code>BlockPublicAccessConfiguration</code>. By default, Port 22 (SSH) is an exception,\n         and public access is allowed on this port. You can change this by updating\n            <code>BlockPublicSecurityGroupRules</code> to remove the exception.</p>\n         <note>\n            <p>For accounts that created clusters in a Region before November 25, 2019, block public\n            access is disabled by default in that Region. To use this feature, you must manually\n            enable and configure it. For accounts that did not create an Amazon EMR cluster\n            in a Region before this date, block public access is enabled by default in that\n            Region.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#PutBlockPublicAccessConfigurationOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#PutManagedScalingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#PutManagedScalingPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#PutManagedScalingPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates a managed scaling policy for an Amazon EMR cluster. The\n         managed scaling policy defines the limits for resources, such as Amazon EC2\n         instances that can be added or terminated from a cluster. The policy only applies to the\n         core and task nodes. The master node cannot be scaled after initial configuration. </p>"
+      }
+    },
+    "com.amazonaws.emr#PutManagedScalingPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of an Amazon EMR cluster where the managed scaling policy is\n         attached. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ManagedScalingPolicy": {
+          "target": "com.amazonaws.emr#ManagedScalingPolicy",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the constraints for the managed scaling policy. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#PutManagedScalingPolicyOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ReconfigurationType": {
+      "type": "enum",
+      "members": {
+        "OVERWRITE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OVERWRITE"
+          }
+        },
+        "MERGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MERGE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ReleaseLabelFilter": {
+      "type": "structure",
+      "members": {
+        "Prefix": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Optional release label version prefix filter. For example, <code>emr-5</code>.</p>"
+          }
+        },
+        "Application": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Optional release label application filter. For example, <code>spark@2.1.0</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The release label filters by application or version prefix.</p>"
+      }
+    },
+    "com.amazonaws.emr#RemoveAutoScalingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#RemoveAutoScalingPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#RemoveAutoScalingPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Removes an automatic scaling policy from a specified instance group within an Amazon EMR cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#RemoveAutoScalingPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of a cluster. The instance group to which the automatic scaling policy\n         is applied is within this cluster.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InstanceGroupId": {
+          "target": "com.amazonaws.emr#InstanceGroupId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of the instance group to which the scaling policy is applied.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveAutoScalingPolicyOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveAutoTerminationPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#RemoveAutoTerminationPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#RemoveAutoTerminationPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Removes an auto-termination policy from an Amazon EMR cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#RemoveAutoTerminationPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the ID of the Amazon EMR cluster from which the auto-termination\n         policy will be removed.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveAutoTerminationPolicyOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveManagedScalingPolicy": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#RemoveManagedScalingPolicyInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#RemoveManagedScalingPolicyOutput"
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Removes a managed scaling policy from a specified Amazon EMR cluster. </p>"
+      }
+    },
+    "com.amazonaws.emr#RemoveManagedScalingPolicyInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p> Specifies the ID of the cluster from which the managed scaling policy will be removed.\n      </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveManagedScalingPolicyOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveTags": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#RemoveTagsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#RemoveTagsOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes tags from an Amazon EMR resource, such as a cluster or Amazon EMR Studio. Tags make it easier to associate resources in various ways, such as grouping\n         clusters to track your Amazon EMR resource allocation costs. For more information,\n         see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html\">Tag\n            Clusters</a>. </p>\n         <p>The following example removes the stack tag with value Prod from a cluster:</p>"
+      }
+    },
+    "com.amazonaws.emr#RemoveTagsInput": {
+      "type": "structure",
+      "members": {
+        "ResourceId": {
+          "target": "com.amazonaws.emr#ResourceId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon EMR resource identifier from which tags will be removed. For example,\n         a cluster identifier or an Amazon EMR Studio ID.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.emr#StringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of tag keys to remove from the resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the cluster that scopes the tag operation. Required when the resource being untagged is a session-scoped resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This input identifies an Amazon EMR resource and a list of tags to\n         remove.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#RemoveTagsOutput": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>This output indicates the result of removing tags from the resource.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#RepoUpgradeOnBoot": {
+      "type": "enum",
+      "members": {
+        "SECURITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SECURITY"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ResourceId": {
+      "type": "string"
+    },
+    "com.amazonaws.emr#RunJobFlow": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#RunJobFlowInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#RunJobFlowOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>RunJobFlow creates and starts running a new cluster (job flow). The cluster runs the\n         steps specified. After the steps complete, the cluster stops and the HDFS partition is\n         lost. To prevent loss of data, configure the last step of the job flow to store results in\n            Amazon S3. If the <a>JobFlowInstancesConfig</a>\n            <code>KeepJobFlowAliveWhenNoSteps</code> parameter is set to <code>TRUE</code>, the cluster\n         transitions to the WAITING state rather than shutting down after the steps have completed. </p>\n         <p>For additional protection, you can set the <a>JobFlowInstancesConfig</a>\n            <code>TerminationProtected</code> parameter to <code>TRUE</code> to lock the cluster and\n         prevent it from being terminated by API call, user intervention, or in the event of a job\n         flow error.</p>\n         <p>A maximum of 256 steps are allowed in each job flow.</p>\n         <p>If your cluster is long-running (such as a Hive data warehouse) or complex, you may\n         require more than 256 steps to process your data. You can bypass the 256-step limitation in\n         various ways, including using the SSH shell to connect to the master node and submitting\n         queries directly to the software running on the master node, such as Hive and\n         Hadoop.</p>\n         <p>For long-running clusters, we recommend that you periodically store your results.</p>\n         <note>\n            <p>The instance fleets configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions. The RunJobFlow request can contain\n            InstanceFleets parameters or InstanceGroups parameters, but not both.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#RunJobFlowInput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the job flow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LogUri": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The location in Amazon S3 to write the log files of the job flow. If a value is\n         not provided, logs are not created.</p>"
+          }
+        },
+        "LogEncryptionKmsKeyId": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key used for encrypting log files. If a value is not\n         provided, the logs remain encrypted by AES-256. This attribute is only available with\n            Amazon EMR releases 5.30.0 and later, excluding Amazon EMR 6.0.0.</p>"
+          }
+        },
+        "AdditionalInfo": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>A JSON string for selecting additional features.</p>"
+          }
+        },
+        "AmiVersion": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies only to Amazon EMR AMI versions 3.x and 2.x. For Amazon EMR\n         releases 4.0 and later, <code>ReleaseLabel</code> is used. To specify a custom AMI, use\n            <code>CustomAmiID</code>.</p>"
+          }
+        },
+        "ReleaseLabel": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EMR release label, which determines the version of open-source\n         application packages installed on the cluster. Release labels are in the form\n            <code>emr-x.x.x</code>, where x.x.x is an Amazon EMR release version such as\n            <code>emr-5.14.0</code>. For more information about Amazon EMR release versions\n         and included application versions and features, see <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/\">https://docs.aws.amazon.com/emr/latest/ReleaseGuide/</a>. The release label applies only to Amazon EMR\n         releases version 4.0 and later. Earlier versions use <code>AmiVersion</code>.</p>"
+          }
+        },
+        "Instances": {
+          "target": "com.amazonaws.emr#JobFlowInstancesConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A specification of the number and type of Amazon EC2 instances.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Steps": {
+          "target": "com.amazonaws.emr#StepConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of steps to run.</p>"
+          }
+        },
+        "StepExecutionRoleArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the runtime role for steps specified in the\n         RunJobFlow request. The runtime role can be a cross-account IAM role.\n         The runtime role ARN is a combination of account ID, role name, and role type using the\n         following format: <code>arn:partition:iam::account-id:role/role-name</code>.</p>\n         <p>For example, <code>arn:aws:iam::1234567890:role/ReadOnly</code> is a correctly formatted\n         runtime role ARN.</p>\n         <p>This parameter applies only to steps included in the <code>Steps</code> parameter of this\n         RunJobFlow request. It does not apply to steps added later to the cluster.</p>"
+          }
+        },
+        "BootstrapActions": {
+          "target": "com.amazonaws.emr#BootstrapActionConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of bootstrap actions to run before Hadoop starts on the cluster nodes.</p>"
+          }
+        },
+        "SupportedProducts": {
+          "target": "com.amazonaws.emr#SupportedProductsList",
+          "traits": {
+            "smithy.api#documentation": "<note>\n            <p>For Amazon EMR releases 3.x and 2.x. For Amazon EMR releases 4.x and\n            later, use Applications.</p>\n         </note>\n         <p>A list of strings that indicates third-party software to use. For more information, see\n         the <a href=\"https://docs.aws.amazon.com/emr/latest/DeveloperGuide/emr-dg.pdf\">Amazon EMR Developer Guide</a>. Currently supported values are:</p>\n         <ul>\n            <li>\n               <p>\"mapr-m3\" - launch the job flow using MapR M3 Edition.</p>\n            </li>\n            <li>\n               <p>\"mapr-m5\" - launch the job flow using MapR M5 Edition.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "NewSupportedProducts": {
+          "target": "com.amazonaws.emr#NewSupportedProductsList",
+          "traits": {
+            "smithy.api#documentation": "<note>\n            <p>For Amazon EMR releases 3.x and 2.x. For Amazon EMR releases 4.x and\n            later, use Applications.</p>\n         </note>\n         <p>A list of strings that indicates third-party software to use with the job flow that\n         accepts a user argument list. Amazon EMR accepts and forwards the argument list to\n         the corresponding installation script as bootstrap action arguments. For more information,\n         see \"Launch a Job Flow on the MapR Distribution for Hadoop\" in the <a href=\"https://docs.aws.amazon.com/emr/latest/DeveloperGuide/emr-dg.pdf\">Amazon EMR\n            Developer Guide</a>. Supported values are:</p>\n         <ul>\n            <li>\n               <p>\"mapr-m3\" - launch the cluster using MapR M3 Edition.</p>\n            </li>\n            <li>\n               <p>\"mapr-m5\" - launch the cluster using MapR M5 Edition.</p>\n            </li>\n            <li>\n               <p>\"mapr\" with the user arguments specifying \"--edition,m3\" or \"--edition,m5\" -\n               launch the job flow using MapR M3 or M5 Edition respectively.</p>\n            </li>\n            <li>\n               <p>\"mapr-m7\" - launch the cluster using MapR M7 Edition.</p>\n            </li>\n            <li>\n               <p>\"hunk\" - launch the cluster with the Hunk Big Data Analytics Platform.</p>\n            </li>\n            <li>\n               <p>\"hue\"- launch the cluster with Hue installed.</p>\n            </li>\n            <li>\n               <p>\"spark\" - launch the cluster with Apache Spark installed.</p>\n            </li>\n            <li>\n               <p>\"ganglia\" - launch the cluster with the Ganglia Monitoring System\n               installed.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Applications": {
+          "target": "com.amazonaws.emr#ApplicationList",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies to Amazon EMR releases 4.0 and later. A case-insensitive list of\n         applications for Amazon EMR to install and configure when launching the cluster.\n         For a list of applications available for each Amazon EMR release version, see the\n            <a href=\"https://docs.aws.amazon.com/emr/latest/ReleaseGuide/\">Amazon EMRRelease\n            Guide</a>.</p>"
+          }
+        },
+        "Configurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>For Amazon EMR releases 4.0 and later. The list of configurations supplied for\n         the Amazon EMR cluster that you are creating.</p>"
+          }
+        },
+        "VisibleToAllUsers": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<important>\n            <p>The VisibleToAllUsers parameter is no longer supported. By default, the value is set\n            to <code>true</code>. Setting it to <code>false</code> now has no effect.</p>\n         </important>\n         <p>Set this value to <code>true</code> so that IAM principals in the Amazon Web Services account associated with the cluster can perform Amazon EMR actions on\n         the cluster that their IAM policies allow. This value defaults to\n            <code>true</code> for clusters created using the Amazon EMR API or the CLI\n         <a href=\"https://docs.aws.amazon.com/cli/latest/reference/emr/create-cluster.html\">create-cluster</a> command.</p>\n         <p>When set to <code>false</code>, only the IAM principal that created the\n         cluster and the Amazon Web Services account root user can perform Amazon EMR actions\n         for the cluster, regardless of the IAM permissions policies attached to\n         other IAM principals. For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/security_IAM_emr-with-IAM.html#security_set_visible_to_all_users\">Understanding the Amazon EMR cluster VisibleToAllUsers setting</a> in the\n               <i>Amazon EMR Management Guide</i>.</p>"
+          }
+        },
+        "JobFlowRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>Also called instance profile and Amazon EC2 role. An IAM role for\n         an Amazon EMR cluster. The Amazon EC2 instances of the cluster assume this\n         role. The default role is <code>EMR_EC2_DefaultRole</code>. In order to use the default\n         role, you must have already created it using the CLI or console.</p>"
+          }
+        },
+        "ServiceRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role that Amazon EMR assumes in order to access Amazon Web Services resources on your behalf. If you've created a custom service role path, you\n         must specify it for the service role when you launch your cluster.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags to associate with a cluster and propagate to Amazon EC2\n         instances.</p>"
+          }
+        },
+        "SecurityConfiguration": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a security configuration to apply to the cluster.</p>"
+          }
+        },
+        "AutoScalingRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>An IAM role for automatic scaling policies. The default role is\n            <code>EMR_AutoScaling_DefaultRole</code>. The IAM role provides\n         permissions that the automatic scaling feature requires to launch and terminate Amazon EC2 instances in an instance group.</p>"
+          }
+        },
+        "ScaleDownBehavior": {
+          "target": "com.amazonaws.emr#ScaleDownBehavior",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the way that individual Amazon EC2 instances terminate when an\n         automatic scale-in activity occurs or an instance group is resized.\n            <code>TERMINATE_AT_INSTANCE_HOUR</code> indicates that Amazon EMR terminates\n         nodes at the instance-hour boundary, regardless of when the request to terminate the\n         instance was submitted. This option is only available with Amazon EMR 5.1.0 and\n         later and is the default for clusters created using that version.\n            <code>TERMINATE_AT_TASK_COMPLETION</code> indicates that Amazon EMR adds nodes\n         to a deny list and drains tasks from nodes before terminating the Amazon EC2\n         instances, regardless of the instance-hour boundary. With either behavior, Amazon EMR removes the least active nodes first and blocks instance termination if it could lead to\n         HDFS corruption. <code>TERMINATE_AT_TASK_COMPLETION</code> available only in Amazon EMR releases 4.1.0 and later, and is the default for releases of Amazon EMR earlier than 5.1.0.</p>"
+          }
+        },
+        "CustomAmiId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Available only in Amazon EMR releases 5.7.0 and later. The ID of a custom Amazon\n         EBS-backed Linux AMI. If specified, Amazon EMR uses this AMI when it launches\n         cluster Amazon EC2 instances. For more information about custom AMIs in Amazon EMR, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-custom-ami.html\">Using a Custom AMI</a> in the\n               <i>Amazon EMR Management Guide</i>. If omitted, the cluster\n         uses the base Linux AMI for the <code>ReleaseLabel</code> specified. For Amazon EMR\n         releases 2.x and 3.x, use <code>AmiVersion</code> instead.</p>\n         <p>For information about creating a custom AMI, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html\">Creating an Amazon EBS-Backed Linux AMI</a> in the <i>Amazon Elastic Compute Cloud User Guide for Linux\n            Instances</i>. For information about finding an AMI ID, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html\">Finding a Linux\n            AMI</a>. </p>"
+          }
+        },
+        "EbsRootVolumeSize": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size, in GiB, of the Amazon EBS root device volume of the Linux AMI that is\n         used for each Amazon EC2 instance. Available in Amazon EMR releases 4.x and\n         later.</p>"
+          }
+        },
+        "RepoUpgradeOnBoot": {
+          "target": "com.amazonaws.emr#RepoUpgradeOnBoot",
+          "traits": {
+            "smithy.api#documentation": "<p>Applies only when <code>CustomAmiID</code> is used. Specifies which updates from the\n         Amazon Linux AMI package repositories to apply automatically when the instance boots using\n         the AMI. If omitted, the default is <code>SECURITY</code>, which indicates that only\n         security updates are applied. If <code>NONE</code> is specified, no updates are applied,\n         and all updates must be applied manually.</p>"
+          }
+        },
+        "KerberosAttributes": {
+          "target": "com.amazonaws.emr#KerberosAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Attributes for Kerberos configuration when Kerberos authentication is enabled using a\n         security configuration. For more information see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos.html\">Use Kerberos Authentication</a>\n         in the <i>Amazon EMR Management Guide</i>.</p>"
+          }
+        },
+        "StepConcurrencyLevel": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the number of steps that can be executed concurrently. The default value is\n            <code>1</code>. The maximum value is <code>256</code>.</p>"
+          }
+        },
+        "ManagedScalingPolicy": {
+          "target": "com.amazonaws.emr#ManagedScalingPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p> The specified managed scaling policy for an Amazon EMR cluster. </p>"
+          }
+        },
+        "PlacementGroupConfigs": {
+          "target": "com.amazonaws.emr#PlacementGroupConfigList",
+          "traits": {
+            "smithy.api#documentation": "<p>The specified placement group configuration for an Amazon EMR cluster.</p>"
+          }
+        },
+        "AutoTerminationPolicy": {
+          "target": "com.amazonaws.emr#AutoTerminationPolicy"
+        },
+        "OSReleaseLabel": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a particular Amazon Linux release for all nodes in a cluster launch RunJobFlow\n         request. If a release is not specified, Amazon EMR uses the latest validated Amazon\n         Linux release for cluster launch.</p>"
+          }
+        },
+        "EbsRootVolumeIops": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The IOPS, of the Amazon EBS root device volume of the Linux AMI that is\n            used for each Amazon EC2 instance. Available in Amazon EMR releases 6.15.0 and\n            later.</p>"
+          }
+        },
+        "EbsRootVolumeThroughput": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The throughput, in MiB/s, of the Amazon EBS root device volume of the Linux AMI that is\n            used for each Amazon EC2 instance. Available in Amazon EMR releases 6.15.0 and\n            later.</p>"
+          }
+        },
+        "ExtendedSupport": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Reserved.</p>"
+          }
+        },
+        "MonitoringConfiguration": {
+          "target": "com.amazonaws.emr#MonitoringConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains CloudWatch log configuration metadata and settings.</p>"
+          }
+        },
+        "SessionEnabled": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether Spark Connect sessions are enabled on the cluster. When set to <code>true</code>, you can start Spark Connect sessions using the <code>StartSession</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Input to the <a>RunJobFlow</a> operation. </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#RunJobFlowOutput": {
+      "type": "structure",
+      "members": {
+        "JobFlowId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the job flow.</p>"
+          }
+        },
+        "ClusterArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the cluster.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The result of the <a>RunJobFlow</a> operation. </p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#S3LoggingConfiguration": {
+      "type": "structure",
+      "members": {
+        "LogTypeUploadPolicy": {
+          "target": "com.amazonaws.emr#LogTypeMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map that specifies the upload policy for each log type. The key is the log type, and the value is the upload policy.</p>\n         <p>Valid log types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>system-logs</code>: EMR Daemon logs.</p>\n            </li>\n            <li>\n               <p>\n                  <code>application-logs</code>: Framework logs from Hadoop, Spark, Hive and other applications running on the cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>persistent-ui-logs</code>: Logs required for persistent application UIs such as Spark History Server and Tez UI.</p>\n            </li>\n         </ul>\n         <p>Valid upload policies:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>emr-managed</code>: Standard behavior. Logs are uploaded to S3 bucket as configured in your\n                LogUri, with certain logs retained by the service for operational\n                support and troubleshooting purposes.</p>\n            </li>\n            <li>\n               <p>\n                  <code>on-customer-s3only</code>: Logs are uploaded only to the customer-specified S3 bucket. This requires you to specify a LogUri\n                when creating the cluster. Persistent-ui-logs cannot have\n                on-customer-s3only policy. Allowed policies for persistent-ui-logs\n                are emr-managed and disabled.</p>\n            </li>\n            <li>\n               <p>\n                  <code>disabled</code>: No S3 upload for this log type.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration for S3 logging behavior in EMR clusters. Defines how different types of logs are uploaded to S3 based on the specified upload policies for each log type.</p>"
+      }
+    },
+    "com.amazonaws.emr#S3MonitoringConfiguration": {
+      "type": "structure",
+      "members": {
+        "LogUri": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 destination URI for log publishing.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key ARN to encrypt the logs published to the given Amazon S3 destination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 configuration for monitoring log publishing. You can configure your step to send log information \n         to Amazon S3. When it's specified, it takes precedence over the cluster's logging configuration. If you don't specify this \n         configuration entirely, or omit individual fields, EMR falls back to cluster-level \n         logging behavior.</p>"
+      }
+    },
+    "com.amazonaws.emr#ScaleDownBehavior": {
+      "type": "enum",
+      "members": {
+        "TERMINATE_AT_INSTANCE_HOUR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE_AT_INSTANCE_HOUR"
+          }
+        },
+        "TERMINATE_AT_TASK_COMPLETION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE_AT_TASK_COMPLETION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ScalingAction": {
+      "type": "structure",
+      "members": {
+        "Market": {
+          "target": "com.amazonaws.emr#MarketType",
+          "traits": {
+            "smithy.api#documentation": "<p>Not available for instance groups. Instance groups use the market type specified for the\n         group.</p>"
+          }
+        },
+        "SimpleScalingPolicyConfiguration": {
+          "target": "com.amazonaws.emr#SimpleScalingPolicyConfiguration",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The type of adjustment the automatic scaling activity makes when triggered, and the\n         periodicity of the adjustment.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The type of adjustment the automatic scaling activity makes when triggered, and the\n         periodicity of the adjustment.</p>"
+      }
+    },
+    "com.amazonaws.emr#ScalingConstraints": {
+      "type": "structure",
+      "members": {
+        "MinCapacity": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The lower boundary of Amazon EC2 instances in an instance group below which\n         scaling activities are not allowed to shrink. Scale-in activities will not terminate\n         instances below this boundary.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxCapacity": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The upper boundary of Amazon EC2 instances in an instance group beyond which\n         scaling activities are not allowed to grow. Scale-out activities will not add instances\n         beyond this boundary.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The upper and lower Amazon EC2 instance limits for an automatic scaling policy.\n         Automatic scaling activities triggered by automatic scaling rules will not cause an\n         instance group to grow above or below these limits.</p>"
+      }
+    },
+    "com.amazonaws.emr#ScalingRule": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name used to identify an automatic scaling rule. Rule names must be unique within a\n         scaling policy.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A friendly, more verbose description of the automatic scaling rule.</p>"
+          }
+        },
+        "Action": {
+          "target": "com.amazonaws.emr#ScalingAction",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The conditions that trigger an automatic scaling activity.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Trigger": {
+          "target": "com.amazonaws.emr#ScalingTrigger",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The CloudWatch alarm definition that determines when automatic scaling activity is\n         triggered.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A scale-in or scale-out rule that defines scaling activity, including the CloudWatch\n         metric alarm that triggers activity, how Amazon EC2 instances are added or removed,\n         and the periodicity of adjustments. The automatic scaling policy for an instance group can\n         comprise one or more automatic scaling rules.</p>"
+      }
+    },
+    "com.amazonaws.emr#ScalingRuleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#ScalingRule"
+      }
+    },
+    "com.amazonaws.emr#ScalingStrategy": {
+      "type": "enum",
+      "members": {
+        "DEFAULT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT"
+          }
+        },
+        "ADVANCED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADVANCED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#ScalingTrigger": {
+      "type": "structure",
+      "members": {
+        "CloudWatchAlarmDefinition": {
+          "target": "com.amazonaws.emr#CloudWatchAlarmDefinition",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The definition of a CloudWatch metric alarm. When the defined alarm conditions are met\n         along with other trigger parameters, scaling activity begins.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The conditions that trigger an automatic scaling activity.</p>"
+      }
+    },
+    "com.amazonaws.emr#ScriptBootstrapActionConfig": {
+      "type": "structure",
+      "members": {
+        "Path": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Location in Amazon S3 of the script to run during a bootstrap action.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Args": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of command line arguments to pass to the bootstrap action script.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration of the script to run during a bootstrap action.</p>"
+      }
+    },
+    "com.amazonaws.emr#SecurityConfigurationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#SecurityConfigurationSummary"
+      }
+    },
+    "com.amazonaws.emr#SecurityConfigurationSummary": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the security configuration.</p>"
+          }
+        },
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the security configuration was created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The creation date and time, and name, of a security configuration.</p>"
+      }
+    },
+    "com.amazonaws.emr#SecurityGroupsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#XmlStringMaxLen256"
+      }
+    },
+    "com.amazonaws.emr#SensitiveString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.emr#Session": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#SessionId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the session.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster that the session belongs to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the session, if one was provided at creation time.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the session.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.emr#SessionState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The current state of the session. Valid values are <code>SUBMITTED</code>, <code>STARTING</code>, <code>STARTED</code>, <code>IDLE</code>, <code>BUSY</code>, <code>TERMINATING</code>, <code>TERMINATED</code>, and <code>FAILED</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>A human-readable message describing the most recent state change.</p>"
+          }
+        },
+        "ReleaseLabel": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EMR release label of the cluster that the session is running on.</p>"
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#IAMRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution role ARN for the session. Amazon EMR uses this role to access Amazon Web Services resources on your behalf during session execution.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID that owns the session.</p>"
+          }
+        },
+        "CreatedAt": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the session was created.</p>"
+          }
+        },
+        "UpdatedAt": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the session was last updated.</p>"
+          }
+        },
+        "StartedAt": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the session entered the <code>STARTED</code> state.</p>"
+          }
+        },
+        "EndedAt": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the session was terminated or failed.</p>"
+          }
+        },
+        "IdleSince": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the session last entered the <code>IDLE</code> state.</p>"
+          }
+        },
+        "EngineConfigurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration overrides for the session. Only runtime configuration overrides are supported.</p>"
+          }
+        },
+        "MonitoringConfiguration": {
+          "target": "com.amazonaws.emr#SessionMonitoringConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The monitoring configuration for the session.</p>"
+          }
+        },
+        "SessionIdleTimeoutInMinutes": {
+          "target": "com.amazonaws.emr#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The idle timeout, in minutes. If the session is idle for this duration, Amazon EMR automatically terminates it.</p>"
+          }
+        },
+        "CertificateAuthority": {
+          "target": "com.amazonaws.emr#CertificateAuthority",
+          "traits": {
+            "smithy.api#documentation": "<p>The certificate authority used to establish an mTLS connection to the Spark Connect server when connecting directly over VPC peering.</p>"
+          }
+        },
+        "ServerUrl": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Spark Connect server URL for the session. Use this URL with the <code>Credentials</code> returned by <code>GetSessionEndpoint</code> to connect directly to the session over VPC peering.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags associated with the session.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about a Spark Connect session.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionCloudWatchLoggingConfiguration": {
+      "type": "structure",
+      "members": {
+        "Enabled": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Whether CloudWatch Logs is enabled for the session.</p>"
+          }
+        },
+        "LogGroup": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the log group where session logs are published.</p>"
+          }
+        },
+        "LogStreamNamePrefix": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix applied to the log stream name where session logs are published.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the KMS key used to encrypt the logs published to CloudWatch Logs.</p>"
+          }
+        },
+        "LogTypes": {
+          "target": "com.amazonaws.emr#LogTypesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of log component names (for example, <code>SPARK_DRIVER</code>, <code>SPARK_EXECUTOR</code>) to the list of log types to publish for that component (for example, <code>stdout</code>, <code>stderr</code>).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The CloudWatch Logs configuration for a session.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.emr#SessionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#Session"
+      }
+    },
+    "com.amazonaws.emr#SessionManagedLoggingConfiguration": {
+      "type": "structure",
+      "members": {
+        "Enabled": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Whether Amazon EMR-managed logging is enabled for the session.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the KMS key used to encrypt the managed logs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon EMR-managed logging configuration for a session.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionMappingDetail": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>"
+          }
+        },
+        "IdentityId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The globally unique identifier (GUID) of the user or group.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the user or group. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserName\">UserName</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-DisplayName\">DisplayName</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the identity mapped to the Amazon EMR Studio is a user or a\n         group.</p>"
+          }
+        },
+        "SessionPolicyArn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the session policy associated with the user or\n         group.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the session mapping was created.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the session mapping was last modified.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details for an Amazon EMR Studio session mapping including creation time, user\n         or group ID, Studio ID, and so on.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionMappingSummary": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>"
+          }
+        },
+        "IdentityId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The globally unique identifier (GUID) of the user or group from the IAM Identity Center\n         Identity Store.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the user or group. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserName\">UserName</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-DisplayName\">DisplayName</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the identity mapped to the Amazon EMR Studio is a user or a\n         group.</p>"
+          }
+        },
+        "SessionPolicyArn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the session policy associated with the user or\n         group.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the session mapping was created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details for an Amazon EMR Studio session mapping. The details do not include the\n         time the session mapping was last modified.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionMappingSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#SessionMappingSummary"
+      }
+    },
+    "com.amazonaws.emr#SessionMonitoringConfiguration": {
+      "type": "structure",
+      "members": {
+        "CloudWatchLoggingConfiguration": {
+          "target": "com.amazonaws.emr#SessionCloudWatchLoggingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The CloudWatch Logs configuration for the session.</p>"
+          }
+        },
+        "ManagedLoggingConfiguration": {
+          "target": "com.amazonaws.emr#SessionManagedLoggingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EMR-managed logging configuration for the session.</p>"
+          }
+        },
+        "S3LoggingConfiguration": {
+          "target": "com.amazonaws.emr#SessionS3LoggingConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 logging configuration for the session.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The monitoring configuration for a session. Controls where session logs are published.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionS3LoggingConfiguration": {
+      "type": "structure",
+      "members": {
+        "Enabled": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Whether Amazon S3 logging is enabled for the session.</p>"
+          }
+        },
+        "LogUri": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 destination URI where session logs are published.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the KMS key used to encrypt logs published to Amazon S3.</p>"
+          }
+        },
+        "LogTypes": {
+          "target": "com.amazonaws.emr#LogTypesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of log component names (for example, <code>SPARK_DRIVER</code>, <code>SPARK_EXECUTOR</code>) to the list of log types to publish for that component (for example, <code>stdout</code>, <code>stderr</code>).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 logging configuration for a session.</p>"
+      }
+    },
+    "com.amazonaws.emr#SessionState": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "STARTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTING"
+          }
+        },
+        "STARTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STARTED"
+          }
+        },
+        "IDLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IDLE"
+          }
+        },
+        "BUSY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BUSY"
+          }
+        },
+        "TERMINATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATING"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#SessionStateList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#SessionState"
+      }
+    },
+    "com.amazonaws.emr#SetKeepJobFlowAliveWhenNoSteps": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#SetKeepJobFlowAliveWhenNoStepsInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>You can use the <code>SetKeepJobFlowAliveWhenNoSteps</code> to configure a cluster (job flow) to terminate after the step execution, i.e., all your \n         steps are executed. If you want a transient cluster that shuts down after the last of the current executing steps are completed, \n         you can configure <code>SetKeepJobFlowAliveWhenNoSteps</code> to false. If you want a long running cluster, configure <code>SetKeepJobFlowAliveWhenNoSteps</code> to true.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/UsingEMR_TerminationProtection.html\">Managing Cluster Termination</a> in the <i>Amazon EMR Management Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.emr#SetKeepJobFlowAliveWhenNoStepsInput": {
+      "type": "structure",
+      "members": {
+        "JobFlowIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of strings that uniquely identify the clusters to protect. This identifier is returned by \n         <a href=\"https://docs.aws.amazon.com/emr/latest/APIReference/API_RunJobFlow.html\">RunJobFlow</a> and can also \n         be obtained from <a href=\"https://docs.aws.amazon.com/emr/latest/APIReference/API_DescribeJobFlows.html\">DescribeJobFlows</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KeepJobFlowAliveWhenNoSteps": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A Boolean that indicates whether to terminate the cluster after all steps are executed.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#SetTerminationProtection": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#SetTerminationProtectionInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>SetTerminationProtection locks a cluster (job flow) so the Amazon EC2 instances\n         in the cluster cannot be terminated by user intervention, an API call, or in the event of a\n         job-flow error. The cluster still terminates upon successful completion of the job flow.\n         Calling <code>SetTerminationProtection</code> on a cluster is similar to calling the\n            Amazon EC2\n         <code>DisableAPITermination</code> API on all Amazon EC2 instances in a\n         cluster.</p>\n         <p>\n            <code>SetTerminationProtection</code> is used to prevent accidental termination of a\n         cluster and to ensure that in the event of an error, the instances persist so that you can\n         recover any data stored in their ephemeral instance storage.</p>\n         <p> To terminate a cluster that has been locked by setting\n            <code>SetTerminationProtection</code> to <code>true</code>, you must first unlock the\n         job flow by a subsequent call to <code>SetTerminationProtection</code> in which you set the\n         value to <code>false</code>. </p>\n         <p> For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/UsingEMR_TerminationProtection.html\">Managing Cluster\n            Termination</a> in the <i>Amazon EMR Management Guide</i>. </p>"
+      }
+    },
+    "com.amazonaws.emr#SetTerminationProtectionInput": {
+      "type": "structure",
+      "members": {
+        "JobFlowIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p> A list of strings that uniquely identify the clusters to protect. This identifier is\n         returned by <a>RunJobFlow</a> and can also be obtained from <a>DescribeJobFlows</a> . </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TerminationProtected": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A Boolean that indicates whether to protect the cluster and prevent the Amazon EC2 instances in the cluster from shutting down due to API calls, user intervention, or\n         job-flow error.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The input argument to the <a>TerminationProtection</a> operation. </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#SetUnhealthyNodeReplacement": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#SetUnhealthyNodeReplacementInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Specify whether to enable unhealthy node replacement, which lets Amazon EMR gracefully \n         replace core nodes on a cluster if any nodes become unhealthy. For example, a node becomes \n         unhealthy if disk usage is above 90%. If unhealthy node replacement is on and <code>TerminationProtected</code> are off, \n         Amazon EMR immediately terminates the unhealthy core nodes. To use unhealthy node replacement \n         and retain unhealthy core nodes, use  to turn on\n         termination protection. In such cases, Amazon EMR adds \n         the unhealthy nodes to a denylist, reducing job interruptions and failures.</p>\n         <p>If unhealthy node replacement is on, Amazon EMR \n         notifies YARN and other applications on the cluster to stop scheduling tasks \n         with these nodes, moves the data, and then terminates the nodes.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-node-replacement.html\">graceful \n         node replacement</a> in the <i>Amazon EMR Management Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.emr#SetUnhealthyNodeReplacementInput": {
+      "type": "structure",
+      "members": {
+        "JobFlowIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The list of strings that uniquely identify the clusters for which to turn on \n         unhealthy node replacement. You can get these identifiers by running the \n         <a>RunJobFlow</a> or the <a>DescribeJobFlows</a> operations.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "UnhealthyNodeReplacement": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Indicates whether to turn on or turn off graceful unhealthy node replacement.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#SetVisibleToAllUsers": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#SetVisibleToAllUsersInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<important>\n            <p>The SetVisibleToAllUsers parameter is no longer supported. Your cluster may be\n            visible to all users in your account. To restrict cluster access using an IAM policy, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-access-IAM.html\">Identity and Access\n               Management for Amazon EMR</a>. </p>\n         </important>\n         <p>Sets the <a>Cluster$VisibleToAllUsers</a> value for an Amazon EMR\n         cluster. When <code>true</code>, IAM principals in the Amazon Web Services account can perform Amazon EMR cluster actions that their IAM policies allow. When <code>false</code>, only the IAM\n         principal that created the cluster and the Amazon Web Services account root user can perform\n            Amazon EMR actions on the cluster, regardless of IAM permissions\n         policies attached to other IAM principals.</p>\n         <p>This action works on running clusters. When you create a cluster, use the <a>RunJobFlowInput$VisibleToAllUsers</a> parameter.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/security_IAM_emr-with-IAM.html#security_set_visible_to_all_users\">Understanding the Amazon EMR Cluster VisibleToAllUsers Setting</a> in the\n               <i>Amazon EMR Management Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.emr#SetVisibleToAllUsersInput": {
+      "type": "structure",
+      "members": {
+        "JobFlowIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the job flow (cluster).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VisibleToAllUsers": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A value of <code>true</code> indicates that an IAM principal in the\n            Amazon Web Services account can perform Amazon EMR actions on the cluster that\n         the IAM policies attached to the principal allow. A value of\n            <code>false</code> indicates that only the IAM principal that created the\n         cluster and the Amazon Web Services root user can perform Amazon EMR actions on the\n         cluster.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input to the SetVisibleToAllUsers action.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#ShrinkPolicy": {
+      "type": "structure",
+      "members": {
+        "DecommissionTimeout": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The desired timeout for decommissioning an instance. Overrides the default YARN\n         decommissioning timeout.</p>"
+          }
+        },
+        "InstanceResizePolicy": {
+          "target": "com.amazonaws.emr#InstanceResizePolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom policy for requesting termination protection or termination of specific instances\n         when shrinking an instance group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Policy for customizing shrink operations. Allows configuration of decommissioning\n         timeout and targeted instance shrinking.</p>"
+      }
+    },
+    "com.amazonaws.emr#SimpleScalingPolicyConfiguration": {
+      "type": "structure",
+      "members": {
+        "AdjustmentType": {
+          "target": "com.amazonaws.emr#AdjustmentType",
+          "traits": {
+            "smithy.api#documentation": "<p>The way in which Amazon EC2 instances are added (if\n            <code>ScalingAdjustment</code> is a positive number) or terminated (if\n            <code>ScalingAdjustment</code> is a negative number) each time the scaling activity is\n         triggered. <code>CHANGE_IN_CAPACITY</code> is the default. <code>CHANGE_IN_CAPACITY</code>\n         indicates that the Amazon EC2 instance count increments or decrements by\n            <code>ScalingAdjustment</code>, which should be expressed as an integer.\n            <code>PERCENT_CHANGE_IN_CAPACITY</code> indicates the instance count increments or\n         decrements by the percentage specified by <code>ScalingAdjustment</code>, which should be\n         expressed as an integer. For example, 20 indicates an increase in 20% increments of cluster\n         capacity. <code>EXACT_CAPACITY</code> indicates the scaling activity results in an instance\n         group with the number of Amazon EC2 instances specified by\n            <code>ScalingAdjustment</code>, which should be expressed as a positive integer.</p>"
+          }
+        },
+        "ScalingAdjustment": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The amount by which to scale in or scale out, based on the specified\n            <code>AdjustmentType</code>. A positive value adds to the instance group's Amazon EC2 instance count while a negative number removes instances. If\n            <code>AdjustmentType</code> is set to <code>EXACT_CAPACITY</code>, the number should\n         only be a positive integer. If <code>AdjustmentType</code> is set to\n            <code>PERCENT_CHANGE_IN_CAPACITY</code>, the value should express the percentage as an\n         integer. For example, -20 indicates a decrease in 20% increments of cluster\n         capacity.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CoolDown": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of time, in seconds, after a scaling activity completes before any further\n         trigger-related scaling activities can start. The default value is 0.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An automatic scaling configuration, which describes how the policy adds or removes\n         instances, the cooldown period, and the number of Amazon EC2 instances that will be\n         added each time the CloudWatch metric alarm condition is satisfied.</p>"
+      }
+    },
+    "com.amazonaws.emr#SimplifiedApplication": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The returned release label application name. For example, <code>hadoop</code>.</p>"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The returned release label application version. For example, <code>3.2.1</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The returned release label application names or versions.</p>"
+      }
+    },
+    "com.amazonaws.emr#SimplifiedApplicationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#SimplifiedApplication"
+      }
+    },
+    "com.amazonaws.emr#SpotProvisioningAllocationStrategy": {
+      "type": "enum",
+      "members": {
+        "CAPACITY_OPTIMIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "capacity-optimized"
+          }
+        },
+        "PRICE_CAPACITY_OPTIMIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "price-capacity-optimized"
+          }
+        },
+        "LOWEST_PRICE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "lowest-price"
+          }
+        },
+        "DIVERSIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "diversified"
+          }
+        },
+        "CAPACITY_OPTIMIZED_PRIORITIZED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "capacity-optimized-prioritized"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#SpotProvisioningSpecification": {
+      "type": "structure",
+      "members": {
+        "TimeoutDurationMinutes": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Spot provisioning timeout period in minutes. If Spot Instances are not provisioned\n         within this time period, the <code>TimeOutAction</code> is taken. Minimum value is 5 and\n         maximum value is 1440. The timeout applies only during initial provisioning, when the\n         cluster is first created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TimeoutAction": {
+          "target": "com.amazonaws.emr#SpotProvisioningTimeoutAction",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The action to take when <code>TargetSpotCapacity</code> has not been fulfilled when the\n            <code>TimeoutDurationMinutes</code> has expired; that is, when all Spot Instances could\n         not be provisioned within the Spot provisioning timeout. Valid values are\n            <code>TERMINATE_CLUSTER</code> and <code>SWITCH_TO_ON_DEMAND</code>. SWITCH_TO_ON_DEMAND\n         specifies that if no Spot Instances are available, On-Demand Instances should be\n         provisioned to fulfill any remaining Spot capacity.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BlockDurationMinutes": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The defined duration for Spot Instances (also known as Spot blocks) in minutes. When\n         specified, the Spot Instance does not terminate before the defined duration expires, and\n         defined duration pricing for Spot Instances applies. Valid values are 60, 120, 180, 240,\n         300, or 360. The duration period starts as soon as a Spot Instance receives its instance\n         ID. At the end of the duration, Amazon EC2 marks the Spot Instance for termination\n         and provides a Spot Instance termination notice, which gives the instance a two-minute\n         warning before it terminates. </p>\n         <note>\n            <p>Spot Instances with a defined duration (also known as Spot blocks) are no longer\n            available to new customers from July 1, 2021. For customers who have previously used the\n            feature, we will continue to support Spot Instances with a defined duration until\n            December 31, 2022. </p>\n         </note>"
+          }
+        },
+        "AllocationStrategy": {
+          "target": "com.amazonaws.emr#SpotProvisioningAllocationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies one of the following strategies to launch Spot Instance fleets: \n         <code>capacity-optimized</code>, <code>price-capacity-optimized</code>, <code>lowest-price</code>, or  \n         <code>diversified</code>, and <code>capacity-optimized-prioritized</code>. For more information on the provisioning strategies, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html\">Allocation strategies for Spot Instances</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <note>\n            <p>When you launch a Spot Instance fleet with the old console, it automatically launches with the <code>capacity-optimized</code> strategy. You can't change the allocation strategy from the old console.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The launch specification for Spot Instances in the instance fleet, which determines the\n         defined duration, provisioning timeout behavior, and allocation strategy.</p>\n         <note>\n            <p>The instance fleet configuration is available only in Amazon EMR releases\n            4.8.0 and later, excluding 5.0.x versions. Spot Instance allocation strategy is\n            available in Amazon EMR releases 5.12.1 and later.</p>\n         </note>\n         <note>\n            <p>Spot Instances with a defined duration (also known as Spot blocks) are no longer\n            available to new customers from July 1, 2021. For customers who have previously used the\n            feature, we will continue to support Spot Instances with a defined duration until\n            December 31, 2022. </p>\n         </note>"
+      }
+    },
+    "com.amazonaws.emr#SpotProvisioningTimeoutAction": {
+      "type": "enum",
+      "members": {
+        "SWITCH_TO_ON_DEMAND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SWITCH_TO_ON_DEMAND"
+          }
+        },
+        "TERMINATE_CLUSTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE_CLUSTER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#SpotResizingSpecification": {
+      "type": "structure",
+      "members": {
+        "TimeoutDurationMinutes": {
+          "target": "com.amazonaws.emr#WholeNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>Spot resize timeout in minutes. If Spot Instances are not provisioned within this time,\n         the resize workflow will stop provisioning of Spot instances. Minimum value is 5 minutes\n         and maximum value is 10,080 minutes (7 days). The timeout applies to all resize workflows\n         on the Instance Fleet. The resize could be triggered by Amazon EMR Managed Scaling\n         or by the customer (via Amazon EMR Console, Amazon EMR CLI\n         modify-instance-fleet or Amazon EMR SDK ModifyInstanceFleet API) or by Amazon EMR due to Amazon EC2 Spot Reclamation.</p>"
+          }
+        },
+        "AllocationStrategy": {
+          "target": "com.amazonaws.emr#SpotProvisioningAllocationStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the allocation strategy to use to launch Spot instances during a resize. If you run Amazon EMR releases 6.9.0 or higher,\n      the default is <code>price-capacity-optimized</code>. If you run Amazon EMR releases 6.8.0 or lower, the default is\n      <code>capacity-optimized</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resize specification for Spot Instances in the instance fleet, which contains the\n         resize timeout period. </p>"
+      }
+    },
+    "com.amazonaws.emr#StartNotebookExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#StartNotebookExecutionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#StartNotebookExecutionOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts a notebook execution.</p>"
+      }
+    },
+    "com.amazonaws.emr#StartNotebookExecutionInput": {
+      "type": "structure",
+      "members": {
+        "EditorId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the Amazon EMR Notebook to use for notebook\n         execution.</p>"
+          }
+        },
+        "RelativePath": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The path and file name of the notebook file for this execution, relative to the path\n         specified for the Amazon EMR Notebook. For example, if you specify a path of\n            <code>s3://MyBucket/MyNotebooks</code> when you create an Amazon EMR Notebook\n         for a notebook with an ID of <code>e-ABCDEFGHIJK1234567890ABCD</code> (the\n            <code>EditorID</code> of this request), and you specify a <code>RelativePath</code> of\n            <code>my_notebook_executions/notebook_execution.ipynb</code>, the location of the file\n         for the notebook execution is\n            <code>s3://MyBucket/MyNotebooks/e-ABCDEFGHIJK1234567890ABCD/my_notebook_executions/notebook_execution.ipynb</code>.</p>"
+          }
+        },
+        "NotebookExecutionName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional name for the notebook execution.</p>"
+          }
+        },
+        "NotebookParams": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>Input parameters in JSON format passed to the Amazon EMR Notebook at runtime for\n         execution.</p>"
+          }
+        },
+        "ExecutionEngine": {
+          "target": "com.amazonaws.emr#ExecutionEngineConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies the execution engine (cluster) that runs the notebook execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ServiceRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name or ARN of the IAM role that is used as the service role for\n            Amazon EMR (the Amazon EMR role) for the notebook execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NotebookInstanceSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the Amazon EC2 security group to associate with the\n            Amazon EMR Notebook for this notebook execution.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags associated with a notebook execution. Tags are user-defined key-value\n         pairs that consist of a required key string with a maximum of 128 characters and an\n         optional value string with a maximum of 256 characters.</p>"
+          }
+        },
+        "NotebookS3Location": {
+          "target": "com.amazonaws.emr#NotebookS3LocationFromInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location for the notebook execution input.</p>"
+          }
+        },
+        "OutputNotebookS3Location": {
+          "target": "com.amazonaws.emr#OutputNotebookS3LocationFromInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location for the notebook execution output.</p>"
+          }
+        },
+        "OutputNotebookFormat": {
+          "target": "com.amazonaws.emr#OutputNotebookFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The output format for the notebook execution.</p>"
+          }
+        },
+        "EnvironmentVariables": {
+          "target": "com.amazonaws.emr#EnvironmentVariablesMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The environment variables associated with the notebook execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#StartNotebookExecutionOutput": {
+      "type": "structure",
+      "members": {
+        "NotebookExecutionId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier of the notebook execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#StartSession": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#StartSessionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#StartSessionOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates and starts a new Spark Connect session on the specified cluster. The cluster must be in the <code>RUNNING</code> or <code>WAITING</code> state and have sessions enabled. This operation is supported in Amazon EMR Spark 8.0.0 and later.</p>"
+      }
+    },
+    "com.amazonaws.emr#StartSessionInput": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>An optional name for the session.</p>"
+          }
+        },
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster on which to start the session.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#IAMRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution role ARN for the session. Amazon EMR uses this role to access Amazon Web Services resources on your behalf during session execution.</p>"
+          }
+        },
+        "EngineConfigurations": {
+          "target": "com.amazonaws.emr#ConfigurationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration overrides for the session. Only runtime configuration overrides are supported.</p>"
+          }
+        },
+        "MonitoringConfiguration": {
+          "target": "com.amazonaws.emr#SessionMonitoringConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The monitoring configuration that controls where session logs are published, such as Amazon S3, CloudWatch, or managed logging.</p>"
+          }
+        },
+        "SessionIdleTimeoutInMinutes": {
+          "target": "com.amazonaws.emr#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The idle timeout, in minutes. If the session is idle for this duration, Amazon EMR EC2 automatically terminates it.</p>"
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.emr#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique, case-sensitive identifier that you provide to ensure the idempotency of the request. If you retry a request that completed successfully using the same client request token, the service returns the original response without performing the operation again.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags to assign to the session.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input to the <code>StartSession</code> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#StartSessionOutput": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#SessionId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The output contains the ID of the session.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the cluster that the session was started on.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The output contains the ARN of the session.</p>"
+          }
+        },
+        "AccountId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services account ID that owns the session.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.emr#SessionState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the session at the time the request returned. When a session is first created, it enters the <code>SUBMITTED</code> state.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output of the <code>StartSession</code> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#Statistic": {
+      "type": "enum",
+      "members": {
+        "SAMPLE_COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SAMPLE_COUNT"
+          }
+        },
+        "AVERAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AVERAGE"
+          }
+        },
+        "SUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUM"
+          }
+        },
+        "MINIMUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MINIMUM"
+          }
+        },
+        "MAXIMUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAXIMUM"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#Step": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#StepId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the cluster step.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the cluster step.</p>"
+          }
+        },
+        "Config": {
+          "target": "com.amazonaws.emr#HadoopStepConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The Hadoop job configuration of the cluster step.</p>"
+          }
+        },
+        "ActionOnFailure": {
+          "target": "com.amazonaws.emr#ActionOnFailure",
+          "traits": {
+            "smithy.api#documentation": "<p>The action to take when the cluster step fails. Possible values are\n            <code>TERMINATE_CLUSTER</code>, <code>CANCEL_AND_WAIT</code>, and <code>CONTINUE</code>.\n            <code>TERMINATE_JOB_FLOW</code> is provided for backward compatibility. We recommend\n         using <code>TERMINATE_CLUSTER</code> instead.</p>\n         <p>If a cluster's <code>StepConcurrencyLevel</code> is greater than <code>1</code>, do not\n         use <code>AddJobFlowSteps</code> to submit a step with this parameter set to\n            <code>CANCEL_AND_WAIT</code> or <code>TERMINATE_CLUSTER</code>. The step is not\n         submitted and the action fails with a message that the <code>ActionOnFailure</code> setting\n         is not valid.</p>\n         <p>If you change a cluster's <code>StepConcurrencyLevel</code> to be greater than 1 while a\n         step is running, the <code>ActionOnFailure</code> parameter may not behave as you expect.\n         In this case, for a step that fails with this parameter set to\n         <code>CANCEL_AND_WAIT</code>, pending steps and the running step are not canceled; for a\n         step that fails with this parameter set to <code>TERMINATE_CLUSTER</code>, the cluster does\n         not terminate.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#StepStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current execution status details of the cluster step.</p>"
+          }
+        },
+        "ExecutionRoleArn": {
+          "target": "com.amazonaws.emr#OptionalArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the runtime role for a step on the cluster. The\n         runtime role can be a cross-account IAM role. The runtime role ARN is a\n         combination of account ID, role name, and role type using the following format:\n            <code>arn:partition:service:region:account:resource</code>. </p>\n         <p>For example, <code>arn:aws:IAM::1234567890:role/ReadOnly</code> is a correctly formatted\n         runtime role ARN.</p>"
+          }
+        },
+        "LogUri": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 destination URI for log publishing.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key ARN to encrypt the logs published to the given Amazon S3\n         destination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This represents a step in a cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepCancellationOption": {
+      "type": "enum",
+      "members": {
+        "SEND_INTERRUPT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEND_INTERRUPT"
+          }
+        },
+        "TERMINATE_PROCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE_PROCESS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#StepConfig": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The name of the step.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ActionOnFailure": {
+          "target": "com.amazonaws.emr#ActionOnFailure",
+          "traits": {
+            "smithy.api#documentation": "<p>The action to take when the step fails. Use one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE_CLUSTER</code> - Shuts down the cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CANCEL_AND_WAIT</code> - Cancels any pending steps and returns the cluster\n               to the <code>WAITING</code> state.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CONTINUE</code> - Continues to the next step in the queue.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TERMINATE_JOB_FLOW</code> - Shuts down the cluster.\n                  <code>TERMINATE_JOB_FLOW</code> is provided for backward compatibility. We\n               recommend using <code>TERMINATE_CLUSTER</code> instead.</p>\n            </li>\n         </ul>\n         <p>If a cluster's <code>StepConcurrencyLevel</code> is greater than <code>1</code>, do not\n         use <code>AddJobFlowSteps</code> to submit a step with this parameter set to\n            <code>CANCEL_AND_WAIT</code> or <code>TERMINATE_CLUSTER</code>. The step is not\n         submitted and the action fails with a message that the <code>ActionOnFailure</code> setting\n         is not valid.</p>\n         <p>If you change a cluster's <code>StepConcurrencyLevel</code> to be greater than 1 while a\n         step is running, the <code>ActionOnFailure</code> parameter may not behave as you expect.\n         In this case, for a step that fails with this parameter set to\n         <code>CANCEL_AND_WAIT</code>, pending steps and the running step are not canceled; for a\n         step that fails with this parameter set to <code>TERMINATE_CLUSTER</code>, the cluster does\n         not terminate.</p>"
+          }
+        },
+        "HadoopJarStep": {
+          "target": "com.amazonaws.emr#HadoopJarStepConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The JAR file used for the step.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StepMonitoringConfiguration": {
+          "target": "com.amazonaws.emr#StepMonitoringConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Object that holds configuration properties for logging.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specification for a cluster (job flow) step.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#StepConfig"
+      }
+    },
+    "com.amazonaws.emr#StepDetail": {
+      "type": "structure",
+      "members": {
+        "StepConfig": {
+          "target": "com.amazonaws.emr#StepConfig",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The step configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ExecutionStatusDetail": {
+          "target": "com.amazonaws.emr#StepExecutionStatusDetail",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The description of the step status.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Combines the execution state and configuration of a step.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#StepDetail"
+      }
+    },
+    "com.amazonaws.emr#StepExecutionState": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "CONTINUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTINUE"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "CANCELLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCELLED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "INTERRUPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERRUPTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#StepExecutionStatusDetail": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#StepExecutionState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The state of the step.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The creation date and time of the step.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "StartDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The start date and time of the step.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The completion date and time of the step.</p>"
+          }
+        },
+        "LastStateChangeReason": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the step's current state.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The execution state of a step.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepId": {
+      "type": "string"
+    },
+    "com.amazonaws.emr#StepIdsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#XmlStringMaxLen256"
+      }
+    },
+    "com.amazonaws.emr#StepMonitoringConfiguration": {
+      "type": "structure",
+      "members": {
+        "S3MonitoringConfiguration": {
+          "target": "com.amazonaws.emr#S3MonitoringConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 configuration for monitoring log publishing. You can configure your step to send log information \n         to Amazon S3. When it's specified, it takes precedence over the cluster's logging configuration. If you don't specify this \n         configuration entirely, or omit individual fields, EMR falls back to cluster-level logging behavior.\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Object that holds configuration properties for logging.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepState": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "CANCEL_PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCEL_PENDING"
+          }
+        },
+        "RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RUNNING"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "CANCELLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCELLED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "INTERRUPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERRUPTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#StepStateChangeReason": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.emr#StepStateChangeReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The programmable code for the state change reason. Note: Currently, the service provides\n         no code for the state change.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The descriptive message for the state change reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of the step state change reason.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepStateChangeReasonCode": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#StepStateList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#StepState"
+      }
+    },
+    "com.amazonaws.emr#StepStatus": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.emr#StepState",
+          "traits": {
+            "smithy.api#documentation": "<p>The execution state of the cluster step.</p>"
+          }
+        },
+        "StateChangeReason": {
+          "target": "com.amazonaws.emr#StepStateChangeReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for the step execution status change.</p>"
+          }
+        },
+        "FailureDetails": {
+          "target": "com.amazonaws.emr#FailureDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The details for the step failure including reason, message, and log file path where the\n         root cause was identified.</p>"
+          }
+        },
+        "Timeline": {
+          "target": "com.amazonaws.emr#StepTimeline",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeline of the cluster step status over time.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The execution status details of the cluster step.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepSummary": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.emr#StepId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the cluster step.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the cluster step.</p>"
+          }
+        },
+        "Config": {
+          "target": "com.amazonaws.emr#HadoopStepConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The Hadoop job configuration of the cluster step.</p>"
+          }
+        },
+        "ActionOnFailure": {
+          "target": "com.amazonaws.emr#ActionOnFailure",
+          "traits": {
+            "smithy.api#documentation": "<p>The action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER,\n         CANCEL_AND_WAIT, and CONTINUE. TERMINATE_JOB_FLOW is available for backward\n         compatibility.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.emr#StepStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current execution status details of the cluster step.</p>"
+          }
+        },
+        "LogUri": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 destination URI for log publishing.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key ARN to encrypt the logs published to the given Amazon S3 \n         destination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The summary of the cluster step.</p>"
+      }
+    },
+    "com.amazonaws.emr#StepSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#StepSummary"
+      }
+    },
+    "com.amazonaws.emr#StepTimeline": {
+      "type": "structure",
+      "members": {
+        "CreationDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the cluster step was created.</p>"
+          }
+        },
+        "StartDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the cluster step execution started.</p>"
+          }
+        },
+        "EndDateTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the cluster step execution completed or failed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The timeline of the cluster step lifecycle.</p>"
+      }
+    },
+    "com.amazonaws.emr#StopNotebookExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#StopNotebookExecutionInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops a notebook execution.</p>"
+      }
+    },
+    "com.amazonaws.emr#StopNotebookExecutionInput": {
+      "type": "structure",
+      "members": {
+        "NotebookExecutionId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The unique identifier of the notebook execution.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#String": {
+      "type": "string"
+    },
+    "com.amazonaws.emr#StringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#String"
+      }
+    },
+    "com.amazonaws.emr#StringMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.emr#String"
+      },
+      "value": {
+        "target": "com.amazonaws.emr#String"
+      }
+    },
+    "com.amazonaws.emr#Studio": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>"
+          }
+        },
+        "StudioArn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon EMR Studio.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon EMR Studio.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The detailed description of the Amazon EMR Studio.</p>"
+          }
+        },
+        "AuthMode": {
+          "target": "com.amazonaws.emr#AuthMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the Amazon EMR Studio authenticates users with IAM or IAM Identity Center.</p>"
+          }
+        },
+        "VpcId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the VPC associated with the Amazon EMR Studio.</p>"
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.emr#SubnetIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of IDs of the subnets associated with the Amazon EMR Studio.</p>"
+          }
+        },
+        "ServiceRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the IAM role assumed by the Amazon EMR Studio.</p>"
+          }
+        },
+        "UserRole": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the IAM role assumed by users logged in to the Amazon EMR Studio. A Studio only requires a <code>UserRole</code> when you use IAM authentication.</p>"
+          }
+        },
+        "WorkspaceSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Workspace security group associated with the Amazon EMR Studio.\n         The Workspace security group allows outbound network traffic to resources in the Engine\n         security group and to the internet.</p>"
+          }
+        },
+        "EngineSecurityGroupId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Engine security group associated with the Amazon EMR Studio. The\n         Engine security group allows inbound network traffic from resources in the Workspace\n         security group.</p>"
+          }
+        },
+        "Url": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique access URL of the Amazon EMR Studio.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the Amazon EMR Studio was created.</p>"
+          }
+        },
+        "DefaultS3Location": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location to back up Amazon EMR Studio Workspaces and\n         notebook files.</p>"
+          }
+        },
+        "IdpAuthUrl": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>Your identity provider's authentication endpoint. Amazon EMR Studio redirects\n         federated users to this endpoint for authentication when logging in to a Studio with the\n         Studio URL.</p>"
+          }
+        },
+        "IdpRelayStateParameterName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of your identity provider's <code>RelayState</code> parameter.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.emr#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags associated with the Amazon EMR Studio.</p>"
+          }
+        },
+        "IdcInstanceArn": {
+          "target": "com.amazonaws.emr#ArnType",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The ARN of the IAM Identity Center instance the Studio application belongs to.\n      </p>"
+          }
+        },
+        "TrustedIdentityPropagationEnabled": {
+          "target": "com.amazonaws.emr#BooleanObject",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Indicates whether the Studio has Trusted identity propagation enabled. The default value is <code>false</code>.\n      </p>"
+          }
+        },
+        "IdcUserAssignment": {
+          "target": "com.amazonaws.emr#IdcUserAssignment",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Indicates whether the Studio has <code>REQUIRED</code> or <code>OPTIONAL</code> IAM Identity Center user assignment. If the value is set to <code>REQUIRED</code>, users must be explicitly assigned to the Studio application to access the Studio.\n      </p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key identifier (ARN) used to encrypt Amazon EMR Studio workspace and notebook files when backed up to Amazon S3.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details for an Amazon EMR Studio including ID, creation time, name, and so\n         on.</p>"
+      }
+    },
+    "com.amazonaws.emr#StudioSummary": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon EMR Studio.</p>"
+          }
+        },
+        "VpcId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the Virtual Private Cloud (Amazon VPC) associated with the Amazon EMR Studio.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The detailed description of the Amazon EMR Studio.</p>"
+          }
+        },
+        "Url": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique access URL of the Amazon EMR Studio.</p>"
+          }
+        },
+        "AuthMode": {
+          "target": "com.amazonaws.emr#AuthMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the Studio authenticates users using IAM or IAM Identity Center.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.emr#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Amazon EMR Studio was created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details for an Amazon EMR Studio, including ID, Name, VPC, and Description. To fetch additional details such as subnets, IAM roles, \n         security groups, and tags for the Studio, use the <a>DescribeStudio</a> API.</p>"
+      }
+    },
+    "com.amazonaws.emr#StudioSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#StudioSummary"
+      }
+    },
+    "com.amazonaws.emr#SubnetIdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#String"
+      }
+    },
+    "com.amazonaws.emr#SupportedInstanceType": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The <a href=\"http://aws.amazon.com/ec2/instance-types/\">Amazon EC2 instance\n            type</a>, for example <code>m5.xlarge</code>, of the\n            <code>SupportedInstanceType</code>.</p>"
+          }
+        },
+        "MemoryGB": {
+          "target": "com.amazonaws.emr#Float",
+          "traits": {
+            "smithy.api#documentation": "<p>The amount of memory that is available to Amazon EMR from the <code>SupportedInstanceType</code>. The kernel and hypervisor\n         software consume some memory, so this value might be lower than the overall memory for the\n         instance type.</p>"
+          }
+        },
+        "StorageGB": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            <code>StorageGB</code> represents the storage capacity of the\n            <code>SupportedInstanceType</code>. This value is <code>0</code> for Amazon EBS-only instance types.</p>"
+          }
+        },
+        "VCPU": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of vCPUs available for the <code>SupportedInstanceType</code>.</p>"
+          }
+        },
+        "Is64BitsOnly": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the <code>SupportedInstanceType</code> only supports 64-bit\n         architecture.</p>"
+          }
+        },
+        "InstanceFamilyId": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon EC2 family and generation for the\n         <code>SupportedInstanceType</code>.</p>"
+          }
+        },
+        "EbsOptimizedAvailable": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the <code>SupportedInstanceType</code> supports Amazon EBS\n         optimization.</p>"
+          }
+        },
+        "EbsOptimizedByDefault": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the <code>SupportedInstanceType</code> uses Amazon EBS\n         optimization by default.</p>"
+          }
+        },
+        "NumberOfDisks": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>Number of disks for the <code>SupportedInstanceType</code>. This value is <code>0</code>\n         for Amazon EBS-only instance types.</p>"
+          }
+        },
+        "EbsStorageOnly": {
+          "target": "com.amazonaws.emr#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the <code>SupportedInstanceType</code> only supports Amazon EBS.</p>"
+          }
+        },
+        "Architecture": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The CPU architecture, for example <code>X86_64</code> or <code>AARCH64</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An instance type that the specified Amazon EMR release supports.</p>"
+      }
+    },
+    "com.amazonaws.emr#SupportedInstanceTypesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#SupportedInstanceType"
+      }
+    },
+    "com.amazonaws.emr#SupportedProductConfig": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the product configuration.</p>"
+          }
+        },
+        "Args": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of user-supplied arguments.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The list of supported product configurations that allow user-supplied arguments. Amazon EMR accepts these arguments and forwards them to the corresponding installation\n         script as bootstrap action arguments.</p>"
+      }
+    },
+    "com.amazonaws.emr#SupportedProductsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#XmlStringMaxLen256"
+      }
+    },
+    "com.amazonaws.emr#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A user-defined key, which is the minimum required information for a valid tag. For more\n         information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html\">Tag</a>. </p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A user-defined value, which is optional in a tag. For more information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html\">Tag\n            Clusters</a>. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair containing user-defined metadata that you can associate with an Amazon EMR resource. Tags make it easier to associate clusters in various ways, such as\n         grouping clusters to track your Amazon EMR resource allocation costs. For more\n         information, see <a href=\"https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html\">Tag Clusters</a>. </p>"
+      }
+    },
+    "com.amazonaws.emr#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#Tag"
+      }
+    },
+    "com.amazonaws.emr#TerminateJobFlows": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#TerminateJobFlowsInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>TerminateJobFlows shuts a list of clusters (job flows) down. When a job flow is shut\n         down, any step not yet completed is canceled and the Amazon EC2 instances on which\n         the cluster is running are stopped. Any log files not already saved are uploaded to Amazon S3 if a LogUri was specified when the cluster was created.</p>\n         <p>The maximum number of clusters allowed is 10. The call to <code>TerminateJobFlows</code>\n         is asynchronous. Depending on the configuration of the cluster, it may take up to 1-5\n         minutes for the cluster to completely terminate and release allocated resources, such as\n            Amazon EC2 instances.</p>"
+      }
+    },
+    "com.amazonaws.emr#TerminateJobFlowsInput": {
+      "type": "structure",
+      "members": {
+        "JobFlowIds": {
+          "target": "com.amazonaws.emr#XmlStringList",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>A list of job flows to be shut down.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Input to the <a>TerminateJobFlows</a> operation. </p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#TerminateSession": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#TerminateSessionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.emr#TerminateSessionOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Terminates an active session. After you call this operation, the session enters the <code>TERMINATING</code> state and then transitions to <code>TERMINATED</code>.</p>"
+      }
+    },
+    "com.amazonaws.emr#TerminateSessionInput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster that the session belongs to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionId": {
+          "target": "com.amazonaws.emr#SessionId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the session to terminate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input to the <code>TerminateSession</code> operation.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#TerminateSessionOutput": {
+      "type": "structure",
+      "members": {
+        "ClusterId": {
+          "target": "com.amazonaws.emr#ClusterId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the cluster that the session belonged to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionId": {
+          "target": "com.amazonaws.emr#SessionId",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the terminated session.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.emr#SessionState",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The state of the session after the terminate request has been accepted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Output of the <code>TerminateSession</code> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.emr#ThroughputVal": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.emr#Unit": {
+      "type": "enum",
+      "members": {
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "SECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SECONDS"
+          }
+        },
+        "MICRO_SECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MICRO_SECONDS"
+          }
+        },
+        "MILLI_SECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MILLI_SECONDS"
+          }
+        },
+        "BYTES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BYTES"
+          }
+        },
+        "KILO_BYTES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KILO_BYTES"
+          }
+        },
+        "MEGA_BYTES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEGA_BYTES"
+          }
+        },
+        "GIGA_BYTES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GIGA_BYTES"
+          }
+        },
+        "TERA_BYTES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERA_BYTES"
+          }
+        },
+        "BITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BITS"
+          }
+        },
+        "KILO_BITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KILO_BITS"
+          }
+        },
+        "MEGA_BITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEGA_BITS"
+          }
+        },
+        "GIGA_BITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GIGA_BITS"
+          }
+        },
+        "TERA_BITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERA_BITS"
+          }
+        },
+        "PERCENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERCENT"
+          }
+        },
+        "COUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COUNT"
+          }
+        },
+        "BYTES_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BYTES_PER_SECOND"
+          }
+        },
+        "KILO_BYTES_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KILO_BYTES_PER_SECOND"
+          }
+        },
+        "MEGA_BYTES_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEGA_BYTES_PER_SECOND"
+          }
+        },
+        "GIGA_BYTES_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GIGA_BYTES_PER_SECOND"
+          }
+        },
+        "TERA_BYTES_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERA_BYTES_PER_SECOND"
+          }
+        },
+        "BITS_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BITS_PER_SECOND"
+          }
+        },
+        "KILO_BITS_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KILO_BITS_PER_SECOND"
+          }
+        },
+        "MEGA_BITS_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEGA_BITS_PER_SECOND"
+          }
+        },
+        "GIGA_BITS_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GIGA_BITS_PER_SECOND"
+          }
+        },
+        "TERA_BITS_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERA_BITS_PER_SECOND"
+          }
+        },
+        "COUNT_PER_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COUNT_PER_SECOND"
+          }
+        }
+      }
+    },
+    "com.amazonaws.emr#UpdateStudio": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#UpdateStudioInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an Amazon EMR Studio configuration, including attributes such as name,\n         description, and subnets.</p>"
+      }
+    },
+    "com.amazonaws.emr#UpdateStudioInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio to update.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>A descriptive name for the Amazon EMR Studio.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>A detailed description to assign to the Amazon EMR Studio.</p>"
+          }
+        },
+        "SubnetIds": {
+          "target": "com.amazonaws.emr#SubnetIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of subnet IDs to associate with the Amazon EMR Studio. The list can\n         include new subnet IDs, but must also include all of the subnet IDs previously associated\n         with the Studio. The list order does not matter. A Studio can have a maximum of 5 subnets.\n         The subnets must belong to the same VPC as the Studio. </p>"
+          }
+        },
+        "DefaultS3Location": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location to back up Workspaces and notebook files for the Amazon EMR Studio.</p>"
+          }
+        },
+        "EncryptionKeyArn": {
+          "target": "com.amazonaws.emr#XmlString",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key identifier (ARN) used to encrypt Amazon EMR Studio workspace and notebook files when backed up to Amazon S3.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#UpdateStudioSessionMapping": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.emr#UpdateStudioSessionMappingInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.emr#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.emr#InvalidRequestException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the session policy attached to the user or group for the specified Amazon EMR Studio.</p>"
+      }
+    },
+    "com.amazonaws.emr#UpdateStudioSessionMappingInput": {
+      "type": "structure",
+      "members": {
+        "StudioId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The ID of the Amazon EMR Studio.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "IdentityId": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The globally unique identifier (GUID) of the user or group. For more information, see\n            <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserId\">UserId</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-GroupId\">GroupId</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified.</p>"
+          }
+        },
+        "IdentityName": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the user or group to update. For more information, see <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_User.html#singlesignon-Type-User-UserName\">UserName</a> and <a href=\"https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html#singlesignon-Type-Group-DisplayName\">DisplayName</a> in the <i>IAM Identity Center Identity Store API\n            Reference</i>. Either <code>IdentityName</code> or <code>IdentityId</code> must\n         be specified.</p>"
+          }
+        },
+        "IdentityType": {
+          "target": "com.amazonaws.emr#IdentityType",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>Specifies whether the identity to update is a user or a group.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SessionPolicyArn": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the session policy to associate with the specified\n         user or group.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.emr#UriString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10280
+        },
+        "smithy.api#pattern": "^[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDBFF-\\uDC00\\uDFFF\\r\\n\\t]*$"
+      }
+    },
+    "com.amazonaws.emr#UsernamePassword": {
+      "type": "structure",
+      "members": {
+        "Username": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The username associated with the temporary credentials that you use to connect to\n         cluster endpoints.</p>"
+          }
+        },
+        "Password": {
+          "target": "com.amazonaws.emr#XmlStringMaxLen256",
+          "traits": {
+            "smithy.api#documentation": "<p>The password associated with the temporary credentials that you use to connect to\n         cluster endpoints.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The username and password that you use to connect to cluster endpoints.</p>",
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.emr#UtilizationPerformanceIndexInteger": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.emr#VolumeSpecification": {
+      "type": "structure",
+      "members": {
+        "VolumeType": {
+          "target": "com.amazonaws.emr#String",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The volume type. Volume types supported are gp3, gp2, io1, st1, sc1, and\n         standard.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Iops": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of I/O operations per second (IOPS) that the volume supports.</p>"
+          }
+        },
+        "SizeInGB": {
+          "target": "com.amazonaws.emr#Integer",
+          "traits": {
+            "smithy.api#clientOptional": {},
+            "smithy.api#documentation": "<p>The volume size, in gibibytes (GiB). This can be a number from 1 - 1024. If the volume\n         type is EBS-optimized, the minimum value is 10.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Throughput": {
+          "target": "com.amazonaws.emr#ThroughputVal",
+          "traits": {
+            "smithy.api#documentation": "<p>The throughput, in mebibyte per second (MiB/s). This optional parameter can be a number\n         from 125 - 1000 and is valid only for gp3 volumes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>EBS volume specifications such as volume type, IOPS, size (GiB) and throughput (MiB/s)\n         that are requested for the EBS volume attached to an Amazon EC2 instance in the\n         cluster.</p>"
+      }
+    },
+    "com.amazonaws.emr#WholeNumber": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.emr#XmlString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10280
+        },
+        "smithy.api#pattern": "^[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*$"
+      }
+    },
+    "com.amazonaws.emr#XmlStringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#XmlString"
+      }
+    },
+    "com.amazonaws.emr#XmlStringMaxLen256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*$"
+      }
+    },
+    "com.amazonaws.emr#XmlStringMaxLen256List": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.emr#XmlStringMaxLen256"
+      }
+    }
+  }
+}

--- a/crates/fakecloud-emr/src/validate.rs
+++ b/crates/fakecloud-emr/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored EMR Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/emr.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 #[derive(Debug, Default)]
 struct MemberConstraint {

--- a/crates/fakecloud-server/tests/no_escaping_include_str.rs
+++ b/crates/fakecloud-server/tests/no_escaping_include_str.rs
@@ -1,0 +1,92 @@
+//! Guard against `include_str!` / `include_bytes!` paths that escape a crate's
+//! own directory. Such a path (e.g. `../../../aws-models/foo.json`) resolves
+//! fine in the workspace but is NOT included in the crate's published tarball
+//! (`cargo package` only bundles files under the crate root), so the crate
+//! fails to compile from crates.io — which shipped broken model crates in
+//! v0.41.0 (`cargo install fakecloud` could not build). Vendor the data inside
+//! the crate instead and reference it with a non-escaping relative path.
+
+use std::path::{Path, PathBuf};
+
+fn rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rs_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// A relative `include_*!` argument escapes the crate when, resolved against the
+/// source file's directory, it climbs above the crate root. Count `../` hops
+/// versus the source file's depth below `crates/<crate>/`.
+fn escapes_crate(src_file: &Path, crate_src_root: &Path, include_arg: &str) -> bool {
+    // Directory the include is resolved relative to = the .rs file's parent.
+    let base = src_file.parent().unwrap_or(src_file);
+    // Depth of `base` below the crate root (…/crates/<crate>/).
+    let depth_below_root = base
+        .strip_prefix(crate_src_root.parent().unwrap())
+        .map(|p| p.components().count())
+        .unwrap_or(0);
+    let up_hops = include_arg.split('/').filter(|c| *c == "..").count();
+    up_hops > depth_below_root
+}
+
+#[test]
+fn no_include_str_escapes_its_crate() {
+    // CARGO_MANIFEST_DIR = <repo>/crates/fakecloud-server
+    let crates_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    assert!(crates_dir.ends_with("crates"), "unexpected layout: {crates_dir:?}");
+
+    let re_arg = regex_lite_arg;
+    let mut offenders = Vec::new();
+    for entry in std::fs::read_dir(&crates_dir).unwrap().flatten() {
+        let crate_dir = entry.path();
+        let src_root = crate_dir.join("src");
+        if !src_root.is_dir() {
+            continue;
+        }
+        let mut files = Vec::new();
+        rs_files(&src_root, &mut files);
+        for f in &files {
+            let Ok(text) = std::fs::read_to_string(f) else {
+                continue;
+            };
+            for macro_name in ["include_str!", "include_bytes!"] {
+                let mut from = 0;
+                while let Some(pos) = text[from..].find(macro_name) {
+                    let start = from + pos + macro_name.len();
+                    if let Some(arg) = re_arg(&text[start..]) {
+                        if arg.starts_with("..") && escapes_crate(f, &src_root, &arg) {
+                            offenders.push(format!("{}: {macro_name}(\"{arg}\")", f.display()));
+                        }
+                    }
+                    from = start;
+                }
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "include_str!/include_bytes! escaping the crate dir breaks published tarballs; \
+         vendor the file inside the crate:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// Extract the first string-literal argument from `(\"...\")`, else None.
+fn regex_lite_arg(rest: &str) -> Option<String> {
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix('(')?.trim_start();
+    let rest = rest.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}

--- a/crates/fakecloud-server/tests/no_escaping_include_str.rs
+++ b/crates/fakecloud-server/tests/no_escaping_include_str.rs
@@ -44,7 +44,10 @@ fn no_include_str_escapes_its_crate() {
         .parent()
         .unwrap()
         .to_path_buf();
-    assert!(crates_dir.ends_with("crates"), "unexpected layout: {crates_dir:?}");
+    assert!(
+        crates_dir.ends_with("crates"),
+        "unexpected layout: {crates_dir:?}"
+    );
 
     let re_arg = regex_lite_arg;
     let mut offenders = Vec::new();

--- a/crates/fakecloud-shield/model.json
+++ b/crates/fakecloud-shield/model.json
@@ -1,0 +1,4869 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.shield#AWSShield_20160616": {
+      "type": "service",
+      "version": "2016-06-02",
+      "operations": [
+        {
+          "target": "com.amazonaws.shield#AssociateDRTLogBucket"
+        },
+        {
+          "target": "com.amazonaws.shield#AssociateDRTRole"
+        },
+        {
+          "target": "com.amazonaws.shield#AssociateHealthCheck"
+        },
+        {
+          "target": "com.amazonaws.shield#AssociateProactiveEngagementDetails"
+        },
+        {
+          "target": "com.amazonaws.shield#CreateProtection"
+        },
+        {
+          "target": "com.amazonaws.shield#CreateProtectionGroup"
+        },
+        {
+          "target": "com.amazonaws.shield#CreateSubscription"
+        },
+        {
+          "target": "com.amazonaws.shield#DeleteProtection"
+        },
+        {
+          "target": "com.amazonaws.shield#DeleteProtectionGroup"
+        },
+        {
+          "target": "com.amazonaws.shield#DeleteSubscription"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeAttack"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeAttackStatistics"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeDRTAccess"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeEmergencyContactSettings"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeProtection"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeProtectionGroup"
+        },
+        {
+          "target": "com.amazonaws.shield#DescribeSubscription"
+        },
+        {
+          "target": "com.amazonaws.shield#DisableApplicationLayerAutomaticResponse"
+        },
+        {
+          "target": "com.amazonaws.shield#DisableProactiveEngagement"
+        },
+        {
+          "target": "com.amazonaws.shield#DisassociateDRTLogBucket"
+        },
+        {
+          "target": "com.amazonaws.shield#DisassociateDRTRole"
+        },
+        {
+          "target": "com.amazonaws.shield#DisassociateHealthCheck"
+        },
+        {
+          "target": "com.amazonaws.shield#EnableApplicationLayerAutomaticResponse"
+        },
+        {
+          "target": "com.amazonaws.shield#EnableProactiveEngagement"
+        },
+        {
+          "target": "com.amazonaws.shield#GetSubscriptionState"
+        },
+        {
+          "target": "com.amazonaws.shield#ListAttacks"
+        },
+        {
+          "target": "com.amazonaws.shield#ListProtectionGroups"
+        },
+        {
+          "target": "com.amazonaws.shield#ListProtections"
+        },
+        {
+          "target": "com.amazonaws.shield#ListResourcesInProtectionGroup"
+        },
+        {
+          "target": "com.amazonaws.shield#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.shield#TagResource"
+        },
+        {
+          "target": "com.amazonaws.shield#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.shield#UpdateApplicationLayerAutomaticResponse"
+        },
+        {
+          "target": "com.amazonaws.shield#UpdateEmergencyContactSettings"
+        },
+        {
+          "target": "com.amazonaws.shield#UpdateProtectionGroup"
+        },
+        {
+          "target": "com.amazonaws.shield#UpdateSubscription"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Shield",
+          "arnNamespace": "shield",
+          "cloudFormationName": "Shield",
+          "cloudTrailEventSource": "shield.amazonaws.com",
+          "endpointPrefix": "shield"
+        },
+        "aws.auth#sigv4": {
+          "name": "shield"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<fullname>Shield Advanced</fullname>\n         <p>This is the <i>Shield Advanced API Reference</i>. This guide is for developers who need detailed information about the Shield Advanced API actions,\n         data types, and errors. For detailed information about WAF and Shield Advanced features and an overview of how to use the WAF and Shield Advanced APIs, see the\n         <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/\">WAF and Shield Developer Guide</a>.</p>",
+        "smithy.api#title": "AWS Shield",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://ddp.amazonaws.com/doc/2016-06-02/"
+        },
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws"
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://shield.us-east-1.amazonaws.com",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "shield",
+                      "signingRegion": "us-east-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://shield-fips.us-east-1.amazonaws.com",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "shield",
+                      "signingRegion": "us-east-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://shield-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://shield-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://shield.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://shield.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 15,
+          "nodes": "/////wAAAAH/////AAAAAAAAAA4AAAADAAAAAQAAAAQF9eENAAAAAgAAAAUF9eENAAAAAwAAAAkAAAAGAAAABAAAAAgAAAAHAAAABgX14QQF9eEMAAAABQX14QoF9eELAAAABAAAAAwAAAAKAAAABgX14QUAAAALAAAABwX14QgF9eEJAAAABQAAAA0F9eEHAAAABwX14QYF9eEHAAAAAwX14QEAAAAPAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://shield.us-east-1.amazonaws.com",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "shield",
+                              "signingRegion": "us-east-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://shield-fips.us-east-1.amazonaws.com",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "shield",
+                              "signingRegion": "us-east-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://shield-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://shield-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://shield.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://shield.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region aws-global with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "shield",
+                        "signingRegion": "us-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://shield.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "aws-global",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region aws-global with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "shield",
+                        "signingRegion": "us-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://shield-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "aws-global",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "shield",
+                        "signingRegion": "us-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://shield-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "shield",
+                        "signingRegion": "us-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://shield.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://shield.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.shield#AccessDeniedException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates the specified <code>AttackId</code> does not exist, or the requester does not have the appropriate permissions to access the <code>AttackId</code>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#AccessDeniedForDependencyException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>In order to grant the necessary access to the Shield Response Team (SRT) the user submitting the request must have the <code>iam:PassRole</code> permission. This error indicates the user did not have the appropriate permissions. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html\">Granting a User Permissions to Pass a Role to an Amazon Web Services Service</a>. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#ApplicationLayerAutomaticResponseConfiguration": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.shield#ApplicationLayerAutomaticResponseStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether automatic application layer DDoS mitigation is enabled for the protection. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Action": {
+          "target": "com.amazonaws.shield#ResponseAction",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the action setting that Shield Advanced should use in the WAF rules that it creates on behalf of the\n   protected resource in response to DDoS attacks. You specify this as part of the configuration for the automatic application layer DDoS mitigation feature,\n   when you enable or update automatic mitigation. Shield Advanced creates the WAF rules in a Shield Advanced-managed rule group, inside the web ACL that you have associated with the resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The automatic application layer DDoS mitigation settings for a <a>Protection</a>.\n       This configuration determines whether Shield Advanced automatically\n       manages rules in the web ACL in order to respond to application layer events that Shield Advanced determines to be DDoS attacks. </p>"
+      }
+    },
+    "com.amazonaws.shield#ApplicationLayerAutomaticResponseStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#AssociateDRTLogBucket": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#AssociateDRTLogBucketRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#AssociateDRTLogBucketResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#AccessDeniedForDependencyException"
+        },
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#LimitsExceededException"
+        },
+        {
+          "target": "com.amazonaws.shield#NoAssociatedRoleException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Authorizes the Shield Response Team (SRT) to access the specified Amazon S3 bucket containing log data such as Application Load Balancer access logs, CloudFront logs, or logs from third party sources. You can associate up to 10 Amazon S3 buckets with your subscription.</p>\n         <p>To use the services of the SRT and make an <code>AssociateDRTLogBucket</code> request, you must be subscribed to the <a href=\"http://aws.amazon.com/premiumsupport/business-support/\">Business Support plan</a> or the <a href=\"http://aws.amazon.com/premiumsupport/enterprise-support/\">Enterprise Support plan</a>.</p>"
+      }
+    },
+    "com.amazonaws.shield#AssociateDRTLogBucketRequest": {
+      "type": "structure",
+      "members": {
+        "LogBucket": {
+          "target": "com.amazonaws.shield#LogBucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that contains the logs that you want to share.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateDRTLogBucketResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateDRTRole": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#AssociateDRTRoleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#AssociateDRTRoleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#AccessDeniedForDependencyException"
+        },
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Authorizes the Shield Response Team (SRT) using the specified role, to access your Amazon Web Services account to assist with DDoS attack mitigation during potential attacks. This enables the SRT to inspect your WAF configuration and create or update WAF rules and web ACLs.</p>\n         <p>You can associate only one <code>RoleArn</code> with your subscription. If you submit an <code>AssociateDRTRole</code> request for an account that already has an associated role, the new <code>RoleArn</code> will replace the existing <code>RoleArn</code>. </p>\n         <p>Prior to making the <code>AssociateDRTRole</code> request, you must attach the <code>AWSShieldDRTAccessPolicy</code> managed policy to the role that you'll specify in the request. You can access this policy in the IAM console at <a href=\"https://console.aws.amazon.com/iam/home?#/policies/arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy\">AWSShieldDRTAccessPolicy</a>. For more information see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html\">Adding and removing IAM identity permissions</a>. The role must also trust the service principal\n<code>drt.shield.amazonaws.com</code>. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html\">IAM JSON policy elements: Principal</a>.</p>\n         <p>The SRT will have access only to your WAF and Shield resources. By submitting this request, you authorize the SRT to inspect your WAF and Shield configuration and create and update WAF rules and web ACLs on your behalf. The SRT takes these actions only if explicitly authorized by you.</p>\n         <p>You must have the <code>iam:PassRole</code> permission to make an <code>AssociateDRTRole</code> request. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html\">Granting a user permissions to pass a role to an Amazon Web Services service</a>. </p>\n         <p>To use the services of the SRT and make an <code>AssociateDRTRole</code> request, you must be subscribed to the <a href=\"http://aws.amazon.com/premiumsupport/business-support/\">Business Support plan</a> or the <a href=\"http://aws.amazon.com/premiumsupport/enterprise-support/\">Enterprise Support plan</a>.</p>"
+      }
+    },
+    "com.amazonaws.shield#AssociateDRTRoleRequest": {
+      "type": "structure",
+      "members": {
+        "RoleArn": {
+          "target": "com.amazonaws.shield#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role the SRT will use to access your Amazon Web Services account.</p>\n         <p>Prior to making the <code>AssociateDRTRole</code> request, you must attach the <a href=\"https://console.aws.amazon.com/iam/home?#/policies/arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy\">AWSShieldDRTAccessPolicy</a> managed policy to this role.  For more information see <a href=\" https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html\">Attaching and Detaching IAM Policies</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateDRTRoleResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateHealthCheck": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#AssociateHealthCheckRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#AssociateHealthCheckResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidResourceException"
+        },
+        {
+          "target": "com.amazonaws.shield#LimitsExceededException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds health-based detection to the Shield Advanced protection for a resource. Shield Advanced health-based detection uses the health of your Amazon Web Services resource to improve responsiveness and accuracy in attack detection and response.  </p>\n         <p>You define the health check in Route\u00a053 and then associate it with your Shield Advanced protection. For more information, see <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html#ddos-advanced-health-check-option\">Shield Advanced Health-Based Detection</a> in the <i>WAF Developer Guide</i>. </p>"
+      }
+    },
+    "com.amazonaws.shield#AssociateHealthCheckRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionId": {
+          "target": "com.amazonaws.shield#ProtectionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the <a>Protection</a> object to add the health check association to. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "HealthCheckArn": {
+          "target": "com.amazonaws.shield#HealthCheckArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the health check to associate with the protection.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateHealthCheckResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateProactiveEngagementDetails": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#AssociateProactiveEngagementDetailsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#AssociateProactiveEngagementDetailsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Initializes proactive engagement and sets the list of contacts for the Shield Response Team (SRT) to use. You must provide at least one phone number in the emergency contact list. </p>\n         <p>After you have initialized proactive engagement using this call, to disable or enable proactive engagement, use the calls <code>DisableProactiveEngagement</code> and <code>EnableProactiveEngagement</code>.  </p>\n         <note>\n            <p>This call defines the list of email addresses and phone numbers that the SRT can use to contact you for escalations to the SRT and to initiate proactive customer support.</p>\n            <p>The contacts that you provide in the request replace any contacts that were already defined. If you already have contacts defined and want to use them, retrieve the list using <code>DescribeEmergencyContactSettings</code> and then provide it to this call.  </p>\n         </note>"
+      }
+    },
+    "com.amazonaws.shield#AssociateProactiveEngagementDetailsRequest": {
+      "type": "structure",
+      "members": {
+        "EmergencyContactList": {
+          "target": "com.amazonaws.shield#EmergencyContactList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you for escalations to the SRT and to initiate proactive customer support. </p>\n         <p>To enable proactive engagement, the contact list must include at least one phone number.</p>\n         <note>\n            <p>The contacts that you provide here replace any contacts that were already defined. If you already have contacts defined and want to use them, retrieve the list using <code>DescribeEmergencyContactSettings</code> and then provide it here.  </p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#AssociateProactiveEngagementDetailsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#AttackDetail": {
+      "type": "structure",
+      "members": {
+        "AttackId": {
+          "target": "com.amazonaws.shield#AttackId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) of the attack.</p>"
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the resource that was attacked.</p>"
+          }
+        },
+        "SubResources": {
+          "target": "com.amazonaws.shield#SubResourceSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>If applicable, additional detail about the resource being attacked, for example, IP address or URL.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.shield#AttackTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the attack started, in Unix time in seconds. </p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.shield#AttackTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the attack ended, in Unix time in seconds. </p>"
+          }
+        },
+        "AttackCounters": {
+          "target": "com.amazonaws.shield#SummarizedCounterList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of counters that describe the attack for the specified time period.</p>"
+          }
+        },
+        "AttackProperties": {
+          "target": "com.amazonaws.shield#AttackProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The array of objects that provide details of the Shield event. </p>\n         <p>For infrastructure\n  layer events (L3 and L4 events), you can view metrics for top contributors in Amazon CloudWatch metrics.\n           For more information, see <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/monitoring-cloudwatch.html#set-ddos-alarms\">Shield metrics and alarms</a>\n               in the <i>WAF Developer Guide</i>. </p>"
+          }
+        },
+        "Mitigations": {
+          "target": "com.amazonaws.shield#MitigationList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of mitigation actions taken for the attack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details of a DDoS attack.</p>"
+      }
+    },
+    "com.amazonaws.shield#AttackId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9\\\\-]*$"
+      }
+    },
+    "com.amazonaws.shield#AttackLayer": {
+      "type": "enum",
+      "members": {
+        "NETWORK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NETWORK"
+          }
+        },
+        "APPLICATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "APPLICATION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#AttackProperties": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#AttackProperty"
+      }
+    },
+    "com.amazonaws.shield#AttackProperty": {
+      "type": "structure",
+      "members": {
+        "AttackLayer": {
+          "target": "com.amazonaws.shield#AttackLayer",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of Shield event that was observed. <code>NETWORK</code> indicates layer 3 and layer 4 events and <code>APPLICATION</code>\n         indicates layer 7 events.</p>\n         <p>For infrastructure\n  layer events (L3 and L4 events), you can view metrics for top contributors in Amazon CloudWatch metrics.\n           For more information, see <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/monitoring-cloudwatch.html#set-ddos-alarms\">Shield metrics and alarms</a>\n               in the <i>WAF Developer Guide</i>. </p>"
+          }
+        },
+        "AttackPropertyIdentifier": {
+          "target": "com.amazonaws.shield#AttackPropertyIdentifier",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines the Shield event property information that is provided. The\n            <code>WORDPRESS_PINGBACK_REFLECTOR</code> and <code>WORDPRESS_PINGBACK_SOURCE</code>\n         values are valid only for WordPress reflective pingback events.</p>"
+          }
+        },
+        "TopContributors": {
+          "target": "com.amazonaws.shield#TopContributors",
+          "traits": {
+            "smithy.api#documentation": "<p>Contributor objects for the top five contributors to a Shield event. A contributor is a source of traffic that Shield Advanced identifies as responsible for some or all of an event.</p>"
+          }
+        },
+        "Unit": {
+          "target": "com.amazonaws.shield#Unit",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit used for the <code>Contributor</code>\n            <code>Value</code> property. </p>"
+          }
+        },
+        "Total": {
+          "target": "com.amazonaws.shield#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The total contributions made to this Shield event by all contributors.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details of a Shield event. This is provided as part of an <a>AttackDetail</a>.</p>"
+      }
+    },
+    "com.amazonaws.shield#AttackPropertyIdentifier": {
+      "type": "enum",
+      "members": {
+        "DESTINATION_URL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESTINATION_URL"
+          }
+        },
+        "REFERRER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REFERRER"
+          }
+        },
+        "SOURCE_ASN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_ASN"
+          }
+        },
+        "SOURCE_COUNTRY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_COUNTRY"
+          }
+        },
+        "SOURCE_IP_ADDRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_IP_ADDRESS"
+          }
+        },
+        "SOURCE_USER_AGENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_USER_AGENT"
+          }
+        },
+        "WORDPRESS_PINGBACK_REFLECTOR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORDPRESS_PINGBACK_REFLECTOR"
+          }
+        },
+        "WORDPRESS_PINGBACK_SOURCE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORDPRESS_PINGBACK_SOURCE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#AttackStatisticsDataItem": {
+      "type": "structure",
+      "members": {
+        "AttackVolume": {
+          "target": "com.amazonaws.shield#AttackVolume",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the volume of attacks during the time period. If the accompanying <code>AttackCount</code> is zero, this setting might be empty.</p>"
+          }
+        },
+        "AttackCount": {
+          "target": "com.amazonaws.shield#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of attacks detected during the time period. This is always present, but might be zero. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A single attack statistics data record. This is returned by <a>DescribeAttackStatistics</a> along with a time range indicating the time period that the attack statistics apply to.  </p>"
+      }
+    },
+    "com.amazonaws.shield#AttackStatisticsDataList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#AttackStatisticsDataItem"
+      }
+    },
+    "com.amazonaws.shield#AttackSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#AttackSummary"
+      }
+    },
+    "com.amazonaws.shield#AttackSummary": {
+      "type": "structure",
+      "members": {
+        "AttackId": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) of the attack.</p>"
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the resource that was attacked.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.shield#AttackTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The start time of the attack, in Unix time in seconds. </p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.shield#AttackTimestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The end time of the attack, in Unix time in seconds. </p>"
+          }
+        },
+        "AttackVectors": {
+          "target": "com.amazonaws.shield#AttackVectorDescriptionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of attacks for a specified time period.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Summarizes all DDoS attacks for a specified time period.</p>"
+      }
+    },
+    "com.amazonaws.shield#AttackTimestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.shield#AttackVectorDescription": {
+      "type": "structure",
+      "members": {
+        "VectorType": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The attack type. Valid values:</p>\n         <ul>\n            <li>\n               <p>UDP_TRAFFIC</p>\n            </li>\n            <li>\n               <p>UDP_FRAGMENT</p>\n            </li>\n            <li>\n               <p>GENERIC_UDP_REFLECTION</p>\n            </li>\n            <li>\n               <p>DNS_REFLECTION</p>\n            </li>\n            <li>\n               <p>NTP_REFLECTION</p>\n            </li>\n            <li>\n               <p>CHARGEN_REFLECTION</p>\n            </li>\n            <li>\n               <p>SSDP_REFLECTION</p>\n            </li>\n            <li>\n               <p>PORT_MAPPER</p>\n            </li>\n            <li>\n               <p>RIP_REFLECTION</p>\n            </li>\n            <li>\n               <p>SNMP_REFLECTION</p>\n            </li>\n            <li>\n               <p>MSSQL_REFLECTION</p>\n            </li>\n            <li>\n               <p>NET_BIOS_REFLECTION</p>\n            </li>\n            <li>\n               <p>SYN_FLOOD</p>\n            </li>\n            <li>\n               <p>ACK_FLOOD</p>\n            </li>\n            <li>\n               <p>REQUEST_FLOOD</p>\n            </li>\n            <li>\n               <p>HTTP_REFLECTION</p>\n            </li>\n            <li>\n               <p>UDS_REFLECTION</p>\n            </li>\n            <li>\n               <p>MEMCACHED_REFLECTION</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the attack.</p>"
+      }
+    },
+    "com.amazonaws.shield#AttackVectorDescriptionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#AttackVectorDescription"
+      }
+    },
+    "com.amazonaws.shield#AttackVolume": {
+      "type": "structure",
+      "members": {
+        "BitsPerSecond": {
+          "target": "com.amazonaws.shield#AttackVolumeStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>A statistics object that uses bits per second as the unit. This is included for network level attacks. </p>"
+          }
+        },
+        "PacketsPerSecond": {
+          "target": "com.amazonaws.shield#AttackVolumeStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>A statistics object that uses packets per second as the unit. This is included for network level attacks. </p>"
+          }
+        },
+        "RequestsPerSecond": {
+          "target": "com.amazonaws.shield#AttackVolumeStatistics",
+          "traits": {
+            "smithy.api#documentation": "<p>A statistics object that uses requests per second as the unit. This is included for application level attacks, and is only available for accounts that are subscribed to Shield Advanced.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the volume of attacks during the time period, included in an <a>AttackStatisticsDataItem</a>. If the accompanying <code>AttackCount</code> in the statistics object is zero, this setting might be empty.</p>"
+      }
+    },
+    "com.amazonaws.shield#AttackVolumeStatistics": {
+      "type": "structure",
+      "members": {
+        "Max": {
+          "target": "com.amazonaws.shield#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum attack volume observed for the given unit.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Statistics objects for the various data types in <a>AttackVolume</a>. </p>"
+      }
+    },
+    "com.amazonaws.shield#AutoRenew": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#BlockAction": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies that Shield Advanced should configure its WAF rules with the WAF <code>Block</code> action. </p>\n         <p>This is only used in the context of the <code>ResponseAction</code> setting. </p>\n         <p>JSON specification: <code>\"Block\": {}</code>\n         </p>"
+      }
+    },
+    "com.amazonaws.shield#ContactNotes": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^[\\w\\s\\.\\-,:/()+@]*$"
+      }
+    },
+    "com.amazonaws.shield#Contributor": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the contributor. The type of name that you'll find here depends on the <code>AttackPropertyIdentifier</code> setting in the <code>AttackProperty</code> where this contributor is defined. For example, if the <code>AttackPropertyIdentifier</code> is <code>SOURCE_COUNTRY</code>, the <code>Name</code> could be <code>United States</code>.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.shield#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The contribution of this contributor expressed in <a>Protection</a> units. For example <code>10,000</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A contributor to the attack and their contribution. </p>"
+      }
+    },
+    "com.amazonaws.shield#CountAction": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies that Shield Advanced should configure its WAF rules with the WAF <code>Count</code> action. </p>\n         <p>This is only used in the context of the <code>ResponseAction</code> setting. </p>\n         <p>JSON specification: <code>\"Count\": {}</code>\n         </p>"
+      }
+    },
+    "com.amazonaws.shield#CreateProtection": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#CreateProtectionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#CreateProtectionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidResourceException"
+        },
+        {
+          "target": "com.amazonaws.shield#LimitsExceededException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceAlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enables Shield Advanced for a specific Amazon Web Services resource. The resource can be an Amazon CloudFront distribution, Amazon Route\u00a053 hosted zone, Global Accelerator standard accelerator, Elastic IP Address, Application Load Balancer, or a Classic Load Balancer. You can protect Amazon EC2 instances and Network Load Balancers by association with protected Amazon EC2 Elastic IP addresses.</p>\n         <p>You can add protection to only a single resource with each <code>CreateProtection</code> request. You can add protection to multiple resources\n          at once through the Shield Advanced console at <a href=\"https://console.aws.amazon.com/wafv2/shieldv2#/\">https://console.aws.amazon.com/wafv2/shieldv2#/</a>.\n              For more information see\n          <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-ddos.html\">Getting Started with Shield Advanced</a>\n              and <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/configure-new-protection.html\">Adding Shield Advanced protection to Amazon Web Services resources</a>.</p>"
+      }
+    },
+    "com.amazonaws.shield#CreateProtectionGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#CreateProtectionGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#CreateProtectionGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#LimitsExceededException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceAlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a grouping of protected resources so they can be handled as a collective. This resource grouping improves the accuracy of detection and reduces false positives. </p>"
+      }
+    },
+    "com.amazonaws.shield#CreateProtectionGroupRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupId": {
+          "target": "com.amazonaws.shield#ProtectionGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Aggregation": {
+          "target": "com.amazonaws.shield#ProtectionGroupAggregation",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines how Shield combines resource data for the group in order to detect, mitigate, and report events.</p>\n         <ul>\n            <li>\n               <p>Sum - Use the total traffic across the group. This is a good choice for most cases. Examples include Elastic IP addresses for EC2 instances that scale manually or automatically.</p>\n            </li>\n            <li>\n               <p>Mean - Use the average of the traffic across the group. This is a good choice for resources that share traffic uniformly. Examples include accelerators and load balancers.</p>\n            </li>\n            <li>\n               <p>Max - Use the highest traffic from each resource. This is useful for resources that don't share traffic and for resources that share that traffic in a non-uniform way. Examples include Amazon CloudFront and origin resources for CloudFront distributions.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Pattern": {
+          "target": "com.amazonaws.shield#ProtectionGroupPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The criteria to use to choose the protected resources for inclusion in the group. You can include all resources that have protections, provide a list of resource Amazon Resource Names (ARNs), or include all resources of a specified resource type. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.shield#ProtectedResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type to include in the protection group. All protected resources of this type are included in the protection group. Newly protected resources of this type are automatically added to the group.\n           You must set this when you set <code>Pattern</code> to <code>BY_RESOURCE_TYPE</code> and you must not set it for any other <code>Pattern</code> setting. </p>"
+          }
+        },
+        "Members": {
+          "target": "com.amazonaws.shield#ProtectionGroupMembers",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Names (ARNs) of the resources to include in the protection group. You must set this when you set <code>Pattern</code> to <code>ARBITRARY</code> and you must not set it for any other <code>Pattern</code> setting. </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.shield#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more tag key-value pairs for the protection group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#CreateProtectionGroupResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#CreateProtectionRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.shield#ProtectionName",
+          "traits": {
+            "smithy.api#documentation": "<p>Friendly name for the <code>Protection</code> you are creating.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the resource to be protected.</p>\n         <p>The ARN should be in one of the following formats:</p>\n         <ul>\n            <li>\n               <p>For an Application Load Balancer: <code>arn:aws:elasticloadbalancing:<i>region</i>:<i>account-id</i>:loadbalancer/app/<i>load-balancer-name</i>/<i>load-balancer-id</i>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>For an Elastic Load Balancer (Classic Load Balancer): <code>arn:aws:elasticloadbalancing:<i>region</i>:<i>account-id</i>:loadbalancer/<i>load-balancer-name</i>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>For an Amazon CloudFront distribution: <code>arn:aws:cloudfront::<i>account-id</i>:distribution/<i>distribution-id</i>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>For an Global Accelerator standard accelerator: <code>arn:aws:globalaccelerator::<i>account-id</i>:accelerator/<i>accelerator-id</i>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>For Amazon Route\u00a053: <code>arn:aws:route53:::hostedzone/<i>hosted-zone-id</i>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>For an Elastic IP address: <code>arn:aws:ec2:<i>region</i>:<i>account-id</i>:eip-allocation/<i>allocation-id</i>\n                  </code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.shield#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more tag key-value pairs for the <a>Protection</a> object that is created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#CreateProtectionResponse": {
+      "type": "structure",
+      "members": {
+        "ProtectionId": {
+          "target": "com.amazonaws.shield#ProtectionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the <a>Protection</a> object that is created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#CreateSubscription": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#CreateSubscriptionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#CreateSubscriptionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceAlreadyExistsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Activates Shield Advanced for an account.</p>\n         <note>\n            <p>For accounts that are members of an Organizations organization, Shield Advanced subscriptions are billed against the organization's payer account,\n              regardless of whether the payer account itself is subscribed. </p>\n         </note>\n         <p>When you initially create a subscription, your subscription is set to be automatically renewed at the end of the existing subscription period.  You can change this by submitting an <code>UpdateSubscription</code> request. </p>"
+      }
+    },
+    "com.amazonaws.shield#CreateSubscriptionRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#CreateSubscriptionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DeleteProtection": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DeleteProtectionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DeleteProtectionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Shield Advanced <a>Protection</a>.</p>"
+      }
+    },
+    "com.amazonaws.shield#DeleteProtectionGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DeleteProtectionGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DeleteProtectionGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes the specified protection group.</p>"
+      }
+    },
+    "com.amazonaws.shield#DeleteProtectionGroupRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupId": {
+          "target": "com.amazonaws.shield#ProtectionGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DeleteProtectionGroupResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DeleteProtectionRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionId": {
+          "target": "com.amazonaws.shield#ProtectionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the <a>Protection</a> object to be\n         deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DeleteProtectionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DeleteSubscription": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DeleteSubscriptionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DeleteSubscriptionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#LockedSubscriptionException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#deprecated": {},
+        "smithy.api#documentation": "<p>Removes Shield Advanced from an account. Shield Advanced requires a 1-year subscription commitment. You cannot delete a subscription prior to the completion of that commitment. </p>"
+      }
+    },
+    "com.amazonaws.shield#DeleteSubscriptionRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#deprecated": {},
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DeleteSubscriptionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#deprecated": {},
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeAttack": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeAttackRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeAttackResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the details of a DDoS attack. </p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeAttackRequest": {
+      "type": "structure",
+      "members": {
+        "AttackId": {
+          "target": "com.amazonaws.shield#AttackId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the attack.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeAttackResponse": {
+      "type": "structure",
+      "members": {
+        "Attack": {
+          "target": "com.amazonaws.shield#AttackDetail",
+          "traits": {
+            "smithy.api#documentation": "<p>The attack that you requested. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeAttackStatistics": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeAttackStatisticsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeAttackStatisticsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the number and type of attacks Shield has detected in the last year for all resources that belong to your account, regardless of whether you've defined Shield protections for them. This operation is available to Shield customers as well as to Shield Advanced customers.</p>\n         <p>The operation returns data for the time range of midnight UTC, one year ago, to midnight UTC, today. For example, if the current time is <code>2020-10-26 15:39:32 PDT</code>, equal to <code>2020-10-26 22:39:32 UTC</code>, then the time range for the attack data returned is from <code>2019-10-26 00:00:00 UTC</code> to <code>2020-10-26 00:00:00 UTC</code>. </p>\n         <p>The time range indicates the period covered by the attack statistics data items.</p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeAttackStatisticsRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeAttackStatisticsResponse": {
+      "type": "structure",
+      "members": {
+        "TimeRange": {
+          "target": "com.amazonaws.shield#TimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The time range of the attack.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataItems": {
+          "target": "com.amazonaws.shield#AttackStatisticsDataList",
+          "traits": {
+            "smithy.api#documentation": "<p>The data that describes the attacks detected during the time period.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeDRTAccess": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeDRTAccessRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeDRTAccessResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the current role and list of Amazon S3 log buckets used by the Shield Response Team (SRT) to access your Amazon Web Services account while assisting with attack mitigation.</p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeDRTAccessRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeDRTAccessResponse": {
+      "type": "structure",
+      "members": {
+        "RoleArn": {
+          "target": "com.amazonaws.shield#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role the SRT used to access your Amazon Web Services account.</p>"
+          }
+        },
+        "LogBucketList": {
+          "target": "com.amazonaws.shield#LogBucketList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of Amazon S3 buckets accessed by the SRT.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeEmergencyContactSettings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeEmergencyContactSettingsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeEmergencyContactSettingsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>A list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you if you have proactive engagement enabled, for escalations to the SRT and to initiate proactive customer support.</p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeEmergencyContactSettingsRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeEmergencyContactSettingsResponse": {
+      "type": "structure",
+      "members": {
+        "EmergencyContactList": {
+          "target": "com.amazonaws.shield#EmergencyContactList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you if you have proactive engagement enabled, for escalations to the SRT and to initiate proactive customer support.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeProtection": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeProtectionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeProtectionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the details of a <a>Protection</a> object.</p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeProtectionGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeProtectionGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeProtectionGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the specification for the specified protection group.</p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeProtectionGroupRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupId": {
+          "target": "com.amazonaws.shield#ProtectionGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeProtectionGroupResponse": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroup": {
+          "target": "com.amazonaws.shield#ProtectionGroup",
+          "traits": {
+            "smithy.api#documentation": "<p>A grouping of protected resources that you and Shield Advanced can monitor as a collective. This resource grouping improves the accuracy of detection and reduces false positives. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeProtectionRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionId": {
+          "target": "com.amazonaws.shield#ProtectionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the <a>Protection</a> object to describe. \n           You must provide either the <code>ResourceArn</code> of the protected resource or the <code>ProtectionID</code> of the protection, but not both.</p>"
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the protected Amazon Web Services resource. \n           You must provide either the <code>ResourceArn</code> of the protected resource or the <code>ProtectionID</code> of the protection, but not both.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeProtectionResponse": {
+      "type": "structure",
+      "members": {
+        "Protection": {
+          "target": "com.amazonaws.shield#Protection",
+          "traits": {
+            "smithy.api#documentation": "<p>The <a>Protection</a> that you requested. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeSubscription": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DescribeSubscriptionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DescribeSubscriptionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details about the Shield Advanced subscription for an account.</p>"
+      }
+    },
+    "com.amazonaws.shield#DescribeSubscriptionRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DescribeSubscriptionResponse": {
+      "type": "structure",
+      "members": {
+        "Subscription": {
+          "target": "com.amazonaws.shield#Subscription",
+          "traits": {
+            "smithy.api#documentation": "<p>The Shield Advanced subscription details for an account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DisableApplicationLayerAutomaticResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DisableApplicationLayerAutomaticResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DisableApplicationLayerAutomaticResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Disable the Shield Advanced automatic application layer DDoS mitigation feature for the protected resource. This\n       stops Shield Advanced from creating, verifying, and applying WAF rules for attacks that it detects for the resource. </p>"
+      }
+    },
+    "com.amazonaws.shield#DisableApplicationLayerAutomaticResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the protected resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DisableApplicationLayerAutomaticResponseResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DisableProactiveEngagement": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DisableProactiveEngagementRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DisableProactiveEngagementResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes authorization from the Shield Response Team (SRT) to notify contacts about escalations to the SRT and to initiate proactive customer support.</p>"
+      }
+    },
+    "com.amazonaws.shield#DisableProactiveEngagementRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DisableProactiveEngagementResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DisassociateDRTLogBucket": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DisassociateDRTLogBucketRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DisassociateDRTLogBucketResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#AccessDeniedForDependencyException"
+        },
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#NoAssociatedRoleException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes the Shield Response Team's (SRT) access to the specified Amazon S3 bucket containing the logs that you shared previously.</p>"
+      }
+    },
+    "com.amazonaws.shield#DisassociateDRTLogBucketRequest": {
+      "type": "structure",
+      "members": {
+        "LogBucket": {
+          "target": "com.amazonaws.shield#LogBucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that contains the logs that you want to share.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DisassociateDRTLogBucketResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DisassociateDRTRole": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DisassociateDRTRoleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DisassociateDRTRoleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes the Shield Response Team's (SRT) access to your Amazon Web Services account.</p>"
+      }
+    },
+    "com.amazonaws.shield#DisassociateDRTRoleRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DisassociateDRTRoleResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#DisassociateHealthCheck": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#DisassociateHealthCheckRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#DisassociateHealthCheckResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidResourceException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes health-based detection from the Shield Advanced protection for a resource. Shield Advanced health-based detection uses the health of your Amazon Web Services resource to improve responsiveness and accuracy in attack detection and response. </p>\n         <p>You define the health check in Route\u00a053 and then associate or disassociate it with your Shield Advanced protection. For more information, see <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html#ddos-advanced-health-check-option\">Shield Advanced Health-Based Detection</a> in the <i>WAF Developer Guide</i>. </p>"
+      }
+    },
+    "com.amazonaws.shield#DisassociateHealthCheckRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionId": {
+          "target": "com.amazonaws.shield#ProtectionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the <a>Protection</a> object to remove the health check association from. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "HealthCheckArn": {
+          "target": "com.amazonaws.shield#HealthCheckArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the health check that is associated with the protection.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#DisassociateHealthCheckResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#Double": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.shield#DurationInSeconds": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.shield#EmailAddress": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 150
+        },
+        "smithy.api#pattern": "^\\S+@\\S+\\.\\S+$"
+      }
+    },
+    "com.amazonaws.shield#EmergencyContact": {
+      "type": "structure",
+      "members": {
+        "EmailAddress": {
+          "target": "com.amazonaws.shield#EmailAddress",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address for the contact.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PhoneNumber": {
+          "target": "com.amazonaws.shield#PhoneNumber",
+          "traits": {
+            "smithy.api#documentation": "<p>The phone number for the contact.</p>"
+          }
+        },
+        "ContactNotes": {
+          "target": "com.amazonaws.shield#ContactNotes",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional notes regarding the contact. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contact information that the SRT can use to contact you if you have proactive engagement enabled, for escalations to the SRT and to initiate proactive customer support.</p>"
+      }
+    },
+    "com.amazonaws.shield#EmergencyContactList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#EmergencyContact"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.shield#EnableApplicationLayerAutomaticResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#EnableApplicationLayerAutomaticResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#EnableApplicationLayerAutomaticResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#LimitsExceededException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enable the Shield Advanced automatic application layer DDoS mitigation for the protected resource. </p>\n         <note>\n            <p>This feature is available for Amazon CloudFront distributions and Application Load Balancers only.</p>\n         </note>\n         <p>This causes Shield Advanced to create, verify, and apply WAF rules for DDoS attacks that it detects for the\n       resource. Shield Advanced applies the rules in a Shield rule group inside the web ACL that you've associated\n           with the resource. For information about how automatic mitigation works and the requirements for using it, see\n   <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/ddos-advanced-automatic-app-layer-response.html\">Shield Advanced automatic application layer DDoS mitigation</a>.</p>\n         <note>\n            <p>Don't use this action to make changes to automatic mitigation settings when it's already enabled for a resource. Instead, use <a>UpdateApplicationLayerAutomaticResponse</a>.</p>\n         </note>\n         <p>To use this feature, you must associate a web ACL with the protected resource. The web ACL must be created using the latest version of WAF (v2). You can associate the web ACL through the Shield Advanced console\n           at <a href=\"https://console.aws.amazon.com/wafv2/shieldv2#/\">https://console.aws.amazon.com/wafv2/shieldv2#/</a>. For more information,\n               see <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-ddos.html\">Getting Started with Shield Advanced</a>. You can also associate the web ACL to the resource through the WAF console or the WAF API, but you must manage Shield Advanced automatic mitigation through Shield Advanced. For information about WAF, see\n       <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/\">WAF Developer Guide</a>.</p>"
+      }
+    },
+    "com.amazonaws.shield#EnableApplicationLayerAutomaticResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the protected resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Action": {
+          "target": "com.amazonaws.shield#ResponseAction",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the action setting that Shield Advanced should use in the WAF rules that it creates on behalf of the\n   protected resource in response to DDoS attacks. You specify this as part of the configuration for the automatic application layer DDoS mitigation feature,\n   when you enable or update automatic mitigation. Shield Advanced creates the WAF rules in a Shield Advanced-managed rule group, inside the web ACL that you have associated with the resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#EnableApplicationLayerAutomaticResponseResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#EnableProactiveEngagement": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#EnableProactiveEngagementRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#EnableProactiveEngagementResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Authorizes the Shield Response Team (SRT) to use email and phone to notify contacts about escalations to the SRT and to initiate proactive customer support.</p>"
+      }
+    },
+    "com.amazonaws.shield#EnableProactiveEngagementRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#EnableProactiveEngagementResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#GetSubscriptionState": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#GetSubscriptionStateRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#GetSubscriptionStateResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the <code>SubscriptionState</code>, either <code>Active</code> or <code>Inactive</code>.</p>"
+      }
+    },
+    "com.amazonaws.shield#GetSubscriptionStateRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#GetSubscriptionStateResponse": {
+      "type": "structure",
+      "members": {
+        "SubscriptionState": {
+          "target": "com.amazonaws.shield#SubscriptionState",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the subscription.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#HealthCheckArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:aws:route53:::healthcheck/\\S{36}$"
+      }
+    },
+    "com.amazonaws.shield#HealthCheckId": {
+      "type": "string"
+    },
+    "com.amazonaws.shield#HealthCheckIds": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#HealthCheckId"
+      }
+    },
+    "com.amazonaws.shield#InclusionProtectionFilters": {
+      "type": "structure",
+      "members": {
+        "ResourceArns": {
+          "target": "com.amazonaws.shield#ResourceArnFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the resource whose protection you want to retrieve.  </p>"
+          }
+        },
+        "ProtectionNames": {
+          "target": "com.amazonaws.shield#ProtectionNameFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection that you want to retrieve.  </p>"
+          }
+        },
+        "ResourceTypes": {
+          "target": "com.amazonaws.shield#ProtectedResourceTypeFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of protected resource whose protections you want to retrieve.  </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Narrows the set of protections that the call retrieves. You can retrieve a single protection by providing its name or the ARN (Amazon Resource Name) of its protected resource. You can also retrieve all protections for a specific resource type. You can provide up to one criteria per filter type. Shield Advanced returns protections that exactly match all of the filter criteria that you provide.</p>"
+      }
+    },
+    "com.amazonaws.shield#InclusionProtectionGroupFilters": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupIds": {
+          "target": "com.amazonaws.shield#ProtectionGroupIdFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the protection group that you want to retrieve.  </p>"
+          }
+        },
+        "Patterns": {
+          "target": "com.amazonaws.shield#ProtectionGroupPatternFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The pattern specification of the protection groups that you want to retrieve.  </p>"
+          }
+        },
+        "ResourceTypes": {
+          "target": "com.amazonaws.shield#ProtectedResourceTypeFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type configuration of the protection groups that you want to retrieve. In the protection group configuration, you specify the resource type when you set the group's <code>Pattern</code> to <code>BY_RESOURCE_TYPE</code>. </p>"
+          }
+        },
+        "Aggregations": {
+          "target": "com.amazonaws.shield#ProtectionGroupAggregationFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>The aggregation setting of the protection groups that you want to retrieve.  </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Narrows the set of protection groups that the call retrieves. You can retrieve a single protection group by its name and you can retrieve all protection groups that are configured with a specific pattern, aggregation, or resource type. You can provide up to one criteria per filter type. Shield Advanced returns the protection groups that exactly match all of the search criteria that you provide.</p>"
+      }
+    },
+    "com.amazonaws.shield#Integer": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.shield#InternalErrorException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that a problem occurred with the service infrastructure. You can retry the request.</p>",
+        "smithy.api#error": "server"
+      }
+    },
+    "com.amazonaws.shield#InvalidOperationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that the operation would not cause any change to occur.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#InvalidPaginationTokenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that the <code>NextToken</code> specified in the request is invalid. Submit the request using the <code>NextToken</code> value that was returned in the prior response.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#InvalidParameterException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        },
+        "reason": {
+          "target": "com.amazonaws.shield#ValidationExceptionReason",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the exception.</p>"
+          }
+        },
+        "fields": {
+          "target": "com.amazonaws.shield#ValidationExceptionFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>Fields that caused the exception.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that the parameters passed to the API are invalid. If available, this exception includes details in additional properties. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#InvalidResourceException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that the resource is invalid. You might not have access to the resource, or the resource might not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#Limit": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of protection.</p>"
+          }
+        },
+        "Max": {
+          "target": "com.amazonaws.shield#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of protections that can be created for the specified <code>Type</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies how many protections of a given type you can create.</p>"
+      }
+    },
+    "com.amazonaws.shield#LimitNumber": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.shield#LimitType": {
+      "type": "string"
+    },
+    "com.amazonaws.shield#Limits": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#Limit"
+      }
+    },
+    "com.amazonaws.shield#LimitsExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        },
+        "Type": {
+          "target": "com.amazonaws.shield#LimitType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of limit that would be exceeded.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.shield#LimitNumber",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The threshold that would be exceeded.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that the operation would exceed a limit.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#ListAttacks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#ListAttacksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#ListAttacksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns all ongoing DDoS attacks or all DDoS attacks during a specified time\n         period.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "AttackSummaries",
+          "pageSize": "MaxResults"
+        },
+        "smithy.test#smokeTests": [
+          {
+            "id": "ListAttacksSuccess",
+            "params": {},
+            "vendorParams": {
+              "region": "us-east-1"
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "expect": {
+              "success": {}
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.shield#ListAttacksRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArns": {
+          "target": "com.amazonaws.shield#ResourceArnFilterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs (Amazon Resource Names) of the resources that were attacked. If you leave this\n         blank, all applicable resources for this account will be included.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.shield#TimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The start of the time period for the attacks. This is a <code>timestamp</code> type. The request syntax listing for this call indicates a <code>number</code> type,\n           but you can provide the time in any valid <a href=\"https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-types.html#parameter-type-timestamp\">timestamp format</a> setting.  </p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.shield#TimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>The end of the time period for the attacks. This is a <code>timestamp</code> type. The request syntax listing for this call indicates a <code>number</code> type,\n           but you can provide the time in any valid <a href=\"https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-types.html#parameter-type-timestamp\">timestamp format</a> setting.  </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>\n         <p>On your first call to a list operation, leave this setting empty.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.shield#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The greatest number of objects that you want Shield Advanced to return to the list request. Shield Advanced might return fewer objects\n         than you indicate in this setting, even if more objects are available. If there are more objects remaining, Shield Advanced will always also return a <code>NextToken</code> value\n         in the response.</p>\n         <p>The default setting is 20.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#ListAttacksResponse": {
+      "type": "structure",
+      "members": {
+        "AttackSummaries": {
+          "target": "com.amazonaws.shield#AttackSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>The attack information for the specified time range.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#ListProtectionGroups": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#ListProtectionGroupsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#ListProtectionGroupsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidPaginationTokenException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves <a>ProtectionGroup</a> objects for the account. You can retrieve all protection groups or you can provide \n       filtering criteria and retrieve just the subset of protection groups that match the criteria. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.shield#ListProtectionGroupsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>\n         <p>On your first call to a list operation, leave this setting empty.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.shield#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The greatest number of objects that you want Shield Advanced to return to the list request. Shield Advanced might return fewer objects\n         than you indicate in this setting, even if more objects are available. If there are more objects remaining, Shield Advanced will always also return a <code>NextToken</code> value\n         in the response.</p>\n         <p>The default setting is 20.</p>"
+          }
+        },
+        "InclusionFilters": {
+          "target": "com.amazonaws.shield#InclusionProtectionGroupFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Narrows the set of protection groups that the call retrieves. You can retrieve a single protection group by its name and you can retrieve all protection groups that are configured with specific pattern or aggregation settings. You can provide up to one criteria per filter type. Shield Advanced returns the protection groups that exactly match all of the search criteria that you provide.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#ListProtectionGroupsResponse": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroups": {
+          "target": "com.amazonaws.shield#ProtectionGroups",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#ListProtections": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#ListProtectionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#ListProtectionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidPaginationTokenException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves <a>Protection</a> objects for the account. You can retrieve all protections or you can provide \n       filtering criteria and retrieve just the subset of protections that match the criteria. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Protections",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.shield#ListProtectionsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>\n         <p>On your first call to a list operation, leave this setting empty.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.shield#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The greatest number of objects that you want Shield Advanced to return to the list request. Shield Advanced might return fewer objects\n         than you indicate in this setting, even if more objects are available. If there are more objects remaining, Shield Advanced will always also return a <code>NextToken</code> value\n         in the response.</p>\n         <p>The default setting is 20.</p>"
+          }
+        },
+        "InclusionFilters": {
+          "target": "com.amazonaws.shield#InclusionProtectionFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Narrows the set of protections that the call retrieves. You can retrieve a single protection by providing its name or the ARN (Amazon Resource Name) of its protected resource. You can also retrieve all protections for a specific resource type. You can provide up to one criteria per filter type. Shield Advanced returns protections that exactly match all of the filter criteria that you provide.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#ListProtectionsResponse": {
+      "type": "structure",
+      "members": {
+        "Protections": {
+          "target": "com.amazonaws.shield#Protections",
+          "traits": {
+            "smithy.api#documentation": "<p>The array of enabled <a>Protection</a> objects.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#ListResourcesInProtectionGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#ListResourcesInProtectionGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#ListResourcesInProtectionGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidPaginationTokenException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves the resources that are included in the protection group. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.shield#ListResourcesInProtectionGroupRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupId": {
+          "target": "com.amazonaws.shield#ProtectionGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>\n         <p>On your first call to a list operation, leave this setting empty.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.shield#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The greatest number of objects that you want Shield Advanced to return to the list request. Shield Advanced might return fewer objects\n         than you indicate in this setting, even if more objects are available. If there are more objects remaining, Shield Advanced will always also return a <code>NextToken</code> value\n         in the response.</p>\n         <p>The default setting is 20.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#ListResourcesInProtectionGroupResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceArns": {
+          "target": "com.amazonaws.shield#ResourceArnList",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Names (ARNs) of the resources that are included in the protection group.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.shield#Token",
+          "traits": {
+            "smithy.api#documentation": "<p>When you request a list of objects from Shield Advanced, if the response does not include all of the remaining available objects,\n           Shield Advanced includes a <code>NextToken</code> value in the response. You can retrieve the next batch of objects by requesting the list again and\n           providing the token that was returned by the prior call in your request. </p>\n         <p>You can indicate the maximum number of objects that you want Shield Advanced to return for a single call with the <code>MaxResults</code>\n           setting. Shield Advanced will not return more than <code>MaxResults</code> objects, but may return fewer, even if more objects are still available.</p>\n         <p>Whenever more objects remain that Shield Advanced has not yet returned to you, the response will include a <code>NextToken</code> value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidResourceException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets information about Amazon Web Services tags for a specified Amazon Resource Name (ARN) in Shield.</p>"
+      }
+    },
+    "com.amazonaws.shield#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource to get tags for.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.shield#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tag key and value pairs associated with the specified resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#LockedSubscriptionException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You are trying to update a subscription that has not yet completed the 1-year commitment. You can change the <code>AutoRenew</code> parameter during the last 30 days of your subscription. This exception indicates that you are attempting to change <code>AutoRenew</code> prior to that period.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#LogBucket": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 63
+        },
+        "smithy.api#pattern": "^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$"
+      }
+    },
+    "com.amazonaws.shield#LogBucketList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#LogBucket"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.shield#Long": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.shield#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 10000
+        }
+      }
+    },
+    "com.amazonaws.shield#Mitigation": {
+      "type": "structure",
+      "members": {
+        "MitigationName": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the mitigation taken for this attack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The mitigation applied to a DDoS attack.</p>"
+      }
+    },
+    "com.amazonaws.shield#MitigationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#Mitigation"
+      }
+    },
+    "com.amazonaws.shield#NoAssociatedRoleException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The ARN of the role that you specified does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#OptimisticLockException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception that indicates that the resource state has been modified by another\n         client. Retrieve the resource and then retry your request.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#PhoneNumber": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 16
+        },
+        "smithy.api#pattern": "^\\+[1-9]\\d{1,14}$"
+      }
+    },
+    "com.amazonaws.shield#ProactiveEngagementStatus": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        },
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectedResourceType": {
+      "type": "enum",
+      "members": {
+        "CLOUDFRONT_DISTRIBUTION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLOUDFRONT_DISTRIBUTION"
+          }
+        },
+        "ROUTE_53_HOSTED_ZONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ROUTE_53_HOSTED_ZONE"
+          }
+        },
+        "ELASTIC_IP_ALLOCATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ELASTIC_IP_ALLOCATION"
+          }
+        },
+        "CLASSIC_LOAD_BALANCER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLASSIC_LOAD_BALANCER"
+          }
+        },
+        "APPLICATION_LOAD_BALANCER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "APPLICATION_LOAD_BALANCER"
+          }
+        },
+        "GLOBAL_ACCELERATOR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GLOBAL_ACCELERATOR"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectedResourceTypeFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ProtectedResourceType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.shield#Protection": {
+      "type": "structure",
+      "members": {
+        "Id": {
+          "target": "com.amazonaws.shield#ProtectionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) of the protection.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.shield#ProtectionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection. For example, <code>My CloudFront distributions</code>.</p>"
+          }
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the Amazon Web Services resource that is protected.</p>"
+          }
+        },
+        "HealthCheckIds": {
+          "target": "com.amazonaws.shield#HealthCheckIds",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) for the Route\u00a053 health check that's associated with the protection. </p>"
+          }
+        },
+        "ProtectionArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the protection.</p>"
+          }
+        },
+        "ApplicationLayerAutomaticResponseConfiguration": {
+          "target": "com.amazonaws.shield#ApplicationLayerAutomaticResponseConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The automatic application layer DDoS mitigation settings for the protection.\n       This configuration determines whether Shield Advanced automatically\n       manages rules in the web ACL in order to respond to application layer events that Shield Advanced determines to be DDoS attacks. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object that represents a resource that is under DDoS protection.</p>"
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroup": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupId": {
+          "target": "com.amazonaws.shield#ProtectionGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Aggregation": {
+          "target": "com.amazonaws.shield#ProtectionGroupAggregation",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines how Shield combines resource data for the group in order to detect, mitigate, and report events.</p>\n         <ul>\n            <li>\n               <p>Sum - Use the total traffic across the group. This is a good choice for most cases. Examples include Elastic IP addresses for EC2 instances that scale manually or automatically.</p>\n            </li>\n            <li>\n               <p>Mean - Use the average of the traffic across the group. This is a good choice for resources that share traffic uniformly. Examples include accelerators and load balancers.</p>\n            </li>\n            <li>\n               <p>Max - Use the highest traffic from each resource. This is useful for resources that don't share traffic and for resources that share that traffic in a non-uniform way. Examples include Amazon CloudFront distributions and origin resources for CloudFront distributions.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Pattern": {
+          "target": "com.amazonaws.shield#ProtectionGroupPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The criteria to use to choose the protected resources for inclusion in the group. You can include all resources that have protections, provide a list of resource ARNs (Amazon Resource Names), or include all resources of a specified resource type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.shield#ProtectedResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type to include in the protection group. All protected resources of this type are included in the protection group.\n           You must set this when you set <code>Pattern</code> to <code>BY_RESOURCE_TYPE</code> and you must not set it for any other <code>Pattern</code> setting. </p>"
+          }
+        },
+        "Members": {
+          "target": "com.amazonaws.shield#ProtectionGroupMembers",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARNs (Amazon Resource Names) of the resources to include in the protection group. You must set this when you set <code>Pattern</code> to <code>ARBITRARY</code> and you must not set it for any other <code>Pattern</code> setting. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ProtectionGroupArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the protection group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A grouping of protected resources that you and Shield Advanced can monitor as a collective. This resource grouping improves the accuracy of detection and reduces false positives. </p>"
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupAggregation": {
+      "type": "enum",
+      "members": {
+        "SUM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUM"
+          }
+        },
+        "MEAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEAN"
+          }
+        },
+        "MAX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MAX"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupAggregationFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ProtectionGroupAggregation"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupArbitraryPatternLimits": {
+      "type": "structure",
+      "members": {
+        "MaxMembers": {
+          "target": "com.amazonaws.shield#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of resources you can specify for a single arbitrary pattern in a protection group.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Limits settings on protection groups with arbitrary pattern type. </p>"
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 36
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9\\\\-]*$"
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupIdFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ProtectionGroupId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupLimits": {
+      "type": "structure",
+      "members": {
+        "MaxProtectionGroups": {
+          "target": "com.amazonaws.shield#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of protection groups that you can have at one time. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PatternTypeLimits": {
+          "target": "com.amazonaws.shield#ProtectionGroupPatternTypeLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits settings by pattern type in the protection groups for your subscription. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Limits settings on protection groups for your subscription. </p>"
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupMembers": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ResourceArn"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10000
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupPattern": {
+      "type": "enum",
+      "members": {
+        "ALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL"
+          }
+        },
+        "ARBITRARY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ARBITRARY"
+          }
+        },
+        "BY_RESOURCE_TYPE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BY_RESOURCE_TYPE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupPatternFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ProtectionGroupPattern"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroupPatternTypeLimits": {
+      "type": "structure",
+      "members": {
+        "ArbitraryPatternLimits": {
+          "target": "com.amazonaws.shield#ProtectionGroupArbitraryPatternLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits settings on protection groups with arbitrary pattern type. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Limits settings by pattern type in the protection groups for your subscription. </p>"
+      }
+    },
+    "com.amazonaws.shield#ProtectionGroups": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ProtectionGroup"
+      }
+    },
+    "com.amazonaws.shield#ProtectionId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 36,
+          "max": 36
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9\\\\-]*$"
+      }
+    },
+    "com.amazonaws.shield#ProtectionLimits": {
+      "type": "structure",
+      "members": {
+        "ProtectedResourceTypeLimits": {
+          "target": "com.amazonaws.shield#Limits",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of resource types that you can specify in a protection.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Limits settings on protections for your subscription. </p>"
+      }
+    },
+    "com.amazonaws.shield#ProtectionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[ a-zA-Z0-9_\\\\.\\\\-]*$"
+      }
+    },
+    "com.amazonaws.shield#ProtectionNameFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ProtectionName"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.shield#Protections": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#Protection"
+      }
+    },
+    "com.amazonaws.shield#ResourceAlreadyExistsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        },
+        "resourceType": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of resource that already exists.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception indicating the specified resource already exists. If available, this exception includes details in additional properties. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#ResourceArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:aws"
+      }
+    },
+    "com.amazonaws.shield#ResourceArnFilterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ResourceArn"
+      }
+    },
+    "com.amazonaws.shield#ResourceArnFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ResourceArn"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.shield#ResourceArnList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ResourceArn"
+      }
+    },
+    "com.amazonaws.shield#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.shield#errorMessage"
+        },
+        "resourceType": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Type of resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Exception indicating the specified resource does not exist. If available, this exception includes details in additional properties. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.shield#ResponseAction": {
+      "type": "structure",
+      "members": {
+        "Block": {
+          "target": "com.amazonaws.shield#BlockAction",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies that Shield Advanced should configure its WAF rules with the WAF <code>Block</code> action. </p>\n         <p>You must specify exactly one action, either <code>Block</code> or <code>Count</code>.</p>"
+          }
+        },
+        "Count": {
+          "target": "com.amazonaws.shield#CountAction",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies that Shield Advanced should configure its WAF rules with the WAF <code>Count</code> action. </p>\n         <p>You must specify exactly one action, either <code>Block</code> or <code>Count</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the action setting that Shield Advanced should use in the WAF rules that it creates on behalf of the\n   protected resource in response to DDoS attacks. You specify this as part of the configuration for the automatic application layer DDoS mitigation feature,\n   when you enable or update automatic mitigation. Shield Advanced creates the WAF rules in a Shield Advanced-managed rule group, inside the web ACL that you have associated with the resource. </p>"
+      }
+    },
+    "com.amazonaws.shield#RoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+      }
+    },
+    "com.amazonaws.shield#String": {
+      "type": "string"
+    },
+    "com.amazonaws.shield#SubResourceSummary": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.shield#SubResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>SubResource</code> type.</p>"
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier (ID) of the <code>SubResource</code>.</p>"
+          }
+        },
+        "AttackVectors": {
+          "target": "com.amazonaws.shield#SummarizedAttackVectorList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of attack types and associated counters.</p>"
+          }
+        },
+        "Counters": {
+          "target": "com.amazonaws.shield#SummarizedCounterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The counters that describe the details of the attack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The attack information for the specified SubResource.</p>"
+      }
+    },
+    "com.amazonaws.shield#SubResourceSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#SubResourceSummary"
+      }
+    },
+    "com.amazonaws.shield#SubResourceType": {
+      "type": "enum",
+      "members": {
+        "IP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IP"
+          }
+        },
+        "URL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "URL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#Subscription": {
+      "type": "structure",
+      "members": {
+        "StartTime": {
+          "target": "com.amazonaws.shield#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The start time of the subscription, in Unix time in seconds. </p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.shield#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time your subscription will end.</p>"
+          }
+        },
+        "TimeCommitmentInSeconds": {
+          "target": "com.amazonaws.shield#DurationInSeconds",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The length, in seconds, of the Shield Advanced subscription for the account.</p>"
+          }
+        },
+        "AutoRenew": {
+          "target": "com.amazonaws.shield#AutoRenew",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>ENABLED</code>, the subscription will be automatically renewed at the end of the existing subscription period.</p>\n         <p>When you initally create a subscription, <code>AutoRenew</code> is set to <code>ENABLED</code>. You can change this by submitting an <code>UpdateSubscription</code> request. If the <code>UpdateSubscription</code> request does not included a value for <code>AutoRenew</code>, the existing value for <code>AutoRenew</code> remains unchanged.</p>"
+          }
+        },
+        "Limits": {
+          "target": "com.amazonaws.shield#Limits",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies how many protections of a given type you can create.</p>"
+          }
+        },
+        "ProactiveEngagementStatus": {
+          "target": "com.amazonaws.shield#ProactiveEngagementStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>ENABLED</code>, the Shield Response Team (SRT) will use email and phone to notify contacts about escalations to the SRT and to initiate proactive customer support.</p>\n         <p>If <code>PENDING</code>, you have requested proactive engagement and the request is pending. The status changes to <code>ENABLED</code> when your request is fully processed.</p>\n         <p>If <code>DISABLED</code>, the SRT will not proactively notify contacts about escalations or to initiate proactive customer support. </p>"
+          }
+        },
+        "SubscriptionLimits": {
+          "target": "com.amazonaws.shield#SubscriptionLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits settings for your subscription. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SubscriptionArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the subscription.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the Shield Advanced subscription for an account.</p>"
+      }
+    },
+    "com.amazonaws.shield#SubscriptionLimits": {
+      "type": "structure",
+      "members": {
+        "ProtectionLimits": {
+          "target": "com.amazonaws.shield#ProtectionLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits settings on protections for your subscription. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ProtectionGroupLimits": {
+          "target": "com.amazonaws.shield#ProtectionGroupLimits",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits settings on protection groups for your subscription. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Limits settings for your subscription. </p>"
+      }
+    },
+    "com.amazonaws.shield#SubscriptionState": {
+      "type": "enum",
+      "members": {
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "INACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INACTIVE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#SummarizedAttackVector": {
+      "type": "structure",
+      "members": {
+        "VectorType": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The attack type, for example, SNMP reflection or SYN flood.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VectorCounters": {
+          "target": "com.amazonaws.shield#SummarizedCounterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of counters that describe the details of the attack.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of information about the attack.</p>"
+      }
+    },
+    "com.amazonaws.shield#SummarizedAttackVectorList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#SummarizedAttackVector"
+      }
+    },
+    "com.amazonaws.shield#SummarizedCounter": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The counter name.</p>"
+          }
+        },
+        "Max": {
+          "target": "com.amazonaws.shield#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum value of the counter for a specified time period.</p>"
+          }
+        },
+        "Average": {
+          "target": "com.amazonaws.shield#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The average value of the counter for a specified time period.</p>"
+          }
+        },
+        "Sum": {
+          "target": "com.amazonaws.shield#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The total of counter values for a specified time period.</p>"
+          }
+        },
+        "N": {
+          "target": "com.amazonaws.shield#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of counters for a specified time period.</p>"
+          }
+        },
+        "Unit": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unit of the counters.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The counter that describes a DDoS attack.</p>"
+      }
+    },
+    "com.amazonaws.shield#SummarizedCounterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#SummarizedCounter"
+      }
+    },
+    "com.amazonaws.shield#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.shield#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Part of the key:value pair that defines a tag. You can use a tag key to describe a category of information, such as \"customer.\" Tag keys are case-sensitive.</p>"
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.shield#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>Part of the key:value pair that defines a tag. You can use a tag value to describe a specific value within a category, such as \"companyA\" or \"companyB.\" Tag values are case-sensitive.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A tag associated with an Amazon Web Services resource. Tags are key:value pairs that you can use to categorize and manage your resources, for purposes like billing or other management. Typically, the tag key represents a category, such as \"environment\", and the tag value represents a specific value within that category, such as \"test,\" \"development,\" or \"production\". Or you might set the tag key to \"customer\" and the value to the customer name or ID. You can specify one or more tags to add to each Amazon Web Services resource, up to 50 tags for a resource.</p>"
+      }
+    },
+    "com.amazonaws.shield#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.shield#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.shield#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.shield#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidResourceException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds or updates tags for a resource in Shield.</p>"
+      }
+    },
+    "com.amazonaws.shield#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource that you want to add or update tags for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.shield#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags that you want to modify or add to the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.shield#TimeRange": {
+      "type": "structure",
+      "members": {
+        "FromInclusive": {
+          "target": "com.amazonaws.shield#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The start time, in Unix time in seconds. </p>"
+          }
+        },
+        "ToExclusive": {
+          "target": "com.amazonaws.shield#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The end time, in Unix time in seconds. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The time range. </p>"
+      }
+    },
+    "com.amazonaws.shield#Timestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.shield#Token": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 4096
+        },
+        "smithy.api#pattern": "^.*$"
+      }
+    },
+    "com.amazonaws.shield#TopContributors": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#Contributor"
+      }
+    },
+    "com.amazonaws.shield#Unit": {
+      "type": "enum",
+      "members": {
+        "BITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BITS"
+          }
+        },
+        "BYTES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BYTES"
+          }
+        },
+        "PACKETS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PACKETS"
+          }
+        },
+        "REQUESTS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUESTS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidResourceException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes tags from a resource in Shield.</p>"
+      }
+    },
+    "com.amazonaws.shield#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource that you want to remove tags from.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.shield#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tag key for each tag that you want to remove from the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateApplicationLayerAutomaticResponse": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#UpdateApplicationLayerAutomaticResponseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#UpdateApplicationLayerAutomaticResponseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidOperationException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an existing Shield Advanced automatic application layer DDoS mitigation configuration for the specified resource.</p>"
+      }
+    },
+    "com.amazonaws.shield#UpdateApplicationLayerAutomaticResponseRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.shield#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN (Amazon Resource Name) of the resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Action": {
+          "target": "com.amazonaws.shield#ResponseAction",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the action setting that Shield Advanced should use in the WAF rules that it creates on behalf of the\n   protected resource in response to DDoS attacks. You specify this as part of the configuration for the automatic application layer DDoS mitigation feature,\n   when you enable or update automatic mitigation. Shield Advanced creates the WAF rules in a Shield Advanced-managed rule group, inside the web ACL that you have associated with the resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateApplicationLayerAutomaticResponseResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateEmergencyContactSettings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#UpdateEmergencyContactSettingsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#UpdateEmergencyContactSettingsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the details of the list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you if you have proactive engagement enabled, for escalations to the SRT and to initiate proactive customer support.</p>"
+      }
+    },
+    "com.amazonaws.shield#UpdateEmergencyContactSettingsRequest": {
+      "type": "structure",
+      "members": {
+        "EmergencyContactList": {
+          "target": "com.amazonaws.shield#EmergencyContactList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you if you have proactive engagement enabled, for escalations to the SRT and to initiate proactive customer support.</p>\n         <p>If you have proactive engagement enabled, the contact list must include at least one phone number.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateEmergencyContactSettingsResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateProtectionGroup": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#UpdateProtectionGroupRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#UpdateProtectionGroupResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an existing protection group. A protection group is a grouping of protected resources so they can be handled as a collective. This resource grouping improves the accuracy of detection and reduces false positives. </p>"
+      }
+    },
+    "com.amazonaws.shield#UpdateProtectionGroupRequest": {
+      "type": "structure",
+      "members": {
+        "ProtectionGroupId": {
+          "target": "com.amazonaws.shield#ProtectionGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Aggregation": {
+          "target": "com.amazonaws.shield#ProtectionGroupAggregation",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines how Shield combines resource data for the group in order to detect, mitigate, and report events.</p>\n         <ul>\n            <li>\n               <p>Sum - Use the total traffic across the group. This is a good choice for most cases. Examples include Elastic IP addresses for EC2 instances that scale manually or automatically.</p>\n            </li>\n            <li>\n               <p>Mean - Use the average of the traffic across the group. This is a good choice for resources that share traffic uniformly. Examples include accelerators and load balancers.</p>\n            </li>\n            <li>\n               <p>Max - Use the highest traffic from each resource. This is useful for resources that don't share traffic and for resources that share that traffic in a non-uniform way. Examples include Amazon CloudFront distributions and origin resources for CloudFront distributions.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "Pattern": {
+          "target": "com.amazonaws.shield#ProtectionGroupPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The criteria to use to choose the protected resources for inclusion in the group. You can include all resources that have protections, provide a list of resource Amazon Resource Names (ARNs), or include all resources of a specified resource type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ResourceType": {
+          "target": "com.amazonaws.shield#ProtectedResourceType",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type to include in the protection group. All protected resources of this type are included in the protection group.\n           You must set this when you set <code>Pattern</code> to <code>BY_RESOURCE_TYPE</code> and you must not set it for any other <code>Pattern</code> setting. </p>"
+          }
+        },
+        "Members": {
+          "target": "com.amazonaws.shield#ProtectionGroupMembers",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Names (ARNs) of the resources to include in the protection group. You must set this when you set <code>Pattern</code> to <code>ARBITRARY</code> and you must not set it for any other <code>Pattern</code> setting. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateProtectionGroupResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateSubscription": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.shield#UpdateSubscriptionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.shield#UpdateSubscriptionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.shield#InternalErrorException"
+        },
+        {
+          "target": "com.amazonaws.shield#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.shield#LockedSubscriptionException"
+        },
+        {
+          "target": "com.amazonaws.shield#OptimisticLockException"
+        },
+        {
+          "target": "com.amazonaws.shield#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the details of an existing subscription. Only enter values for parameters you want to change. Empty parameters are not updated.</p>\n         <note>\n            <p>For accounts that are members of an Organizations organization, Shield Advanced subscriptions are billed against the organization's payer account,\n              regardless of whether the payer account itself is subscribed. </p>\n         </note>"
+      }
+    },
+    "com.amazonaws.shield#UpdateSubscriptionRequest": {
+      "type": "structure",
+      "members": {
+        "AutoRenew": {
+          "target": "com.amazonaws.shield#AutoRenew",
+          "traits": {
+            "smithy.api#documentation": "<p>When you initally create a subscription, <code>AutoRenew</code> is set to <code>ENABLED</code>. If <code>ENABLED</code>, the subscription will be automatically renewed at the end of the existing subscription period. You can change this by submitting an <code>UpdateSubscription</code> request. If the <code>UpdateSubscription</code> request does not included a value for <code>AutoRenew</code>, the existing value for <code>AutoRenew</code> remains unchanged.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.shield#UpdateSubscriptionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.shield#ValidationExceptionField": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parameter that failed validation.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "message": {
+          "target": "com.amazonaws.shield#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The message describing why the parameter failed validation.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a particular parameter passed inside a request that resulted in an exception.</p>"
+      }
+    },
+    "com.amazonaws.shield#ValidationExceptionFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.shield#ValidationExceptionField"
+      }
+    },
+    "com.amazonaws.shield#ValidationExceptionReason": {
+      "type": "enum",
+      "members": {
+        "FIELD_VALIDATION_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FIELD_VALIDATION_FAILED"
+          }
+        },
+        "OTHER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OTHER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.shield#errorMessage": {
+      "type": "string"
+    }
+  }
+}

--- a/crates/fakecloud-shield/src/validate.rs
+++ b/crates/fakecloud-shield/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored Shield Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/shield.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 #[derive(Debug, Default)]
 struct MemberConstraint {

--- a/crates/fakecloud-support/model.json
+++ b/crates/fakecloud-support/model.json
@@ -1,0 +1,3716 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.support#AWSSupport_20130415": {
+      "type": "service",
+      "version": "2013-04-15",
+      "operations": [
+        {
+          "target": "com.amazonaws.support#AddAttachmentsToSet"
+        },
+        {
+          "target": "com.amazonaws.support#AddCommunicationToCase"
+        },
+        {
+          "target": "com.amazonaws.support#CreateCase"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeAttachment"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeCases"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeCommunications"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeCreateCaseOptions"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeServices"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeSeverityLevels"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeSupportedLanguages"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckRefreshStatuses"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckResult"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeTrustedAdvisorChecks"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckSummaries"
+        },
+        {
+          "target": "com.amazonaws.support#RefreshTrustedAdvisorCheck"
+        },
+        {
+          "target": "com.amazonaws.support#ResolveCase"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Support",
+          "arnNamespace": "support",
+          "cloudFormationName": "Support",
+          "cloudTrailEventSource": "support.amazonaws.com",
+          "endpointPrefix": "support"
+        },
+        "aws.auth#sigv4": {
+          "name": "support"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<fullname>Amazon Web Services Support</fullname>\n         <p>The <i>Amazon Web Services Support API Reference</i> is intended for programmers who need detailed\n            information about the Amazon Web Services Support operations and data types. You can use the API to manage\n            your support cases programmatically. The Amazon Web Services Support API uses HTTP methods that return\n            results in JSON format.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>\n         <p>You can also use the Amazon Web Services Support API to access features for <a href=\"http://aws.amazon.com/premiumsupport/trustedadvisor/\">Trusted Advisor</a>. You can return a list of\n            checks and their descriptions, get check results, specify checks to refresh, and get the\n            refresh status of checks.</p>\n         <p>You can manage your support cases with the following Amazon Web Services Support API operations:</p>\n         <ul>\n            <li>\n               <p>The <a>CreateCase</a>, <a>DescribeCases</a>, <a>DescribeAttachment</a>, and <a>ResolveCase</a> operations\n                    create Amazon Web Services Support cases, retrieve information about cases, and resolve cases.</p>\n            </li>\n            <li>\n               <p>The <a>DescribeCommunications</a>, <a>AddCommunicationToCase</a>, and <a>AddAttachmentsToSet</a> operations retrieve and add communications and attachments to Amazon Web Services Support\n                    cases.</p>\n            </li>\n            <li>\n               <p>The <a>DescribeServices</a> and <a>DescribeSeverityLevels</a> operations return Amazon Web Services service names, service codes, service categories, and problem\n                    severity levels. You use these values when you call the <a>CreateCase</a> operation.</p>\n            </li>\n         </ul>\n         <p>You can also use the Amazon Web Services Support API to call the  Trusted Advisor operations. For more\n            information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor.html\">Trusted Advisor</a> in the\n                <i>Amazon Web Services Support User Guide</i>.</p>\n         <p>For authentication of requests, Amazon Web Services Support uses <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing\n                Process</a>.</p>\n         <p>For more information about this service and the endpoints to use, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html\">About the\n                Amazon Web Services Support API</a> in the <i>Amazon Web Services Support User Guide</i>.</p>",
+        "smithy.api#title": "AWS Support",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://support.amazonaws.com/doc/2013-04-15/"
+        },
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws"
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-cn"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-iso"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-iso-b"
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.us-east-1.amazonaws.com",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "support",
+                      "signingRegion": "us-east-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.cn-north-1.amazonaws.com.cn",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "support",
+                      "signingRegion": "cn-north-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.us-gov-west-1.amazonaws.com",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "support",
+                      "signingRegion": "us-gov-west-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.us-iso-east-1.c2s.ic.gov",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "support",
+                      "signingRegion": "us-iso-east-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.us-isob-east-1.sc2s.sgov.gov",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4",
+                      "signingName": "support",
+                      "signingRegion": "us-isob-east-1"
+                    }
+                  ]
+                },
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://support.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 19,
+          "nodes": "/////wAAAAH/////AAAAAAAAABIAAAADAAAAAQAAAAQF9eEQAAAAAgAAAAUF9eEQAAAAAwAAAA0AAAAGAAAABAAAAAwAAAAHAAAABQX14QQAAAAIAAAABwX14QUAAAAJAAAACAX14QYAAAAKAAAACgX14QcAAAALAAAACwX14QgF9eEPAAAABgX14Q0F9eEOAAAABAAAABAAAAAOAAAACAX14QYAAAAPAAAACQX14QsF9eEMAAAABgAAABEF9eEKAAAACQX14QkF9eEKAAAAAwX14QEAAAATAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://support.us-east-1.amazonaws.com",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "support",
+                              "signingRegion": "us-east-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws-cn"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://support.cn-north-1.amazonaws.com.cn",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "support",
+                              "signingRegion": "cn-north-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws-us-gov"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://support.us-gov-west-1.amazonaws.com",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "support",
+                              "signingRegion": "us-gov-west-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws-us-gov"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://support.us-gov-west-1.amazonaws.com",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "support",
+                              "signingRegion": "us-gov-west-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws-iso"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://support.us-iso-east-1.c2s.ic.gov",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "support",
+                              "signingRegion": "us-iso-east-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws-iso-b"
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            false
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            false
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://support.us-isob-east-1.sc2s.sgov.gov",
+                        "properties": {
+                          "authSchemes": [
+                            {
+                              "name": "sigv4",
+                              "signingName": "support",
+                              "signingRegion": "us-isob-east-1"
+                            }
+                          ]
+                        },
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://support-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://support-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://support.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://support.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region aws-global with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "aws-global",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region aws-cn-global with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "cn-north-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "aws-cn-global",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "cn-north-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region aws-us-gov-global with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-gov-west-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "aws-us-gov-global",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region aws-us-gov-global with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-gov-west-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "aws-us-gov-global",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-gov-west-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-gov-west-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region aws-iso-global with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-iso-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "aws-iso-global",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-iso-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region aws-iso-b-global with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-isob-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "aws-iso-b-global",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://support-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "properties": {
+                    "authSchemes": [
+                      {
+                        "name": "sigv4",
+                        "signingName": "support",
+                        "signingRegion": "us-isob-east-1"
+                      }
+                    ]
+                  },
+                  "url": "https://support.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.support#AddAttachmentsToSet": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#AddAttachmentsToSetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#AddAttachmentsToSetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#AttachmentLimitExceeded"
+        },
+        {
+          "target": "com.amazonaws.support#AttachmentSetExpired"
+        },
+        {
+          "target": "com.amazonaws.support#AttachmentSetIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#AttachmentSetSizeLimitExceeded"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds one or more attachments to an attachment set. </p>\n         <p>An attachment set is a temporary container for attachments that you add to a case or\n            case communication. The set is available for 1 hour after it's created. The\n                <code>expiryTime</code> returned in the response is when the set expires. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#AddAttachmentsToSetRequest": {
+      "type": "structure",
+      "members": {
+        "attachmentSetId": {
+          "target": "com.amazonaws.support#AttachmentSetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the attachment set. If an <code>attachmentSetId</code> is not specified, a\n            new attachment set is created, and the ID of the set is returned in the response. If an\n                <code>attachmentSetId</code> is specified, the attachments are added to the\n            specified set, if it exists.</p>"
+          }
+        },
+        "attachments": {
+          "target": "com.amazonaws.support#Attachments",
+          "traits": {
+            "smithy.api#documentation": "<p>One or more attachments to add to the set. You can add up to three attachments per\n            set. The size limit is 5 MB per attachment.</p>\n         <p>In the <code>Attachment</code> object, use the <code>data</code> parameter to specify\n            the contents of the attachment file. In the previous request syntax, the value for\n                <code>data</code> appear as <code>blob</code>, which is represented as a\n            base64-encoded string. The value for <code>fileName</code> is the name of the\n            attachment, such as <code>troubleshoot-screenshot.png</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#AddAttachmentsToSetResponse": {
+      "type": "structure",
+      "members": {
+        "attachmentSetId": {
+          "target": "com.amazonaws.support#AttachmentSetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the attachment set. If an <code>attachmentSetId</code> was not specified, a\n            new attachment set is created, and the ID of the set is returned in the response. If an\n                <code>attachmentSetId</code> was specified, the attachments are added to the\n            specified set, if it exists.</p>"
+          }
+        },
+        "expiryTime": {
+          "target": "com.amazonaws.support#ExpiryTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time and date when the attachment set expires.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The ID and expiry time of the attachment set returned by the <a>AddAttachmentsToSet</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#AddCommunicationToCase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#AddCommunicationToCaseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#AddCommunicationToCaseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#AttachmentSetExpired"
+        },
+        {
+          "target": "com.amazonaws.support#AttachmentSetIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#CaseIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds additional customer communication to an Amazon Web Services Support case. Use the <code>caseId</code>\n            parameter to identify the case to which to add communication. You can list a set of\n            email addresses to copy on the communication by using the <code>ccEmailAddresses</code>\n            parameter. The <code>communicationBody</code> value contains the text of the\n            communication.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#AddCommunicationToCaseRequest": {
+      "type": "structure",
+      "members": {
+        "caseId": {
+          "target": "com.amazonaws.support#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The support case ID requested or returned in the call. The case ID is an alphanumeric\n            string formatted as shown in this example:\n                case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>\n         </p>"
+          }
+        },
+        "communicationBody": {
+          "target": "com.amazonaws.support#CommunicationBody",
+          "traits": {
+            "smithy.api#documentation": "<p>The body of an email communication to add to the support case.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ccEmailAddresses": {
+          "target": "com.amazonaws.support#CcEmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>The email addresses in the CC line of an email to be added to the support case.</p>"
+          }
+        },
+        "attachmentSetId": {
+          "target": "com.amazonaws.support#AttachmentSetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of a set of one or more attachments for the communication to add to the case.\n            Create the set by calling <a>AddAttachmentsToSet</a>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#AddCommunicationToCaseResponse": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "com.amazonaws.support#Result",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>True if <a>AddCommunicationToCase</a> succeeds. Otherwise, returns an\n            error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of the <a>AddCommunicationToCase</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#AfterTime": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Attachment": {
+      "type": "structure",
+      "members": {
+        "fileName": {
+          "target": "com.amazonaws.support#FileName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the attachment file.</p>"
+          }
+        },
+        "data": {
+          "target": "com.amazonaws.support#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The content of the attachment file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An attachment to a case communication. The attachment consists of the file name and\n            the content of the file. Each attachment file size should not exceed 5 MB. File types that are supported include the following: pdf, jpeg,.doc, .log, .text </p>"
+      }
+    },
+    "com.amazonaws.support#AttachmentDetails": {
+      "type": "structure",
+      "members": {
+        "attachmentId": {
+          "target": "com.amazonaws.support#AttachmentId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the attachment.</p>"
+          }
+        },
+        "fileName": {
+          "target": "com.amazonaws.support#FileName",
+          "traits": {
+            "smithy.api#documentation": "<p>The file name of the attachment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The file name and ID of an attachment to a case communication. You can use the ID to\n            retrieve the attachment with the <a>DescribeAttachment</a> operation.</p>"
+      }
+    },
+    "com.amazonaws.support#AttachmentId": {
+      "type": "string"
+    },
+    "com.amazonaws.support#AttachmentIdNotFound": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>An attachment with the specified ID could not be found.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An attachment with the specified ID could not be found.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#AttachmentLimitExceeded": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit for the number of attachment sets created in a short period of time has been\n            exceeded.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The limit for the number of attachment sets created in a short period of time has been\n            exceeded.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#AttachmentSet": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#AttachmentDetails"
+      }
+    },
+    "com.amazonaws.support#AttachmentSetExpired": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The expiration time of the attachment set has passed. The set expires one hour after\n            it is created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The expiration time of the attachment set has passed. The set expires 1 hour after it\n            is created.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#AttachmentSetId": {
+      "type": "string"
+    },
+    "com.amazonaws.support#AttachmentSetIdNotFound": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>An attachment set with the specified ID could not be found.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An attachment set with the specified ID could not be found.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#AttachmentSetSizeLimitExceeded": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A limit for the size of an attachment set has been exceeded. The limits are three\n            attachments and 5 MB per attachment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A limit for the size of an attachment set has been exceeded. The limits are three\n            attachments and 5 MB per attachment.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#Attachments": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#Attachment"
+      }
+    },
+    "com.amazonaws.support#AvailabilityErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.support#BeforeTime": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Boolean": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.support#CaseCreationLimitExceeded": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>An error message that indicates that you have exceeded the number of cases you can\n            have open.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The case creation limit for the account has been exceeded.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#CaseDetails": {
+      "type": "structure",
+      "members": {
+        "caseId": {
+          "target": "com.amazonaws.support#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The support case ID requested or returned in the call. The case ID is an alphanumeric\n            string formatted as shown in this example:\n                case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>\n         </p>"
+          }
+        },
+        "displayId": {
+          "target": "com.amazonaws.support#DisplayId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID displayed for the case in the Amazon Web Services Support Center. This is a numeric\n            string.</p>"
+          }
+        },
+        "subject": {
+          "target": "com.amazonaws.support#Subject",
+          "traits": {
+            "smithy.api#documentation": "<p>The subject line for the case in the Amazon Web Services Support Center.</p>"
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.support#Status",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the case.</p>\n         <p>Valid values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>all-open</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>customer-action-completed</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>opened</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>pending-customer-action</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>reopened</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>resolved</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>unassigned</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>work-in-progress</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        },
+        "serviceCode": {
+          "target": "com.amazonaws.support#ServiceCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for the Amazon Web Services service. You can get a list of codes and the corresponding\n            service names by calling <a>DescribeServices</a>.</p>"
+          }
+        },
+        "categoryCode": {
+          "target": "com.amazonaws.support#CategoryCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The category of problem for the support case.</p>"
+          }
+        },
+        "severityCode": {
+          "target": "com.amazonaws.support#SeverityCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for the severity level returned by the call to <a>DescribeSeverityLevels</a>.</p>"
+          }
+        },
+        "submittedBy": {
+          "target": "com.amazonaws.support#SubmittedBy",
+          "traits": {
+            "smithy.api#documentation": "<p>The email address of the account that submitted the case.</p>"
+          }
+        },
+        "timeCreated": {
+          "target": "com.amazonaws.support#TimeCreated",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the case was created in the Amazon Web Services Support Center.</p>"
+          }
+        },
+        "recentCommunications": {
+          "target": "com.amazonaws.support#RecentCaseCommunications",
+          "traits": {
+            "smithy.api#documentation": "<p>The five most recent communications between you and Amazon Web Services Support Center, including the\n            IDs of any attachments to the communications. Also includes a <code>nextToken</code>\n            that you can use to retrieve earlier communications.</p>"
+          }
+        },
+        "ccEmailAddresses": {
+          "target": "com.amazonaws.support#CcEmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>The email addresses that receive copies of communication about the case.</p>"
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A JSON-formatted object that contains the metadata for a support case. It is contained\n            in the response from a <a>DescribeCases</a> request. <b>CaseDetails</b> contains the following fields:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>caseId</b> - The support case ID requested\n                    or returned in the call. The case ID is an alphanumeric string formatted as\n                    shown in this example:\n                        case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>categoryCode</b> - The category of problem\n                    for the support case. Corresponds to the <code>CategoryCode</code> values\n                    returned by a call to <a>DescribeServices</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>displayId</b> - The identifier for the case\n                    on pages in the Amazon Web Services Support Center.</p>\n            </li>\n            <li>\n               <p>\n                  <b>language</b> - The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>\n            </li>\n            <li>\n               <p>\n                  <b>nextToken</b> - A resumption point for\n                    pagination.</p>\n            </li>\n            <li>\n               <p>\n                  <b>recentCommunications</b> - One or more <a>Communication</a> objects. Fields of these objects are\n                        <code>attachments</code>, <code>body</code>, <code>caseId</code>,\n                        <code>submittedBy</code>, and <code>timeCreated</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>serviceCode</b> - The identifier for the\n                    Amazon Web Services service that corresponds to the service code defined in the call to <a>DescribeServices</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>severityCode</b> - The severity code\n                    assigned to the case. Contains one of the values returned by the call to <a>DescribeSeverityLevels</a>. The possible values are:\n                        <code>low</code>, <code>normal</code>, <code>high</code>,\n                        <code>urgent</code>, and <code>critical</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>status</b> - The status of the case in the\n                    Amazon Web Services Support Center. Valid values:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>all-open</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>customer-action-completed</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>opened</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>pending-customer-action</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>reopened</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>resolved</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>unassigned</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>work-in-progress</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <b>subject</b> - The subject line of the\n                    case.</p>\n            </li>\n            <li>\n               <p>\n                  <b>submittedBy</b> - The email address of the\n                    account that submitted the case.</p>\n            </li>\n            <li>\n               <p>\n                  <b>timeCreated</b> - The time the case was\n                    created, in ISO-8601 format.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.support#CaseId": {
+      "type": "string"
+    },
+    "com.amazonaws.support#CaseIdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#CaseId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#CaseIdNotFound": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The requested <code>CaseId</code> could not be located.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested <code>caseId</code> couldn't be located.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#CaseList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#CaseDetails"
+      }
+    },
+    "com.amazonaws.support#CaseStatus": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Category": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "com.amazonaws.support#CategoryCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The category code for the support case.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.support#CategoryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The category name for the support case.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A JSON-formatted name/value pair that represents the category name and category code\n            of the problem, selected from the <a>DescribeServices</a> response for each\n            Amazon Web Services service.</p>"
+      }
+    },
+    "com.amazonaws.support#CategoryCode": {
+      "type": "string"
+    },
+    "com.amazonaws.support#CategoryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#Category"
+      }
+    },
+    "com.amazonaws.support#CategoryName": {
+      "type": "string"
+    },
+    "com.amazonaws.support#CcEmailAddress": {
+      "type": "string"
+    },
+    "com.amazonaws.support#CcEmailAddressList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#CcEmailAddress"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.support#Code": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Communication": {
+      "type": "structure",
+      "members": {
+        "caseId": {
+          "target": "com.amazonaws.support#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The support case ID requested or returned in the call. The case ID is an alphanumeric\n            string formatted as shown in this example:\n                case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>\n         </p>"
+          }
+        },
+        "body": {
+          "target": "com.amazonaws.support#ValidatedCommunicationBody",
+          "traits": {
+            "smithy.api#documentation": "<p>The text of the communication between the customer and Amazon Web Services Support.</p>"
+          }
+        },
+        "submittedBy": {
+          "target": "com.amazonaws.support#SubmittedBy",
+          "traits": {
+            "smithy.api#documentation": "<p>The identity of the account that submitted, or responded to, the support case.\n            Customer entries include the IAM role as well as the email address (for example,\n            \"AdminRole (Role) <janedoe@example.com>). Entries from the Amazon Web Services Support team display\n            \"Amazon Web Services,\" and don't show an email address.\n            </p>"
+          }
+        },
+        "timeCreated": {
+          "target": "com.amazonaws.support#TimeCreated",
+          "traits": {
+            "smithy.api#documentation": "<p>The time the communication was created.</p>"
+          }
+        },
+        "attachmentSet": {
+          "target": "com.amazonaws.support#AttachmentSet",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the attachments to the case communication.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A communication associated with a support case. The communication consists of the case\n            ID, the message body, attachment information, the submitter of the communication, and\n            the date and time of the communication.</p>"
+      }
+    },
+    "com.amazonaws.support#CommunicationBody": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 8000
+        }
+      }
+    },
+    "com.amazonaws.support#CommunicationList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#Communication"
+      }
+    },
+    "com.amazonaws.support#CommunicationTypeOptions": {
+      "type": "structure",
+      "members": {
+        "type": {
+          "target": "com.amazonaws.support#Type",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        A string value indicating the communication type. At the moment the type value can assume one of 3 values at the moment chat, web and call.\n        </p>"
+          }
+        },
+        "supportedHours": {
+          "target": "com.amazonaws.support#SupportedHoursList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        A JSON-formatted list containing time ranges when support is available.\n        </p>"
+          }
+        },
+        "datesWithoutSupport": {
+          "target": "com.amazonaws.support#DatesWithoutSupportList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        A JSON-formatted list containing date and time ranges for periods without support\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A JSON-formatted object that contains the CommunicationTypeOptions for creating a case for a certain\n        communication channel. It is contained in the response from a <a>DescribeCreateCaseOptions</a> request. <b>CommunicationTypeOptions</b> contains the following fields:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>datesWithoutSupport</b> - \n                    A JSON-formatted list containing date and time ranges for periods \n                    without support in UTC time. Date and time format is RFC 3339 : 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ'.\n                    </p>\n            </li>\n            <li>\n               <p>\n                  <b>supportedHours</b> - \n                    A JSON-formatted list containing time ranges when support are available. \n                    Time format is RFC 3339 : 'HH:mm:ss.SSS'.\n                    </p>\n            </li>\n            <li>\n               <p>\n                  <b>type</b> - \n                   A string value indicating the communication type that the aforementioned rules apply to. At the moment\n                   the type value can assume one of 3 values at the moment <code>chat</code>, <code>web</code> and \n                   <code>call</code>.\n                    </p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.support#CommunicationTypeOptionsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#CommunicationTypeOptions"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#CreateCase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#CreateCaseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#CreateCaseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#AttachmentSetExpired"
+        },
+        {
+          "target": "com.amazonaws.support#AttachmentSetIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#CaseCreationLimitExceeded"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a case in the Amazon Web Services Support Center. This operation is similar to how you create a case\n            in the Amazon Web Services Support Center <a href=\"https://console.aws.amazon.com/support/home#/case/create\">Create\n                Case</a> page.</p>\n         <p>The Amazon Web Services Support API doesn't support requesting service limit increases. You can submit a\n            service limit increase in the following ways: </p>\n         <ul>\n            <li>\n               <p>Submit a request from the Amazon Web Services Support Center <a href=\"https://console.aws.amazon.com/support/home#/case/create\">Create Case</a> page.</p>\n            </li>\n            <li>\n               <p>Use the Service Quotas <a href=\"https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_RequestServiceQuotaIncrease.html\">RequestServiceQuotaIncrease</a> operation.</p>\n            </li>\n         </ul>\n         <p>A successful <code>CreateCase</code> request returns an Amazon Web Services Support case number. You can use\n            the <a>DescribeCases</a> operation and specify the case number to get\n            existing Amazon Web Services Support cases. After you create a case, use the <a>AddCommunicationToCase</a> operation to add additional communication or\n            attachments to an existing case.</p>\n         <p>The <code>caseId</code> is separate from the <code>displayId</code> that appears in\n            the <a href=\"https://console.aws.amazon.com/support\">Amazon Web Services Support Center</a>. Use the <a>DescribeCases</a> operation to get the <code>displayId</code>.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#CreateCaseRequest": {
+      "type": "structure",
+      "members": {
+        "subject": {
+          "target": "com.amazonaws.support#Subject",
+          "traits": {
+            "smithy.api#documentation": "<p>The title of the support case. The title appears in the <b>Subject</b> field on the Amazon Web Services Support Center <a href=\"https://console.aws.amazon.com/support/home#/case/create\">Create Case</a> page.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceCode": {
+          "target": "com.amazonaws.support#ServiceCode2",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for the Amazon Web Services service. You can use the <a>DescribeServices</a>\n            operation to get the possible <code>serviceCode</code> values.</p>"
+          }
+        },
+        "severityCode": {
+          "target": "com.amazonaws.support#SeverityCode",
+          "traits": {
+            "smithy.api#documentation": "<p>A value that indicates the urgency of the case. This value determines the response\n            time according to your service level agreement with Amazon Web Services Support. You can use the <a>DescribeSeverityLevels</a> operation to get the possible values for\n                <code>severityCode</code>. </p>\n         <p>For more information, see <a>SeverityLevel</a> and <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/getting-started.html#choosing-severity\">Choosing a\n                Severity</a> in the <i>Amazon Web Services Support User Guide</i>.</p>\n         <note>\n            <p>The availability of severity levels depends on the support plan for the\n                Amazon Web Services account.</p>\n         </note>"
+          }
+        },
+        "categoryCode": {
+          "target": "com.amazonaws.support#CategoryCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The category of problem for the support case. You also use the <a>DescribeServices</a> operation to get the category code for a service. Each\n            Amazon Web Services service defines its own set of category codes.</p>"
+          }
+        },
+        "communicationBody": {
+          "target": "com.amazonaws.support#CommunicationBody",
+          "traits": {
+            "smithy.api#documentation": "<p>The communication body text that describes the issue. This text appears in the\n                <b>Description</b> field on the Amazon Web Services Support Center <a href=\"https://console.aws.amazon.com/support/home#/case/create\">Create Case</a> page.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ccEmailAddresses": {
+          "target": "com.amazonaws.support#CcEmailAddressList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of email addresses that Amazon Web Services Support copies on case correspondence. Amazon Web Services Support\n            identifies the account that creates the case when you specify your Amazon Web Services credentials in\n            an HTTP POST method or use the <a href=\"http://aws.amazon.com/tools/\">Amazon Web Services SDKs</a>.\n        </p>"
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>"
+          }
+        },
+        "issueType": {
+          "target": "com.amazonaws.support#IssueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of issue for the case. You can specify <code>customer-service</code> or\n                <code>technical</code>. If you don't specify a value, the default is\n                <code>technical</code>.</p>"
+          }
+        },
+        "attachmentSetId": {
+          "target": "com.amazonaws.support#AttachmentSetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of a set of one or more attachments for the case. Create the set by using the\n                <a>AddAttachmentsToSet</a> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#CreateCaseResponse": {
+      "type": "structure",
+      "members": {
+        "caseId": {
+          "target": "com.amazonaws.support#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The support case ID requested or returned in the call. The case ID is an alphanumeric\n            string in the following format:\n                case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The support case ID returned by a successful completion of the <a>CreateCase</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#Data": {
+      "type": "blob"
+    },
+    "com.amazonaws.support#DateInterval": {
+      "type": "structure",
+      "members": {
+        "startDateTime": {
+          "target": "com.amazonaws.support#ValidatedDateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        A JSON object containing start and date time (UTC). Date and time format is RFC 3339 : 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ'.\n        </p>"
+          }
+        },
+        "endDateTime": {
+          "target": "com.amazonaws.support#ValidatedDateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        End Date Time (UTC). RFC 3339 format : 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ'.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Date and time (UTC) format in RFC 3339 : 'yyyy-MM-dd'T'HH:mm:ss.SSSZZ'.</p>"
+      }
+    },
+    "com.amazonaws.support#DatesWithoutSupportList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#DateInterval"
+      }
+    },
+    "com.amazonaws.support#DescribeAttachment": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeAttachmentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeAttachmentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#AttachmentIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#DescribeAttachmentLimitExceeded"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the attachment that has the specified ID. Attachments can include screenshots,\n            error logs, or other files that describe your issue. Attachment IDs are generated by the\n            case management system when you add an attachment to a case or case communication.\n            Attachment IDs are returned in the <a>AttachmentDetails</a> objects that are\n            returned by the <a>DescribeCommunications</a> operation.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#DescribeAttachmentLimitExceeded": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The limit for the number of <a>DescribeAttachment</a> requests in a short\n            period of time has been exceeded.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The limit for the number of <a>DescribeAttachment</a> requests in a short\n            period of time has been exceeded.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.support#DescribeAttachmentRequest": {
+      "type": "structure",
+      "members": {
+        "attachmentId": {
+          "target": "com.amazonaws.support#AttachmentId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the attachment to return. Attachment IDs are returned by the <a>DescribeCommunications</a> operation.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeAttachmentResponse": {
+      "type": "structure",
+      "members": {
+        "attachment": {
+          "target": "com.amazonaws.support#Attachment",
+          "traits": {
+            "smithy.api#documentation": "<p>This object includes the attachment content and file name.</p>\n         <p>In the previous response syntax, the value for the <code>data</code> parameter appears\n            as <code>blob</code>, which is represented as a base64-encoded string. The value for\n                <code>fileName</code> is the name of the attachment, such as\n                <code>troubleshoot-screenshot.png</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The content and file name of the attachment returned by the <a>DescribeAttachment</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeCases": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeCasesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeCasesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#CaseIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of cases that you specify by passing one or more case IDs. You can use\n            the <code>afterTime</code> and <code>beforeTime</code> parameters to filter the cases by\n            date. You can set values for the <code>includeResolvedCases</code> and\n                <code>includeCommunications</code> parameters to specify how much information to\n            return.</p>\n         <p>The response returns the following in JSON format:</p>\n         <ul>\n            <li>\n               <p>One or more <a href=\"https://docs.aws.amazon.com/awssupport/latest/APIReference/API_CaseDetails.html\">CaseDetails</a> data types.</p>\n            </li>\n            <li>\n               <p>One or more <code>nextToken</code> values, which specify where to paginate the\n                    returned records represented by the <code>CaseDetails</code> objects.</p>\n            </li>\n         </ul>\n         <p>Case data is available for 12 months after creation. If a case was created more than\n            12 months ago, a request might return an error.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "cases",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.support#DescribeCasesRequest": {
+      "type": "structure",
+      "members": {
+        "caseIdList": {
+          "target": "com.amazonaws.support#CaseIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of ID numbers of the support cases you want returned. The maximum number of\n            cases is 100.</p>"
+          }
+        },
+        "displayId": {
+          "target": "com.amazonaws.support#DisplayId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID displayed for a case in the Amazon Web Services Support Center user interface.</p>"
+          }
+        },
+        "afterTime": {
+          "target": "com.amazonaws.support#AfterTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The start date for a filtered date search on support case communications. Case\n            communications are available for 12 months after creation.</p>"
+          }
+        },
+        "beforeTime": {
+          "target": "com.amazonaws.support#BeforeTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The end date for a filtered date search on support case communications. Case\n            communications are available for 12 months after creation.</p>"
+          }
+        },
+        "includeResolvedCases": {
+          "target": "com.amazonaws.support#IncludeResolvedCases",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether to include resolved support cases in the <code>DescribeCases</code>\n            response. By default, resolved cases aren't included.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.support#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A resumption point for pagination.</p>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.support#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return before paginating.</p>"
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>"
+          }
+        },
+        "includeCommunications": {
+          "target": "com.amazonaws.support#IncludeCommunications",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether to include communications in the <code>DescribeCases</code>\n            response. By default, communications are included.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeCasesResponse": {
+      "type": "structure",
+      "members": {
+        "cases": {
+          "target": "com.amazonaws.support#CaseList",
+          "traits": {
+            "smithy.api#documentation": "<p>The details for the cases that match the request.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.support#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A resumption point for pagination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns an array of <a href=\"https://docs.aws.amazon.com/awssupport/latest/APIReference/API_CaseDetails.html\">CaseDetails</a>\n            objects and a <code>nextToken</code> that defines a point for pagination in the result\n            set.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeCommunications": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeCommunicationsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeCommunicationsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#CaseIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns communications and attachments for one or more support cases. Use the\n                <code>afterTime</code> and <code>beforeTime</code> parameters to filter by date. You\n            can use the <code>caseId</code> parameter to restrict the results to a specific\n            case.</p>\n         <p>Case data is available for 12 months after creation. If a case was created more than\n            12 months ago, a request for data might cause an error.</p>\n         <p>You can use the <code>maxResults</code> and <code>nextToken</code> parameters to\n            control the pagination of the results. Set <code>maxResults</code> to the number of\n            cases that you want to display on each page, and use <code>nextToken</code> to specify\n            the resumption of pagination.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>",
+        "smithy.api#paginated": {
+          "inputToken": "nextToken",
+          "outputToken": "nextToken",
+          "items": "communications",
+          "pageSize": "maxResults"
+        }
+      }
+    },
+    "com.amazonaws.support#DescribeCommunicationsRequest": {
+      "type": "structure",
+      "members": {
+        "caseId": {
+          "target": "com.amazonaws.support#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The support case ID requested or returned in the call. The case ID is an alphanumeric\n            string formatted as shown in this example:\n                case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "beforeTime": {
+          "target": "com.amazonaws.support#BeforeTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The end date for a filtered date search on support case communications. Case\n            communications are available for 12 months after creation.</p>"
+          }
+        },
+        "afterTime": {
+          "target": "com.amazonaws.support#AfterTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The start date for a filtered date search on support case communications. Case\n            communications are available for 12 months after creation.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.support#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A resumption point for pagination.</p>"
+          }
+        },
+        "maxResults": {
+          "target": "com.amazonaws.support#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return before paginating.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeCommunicationsResponse": {
+      "type": "structure",
+      "members": {
+        "communications": {
+          "target": "com.amazonaws.support#CommunicationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The communications for the case.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.support#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A resumption point for pagination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The communications returned by the <a>DescribeCommunications</a>\n            operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeCreateCaseOptions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeCreateCaseOptionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeCreateCaseOptionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.support#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of CreateCaseOption types along with the \n        corresponding supported hours and language availability. You can specify the <code>language</code>\n            <code>categoryCode</code>, \n        <code>issueType</code> and <code>serviceCode</code> used to retrieve the CreateCaseOptions.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#DescribeCreateCaseOptionsRequest": {
+      "type": "structure",
+      "members": {
+        "issueType": {
+          "target": "com.amazonaws.support#IssueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of issue for the case. You can specify <code>customer-service</code> or\n                <code>technical</code>. If you don't specify a value, the default is\n                <code>technical</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceCode": {
+          "target": "com.amazonaws.support#ServiceCode2",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for the Amazon Web Services service. You can use the <a>DescribeServices</a>\n            operation to get the possible <code>serviceCode</code> values.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "categoryCode": {
+          "target": "com.amazonaws.support#CategoryCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The category of problem for the support case. You also use the <a>DescribeServices</a> operation to get the category code for a service. Each\n            Amazon Web Services service defines its own set of category codes.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeCreateCaseOptionsResponse": {
+      "type": "structure",
+      "members": {
+        "languageAvailability": {
+          "target": "com.amazonaws.support#ValidatedLanguageAvailability",
+          "traits": {
+            "smithy.api#documentation": "<p>Language availability can be any of the following:</p>\n         <ul>\n            <li>\n               <p>\n                    available\n                </p>\n            </li>\n            <li>\n               <p>\n                    best_effort\n                </p>\n            </li>\n            <li>\n               <p>\n                    unavailable\n                </p>\n            </li>\n         </ul>"
+          }
+        },
+        "communicationTypes": {
+          "target": "com.amazonaws.support#CommunicationTypeOptionsList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        A JSON-formatted array that contains the available communication type options, along with the available support \n        timeframes for the given inputs.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeServices": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeServicesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeServicesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the current list of Amazon Web Services services and a list of service categories for each\n            service. You then use service names and categories in your <a>CreateCase</a>\n            requests. Each Amazon Web Services service has its own set of categories.</p>\n         <p>The service codes and category codes correspond to the values that appear in the\n                <b>Service</b> and <b>Category</b> lists on the Amazon Web Services Support Center <a href=\"https://console.aws.amazon.com/support/home#/case/create\">Create Case</a> page. The values in those fields\n            don't necessarily match the service codes and categories returned by the\n                <code>DescribeServices</code> operation. Always use the service codes and categories\n            that the <code>DescribeServices</code> operation returns, so that you have the most\n            recent set of service and category codes.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#DescribeServicesRequest": {
+      "type": "structure",
+      "members": {
+        "serviceCodeList": {
+          "target": "com.amazonaws.support#ServiceCodeList",
+          "traits": {
+            "smithy.api#documentation": "<p>A JSON-formatted list of service codes available for Amazon Web Services services.</p>"
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeServicesResponse": {
+      "type": "structure",
+      "members": {
+        "services": {
+          "target": "com.amazonaws.support#ServiceList",
+          "traits": {
+            "smithy.api#documentation": "<p>A JSON-formatted list of Amazon Web Services services.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The list of Amazon Web Services services returned by the <a>DescribeServices</a>\n            operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeSeverityLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeSeverityLevelsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeSeverityLevelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the list of severity levels that you can assign to a support case. The\n            severity level for a case is also a field in the <a>CaseDetails</a> data type\n            that you include for a <a>CreateCase</a> request.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#DescribeSeverityLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>The language in which Amazon Web Services Support handles the case. Amazon Web Services Support\ncurrently supports Chinese (\u201czh\u201d), English (\"en\"), Japanese (\"ja\") and Korean (\u201cko\u201d). You must specify the ISO 639-1\ncode for the <code>language</code> parameter if you want support in that language.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeSeverityLevelsResponse": {
+      "type": "structure",
+      "members": {
+        "severityLevels": {
+          "target": "com.amazonaws.support#SeverityLevelsList",
+          "traits": {
+            "smithy.api#documentation": "<p>The available severity levels for the support case. Available severity levels are\n            defined by your service level agreement with Amazon Web Services.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The list of severity levels returned by the <a>DescribeSeverityLevels</a>\n            operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeSupportedLanguages": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeSupportedLanguagesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeSupportedLanguagesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.support#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of supported languages for a specified <code>categoryCode</code>, \n        <code>issueType</code> and <code>serviceCode</code>. The returned supported languages will \n        include a ISO 639-1 code for the <code>language</code>, and the language display name.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#DescribeSupportedLanguagesRequest": {
+      "type": "structure",
+      "members": {
+        "issueType": {
+          "target": "com.amazonaws.support#ValidatedIssueTypeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of issue for the case. You can specify <code>customer-service</code> or\n                <code>technical</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "serviceCode": {
+          "target": "com.amazonaws.support#ValidatedServiceCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for the Amazon Web Services service. You can use the <a>DescribeServices</a>\n            operation to get the possible <code>serviceCode</code> values.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "categoryCode": {
+          "target": "com.amazonaws.support#ValidatedCategoryCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The category of problem for the support case. You also use the <a>DescribeServices</a> operation to get the category code for a service. Each\n            Amazon Web Services service defines its own set of category codes.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeSupportedLanguagesResponse": {
+      "type": "structure",
+      "members": {
+        "supportedLanguages": {
+          "target": "com.amazonaws.support#SupportedLanguagesList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        A JSON-formatted array that contains the available ISO 639-1 language codes.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckRefreshStatuses": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckRefreshStatusesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckRefreshStatusesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.support#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the refresh status of the Trusted Advisor checks that have the specified check\n            IDs. You can get the check IDs by calling the <a>DescribeTrustedAdvisorChecks</a> operation.</p>\n         <p>Some checks are refreshed automatically, and you can't return their refresh statuses\n            by using the <code>DescribeTrustedAdvisorCheckRefreshStatuses</code> operation. If you\n            call this operation for these checks, you might see an\n                <code>InvalidParameterValue</code> error.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>\n         <p>To call the Trusted Advisor operations in\nthe Amazon Web Services Support API, you must use the US East (N. Virginia) endpoint. Currently, the US West (Oregon) and Europe (Ireland) \nendpoints don't support the Trusted Advisor operations. For more information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html#endpoint\">About the Amazon Web Services Support\nAPI</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckRefreshStatusesRequest": {
+      "type": "structure",
+      "members": {
+        "checkIds": {
+          "target": "com.amazonaws.support#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The IDs of the Trusted Advisor checks to get the status.</p>\n         <note>\n            <p>If you specify the check ID of a check that is automatically refreshed, you might\n                see an <code>InvalidParameterValue</code> error.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckRefreshStatusesResponse": {
+      "type": "structure",
+      "members": {
+        "statuses": {
+          "target": "com.amazonaws.support#TrustedAdvisorCheckRefreshStatusList",
+          "traits": {
+            "smithy.api#documentation": "<p>The refresh status of the specified Trusted Advisor checks.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The statuses of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckRefreshStatuses</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckResult": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckResultRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckResultResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.support#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the results of the Trusted Advisor check that has the specified check ID. You\n            can get the check IDs by calling the <a>DescribeTrustedAdvisorChecks</a>\n            operation.</p>\n         <p>The response contains a <a>TrustedAdvisorCheckResult</a> object, which\n            contains these three objects:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>TrustedAdvisorCategorySpecificSummary</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>TrustedAdvisorResourceDetail</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>TrustedAdvisorResourcesSummary</a>\n               </p>\n            </li>\n         </ul>\n         <p>In addition, the response contains these fields:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>status</b> - The alert status of the check\n                    can be <code>ok</code> (green), <code>warning</code> (yellow),\n                        <code>error</code> (red), or <code>not_available</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>timestamp</b> - The time of the last refresh\n                    of the check.</p>\n            </li>\n            <li>\n               <p>\n                  <b>checkId</b> - The unique identifier for the\n                    check.</p>\n            </li>\n         </ul>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>\n         <p>To call the Trusted Advisor operations in\nthe Amazon Web Services Support API, you must use the US East (N. Virginia) endpoint. Currently, the US West (Oregon) and Europe (Ireland) \nendpoints don't support the Trusted Advisor operations. For more information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html#endpoint\">About the Amazon Web Services Support\nAPI</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckResultRequest": {
+      "type": "structure",
+      "members": {
+        "checkId": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ISO 639-1 code for the language that you want your check results to appear\n            in.</p>\n         <p>The Amazon Web Services Support API currently supports the following languages for Trusted Advisor:</p>\n         <ul>\n            <li>\n               <p>Chinese, Simplified - <code>zh</code>\n               </p>\n            </li>\n            <li>\n               <p>Chinese, Traditional - <code>zh_TW</code>\n               </p>\n            </li>\n            <li>\n               <p>English - <code>en</code>\n               </p>\n            </li>\n            <li>\n               <p>French - <code>fr</code>\n               </p>\n            </li>\n            <li>\n               <p>German - <code>de</code>\n               </p>\n            </li>\n            <li>\n               <p>Indonesian - <code>id</code>\n               </p>\n            </li>\n            <li>\n               <p>Italian - <code>it</code>\n               </p>\n            </li>\n            <li>\n               <p>Japanese - <code>ja</code>\n               </p>\n            </li>\n            <li>\n               <p>Korean - <code>ko</code>\n               </p>\n            </li>\n            <li>\n               <p>Portuguese, Brazilian - <code>pt_BR</code>\n               </p>\n            </li>\n            <li>\n               <p>Spanish - <code>es</code>\n               </p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckResultResponse": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "com.amazonaws.support#TrustedAdvisorCheckResult",
+          "traits": {
+            "smithy.api#documentation": "<p>The detailed results of the Trusted Advisor check.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The result of the Trusted Advisor check returned by the <a>DescribeTrustedAdvisorCheckResult</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckSummaries": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckSummariesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorCheckSummariesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.support#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the results for the Trusted Advisor check summaries for the check IDs that you\n            specified. You can get the check IDs by calling the <a>DescribeTrustedAdvisorChecks</a> operation.</p>\n         <p>The response contains an array of <a>TrustedAdvisorCheckSummary</a>\n            objects.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>\n         <p>To call the Trusted Advisor operations in\nthe Amazon Web Services Support API, you must use the US East (N. Virginia) endpoint. Currently, the US West (Oregon) and Europe (Ireland) \nendpoints don't support the Trusted Advisor operations. For more information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html#endpoint\">About the Amazon Web Services Support\nAPI</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckSummariesRequest": {
+      "type": "structure",
+      "members": {
+        "checkIds": {
+          "target": "com.amazonaws.support#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The IDs of the Trusted Advisor checks.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorCheckSummariesResponse": {
+      "type": "structure",
+      "members": {
+        "summaries": {
+          "target": "com.amazonaws.support#TrustedAdvisorCheckSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The summary information for the requested Trusted Advisor checks.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The summaries of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckSummaries</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorChecks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorChecksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#DescribeTrustedAdvisorChecksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.support#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about all available Trusted Advisor checks, including the name, ID,\n            category, description, and metadata. You must specify a language code.</p>\n         <p>The response contains a <a>TrustedAdvisorCheckDescription</a> object for\n            each check. You must set the Amazon Web Services Region to us-east-1.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the <code>SubscriptionRequiredException</code> error\n                        message appears. For information about changing your support plan, see\n                            <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n               <li>\n                  <p>The names and descriptions for Trusted Advisor checks are subject to change. We\n                        recommend that you specify the check ID in your code to uniquely identify a\n                        check.</p>\n               </li>\n            </ul>\n         </note>\n         <p>To call the Trusted Advisor operations in\nthe Amazon Web Services Support API, you must use the US East (N. Virginia) endpoint. Currently, the US West (Oregon) and Europe (Ireland) \nendpoints don't support the Trusted Advisor operations. For more information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html#endpoint\">About the Amazon Web Services Support\nAPI</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorChecksRequest": {
+      "type": "structure",
+      "members": {
+        "language": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ISO 639-1 code for the language that you want your checks to appear in.</p>\n         <p>The Amazon Web Services Support API currently supports the following languages for Trusted Advisor:</p>\n         <ul>\n            <li>\n               <p>Chinese, Simplified - <code>zh</code>\n               </p>\n            </li>\n            <li>\n               <p>Chinese, Traditional - <code>zh_TW</code>\n               </p>\n            </li>\n            <li>\n               <p>English - <code>en</code>\n               </p>\n            </li>\n            <li>\n               <p>French - <code>fr</code>\n               </p>\n            </li>\n            <li>\n               <p>German - <code>de</code>\n               </p>\n            </li>\n            <li>\n               <p>Indonesian - <code>id</code>\n               </p>\n            </li>\n            <li>\n               <p>Italian - <code>it</code>\n               </p>\n            </li>\n            <li>\n               <p>Japanese - <code>ja</code>\n               </p>\n            </li>\n            <li>\n               <p>Korean - <code>ko</code>\n               </p>\n            </li>\n            <li>\n               <p>Portuguese, Brazilian - <code>pt_BR</code>\n               </p>\n            </li>\n            <li>\n               <p>Spanish - <code>es</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#DescribeTrustedAdvisorChecksResponse": {
+      "type": "structure",
+      "members": {
+        "checks": {
+          "target": "com.amazonaws.support#TrustedAdvisorCheckList",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about all available Trusted Advisor checks.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorChecks</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#Display": {
+      "type": "string"
+    },
+    "com.amazonaws.support#DisplayId": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Double": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.support#EndTime": {
+      "type": "string"
+    },
+    "com.amazonaws.support#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.support#ExpiryTime": {
+      "type": "string"
+    },
+    "com.amazonaws.support#FileName": {
+      "type": "string"
+    },
+    "com.amazonaws.support#IncludeCommunications": {
+      "type": "boolean"
+    },
+    "com.amazonaws.support#IncludeResolvedCases": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.support#InternalServerError": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>An internal server error occurred.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An internal server error occurred.</p>",
+        "smithy.api#error": "server"
+      }
+    },
+    "com.amazonaws.support#IssueType": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Language": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Long": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.support#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 10,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#NextToken": {
+      "type": "string"
+    },
+    "com.amazonaws.support#RecentCaseCommunications": {
+      "type": "structure",
+      "members": {
+        "communications": {
+          "target": "com.amazonaws.support#CommunicationList",
+          "traits": {
+            "smithy.api#documentation": "<p>The five most recent communications associated with the case.</p>"
+          }
+        },
+        "nextToken": {
+          "target": "com.amazonaws.support#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A resumption point for pagination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The five most recent communications associated with the case.</p>"
+      }
+    },
+    "com.amazonaws.support#RefreshTrustedAdvisorCheck": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#RefreshTrustedAdvisorCheckRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#RefreshTrustedAdvisorCheckResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Refreshes the Trusted Advisor check that you specify using the check ID. You can get the\n            check IDs by calling the <a>DescribeTrustedAdvisorChecks</a>\n            operation.</p>\n         <p>Some checks are refreshed automatically. If you call the\n            <code>RefreshTrustedAdvisorCheck</code> operation to refresh them, you might see\n            the <code>InvalidParameterValue</code> error.</p>\n         <p>The response contains a <a>TrustedAdvisorCheckRefreshStatus</a>\n            object.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>\n         <p>To call the Trusted Advisor operations in\nthe Amazon Web Services Support API, you must use the US East (N. Virginia) endpoint. Currently, the US West (Oregon) and Europe (Ireland) \nendpoints don't support the Trusted Advisor operations. For more information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/about-support-api.html#endpoint\">About the Amazon Web Services Support\nAPI</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.support#RefreshTrustedAdvisorCheckRequest": {
+      "type": "structure",
+      "members": {
+        "checkId": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the Trusted Advisor check to refresh.</p>\n         <note>\n            <p>Specifying the check ID of a check that is automatically refreshed causes an\n                    <code>InvalidParameterValue</code> error.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#RefreshTrustedAdvisorCheckResponse": {
+      "type": "structure",
+      "members": {
+        "status": {
+          "target": "com.amazonaws.support#TrustedAdvisorCheckRefreshStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current refresh status for a check, including the amount of time until the check\n            is eligible for refresh.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The current refresh status of a Trusted Advisor check.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#ResolveCase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.support#ResolveCaseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.support#ResolveCaseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.support#CaseIdNotFound"
+        },
+        {
+          "target": "com.amazonaws.support#InternalServerError"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Resolves a support case. This operation takes a <code>caseId</code> and returns the\n            initial and final state of the case.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>You must have a Business, Enterprise On-Ramp, or Enterprise Support plan to use the Amazon Web Services Support\n                        API. </p>\n               </li>\n               <li>\n                  <p>If you call the Amazon Web Services Support API from an account that doesn't have a\n                        Business, Enterprise On-Ramp, or Enterprise Support plan, the\n                            <code>SubscriptionRequiredException</code> error message appears. For\n                        information about changing your support plan, see <a href=\"http://aws.amazon.com/premiumsupport/\">Amazon Web Services Support</a>.</p>\n               </li>\n            </ul>\n         </note>"
+      }
+    },
+    "com.amazonaws.support#ResolveCaseRequest": {
+      "type": "structure",
+      "members": {
+        "caseId": {
+          "target": "com.amazonaws.support#CaseId",
+          "traits": {
+            "smithy.api#documentation": "<p>The support case ID requested or returned in the call. The case ID is an alphanumeric\n            string formatted as shown in this example:\n                case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.support#ResolveCaseResponse": {
+      "type": "structure",
+      "members": {
+        "initialCaseStatus": {
+          "target": "com.amazonaws.support#CaseStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the case when the <a>ResolveCase</a> request was sent.</p>"
+          }
+        },
+        "finalCaseStatus": {
+          "target": "com.amazonaws.support#CaseStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the case after the <a>ResolveCase</a> request was\n            processed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The status of the case returned by the <a>ResolveCase</a> operation.</p>",
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.support#Result": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.support#Service": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "com.amazonaws.support#ServiceCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for an Amazon Web Services service returned by the <a>DescribeServices</a>\n            response. The <code>name</code> element contains the corresponding friendly name.</p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.support#ServiceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The friendly name for an Amazon Web Services service. The <code>code</code> element contains the\n            corresponding code.</p>"
+          }
+        },
+        "categories": {
+          "target": "com.amazonaws.support#CategoryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of categories that describe the type of support issue a case describes.\n            Categories consist of a category name and a category code. Category names and codes are\n            passed to Amazon Web Services Support when you call <a>CreateCase</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about an Amazon Web Services service returned by the <a>DescribeServices</a>\n            operation.</p>"
+      }
+    },
+    "com.amazonaws.support#ServiceCode": {
+      "type": "string"
+    },
+    "com.amazonaws.support#ServiceCode2": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^[0-9a-z\\-_]+$"
+      }
+    },
+    "com.amazonaws.support#ServiceCodeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#ServiceCode2"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#ServiceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#Service"
+      }
+    },
+    "com.amazonaws.support#ServiceName": {
+      "type": "string"
+    },
+    "com.amazonaws.support#SeverityCode": {
+      "type": "string"
+    },
+    "com.amazonaws.support#SeverityLevel": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "com.amazonaws.support#SeverityLevelCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The code for case severity level.</p>\n         <p>Valid values: <code>low</code> | <code>normal</code> | <code>high</code> |\n                <code>urgent</code> | <code>critical</code>\n         </p>"
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.support#SeverityLevelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the severity level that corresponds to the severity level code.</p>\n         <note>\n            <p>The values returned by the API are different from the values that appear in the\n                Amazon Web Services Support Center. For example, the API uses the code <code>low</code>, but the name\n                appears as General guidance in Support Center. </p>\n            <p>The following are the API code names and how they appear in the console:</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>low</code> - General guidance</p>\n               </li>\n               <li>\n                  <p>\n                     <code>normal</code> - System impaired</p>\n               </li>\n               <li>\n                  <p>\n                     <code>high</code> - Production system impaired</p>\n               </li>\n               <li>\n                  <p>\n                     <code>urgent</code> - Production system down</p>\n               </li>\n               <li>\n                  <p>\n                     <code>critical</code> - Business-critical system down</p>\n               </li>\n            </ul>\n         </note>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/case-management.html#choosing-severity\">Choosing a\n                severity</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A code and name pair that represents the severity level of a support case. The\n            available values depend on the support plan for the account. For more information, see\n                <a href=\"https://docs.aws.amazon.com/awssupport/latest/user/case-management.html#choosing-severity\">Choosing a\n                severity</a> in the <i>Amazon Web Services Support User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.support#SeverityLevelCode": {
+      "type": "string"
+    },
+    "com.amazonaws.support#SeverityLevelName": {
+      "type": "string"
+    },
+    "com.amazonaws.support#SeverityLevelsList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#SeverityLevel"
+      }
+    },
+    "com.amazonaws.support#StartTime": {
+      "type": "string"
+    },
+    "com.amazonaws.support#Status": {
+      "type": "string"
+    },
+    "com.amazonaws.support#String": {
+      "type": "string"
+    },
+    "com.amazonaws.support#StringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#String"
+      },
+      "traits": {
+        "smithy.api#sparse": {}
+      }
+    },
+    "com.amazonaws.support#Subject": {
+      "type": "string"
+    },
+    "com.amazonaws.support#SubmittedBy": {
+      "type": "string"
+    },
+    "com.amazonaws.support#SupportedHour": {
+      "type": "structure",
+      "members": {
+        "startTime": {
+          "target": "com.amazonaws.support#StartTime",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        Start Time. RFC 3339 format <code>'HH:mm:ss.SSS'</code>.\n        </p>"
+          }
+        },
+        "endTime": {
+          "target": "com.amazonaws.support#EndTime",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        End Time. RFC 3339 format <code>'HH:mm:ss.SSS'</code>.\n        </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Time range object with <code>startTime</code> and <code>endTime</code> range in RFC 3339 format. <code>'HH:mm:ss.SSS'</code>.</p>"
+      }
+    },
+    "com.amazonaws.support#SupportedHoursList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#SupportedHour"
+      }
+    },
+    "com.amazonaws.support#SupportedLanguage": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "com.amazonaws.support#Code",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        2 digit ISO 639-1 code. e.g. <code>en</code>\n         </p>"
+          }
+        },
+        "language": {
+          "target": "com.amazonaws.support#Language",
+          "traits": {
+            "smithy.api#documentation": "<p>\n        Full language description e.g. <code>ENGLISH</code>\n         </p>"
+          }
+        },
+        "display": {
+          "target": "com.amazonaws.support#Display",
+          "traits": {
+            "smithy.api#documentation": "<p>\n            Language display value e.g. <code>ENGLISH</code>\n         </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n            A JSON-formatted object that contains the available ISO 639-1 language <code>code</code>,\n            <code>language</code> name and langauge <code>display</code> value. The language code is what should be used\n            in the <a>CreateCase</a> call.\n        </p>"
+      }
+    },
+    "com.amazonaws.support#SupportedLanguagesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#SupportedLanguage"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#ThrottlingException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.support#AvailabilityErrorMessage"
+        }
+      },
+      "traits": {
+        "aws.protocols#awsQueryError": {
+          "code": "Throttling",
+          "httpResponseCode": 400
+        },
+        "smithy.api#documentation": "<p>\n        You have exceeded the maximum allowed TPS (Transactions Per Second) for the operations.\n        </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.support#TimeCreated": {
+      "type": "string"
+    },
+    "com.amazonaws.support#TrustedAdvisorCategorySpecificSummary": {
+      "type": "structure",
+      "members": {
+        "costOptimizing": {
+          "target": "com.amazonaws.support#TrustedAdvisorCostOptimizingSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>The summary information about cost savings for a Trusted Advisor check that is in the Cost\n            Optimizing category.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The container for summary information that relates to the category of the Trusted Advisor\n            check.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckDescription": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The display name for the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the Trusted Advisor check, which includes the alert criteria and\n            recommended operations (contains HTML markup).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "category": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The category of the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "metadata": {
+          "target": "com.amazonaws.support#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The column headings for the data returned by the Trusted Advisor check. The order of the\n            headings corresponds to the order of the data in the <b>Metadata</b> element of the <a>TrustedAdvisorResourceDetail</a>\n            for the check. <b>Metadata</b> contains all the data that is\n            shown in the Excel download, even in those cases where the UI shows just summary data.\n        </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The description and metadata for a Trusted Advisor check.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#TrustedAdvisorCheckDescription"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckRefreshStatus": {
+      "type": "structure",
+      "members": {
+        "checkId": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the Trusted Advisor check for which a refresh has been requested:\n            </p>\n         <ul>\n            <li>\n               <p>\n                  <code>none</code> - The check is not refreshed or the non-success\n                    status exceeds the timeout</p>\n            </li>\n            <li>\n               <p>\n                  <code>enqueued</code> - The check refresh requests has entered the\n                    refresh queue</p>\n            </li>\n            <li>\n               <p>\n                  <code>processing</code> - The check refresh request is picked up by the\n                    rule processing engine</p>\n            </li>\n            <li>\n               <p>\n                  <code>success</code> - The check is successfully refreshed</p>\n            </li>\n            <li>\n               <p>\n                  <code>abandoned</code> - The check refresh has failed</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "millisUntilNextRefreshable": {
+          "target": "com.amazonaws.support#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The amount of time, in milliseconds, until the Trusted Advisor check is eligible for\n            refresh.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The refresh status of a Trusted Advisor check.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckRefreshStatusList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#TrustedAdvisorCheckRefreshStatus"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckResult": {
+      "type": "structure",
+      "members": {
+        "checkId": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "timestamp": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the last refresh of the check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The alert status of the check: \"ok\" (green), \"warning\" (yellow), \"error\" (red), or\n            \"not_available\".</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourcesSummary": {
+          "target": "com.amazonaws.support#TrustedAdvisorResourcesSummary",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "categorySpecificSummary": {
+          "target": "com.amazonaws.support#TrustedAdvisorCategorySpecificSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>Summary information that relates to the category of the check. Cost Optimizing is the\n            only category that is currently supported.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "flaggedResources": {
+          "target": "com.amazonaws.support#TrustedAdvisorResourceDetailList",
+          "traits": {
+            "smithy.api#documentation": "<p>The details about each resource listed in the check result.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The results of a Trusted Advisor check returned by <a>DescribeTrustedAdvisorCheckResult</a>.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckSummary": {
+      "type": "structure",
+      "members": {
+        "checkId": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "timestamp": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The time of the last refresh of the check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The alert status of the check: \"ok\" (green), \"warning\" (yellow), \"error\" (red), or\n            \"not_available\".</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "hasFlaggedResources": {
+          "target": "com.amazonaws.support#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether the Trusted Advisor check has flagged resources.</p>"
+          }
+        },
+        "resourcesSummary": {
+          "target": "com.amazonaws.support#TrustedAdvisorResourcesSummary",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "categorySpecificSummary": {
+          "target": "com.amazonaws.support#TrustedAdvisorCategorySpecificSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>Summary information that relates to the category of the check. Cost Optimizing is the\n            only category that is currently supported.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A summary of a Trusted Advisor check result, including the alert status, last refresh, and\n            number of resources examined.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCheckSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#TrustedAdvisorCheckSummary"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorCostOptimizingSummary": {
+      "type": "structure",
+      "members": {
+        "estimatedMonthlySavings": {
+          "target": "com.amazonaws.support#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The estimated monthly savings that might be realized if the recommended operations are\n            taken.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "estimatedPercentMonthlySavings": {
+          "target": "com.amazonaws.support#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The estimated percentage of savings that might be realized if the recommended\n            operations are taken.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The estimated cost savings that might be realized if the recommended operations are\n            taken.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorResourceDetail": {
+      "type": "structure",
+      "members": {
+        "status": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The status code for the resource identified in the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "region": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Web Services Region in which the identified resource is located.</p>"
+          }
+        },
+        "resourceId": {
+          "target": "com.amazonaws.support#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique identifier for the identified resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "isSuppressed": {
+          "target": "com.amazonaws.support#Boolean",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Specifies whether the Amazon Web Services resource was ignored by Trusted Advisor because it was marked as\n            suppressed by the user.</p>"
+          }
+        },
+        "metadata": {
+          "target": "com.amazonaws.support#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information about the identified resource. The exact metadata and its order\n            can be obtained by inspecting the <a>TrustedAdvisorCheckDescription</a>\n            object returned by the call to <a>DescribeTrustedAdvisorChecks</a>. <b>Metadata</b> contains all the data that is shown in the Excel\n            download, even in those cases where the UI shows just summary data.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a resource identified by a Trusted Advisor check.</p>"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorResourceDetailList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.support#TrustedAdvisorResourceDetail"
+      }
+    },
+    "com.amazonaws.support#TrustedAdvisorResourcesSummary": {
+      "type": "structure",
+      "members": {
+        "resourcesProcessed": {
+          "target": "com.amazonaws.support#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources that were analyzed by the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourcesFlagged": {
+          "target": "com.amazonaws.support#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources that were flagged (listed) by the Trusted Advisor check.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourcesIgnored": {
+          "target": "com.amazonaws.support#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources ignored by Trusted Advisor because information was\n            unavailable.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "resourcesSuppressed": {
+          "target": "com.amazonaws.support#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of Amazon Web Services resources ignored by Trusted Advisor because they were marked as\n            suppressed by the user.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about Amazon Web Services resources that were analyzed in a call to Trusted Advisor <a>DescribeTrustedAdvisorCheckSummaries</a>.</p>"
+      }
+    },
+    "com.amazonaws.support#Type": {
+      "type": "string"
+    },
+    "com.amazonaws.support#ValidatedCategoryCode": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#ValidatedCommunicationBody": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 8000
+        }
+      }
+    },
+    "com.amazonaws.support#ValidatedDateTime": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 8,
+          "max": 30
+        }
+      }
+    },
+    "com.amazonaws.support#ValidatedIssueTypeString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 9,
+          "max": 22
+        }
+      }
+    },
+    "com.amazonaws.support#ValidatedLanguageAvailability": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.support#ValidatedServiceCode": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    }
+  }
+}

--- a/crates/fakecloud-support/src/validate.rs
+++ b/crates/fakecloud-support/src/validate.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 
 /// The vendored Support Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/support.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 /// The embedded model parses to exactly this many operations; a mismatch means
 /// the vendored model drifted from the implemented surface.

--- a/crates/fakecloud-swf/model.json
+++ b/crates/fakecloud-swf/model.json
@@ -1,0 +1,8762 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.swf#ActivityId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#ActivityTask": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The opaque string used as a handle on the task. This token is used by workers to communicate progress and response information back to the system about the task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskStarted</code> event recorded in the history.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow execution that started this activity task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of this activity task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The inputs provided when the activity task was scheduled. The form of the input is user defined and should be meaningful to the activity implementation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Unit of work sent to an activity worker.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskCancelRequestedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>RequestCancelActivityTask</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the task.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskCancelRequested</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskCanceledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Details of the cancellation.</p>"
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskScheduled</code> event that was recorded when this activity task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskStarted</code> event recorded when this activity task was started. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "latestCancelRequestedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>If set, contains the ID of the last <code>ActivityTaskCancelRequested</code> event recorded for this activity task. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskCanceled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskCompletedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The results of the activity task.</p>"
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskScheduled</code> event that was recorded when this activity task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskStarted</code> event recorded when this activity task was started. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskCompleted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "reason": {
+          "target": "com.amazonaws.swf#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason provided for the failure.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the failure.</p>"
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskScheduled</code> event that was recorded when this activity task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskStarted</code> event recorded when this activity task was started. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskScheduledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the activity task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the activity task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the activity task.</p>"
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that can be used by the decider in subsequent workflow tasks. This data isn't sent to the activity.</p>"
+          }
+        },
+        "scheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time the activity task can wait to be assigned to a worker.</p>"
+          }
+        },
+        "scheduleToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time for this activity task.</p>"
+          }
+        },
+        "startToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time a worker may take to process the activity task.</p>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The task list in which the activity task has been scheduled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The priority to assign to the scheduled activity task. If set, this overrides any default\n      priority value that was assigned when the activity type was registered.</p>\n         <p>Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision that resulted in the scheduling of this activity task. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "heartbeatTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum time before which the worker processing this task must report progress by calling\n      <a>RecordActivityTaskHeartbeat</a>. If the timeout is exceeded, the activity task is automatically timed out. If\n      the worker subsequently attempts to record a heartbeat or return a result, it is ignored.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskScheduled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskStartedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "identity": {
+          "target": "com.amazonaws.swf#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>Identity of the worker that was assigned this task. This aids diagnostics when problems arise. The form of this identity is user defined.</p>"
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskScheduled</code> event that was recorded when this activity task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskStarted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskStatus": {
+      "type": "structure",
+      "members": {
+        "cancelRequested": {
+          "target": "com.amazonaws.swf#Canceled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Set to <code>true</code> if cancellation of the task is requested.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Status information about an activity task.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskTimedOutEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timeoutType": {
+          "target": "com.amazonaws.swf#ActivityTaskTimeoutType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the timeout that caused this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskScheduled</code> event that was recorded when this activity task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskStarted</code> event recorded when this activity task was started. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#LimitedData",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the content of the <code>details</code> parameter for the last call made by the activity to\n      <code>RecordActivityTaskHeartbeat</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ActivityTaskTimedOut</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTaskTimeoutType": {
+      "type": "enum",
+      "members": {
+        "START_TO_CLOSE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "START_TO_CLOSE"
+          }
+        },
+        "SCHEDULE_TO_START": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCHEDULE_TO_START"
+          }
+        },
+        "SCHEDULE_TO_CLOSE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCHEDULE_TO_CLOSE"
+          }
+        },
+        "HEARTBEAT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HEARTBEAT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ActivityType": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of this activity.</p>\n         <note>\n            <p>The combination of activity type name and version must be unique within a domain.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.swf#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of this activity.</p>\n         <note>\n            <p>The combination of activity type name and version must be unique with in a domain.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an activity type.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTypeConfiguration": {
+      "type": "structure",
+      "members": {
+        "defaultTaskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default maximum duration for tasks of an activity type specified when registering the activity\n      type. You can override this default when scheduling a task through the <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskHeartbeatTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default maximum time, in seconds, before which a worker processing a task must report\n      progress by calling <a>RecordActivityTaskHeartbeat</a>.</p>\n         <p>You can specify this value only when <i>registering</i> an activity type. The registered default value can be\n      overridden when you schedule a task through the <code>ScheduleActivityTask</code>\n            <a>Decision</a>. If the activity\n      worker subsequently attempts to record a heartbeat or returns a result, the activity worker receives an\n      <code>UnknownResource</code> fault. In this case, Amazon SWF no longer considers the activity task to be valid;\n      the activity worker should clean up the activity task.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default task list specified for this activity type at registration. This default is used if\n      a task list isn't provided when a task is scheduled through the <code>ScheduleActivityTask</code>\n            <a>Decision</a>. You can override the default registered task list when scheduling a task through the\n      <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>"
+          }
+        },
+        "defaultTaskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default task priority for tasks of this activity type, specified at registration. If not\n      set, then <code>0</code> is used as the default priority. This default can be overridden when scheduling an activity\n      task.</p>\n         <p>Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "defaultTaskScheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default maximum duration, specified when registering the activity type, that a task of an\n      activity type can wait before being assigned to a worker. You can override this default when scheduling a task\n      through the <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskScheduleToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default maximum duration, specified when registering the activity type, for tasks of this activity\n      type. You can override this default when scheduling a task through the <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration settings registered with the activity type.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTypeDetail": {
+      "type": "structure",
+      "members": {
+        "typeInfo": {
+          "target": "com.amazonaws.swf#ActivityTypeInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>General information about the activity type.</p>\n         <p>The status of activity type (returned in the ActivityTypeInfo structure) can be one of the following.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>REGISTERED</code> \u2013 The type is registered and available. Workers supporting this\n        type should be running.\n      </p>\n            </li>\n            <li>\n               <p>\n                  <code>DEPRECATED</code> \u2013 The type was deprecated using <a>DeprecateActivityType</a>, but is\n        still in use. You should keep workers supporting this type running.\n        You cannot create new tasks of this type.\n      </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "configuration": {
+          "target": "com.amazonaws.swf#ActivityTypeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings registered with the activity type.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about an activity type.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTypeInfo": {
+      "type": "structure",
+      "members": {
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The <a>ActivityType</a> type structure representing the activity type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.swf#RegistrationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the activity type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.swf#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the activity type provided in <a>RegisterActivityType</a>.</p>"
+          }
+        },
+        "creationDate": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time this activity type was created through <a>RegisterActivityType</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "deprecationDate": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>If DEPRECATED, the date and time <a>DeprecateActivityType</a> was called.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Detailed information about an activity type.</p>"
+      }
+    },
+    "com.amazonaws.swf#ActivityTypeInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#ActivityTypeInfo"
+      }
+    },
+    "com.amazonaws.swf#ActivityTypeInfos": {
+      "type": "structure",
+      "members": {
+        "typeInfos": {
+          "target": "com.amazonaws.swf#ActivityTypeInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of activity type information.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If a <code>NextPageToken</code> was returned by a previous call, there are more\n  results available. To retrieve the next page of results, make the call again using the returned token in\n  <code>nextPageToken</code>. Keep all other arguments unchanged.</p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains a paginated list of activity type information structures.</p>"
+      }
+    },
+    "com.amazonaws.swf#Arn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1600
+        }
+      }
+    },
+    "com.amazonaws.swf#CancelTimerDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The unique ID of the timer to cancel.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>CancelTimer</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CancelTimerFailedCause": {
+      "type": "enum",
+      "members": {
+        "TIMER_ID_UNKNOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMER_ID_UNKNOWN"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#CancelTimerFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>The timerId provided in the <code>CancelTimer</code> decision that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#CancelTimerFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n        because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelTimer</code> decision to cancel this timer. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>CancelTimerFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#CancelWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Details of the cancellation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>CancelWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CancelWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "UNHANDLED_DECISION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNHANDLED_DECISION"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#CancelWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "cause": {
+          "target": "com.amazonaws.swf#CancelWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n        because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>CancelWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#Canceled": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.swf#CauseMessage": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1728
+        }
+      }
+    },
+    "com.amazonaws.swf#ChildPolicy": {
+      "type": "enum",
+      "members": {
+        "TERMINATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATE"
+          }
+        },
+        "REQUEST_CANCEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUEST_CANCEL"
+          }
+        },
+        "ABANDON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ABANDON"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ChildWorkflowExecutionCanceledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The child workflow execution that was canceled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Details of the cancellation (if provided).</p>"
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this child workflow execution.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ChildWorkflowExecutionStarted</code> event recorded when this child workflow execution was\n      started. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ChildWorkflowExecutionCompletedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The child workflow execution that was completed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "result": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The result of the child workflow execution.</p>"
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ChildWorkflowExecutionStarted</code> event recorded when this child workflow execution was\n      started. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ChildWorkflowExecutionCompleted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ChildWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The child workflow execution that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.swf#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason for the failure (if provided).</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the failure (if provided).</p>"
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this child workflow execution.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ChildWorkflowExecutionStarted</code> event recorded when this child workflow execution was\n      started. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ChildWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ChildWorkflowExecutionStartedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The child workflow execution that was started.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this child workflow execution.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ChildWorkflowExecutionStarted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ChildWorkflowExecutionTerminatedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The child workflow execution that was terminated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this child workflow execution.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ChildWorkflowExecutionStarted</code> event recorded when this child workflow execution was\n      started. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ChildWorkflowExecutionTerminated</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ChildWorkflowExecutionTimedOutEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The child workflow execution that timed out.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "timeoutType": {
+          "target": "com.amazonaws.swf#WorkflowExecutionTimeoutType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the timeout that caused the child workflow execution to time out.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ChildWorkflowExecutionStarted</code> event recorded when this child workflow execution was\n      started. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ChildWorkflowExecutionTimedOut</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#CloseStatus": {
+      "type": "enum",
+      "members": {
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "CANCELED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CANCELED"
+          }
+        },
+        "TERMINATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TERMINATED"
+          }
+        },
+        "CONTINUED_AS_NEW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTINUED_AS_NEW"
+          }
+        },
+        "TIMED_OUT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMED_OUT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#CloseStatusFilter": {
+      "type": "structure",
+      "members": {
+        "status": {
+          "target": "com.amazonaws.swf#CloseStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The close status that must match the close status of an execution for it to meet the criteria of\n      this filter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to filter the closed workflow executions in visibility APIs by their close status.</p>"
+      }
+    },
+    "com.amazonaws.swf#CompleteWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The result of the workflow execution. The form of the result is implementation defined.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>CompleteWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CompleteWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "UNHANDLED_DECISION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNHANDLED_DECISION"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#CompleteWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "cause": {
+          "target": "com.amazonaws.swf#CompleteWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n        because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>CompleteWorkflowExecution</code> decision to complete this execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ContinueAsNewWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the new workflow execution.</p>"
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the total duration for this workflow execution. This overrides the\n      <code>defaultExecutionStartToCloseTimeout</code> specified when registering the workflow type.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>An execution start-to-close timeout for this workflow execution must be specified either as a default for the workflow type or through this field. If neither this field is set nor a default execution start-to-close timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The task list to use for the decisions of the new (continued) workflow\n      execution.</p>"
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The task priority that, if set, specifies the priority for the decision tasks for this workflow\n      execution. This overrides the defaultTaskPriority specified when registering the workflow type.\n      Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a>  in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the maximum duration of decision tasks for the new workflow execution. This parameter overrides the\n      <code>defaultTaskStartToCloseTimout</code> specified when registering the workflow type using\n      <a>RegisterWorkflowType</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>A task start-to-close timeout for the new workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default task start-to-close timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the policy to use for the child workflow executions of the new execution if it is terminated\n      by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy\n      overrides the default child policy specified when registering the workflow type using\n      <a>RegisterWorkflowType</a>.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>\n         <note>\n            <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags to associate with the new workflow execution. A maximum of 5 tags can be specified. You can\n      list workflow executions with a specific tag by calling <a>ListOpenWorkflowExecutions</a> or\n      <a>ListClosedWorkflowExecutions</a> and specifying a <a>TagFilter</a>.</p>"
+          }
+        },
+        "workflowTypeVersion": {
+          "target": "com.amazonaws.swf#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the workflow to start.</p>"
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role to attach to the new (continued) execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ContinueAsNewWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with the\n              appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tag</code> \u2013 A tag used to identify the workflow execution</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>taskList</code> \u2013 String constraint. The key is <code>swf:taskList.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code> \u2013 String constraint. The key is <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#ContinueAsNewWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "UNHANDLED_DECISION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNHANDLED_DECISION"
+          }
+        },
+        "WORKFLOW_TYPE_DEPRECATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORKFLOW_TYPE_DEPRECATED"
+          }
+        },
+        "WORKFLOW_TYPE_DOES_NOT_EXIST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORKFLOW_TYPE_DOES_NOT_EXIST"
+          }
+        },
+        "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_TASK_LIST_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_TASK_LIST_UNDEFINED"
+          }
+        },
+        "DEFAULT_CHILD_POLICY_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_CHILD_POLICY_UNDEFINED"
+          }
+        },
+        "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ContinueAsNewWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "cause": {
+          "target": "com.amazonaws.swf#ContinueAsNewWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n        because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>ContinueAsNewWorkflowExecution</code> decision that started this execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#Count": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.swf#CountClosedWorkflowExecutions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#CountClosedWorkflowExecutionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowExecutionCount"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the number of closed workflow executions within the given domain that meet the\n      specified filtering criteria.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tagFilter.tag</code>: String constraint. The key is\n                <code>swf:tagFilter.tag</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.name</code>: String constraint. The key is\n                <code>swf:typeFilter.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.version</code>: String constraint. The key is\n                <code>swf:typeFilter.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CountClosedWorkflowExecutionsInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the workflow executions to count.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startTimeFilter": {
+          "target": "com.amazonaws.swf#ExecutionTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions that meet the start time criteria of the filter\n      are counted.</p>\n         <note>\n            <p>\n               <code>startTimeFilter</code> and <code>closeTimeFilter</code> are mutually exclusive. You\n        must specify one of these in a request but not both.</p>\n         </note>"
+          }
+        },
+        "closeTimeFilter": {
+          "target": "com.amazonaws.swf#ExecutionTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions that meet the close time criteria of the filter\n      are counted.</p>\n         <note>\n            <p>\n               <code>startTimeFilter</code> and <code>closeTimeFilter</code> are mutually exclusive. You\n        must specify one of these in a request but not both.</p>\n         </note>"
+          }
+        },
+        "executionFilter": {
+          "target": "com.amazonaws.swf#WorkflowExecutionFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions matching the <code>WorkflowId</code> in the\n      filter are counted.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "typeFilter": {
+          "target": "com.amazonaws.swf#WorkflowTypeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, indicates the type of the workflow executions to be counted.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "tagFilter": {
+          "target": "com.amazonaws.swf#TagFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only executions that have a tag that matches the filter are\n      counted.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "closeStatusFilter": {
+          "target": "com.amazonaws.swf#CloseStatusFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions that match this close status are counted. This\n      filter has an affect only if <code>executionStatus</code> is specified as\n      <code>CLOSED</code>.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#CountOpenWorkflowExecutions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#CountOpenWorkflowExecutionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowExecutionCount"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the number of open workflow executions within the given domain that meet the\n      specified filtering criteria.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tagFilter.tag</code>: String constraint. The key is\n                <code>swf:tagFilter.tag</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.name</code>: String constraint. The key is\n                <code>swf:typeFilter.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.version</code>: String constraint. The key is\n                <code>swf:typeFilter.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CountOpenWorkflowExecutionsInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the workflow executions to count.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startTimeFilter": {
+          "target": "com.amazonaws.swf#ExecutionTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the start time criteria that workflow executions must meet in order to be\n      counted.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "typeFilter": {
+          "target": "com.amazonaws.swf#WorkflowTypeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the type of the workflow executions to be counted.</p>\n         <note>\n            <p>\n               <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are\n        mutually exclusive. You can specify at most one of these in a request.</p>\n         </note>"
+          }
+        },
+        "tagFilter": {
+          "target": "com.amazonaws.swf#TagFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only executions that have a tag that matches the filter are\n      counted.</p>\n         <note>\n            <p>\n               <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are\n        mutually exclusive. You can specify at most one of these in a request.</p>\n         </note>"
+          }
+        },
+        "executionFilter": {
+          "target": "com.amazonaws.swf#WorkflowExecutionFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions matching the <code>WorkflowId</code> in the\n      filter are counted.</p>\n         <note>\n            <p>\n               <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are\n        mutually exclusive. You can specify at most one of these in a request.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#CountPendingActivityTasks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#CountPendingActivityTasksInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#PendingTaskCount"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the estimated number of activity tasks in the specified task list. The count\n      returned is an approximation and isn't guaranteed to be exact. If you specify a task list that\n      no activity task was ever scheduled in then <code>0</code> is returned.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the <code>taskList.name</code> parameter by using a\n            <code>Condition</code> element with the <code>swf:taskList.name</code> key to allow the\n          action to access only certain task lists.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CountPendingActivityTasksInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain that contains the task list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#CountPendingDecisionTasks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#CountPendingDecisionTasksInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#PendingTaskCount"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the estimated number of decision tasks in the specified task list. The count\n      returned is an approximation and isn't guaranteed to be exact. If you specify a task list that\n      no decision task was ever scheduled in then <code>0</code> is returned.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the <code>taskList.name</code> parameter by using a\n            <code>Condition</code> element with the <code>swf:taskList.name</code> key to allow the\n          action to access only certain task lists.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#CountPendingDecisionTasksInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain that contains the task list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#Data": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 32768
+        }
+      }
+    },
+    "com.amazonaws.swf#Decision": {
+      "type": "structure",
+      "members": {
+        "decisionType": {
+          "target": "com.amazonaws.swf#DecisionType",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the type of the decision.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "scheduleActivityTaskDecisionAttributes": {
+          "target": "com.amazonaws.swf#ScheduleActivityTaskDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>ScheduleActivityTask</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "requestCancelActivityTaskDecisionAttributes": {
+          "target": "com.amazonaws.swf#RequestCancelActivityTaskDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelActivityTask</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "completeWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#CompleteWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>CompleteWorkflowExecution</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "failWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#FailWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>FailWorkflowExecution</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "cancelWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#CancelWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>CancelWorkflowExecution</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "continueAsNewWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#ContinueAsNewWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>ContinueAsNewWorkflowExecution</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "recordMarkerDecisionAttributes": {
+          "target": "com.amazonaws.swf#RecordMarkerDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>RecordMarker</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "startTimerDecisionAttributes": {
+          "target": "com.amazonaws.swf#StartTimerDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>StartTimer</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "cancelTimerDecisionAttributes": {
+          "target": "com.amazonaws.swf#CancelTimerDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>CancelTimer</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "signalExternalWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#SignalExternalWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>SignalExternalWorkflowExecution</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "requestCancelExternalWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelExternalWorkflowExecution</code> decision.\n      It isn't set for other decision types.</p>"
+          }
+        },
+        "startChildWorkflowExecutionDecisionAttributes": {
+          "target": "com.amazonaws.swf#StartChildWorkflowExecutionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>StartChildWorkflowExecution</code> decision. It isn't set for other decision types.</p>"
+          }
+        },
+        "scheduleLambdaFunctionDecisionAttributes": {
+          "target": "com.amazonaws.swf#ScheduleLambdaFunctionDecisionAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>ScheduleLambdaFunction</code> decision. It isn't set\n      for other decision types.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies a decision made by the decider. A decision can be one of these types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CancelTimer</code> \u2013 Cancels a previously started timer and records a <code>TimerCanceled</code> event in the\n        history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CancelWorkflowExecution</code> \u2013 Closes the workflow execution and records a\n        <code>WorkflowExecutionCanceled</code> event in the history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CompleteWorkflowExecution</code> \u2013 Closes the workflow execution and records a\n        <code>WorkflowExecutionCompleted</code> event in the history .</p>\n            </li>\n            <li>\n               <p>\n                  <code>ContinueAsNewWorkflowExecution</code> \u2013 Closes the workflow execution and starts a new workflow execution of the\n        same type using the same workflow ID and a unique run Id. A <code>WorkflowExecutionContinuedAsNew</code> event\n        is recorded in the history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FailWorkflowExecution</code> \u2013 Closes the workflow execution and records a <code>WorkflowExecutionFailed</code>\n        event in the history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RecordMarker</code> \u2013 Records a <code>MarkerRecorded</code> event in the history. Markers can be used for adding\n        custom information in the history for instance to let deciders know that they don't need to look at the history\n        beyond the marker event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelActivityTask</code> \u2013 Attempts to cancel a previously scheduled activity task. If the activity task\n        was scheduled but has not been assigned to a worker, then it is canceled. If the activity task was already\n        assigned to a worker, then the worker is informed that cancellation has been requested in the response to\n        <a>RecordActivityTaskHeartbeat</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelExternalWorkflowExecution</code> \u2013 Requests that a request be made to cancel the specified external\n        workflow execution and records a <code>RequestCancelExternalWorkflowExecutionInitiated</code> event in the\n        history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ScheduleActivityTask</code> \u2013 Schedules an activity task.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SignalExternalWorkflowExecution</code> \u2013 Requests a signal to be delivered to the specified external workflow\n        execution and records a <code>SignalExternalWorkflowExecutionInitiated</code> event in the history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartChildWorkflowExecution</code> \u2013 Requests that a child workflow execution be started and records a\n        <code>StartChildWorkflowExecutionInitiated</code> event in the history. The child workflow execution is a\n        separate workflow execution with its own history.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartTimer</code> \u2013 Starts a timer for this workflow execution and records a <code>TimerStarted</code> event in\n        the history. This timer fires after the specified delay and record a <code>TimerFired</code> event.</p>\n            </li>\n         </ul>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>If you grant permission to use <code>RespondDecisionTaskCompleted</code>, you can use IAM policies to express\n      permissions for the list of decisions returned by this action as if they were members of the API. Treating\n      decisions as a pseudo API maintains a uniform conceptual model and helps keep policies readable. For details and\n      example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n          Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>\n         <p>\n            <b>Decision Failure</b>\n         </p>\n         <p>Decisions can fail for several reasons</p>\n         <ul>\n            <li>\n               <p>The ordering of decisions should follow a logical flow. Some decisions might not make sense in the current context of the workflow execution and therefore fails.</p>\n            </li>\n            <li>\n               <p>A limit on your account was reached.</p>\n            </li>\n            <li>\n               <p>The decision lacks sufficient permissions.</p>\n            </li>\n         </ul>\n         <p>One of the following events might be added to the history to indicate an error. The event attribute's\n          <code>cause</code> parameter indicates the cause. If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ScheduleActivityTaskFailed</code> \u2013 A <code>ScheduleActivityTask</code> decision failed. This could happen if the\n        activity type specified in the decision isn't registered, is in a deprecated state, or the decision isn't\n        properly configured.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelActivityTaskFailed</code> \u2013 A\n                        <code>RequestCancelActivityTask</code> decision failed. This could happen if\n                    there is no open activity task with the specified activityId.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartTimerFailed</code> \u2013 A <code>StartTimer</code> decision failed. This\n                    could happen if there is another open timer with the same timerId.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CancelTimerFailed</code> \u2013 A <code>CancelTimer</code> decision failed.\n                    This could happen if there is no open timer with the specified\n                    timerId.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartChildWorkflowExecutionFailed</code> \u2013 A\n                        <code>StartChildWorkflowExecution</code> decision failed. This could happen\n                    if the workflow type specified isn't registered, is deprecated, or the decision\n                    isn't properly configured.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SignalExternalWorkflowExecutionFailed</code> \u2013 A\n                        <code>SignalExternalWorkflowExecution</code> decision failed. This could\n                    happen if the <code>workflowID</code> specified in the decision was\n                    incorrect.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelExternalWorkflowExecutionFailed</code> \u2013 A\n                        <code>RequestCancelExternalWorkflowExecution</code> decision failed. This\n                    could happen if the <code>workflowID</code> specified in the decision was\n                    incorrect.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CancelWorkflowExecutionFailed</code> \u2013 A\n                        <code>CancelWorkflowExecution</code> decision failed. This could happen if\n                    there is an unhandled decision task pending in the workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CompleteWorkflowExecutionFailed</code> \u2013 A\n                        <code>CompleteWorkflowExecution</code> decision failed. This could happen if\n                    there is an unhandled decision task pending in the workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ContinueAsNewWorkflowExecutionFailed</code> \u2013 A\n                        <code>ContinueAsNewWorkflowExecution</code> decision failed. This could\n                    happen if there is an unhandled decision task pending in the workflow execution\n                    or the ContinueAsNewWorkflowExecution decision was not configured\n                    correctly.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FailWorkflowExecutionFailed</code> \u2013 A <code>FailWorkflowExecution</code>\n                    decision failed. This could happen if there is an unhandled decision task\n                    pending in the workflow execution.</p>\n            </li>\n         </ul>\n         <p>The preceding error events might occur due to an error in the decider logic, which might put the workflow execution in an unstable state The cause field in the event structure for the error event indicates the cause of the error.</p>\n         <note>\n            <p>A workflow execution may be closed by the decider by returning one of the following decisions when completing\n      a decision task: <code>CompleteWorkflowExecution</code>, <code>FailWorkflowExecution</code>,\n          <code>CancelWorkflowExecution</code> and <code>ContinueAsNewWorkflowExecution</code>. An <code>UnhandledDecision</code> fault\n      is returned if a workflow closing decision is specified and a signal or activity event had been added to the\n      history while the decision task was being performed by the decider. Unlike the above situations which are logic\n      issues, this fault is always possible because of race conditions in a distributed system. The right action here is\n      to call <a>RespondDecisionTaskCompleted</a>  without any decisions. This would result in another decision task\n      with these new events included in the history. The decider should handle the new events and may decide to close\n      the workflow execution.</p>\n         </note>\n         <p>\n            <b>How to Code a Decision</b>\n         </p>\n         <p>You code a decision by first setting the decision type field to one of the above decision values, and then set the corresponding attributes field shown below:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>\n                     <a>ScheduleActivityTaskDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>RequestCancelActivityTaskDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>CompleteWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>FailWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>CancelWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>ContinueAsNewWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>RecordMarkerDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>StartTimerDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>CancelTimerDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>SignalExternalWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>RequestCancelExternalWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>\n                     <a>StartChildWorkflowExecutionDecisionAttributes</a>\n                  </code>\n               </p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.swf#DecisionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#Decision"
+      }
+    },
+    "com.amazonaws.swf#DecisionTask": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The opaque string used as a handle on the task. This token is used by workers to communicate progress and response information back to the system about the task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskStarted</code> event recorded in the history.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow execution for which this decision task was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the workflow execution for which this decision task was created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "events": {
+          "target": "com.amazonaws.swf#HistoryEventList",
+          "traits": {
+            "smithy.api#documentation": "<p>A paginated list of history events of the workflow execution. The decider uses this during the processing of the decision task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If a <code>NextPageToken</code> was returned by a previous call, there are more\n  results available. To retrieve the next page of results, make the call again using the returned token in\n  <code>nextPageToken</code>. Keep all other arguments unchanged.</p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"
+          }
+        },
+        "previousStartedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the DecisionTaskStarted event of the previous decision task of this workflow execution that was processed by the decider. This can be used to determine the events in the history new since the last decision task received by the decider.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that represents a decision task. Decision tasks are sent to deciders in order for them to make decisions.</p>"
+      }
+    },
+    "com.amazonaws.swf#DecisionTaskCompletedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "executionContext": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>User defined context for the workflow execution.</p>"
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskScheduled</code> event that was recorded when this decision task was scheduled.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskStarted</code> event recorded when this decision task was started.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList"
+        },
+        "taskListScheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time the decision task can wait to be assigned to a worker.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>DecisionTaskCompleted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#DecisionTaskScheduledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list in which the decision task was scheduled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         A task priority that, if set, specifies the priority for this decision task.\n      Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "startToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration for this decision task. The task is considered timed out if it doesn't completed within this duration.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "scheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time the decision task can wait to be assigned to a worker.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details about the <code>DecisionTaskScheduled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#DecisionTaskStartedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "identity": {
+          "target": "com.amazonaws.swf#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>Identity of the decider making the request. This enables diagnostic tracing when problems arise. The form of this identity is user defined.</p>"
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskScheduled</code> event that was recorded when this decision task was scheduled.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>DecisionTaskStarted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#DecisionTaskTimedOutEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timeoutType": {
+          "target": "com.amazonaws.swf#DecisionTaskTimeoutType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of timeout that expired before the decision task could be completed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskScheduled</code> event that was recorded when this decision task was scheduled.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskStarted</code> event recorded when this decision task was started. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>DecisionTaskTimedOut</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#DecisionTaskTimeoutType": {
+      "type": "enum",
+      "members": {
+        "START_TO_CLOSE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "START_TO_CLOSE"
+          }
+        },
+        "SCHEDULE_TO_START": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SCHEDULE_TO_START"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#DecisionType": {
+      "type": "enum",
+      "members": {
+        "ScheduleActivityTask": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ScheduleActivityTask"
+          }
+        },
+        "RequestCancelActivityTask": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RequestCancelActivityTask"
+          }
+        },
+        "CompleteWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CompleteWorkflowExecution"
+          }
+        },
+        "FailWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FailWorkflowExecution"
+          }
+        },
+        "CancelWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CancelWorkflowExecution"
+          }
+        },
+        "ContinueAsNewWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ContinueAsNewWorkflowExecution"
+          }
+        },
+        "RecordMarker": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RecordMarker"
+          }
+        },
+        "StartTimer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "StartTimer"
+          }
+        },
+        "CancelTimer": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CancelTimer"
+          }
+        },
+        "SignalExternalWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SignalExternalWorkflowExecution"
+          }
+        },
+        "RequestCancelExternalWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RequestCancelExternalWorkflowExecution"
+          }
+        },
+        "StartChildWorkflowExecution": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "StartChildWorkflowExecution"
+          }
+        },
+        "ScheduleLambdaFunction": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ScheduleLambdaFunction"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#DefaultUndefinedFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>StartWorkflowExecution</code> API action was called without the required\n      parameters set.</p>\n         <p>Some workflow execution parameters, such as the decision <code>taskList</code>, must be\n      set to start the execution. However, these parameters might have been set as defaults when the\n      workflow type was registered. In this case, you can omit these parameters from the\n        <code>StartWorkflowExecution</code> call and Amazon SWF uses the values defined in the workflow\n      type.</p>\n         <note>\n            <p>If these parameters aren't set and no default parameters were defined in the workflow\n        type, this error is displayed.</p>\n         </note>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#DeleteActivityType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DeleteActivityTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeNotDeprecatedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified <i>activity type</i>.</p>\n         <p>Note: Prior to deletion, activity types must first be <b>deprecated</b>. </p>\n         <p>\n         After an activity type has been deleted, you cannot schedule new activities of that type. Activities that started before the type was deleted will continue to run.\n     </p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n            only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n            action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n            the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>activityType.name</code>: String constraint. The key is\n                <code>swf:activityType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>activityType.version</code>: String constraint. The key is\n                <code>swf:activityType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n        parameter values fall outside the specified constraints, the action fails. The associated\n        event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n        For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DeleteActivityTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the activity type is registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The activity type to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DeleteWorkflowType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DeleteWorkflowTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeNotDeprecatedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified <i>workflow type</i>.</p>\n         <p>Note: Prior to deletion, workflow types must first be <b>deprecated</b>.</p>\n         <p>\n         After a workflow type has been deleted, you cannot create new executions of that type. Executions that\n      started before the type was deleted will continue to run.\n     </p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n            only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n            action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n            the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>workflowType.name</code>: String constraint. The key is\n                <code>swf:workflowType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code>: String constraint. The key is\n                <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n        parameter values fall outside the specified constraints, the action fails. The associated\n        event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n        For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DeleteWorkflowTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the workflow type is registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DeprecateActivityType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DeprecateActivityTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeDeprecatedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deprecates the specified <i>activity type</i>. After an activity type has\n      been deprecated, you cannot create new tasks of that activity type. Tasks of this type that\n      were scheduled before the type was deprecated continue to run.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>activityType.name</code>: String constraint. The key is\n                <code>swf:activityType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>activityType.version</code>: String constraint. The key is\n                <code>swf:activityType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DeprecateActivityTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the activity type is registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The activity type to deprecate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DeprecateDomain": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DeprecateDomainInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#DomainDeprecatedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deprecates the specified domain. After a domain has been deprecated it cannot be used\n      to create new workflow executions or register new types. However, you can still use visibility\n      actions on this domain. Deprecating a domain also deprecates all activity and workflow types\n      registered in the domain. Executions that were started before the domain was deprecated\n      continues to run.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DeprecateDomainInput": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain to deprecate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DeprecateWorkflowType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DeprecateWorkflowTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeDeprecatedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deprecates the specified <i>workflow type</i>. After a workflow type has\n      been deprecated, you cannot create new executions of that type. Executions that were started\n      before the type was deprecated continues to run. A deprecated workflow type may still be used\n      when calling visibility actions.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>workflowType.name</code>: String constraint. The key is\n                <code>swf:workflowType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code>: String constraint. The key is\n                <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DeprecateWorkflowTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the workflow type is registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type to deprecate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DescribeActivityType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DescribeActivityTypeInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#ActivityTypeDetail"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about the specified activity type. This includes configuration\n      settings provided when the type was registered and other general information about the\n      type.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>activityType.name</code>: String constraint. The key is\n                <code>swf:activityType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>activityType.version</code>: String constraint. The key is\n                <code>swf:activityType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DescribeActivityTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the activity type is registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The activity type to get information about. Activity types are identified by the\n        <code>name</code> and <code>version</code> that were supplied when the activity was\n      registered.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DescribeDomain": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DescribeDomainInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#DomainDetail"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about the specified domain, including description and\n      status.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DescribeDomainInput": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain to describe.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DescribeWorkflowExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DescribeWorkflowExecutionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowExecutionDetail"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about the specified workflow execution including its type and some\n      statistics.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DescribeWorkflowExecutionInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "execution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow execution to describe.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#DescribeWorkflowType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#DescribeWorkflowTypeInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowTypeDetail"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about the specified <i>workflow type</i>. This\n      includes configuration settings specified when the type was registered and other information\n      such as creation date, current status, etc.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>workflowType.name</code>: String constraint. The key is\n                <code>swf:workflowType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code>: String constraint. The key is\n                <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#DescribeWorkflowTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which this workflow type is registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type to describe.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#Description": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.swf#DomainAlreadyExistsFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned if the domain already exists. You may get this fault if you are registering a domain that is either already registered or deprecated, or if you undeprecate a domain that is currently registered.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#DomainConfiguration": {
+      "type": "structure",
+      "members": {
+        "workflowExecutionRetentionPeriodInDays": {
+          "target": "com.amazonaws.swf#DurationInDays",
+          "traits": {
+            "smithy.api#documentation": "<p>The retention period for workflow executions in this domain.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the configuration settings of a domain.</p>"
+      }
+    },
+    "com.amazonaws.swf#DomainDeprecatedFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned when the specified domain has been deprecated.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#DomainDetail": {
+      "type": "structure",
+      "members": {
+        "domainInfo": {
+          "target": "com.amazonaws.swf#DomainInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>The basic information about a domain, such as its name, status, and\n      description.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "configuration": {
+          "target": "com.amazonaws.swf#DomainConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain configuration. Currently, this includes only the domain's retention\n      period.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains details of a domain.</p>"
+      }
+    },
+    "com.amazonaws.swf#DomainInfo": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain. This name is unique within the account.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.swf#RegistrationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the domain:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>REGISTERED</code> \u2013 The domain is properly registered and available. You can use this domain\n         for registering types and creating new workflow executions.\n      </p>\n            </li>\n            <li>\n               <p>\n                  <code>DEPRECATED</code> \u2013 The domain was deprecated using <a>DeprecateDomain</a>, but is\n         still in use. You should not create new workflow executions in this domain.\n      </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.swf#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the domain provided through <a>RegisterDomain</a>.</p>"
+          }
+        },
+        "arn": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the domain.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains general information about a domain.</p>"
+      }
+    },
+    "com.amazonaws.swf#DomainInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#DomainInfo"
+      }
+    },
+    "com.amazonaws.swf#DomainInfos": {
+      "type": "structure",
+      "members": {
+        "domainInfos": {
+          "target": "com.amazonaws.swf#DomainInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of DomainInfo structures.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If a <code>NextPageToken</code> was returned by a previous call, there are more\n  results available. To retrieve the next page of results, make the call again using the returned token in\n  <code>nextPageToken</code>. Keep all other arguments unchanged.</p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains a paginated collection of DomainInfo structures.</p>"
+      }
+    },
+    "com.amazonaws.swf#DomainName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#DurationInDays": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 8
+        }
+      }
+    },
+    "com.amazonaws.swf#DurationInSeconds": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 8
+        }
+      }
+    },
+    "com.amazonaws.swf#DurationInSecondsOptional": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 8
+        }
+      }
+    },
+    "com.amazonaws.swf#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.swf#EventId": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.swf#EventType": {
+      "type": "enum",
+      "members": {
+        "WorkflowExecutionStarted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionStarted"
+          }
+        },
+        "WorkflowExecutionCancelRequested": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionCancelRequested"
+          }
+        },
+        "WorkflowExecutionCompleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionCompleted"
+          }
+        },
+        "CompleteWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CompleteWorkflowExecutionFailed"
+          }
+        },
+        "WorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionFailed"
+          }
+        },
+        "FailWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FailWorkflowExecutionFailed"
+          }
+        },
+        "WorkflowExecutionTimedOut": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionTimedOut"
+          }
+        },
+        "WorkflowExecutionCanceled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionCanceled"
+          }
+        },
+        "CancelWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CancelWorkflowExecutionFailed"
+          }
+        },
+        "WorkflowExecutionContinuedAsNew": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionContinuedAsNew"
+          }
+        },
+        "ContinueAsNewWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ContinueAsNewWorkflowExecutionFailed"
+          }
+        },
+        "WorkflowExecutionTerminated": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionTerminated"
+          }
+        },
+        "DecisionTaskScheduled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DecisionTaskScheduled"
+          }
+        },
+        "DecisionTaskStarted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DecisionTaskStarted"
+          }
+        },
+        "DecisionTaskCompleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DecisionTaskCompleted"
+          }
+        },
+        "DecisionTaskTimedOut": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DecisionTaskTimedOut"
+          }
+        },
+        "ActivityTaskScheduled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskScheduled"
+          }
+        },
+        "ScheduleActivityTaskFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ScheduleActivityTaskFailed"
+          }
+        },
+        "ActivityTaskStarted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskStarted"
+          }
+        },
+        "ActivityTaskCompleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskCompleted"
+          }
+        },
+        "ActivityTaskFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskFailed"
+          }
+        },
+        "ActivityTaskTimedOut": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskTimedOut"
+          }
+        },
+        "ActivityTaskCanceled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskCanceled"
+          }
+        },
+        "ActivityTaskCancelRequested": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ActivityTaskCancelRequested"
+          }
+        },
+        "RequestCancelActivityTaskFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RequestCancelActivityTaskFailed"
+          }
+        },
+        "WorkflowExecutionSignaled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WorkflowExecutionSignaled"
+          }
+        },
+        "MarkerRecorded": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MarkerRecorded"
+          }
+        },
+        "RecordMarkerFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RecordMarkerFailed"
+          }
+        },
+        "TimerStarted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TimerStarted"
+          }
+        },
+        "StartTimerFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "StartTimerFailed"
+          }
+        },
+        "TimerFired": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TimerFired"
+          }
+        },
+        "TimerCanceled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TimerCanceled"
+          }
+        },
+        "CancelTimerFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CancelTimerFailed"
+          }
+        },
+        "StartChildWorkflowExecutionInitiated": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "StartChildWorkflowExecutionInitiated"
+          }
+        },
+        "StartChildWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "StartChildWorkflowExecutionFailed"
+          }
+        },
+        "ChildWorkflowExecutionStarted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ChildWorkflowExecutionStarted"
+          }
+        },
+        "ChildWorkflowExecutionCompleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ChildWorkflowExecutionCompleted"
+          }
+        },
+        "ChildWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ChildWorkflowExecutionFailed"
+          }
+        },
+        "ChildWorkflowExecutionTimedOut": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ChildWorkflowExecutionTimedOut"
+          }
+        },
+        "ChildWorkflowExecutionCanceled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ChildWorkflowExecutionCanceled"
+          }
+        },
+        "ChildWorkflowExecutionTerminated": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ChildWorkflowExecutionTerminated"
+          }
+        },
+        "SignalExternalWorkflowExecutionInitiated": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SignalExternalWorkflowExecutionInitiated"
+          }
+        },
+        "SignalExternalWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SignalExternalWorkflowExecutionFailed"
+          }
+        },
+        "ExternalWorkflowExecutionSignaled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ExternalWorkflowExecutionSignaled"
+          }
+        },
+        "RequestCancelExternalWorkflowExecutionInitiated": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RequestCancelExternalWorkflowExecutionInitiated"
+          }
+        },
+        "RequestCancelExternalWorkflowExecutionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RequestCancelExternalWorkflowExecutionFailed"
+          }
+        },
+        "ExternalWorkflowExecutionCancelRequested": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ExternalWorkflowExecutionCancelRequested"
+          }
+        },
+        "LambdaFunctionScheduled": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LambdaFunctionScheduled"
+          }
+        },
+        "LambdaFunctionStarted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LambdaFunctionStarted"
+          }
+        },
+        "LambdaFunctionCompleted": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LambdaFunctionCompleted"
+          }
+        },
+        "LambdaFunctionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LambdaFunctionFailed"
+          }
+        },
+        "LambdaFunctionTimedOut": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LambdaFunctionTimedOut"
+          }
+        },
+        "ScheduleLambdaFunctionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ScheduleLambdaFunctionFailed"
+          }
+        },
+        "StartLambdaFunctionFailed": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "StartLambdaFunctionFailed"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ExecutionStatus": {
+      "type": "enum",
+      "members": {
+        "OPEN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN"
+          }
+        },
+        "CLOSED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLOSED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ExecutionTimeFilter": {
+      "type": "structure",
+      "members": {
+        "oldestDate": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the oldest start or close date and time to return.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "latestDate": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the latest start or close date and time to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to filter the workflow executions in visibility APIs by various time-based rules. Each parameter, if\n      specified, defines a rule that must be satisfied by each returned query result. The parameter values are in the <a href=\"https://en.wikipedia.org/wiki/Unix_time\">Unix Time format</a>. For example:\n      <code>\"oldestDate\": 1325376070.</code>\n         </p>"
+      }
+    },
+    "com.amazonaws.swf#ExternalWorkflowExecutionCancelRequestedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The external workflow execution to which the cancellation request was delivered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event corresponding to the\n      <code>RequestCancelExternalWorkflowExecution</code> decision to cancel this external workflow execution. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ExternalWorkflowExecutionCancelRequested</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ExternalWorkflowExecutionSignaledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The external workflow execution that the signal was delivered to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the\n      <code>SignalExternalWorkflowExecution</code> decision to request this signal. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ExternalWorkflowExecutionSignaled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#FailWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "reason": {
+          "target": "com.amazonaws.swf#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>A descriptive reason for the failure that may help in diagnostics.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Details of the failure.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>FailWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n  <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#FailWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "UNHANDLED_DECISION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNHANDLED_DECISION"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#FailWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "cause": {
+          "target": "com.amazonaws.swf#FailWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>FailWorkflowExecution</code> decision to fail this execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>FailWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#FailureReason": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#FunctionId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#FunctionInput": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 32768
+        }
+      }
+    },
+    "com.amazonaws.swf#FunctionName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.swf#GetWorkflowExecutionHistory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#GetWorkflowExecutionHistoryInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#History"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the history of the specified workflow execution. The results may be split into\n      multiple pages. To retrieve subsequent pages, make the call again using the\n        <code>nextPageToken</code> returned by the initial call.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "events",
+          "pageSize": "maximumPageSize"
+        }
+      }
+    },
+    "com.amazonaws.swf#GetWorkflowExecutionHistoryInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "execution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the workflow execution for which to return the history.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>"
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the events in reverse order. By default the\n      results are returned in ascending order of the <code>eventTimeStamp</code> of the\n      events.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#History": {
+      "type": "structure",
+      "members": {
+        "events": {
+          "target": "com.amazonaws.swf#HistoryEventList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of history events.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If a <code>NextPageToken</code> was returned by a previous call, there are more\n  results available. To retrieve the next page of results, make the call again using the returned token in\n  <code>nextPageToken</code>. Keep all other arguments unchanged.</p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Paginated representation of a workflow history for a workflow execution. This is the up to date, complete and authoritative record of the events related to all tasks and events in the life of the workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#HistoryEvent": {
+      "type": "structure",
+      "members": {
+        "eventTimestamp": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time when the event occurred.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "eventType": {
+          "target": "com.amazonaws.swf#EventType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the history event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "eventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The system generated ID of the event. This ID uniquely identifies the event with in the workflow execution history.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowExecutionStartedEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionStartedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionStarted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionCompletedEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionCompletedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionCompleted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "completeWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#CompleteWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>CompleteWorkflowExecutionFailed</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "failWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#FailWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>FailWorkflowExecutionFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionTimedOutEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionTimedOutEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionTimedOut</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionCanceledEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionCanceledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionCanceled</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "cancelWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#CancelWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>CancelWorkflowExecutionFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionContinuedAsNewEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionContinuedAsNewEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionContinuedAsNew</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "continueAsNewWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#ContinueAsNewWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ContinueAsNewWorkflowExecutionFailed</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionTerminatedEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionTerminatedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionTerminated</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionCancelRequestedEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionCancelRequestedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionCancelRequested</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "decisionTaskScheduledEventAttributes": {
+          "target": "com.amazonaws.swf#DecisionTaskScheduledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>DecisionTaskScheduled</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "decisionTaskStartedEventAttributes": {
+          "target": "com.amazonaws.swf#DecisionTaskStartedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>DecisionTaskStarted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "decisionTaskCompletedEventAttributes": {
+          "target": "com.amazonaws.swf#DecisionTaskCompletedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>DecisionTaskCompleted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "decisionTaskTimedOutEventAttributes": {
+          "target": "com.amazonaws.swf#DecisionTaskTimedOutEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>DecisionTaskTimedOut</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskScheduledEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskScheduledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskScheduled</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskStartedEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskStartedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskStarted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskCompletedEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskCompletedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskCompleted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskFailedEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskTimedOutEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskTimedOutEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskTimedOut</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskCanceledEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskCanceledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskCanceled</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "activityTaskCancelRequestedEventAttributes": {
+          "target": "com.amazonaws.swf#ActivityTaskCancelRequestedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ActivityTaskcancelRequested</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "workflowExecutionSignaledEventAttributes": {
+          "target": "com.amazonaws.swf#WorkflowExecutionSignaledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>WorkflowExecutionSignaled</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "markerRecordedEventAttributes": {
+          "target": "com.amazonaws.swf#MarkerRecordedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>MarkerRecorded</code> then this member is set and provides detailed information\n      about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "recordMarkerFailedEventAttributes": {
+          "target": "com.amazonaws.swf#RecordMarkerFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>DecisionTaskFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "timerStartedEventAttributes": {
+          "target": "com.amazonaws.swf#TimerStartedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>TimerStarted</code> then this member is set and provides detailed information\n      about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "timerFiredEventAttributes": {
+          "target": "com.amazonaws.swf#TimerFiredEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>TimerFired</code> then this member is set and provides detailed information about\n      the event. It isn't set for other event types.</p>"
+          }
+        },
+        "timerCanceledEventAttributes": {
+          "target": "com.amazonaws.swf#TimerCanceledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>TimerCanceled</code> then this member is set and provides detailed information\n      about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "startChildWorkflowExecutionInitiatedEventAttributes": {
+          "target": "com.amazonaws.swf#StartChildWorkflowExecutionInitiatedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>StartChildWorkflowExecutionInitiated</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "childWorkflowExecutionStartedEventAttributes": {
+          "target": "com.amazonaws.swf#ChildWorkflowExecutionStartedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ChildWorkflowExecutionStarted</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "childWorkflowExecutionCompletedEventAttributes": {
+          "target": "com.amazonaws.swf#ChildWorkflowExecutionCompletedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ChildWorkflowExecutionCompleted</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "childWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#ChildWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ChildWorkflowExecutionFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "childWorkflowExecutionTimedOutEventAttributes": {
+          "target": "com.amazonaws.swf#ChildWorkflowExecutionTimedOutEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ChildWorkflowExecutionTimedOut</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "childWorkflowExecutionCanceledEventAttributes": {
+          "target": "com.amazonaws.swf#ChildWorkflowExecutionCanceledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ChildWorkflowExecutionCanceled</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "childWorkflowExecutionTerminatedEventAttributes": {
+          "target": "com.amazonaws.swf#ChildWorkflowExecutionTerminatedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ChildWorkflowExecutionTerminated</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "signalExternalWorkflowExecutionInitiatedEventAttributes": {
+          "target": "com.amazonaws.swf#SignalExternalWorkflowExecutionInitiatedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>SignalExternalWorkflowExecutionInitiated</code> then this member is set and\n      provides detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "externalWorkflowExecutionSignaledEventAttributes": {
+          "target": "com.amazonaws.swf#ExternalWorkflowExecutionSignaledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ExternalWorkflowExecutionSignaled</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "signalExternalWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#SignalExternalWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>SignalExternalWorkflowExecutionFailed</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "externalWorkflowExecutionCancelRequestedEventAttributes": {
+          "target": "com.amazonaws.swf#ExternalWorkflowExecutionCancelRequestedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ExternalWorkflowExecutionCancelRequested</code> then this member is set and\n      provides detailed information about the event. It isn't set for other event types. </p>"
+          }
+        },
+        "requestCancelExternalWorkflowExecutionInitiatedEventAttributes": {
+          "target": "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionInitiatedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>RequestCancelExternalWorkflowExecutionInitiated</code> then this member is set and\n      provides detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "requestCancelExternalWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>RequestCancelExternalWorkflowExecutionFailed</code> then this member is set and\n      provides detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "scheduleActivityTaskFailedEventAttributes": {
+          "target": "com.amazonaws.swf#ScheduleActivityTaskFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>ScheduleActivityTaskFailed</code> then this member is set and provides detailed\n      information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "requestCancelActivityTaskFailedEventAttributes": {
+          "target": "com.amazonaws.swf#RequestCancelActivityTaskFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>RequestCancelActivityTaskFailed</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "startTimerFailedEventAttributes": {
+          "target": "com.amazonaws.swf#StartTimerFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>StartTimerFailed</code> then this member is set and provides detailed information\n      about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "cancelTimerFailedEventAttributes": {
+          "target": "com.amazonaws.swf#CancelTimerFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>CancelTimerFailed</code> then this member is set and provides detailed information\n      about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "startChildWorkflowExecutionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#StartChildWorkflowExecutionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event is of type <code>StartChildWorkflowExecutionFailed</code> then this member is set and provides\n      detailed information about the event. It isn't set for other event types.</p>"
+          }
+        },
+        "lambdaFunctionScheduledEventAttributes": {
+          "target": "com.amazonaws.swf#LambdaFunctionScheduledEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionScheduled</code> event. It isn't set\n      for other event types.</p>"
+          }
+        },
+        "lambdaFunctionStartedEventAttributes": {
+          "target": "com.amazonaws.swf#LambdaFunctionStartedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionStarted</code> event. It isn't set for\n      other event types.</p>"
+          }
+        },
+        "lambdaFunctionCompletedEventAttributes": {
+          "target": "com.amazonaws.swf#LambdaFunctionCompletedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionCompleted</code> event. It isn't set\n      for other event types.</p>"
+          }
+        },
+        "lambdaFunctionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#LambdaFunctionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionFailed</code> event. It isn't set for\n      other event types.</p>"
+          }
+        },
+        "lambdaFunctionTimedOutEventAttributes": {
+          "target": "com.amazonaws.swf#LambdaFunctionTimedOutEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionTimedOut</code> event. It isn't set for\n      other event types.</p>"
+          }
+        },
+        "scheduleLambdaFunctionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#ScheduleLambdaFunctionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>ScheduleLambdaFunctionFailed</code> event. It isn't\n      set for other event types.</p>"
+          }
+        },
+        "startLambdaFunctionFailedEventAttributes": {
+          "target": "com.amazonaws.swf#StartLambdaFunctionFailedEventAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the details of the <code>StartLambdaFunctionFailed</code> event. It isn't set\n      for other event types.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Event within a workflow execution. A history event can be one of these types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ActivityTaskCancelRequested</code> \u2013 A <code>RequestCancelActivityTask</code> decision was received by the\n        system.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ActivityTaskCanceled</code> \u2013 The activity task was successfully canceled.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ActivityTaskCompleted</code> \u2013 An activity worker successfully completed an activity task by calling\n        <a>RespondActivityTaskCompleted</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ActivityTaskFailed</code> \u2013 An activity worker failed an activity task by calling\n        <a>RespondActivityTaskFailed</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ActivityTaskScheduled</code> \u2013 An activity task was scheduled for execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ActivityTaskStarted</code> \u2013 The scheduled activity task was dispatched to a worker.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ActivityTaskTimedOut</code> \u2013 The activity task timed out.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CancelTimerFailed</code> \u2013 Failed to process CancelTimer decision. This happens when the decision isn't\n        configured properly, for example no timer exists with the specified timer Id.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CancelWorkflowExecutionFailed</code> \u2013 A request to cancel a workflow execution failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ChildWorkflowExecutionCanceled</code> \u2013 A child workflow execution, started by this workflow execution, was\n        canceled and closed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ChildWorkflowExecutionCompleted</code> \u2013 A child workflow execution, started by this workflow execution,\n        completed successfully and was closed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ChildWorkflowExecutionFailed</code> \u2013 A child workflow execution,\n        started by this workflow execution, failed to complete successfully and was closed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ChildWorkflowExecutionStarted</code> \u2013 A child workflow execution was successfully started.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ChildWorkflowExecutionTerminated</code> \u2013  A child workflow execution, started by this workflow execution, was\n        terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ChildWorkflowExecutionTimedOut</code> \u2013  A child workflow execution, started by this workflow execution, timed\n        out and was closed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CompleteWorkflowExecutionFailed</code> \u2013 The workflow execution failed to complete.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ContinueAsNewWorkflowExecutionFailed</code> \u2013 The workflow execution failed to complete after being continued\n        as a new workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DecisionTaskCompleted</code> \u2013 The decider successfully completed a decision task by calling\n        <a>RespondDecisionTaskCompleted</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DecisionTaskScheduled</code> \u2013 A decision task was scheduled for the workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DecisionTaskStarted</code> \u2013 The decision task was dispatched to a decider.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DecisionTaskTimedOut</code> \u2013 The decision task timed out.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ExternalWorkflowExecutionCancelRequested</code> \u2013 Request to cancel an external workflow execution was\n        successfully delivered to the target execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ExternalWorkflowExecutionSignaled</code> \u2013 A signal, requested by this workflow execution, was successfully\n        delivered to the target external workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FailWorkflowExecutionFailed</code> \u2013 A request to mark a workflow execution as failed, itself failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MarkerRecorded</code> \u2013 A marker was recorded in the workflow history as the result of a\n        <code>RecordMarker</code> decision.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RecordMarkerFailed</code> \u2013 A <code>RecordMarker</code> decision was returned as failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelActivityTaskFailed</code> \u2013 Failed to process RequestCancelActivityTask decision. This happens\n        when the decision isn't configured properly.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelExternalWorkflowExecutionFailed</code> \u2013 Request to cancel an external workflow execution\n        failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>RequestCancelExternalWorkflowExecutionInitiated</code> \u2013 A request was made to request the cancellation of an\n        external workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ScheduleActivityTaskFailed</code> \u2013 Failed to process ScheduleActivityTask decision. This happens when the\n        decision isn't configured properly, for example the activity type specified isn't registered.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SignalExternalWorkflowExecutionFailed</code> \u2013 The request to signal an external workflow execution\n        failed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SignalExternalWorkflowExecutionInitiated</code> \u2013 A request to signal an external workflow was made.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartActivityTaskFailed</code> \u2013 A scheduled activity task failed to start.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartChildWorkflowExecutionFailed</code> \u2013 Failed to process StartChildWorkflowExecution decision. This happens\n        when the decision isn't configured properly, for example the workflow type specified isn't registered.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartChildWorkflowExecutionInitiated</code> \u2013 A request was made to start a child workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>StartTimerFailed</code> \u2013 Failed to process StartTimer decision. This happens when the decision isn't\n        configured properly, for example a timer already exists with the specified timer Id.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TimerCanceled</code> \u2013 A timer, previously started for this workflow execution, was successfully canceled.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TimerFired</code> \u2013 A timer, previously started for this workflow execution, fired.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TimerStarted</code> \u2013 A timer was started for the workflow execution due to a <code>StartTimer</code>\n        decision.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionCancelRequested</code> \u2013 A request to cancel this workflow execution was made.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionCanceled</code> \u2013 The workflow execution was successfully canceled and closed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionCompleted</code> \u2013 The workflow execution was closed due to successful completion.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionContinuedAsNew</code> \u2013 The workflow execution was closed and a new execution of the same type\n        was created with the same workflowId.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionFailed</code> \u2013 The workflow execution closed due to a failure.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionSignaled</code> \u2013 An external signal was received for the workflow execution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionStarted</code> \u2013 The workflow execution was started.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionTerminated</code> \u2013 The workflow execution was terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>WorkflowExecutionTimedOut</code> \u2013 The workflow execution was closed because a time out was exceeded.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.swf#HistoryEventList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#HistoryEvent"
+      }
+    },
+    "com.amazonaws.swf#Identity": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#LambdaFunctionCompletedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this\n      Lambda task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionStarted</code> event recorded when this activity task\n      started. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "result": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The results of the Lambda task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionCompleted</code> event. It isn't set\n      for other event types.</p>"
+      }
+    },
+    "com.amazonaws.swf#LambdaFunctionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this\n      activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionStarted</code> event recorded when this activity task\n      started. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.swf#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason provided for the failure.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the failure.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionFailed</code> event. It isn't set for\n      other event types.</p>"
+      }
+    },
+    "com.amazonaws.swf#LambdaFunctionScheduledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "com.amazonaws.swf#FunctionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the Lambda task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#FunctionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Lambda function.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that the decider can use in subsequent workflow tasks. This\n      data isn't sent to the Lambda task.</p>"
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#FunctionInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the Lambda task.</p>"
+          }
+        },
+        "startToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum amount of time a worker can take to process the Lambda task.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionCompleted</code> event corresponding to the decision\n      that resulted in scheduling this activity task. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionScheduled</code> event. It isn't set\n      for other event types.</p>"
+      }
+    },
+    "com.amazonaws.swf#LambdaFunctionStartedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this\n      activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>LambdaFunctionStarted</code> event. It isn't set for\n      other event types.</p>"
+      }
+    },
+    "com.amazonaws.swf#LambdaFunctionTimedOutEventAttributes": {
+      "type": "structure",
+      "members": {
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this\n      activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskStarted</code> event that was recorded when this\n      activity task started. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "timeoutType": {
+          "target": "com.amazonaws.swf#LambdaFunctionTimeoutType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the timeout that caused this event.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details of the <code>LambdaFunctionTimedOut</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#LambdaFunctionTimeoutType": {
+      "type": "enum",
+      "members": {
+        "START_TO_CLOSE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "START_TO_CLOSE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#LimitExceededFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned by any operation if a system imposed limitation has been reached. To address this fault you should either clean up unused resources or increase the limit by contacting AWS.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#LimitedData": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.swf#ListActivityTypes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#ListActivityTypesInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#ActivityTypeInfos"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about all activities registered in the specified domain that match\n      the specified name and registration status. The result includes information like creation\n      date, current status of the activity, etc. The results may be split into multiple pages. To\n      retrieve subsequent pages, make the call again using the <code>nextPageToken</code> returned\n      by the initial call.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "typeInfos",
+          "pageSize": "maximumPageSize"
+        }
+      }
+    },
+    "com.amazonaws.swf#ListActivityTypesInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the activity types have been registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only lists the activity types that have this name.</p>"
+          }
+        },
+        "registrationStatus": {
+          "target": "com.amazonaws.swf#RegistrationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the registration status of the activity types to list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>"
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the results in reverse order. By default, the\n      results are returned in ascending alphabetical order by <code>name</code> of the activity\n      types.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ListClosedWorkflowExecutions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#ListClosedWorkflowExecutionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowExecutionInfos"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of closed workflow executions in the specified domain that meet the\n      filtering criteria. The results may be split into multiple pages. To retrieve subsequent\n      pages, make the call again using the nextPageToken returned by the initial call.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tagFilter.tag</code>: String constraint. The key is\n                <code>swf:tagFilter.tag</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.name</code>: String constraint. The key is\n                <code>swf:typeFilter.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.version</code>: String constraint. The key is\n                <code>swf:typeFilter.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "executionInfos",
+          "pageSize": "maximumPageSize"
+        }
+      }
+    },
+    "com.amazonaws.swf#ListClosedWorkflowExecutionsInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain that contains the workflow executions to list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startTimeFilter": {
+          "target": "com.amazonaws.swf#ExecutionTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, the workflow executions are included in the returned results based on\n      whether their start times are within the range specified by this filter. Also, if this\n      parameter is specified, the returned results are ordered by their start times.</p>\n         <note>\n            <p>\n               <code>startTimeFilter</code> and <code>closeTimeFilter</code> are mutually exclusive. You\n        must specify one of these in a request but not both.</p>\n         </note>"
+          }
+        },
+        "closeTimeFilter": {
+          "target": "com.amazonaws.swf#ExecutionTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, the workflow executions are included in the returned results based on\n      whether their close times are within the range specified by this filter. Also, if this\n      parameter is specified, the returned results are ordered by their close times.</p>\n         <note>\n            <p>\n               <code>startTimeFilter</code> and <code>closeTimeFilter</code> are mutually exclusive. You\n        must specify one of these in a request but not both.</p>\n         </note>"
+          }
+        },
+        "executionFilter": {
+          "target": "com.amazonaws.swf#WorkflowExecutionFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions matching the workflow ID specified in the filter\n      are returned.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "closeStatusFilter": {
+          "target": "com.amazonaws.swf#CloseStatusFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions that match this <i>close\n        status</i> are listed. For example, if TERMINATED is specified, then only TERMINATED\n      workflow executions are listed.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "typeFilter": {
+          "target": "com.amazonaws.swf#WorkflowTypeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only executions of the type specified in the filter are\n      returned.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "tagFilter": {
+          "target": "com.amazonaws.swf#TagFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only executions that have the matching tag are listed.</p>\n         <note>\n            <p>\n               <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and\n          <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a\n        request.</p>\n         </note>"
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>"
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the results in reverse order. By default the\n      results are returned in descending order of the start or the close time of the\n      executions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ListDomains": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#ListDomainsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#DomainInfos"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the list of domains registered in the account. The results may be split into\n      multiple pages. To retrieve subsequent pages, make the call again using the nextPageToken\n      returned by the initial call.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains. The element must be set to\n            <code>arn:aws:swf::AccountID:domain/*</code>, where <i>AccountID</i> is\n          the account ID, with no dashes.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "domainInfos",
+          "pageSize": "maximumPageSize"
+        },
+        "smithy.test#smokeTests": [
+          {
+            "id": "ListDomainsSuccess",
+            "params": {
+              "registrationStatus": "REGISTERED"
+            },
+            "vendorParams": {
+              "region": "us-west-2"
+            },
+            "vendorParamsShape": "aws.test#AwsVendorParams",
+            "expect": {
+              "success": {}
+            }
+          }
+        ]
+      }
+    },
+    "com.amazonaws.swf#ListDomainsInput": {
+      "type": "structure",
+      "members": {
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>"
+          }
+        },
+        "registrationStatus": {
+          "target": "com.amazonaws.swf#RegistrationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the registration status of the domains to list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the results in reverse order. By default, the\n      results are returned in ascending alphabetical order by <code>name</code> of the\n      domains.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ListOpenWorkflowExecutions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#ListOpenWorkflowExecutionsInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowExecutionInfos"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of open workflow executions in the specified domain that meet the\n      filtering criteria. The results may be split into multiple pages. To retrieve subsequent\n      pages, make the call again using the nextPageToken returned by the initial call.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tagFilter.tag</code>: String constraint. The key is\n                <code>swf:tagFilter.tag</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.name</code>: String constraint. The key is\n                <code>swf:typeFilter.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>typeFilter.version</code>: String constraint. The key is\n                <code>swf:typeFilter.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "executionInfos",
+          "pageSize": "maximumPageSize"
+        }
+      }
+    },
+    "com.amazonaws.swf#ListOpenWorkflowExecutionsInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain that contains the workflow executions to list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startTimeFilter": {
+          "target": "com.amazonaws.swf#ExecutionTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Workflow executions are included in the returned results based on whether their start\n      times are within the range specified by this filter.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "typeFilter": {
+          "target": "com.amazonaws.swf#WorkflowTypeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only executions of the type specified in the filter are\n      returned.</p>\n         <note>\n            <p>\n               <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are\n        mutually exclusive. You can specify at most one of these in a request.</p>\n         </note>"
+          }
+        },
+        "tagFilter": {
+          "target": "com.amazonaws.swf#TagFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only executions that have the matching tag are listed.</p>\n         <note>\n            <p>\n               <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are\n        mutually exclusive. You can specify at most one of these in a request.</p>\n         </note>"
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>"
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the results in reverse order. By default the\n      results are returned in descending order of the start time of the executions.</p>"
+          }
+        },
+        "executionFilter": {
+          "target": "com.amazonaws.swf#WorkflowExecutionFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, only workflow executions matching the workflow ID specified in the filter\n      are returned.</p>\n         <note>\n            <p>\n               <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are\n        mutually exclusive. You can specify at most one of these in a request.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#ListTagsForResourceInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#ListTagsForResourceOutput"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List tags for a given domain.</p>"
+      }
+    },
+    "com.amazonaws.swf#ListTagsForResourceInput": {
+      "type": "structure",
+      "members": {
+        "resourceArn": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the Amazon SWF domain.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ListTagsForResourceOutput": {
+      "type": "structure",
+      "members": {
+        "tags": {
+          "target": "com.amazonaws.swf#ResourceTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of tags associated with the domain.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.swf#ListWorkflowTypes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#ListWorkflowTypesInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#WorkflowTypeInfos"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns information about workflow types in the specified domain. The results may be\n      split into multiple pages that can be retrieved by making the call repeatedly.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "typeInfos",
+          "pageSize": "maximumPageSize"
+        }
+      }
+    },
+    "com.amazonaws.swf#ListWorkflowTypesInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the workflow types have been registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, lists the workflow type with this name.</p>"
+          }
+        },
+        "registrationStatus": {
+          "target": "com.amazonaws.swf#RegistrationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the registration status of the workflow types to list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>"
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the results in reverse order. By default the\n      results are returned in ascending alphabetical order of the <code>name</code> of the workflow\n      types.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#MarkerName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#MarkerRecordedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "markerName": {
+          "target": "com.amazonaws.swf#MarkerName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the marker.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the marker.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>RecordMarker</code> decision that requested this marker. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>MarkerRecorded</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#Name": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#OpenDecisionTasksCount": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.swf#OperationNotPermittedFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned when the caller doesn't have sufficient permissions to invoke the action.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#PageSize": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.swf#PageToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.swf#PendingTaskCount": {
+      "type": "structure",
+      "members": {
+        "count": {
+          "target": "com.amazonaws.swf#Count",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of tasks in the task list.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "truncated": {
+          "target": "com.amazonaws.swf#Truncated",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If set to true, indicates that the actual count was more than the maximum supported by this API and the count returned is the truncated value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the count of tasks in a task list.</p>"
+      }
+    },
+    "com.amazonaws.swf#PollForActivityTask": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#PollForActivityTaskInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#ActivityTask"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by workers to get an <a>ActivityTask</a> from the specified activity\n        <code>taskList</code>. This initiates a long poll, where the service holds the HTTP\n      connection open and responds as soon as a task becomes available. The maximum time the service\n      holds on to the request before responding is 60 seconds. If no task is available within 60\n      seconds, the poll returns an empty result. An empty result, in this context, means that an\n      ActivityTask is returned, but that the value of taskToken is an empty string. If a task is\n      returned, the worker should use its type to identify and process it correctly.</p>\n         <important>\n            <p>Workers should set their client side socket timeout to at least 70 seconds (10\n        seconds higher than the maximum time service may hold the poll request).</p>\n         </important>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the <code>taskList.name</code> parameter by using a\n            <code>Condition</code> element with the <code>swf:taskList.name</code> key to allow the\n          action to access only certain task lists.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#PollForActivityTaskInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain that contains the task lists being polled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the task list to poll for activity tasks.</p>\n         <p>The specified string must not start or end with whitespace. It must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "identity": {
+          "target": "com.amazonaws.swf#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>Identity of the worker making the request, recorded in the\n        <code>ActivityTaskStarted</code> event in the workflow history. This enables diagnostic\n      tracing when problems arise. The form of this identity is user defined.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#PollForDecisionTask": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#PollForDecisionTaskInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#DecisionTask"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by deciders to get a <a>DecisionTask</a> from the specified decision\n        <code>taskList</code>. A decision task may be returned for any open workflow execution that\n      is using the specified task list. The task includes a paginated view of the history of the\n      workflow execution. The decider should use the workflow type and the history to determine how\n      to properly handle the task.</p>\n         <p>This action initiates a long poll, where the service holds the HTTP connection open and\n      responds as soon a task becomes available. If no decision task is available in the specified\n      task list before the timeout of 60 seconds expires, an empty result is returned. An empty\n      result, in this context, means that a DecisionTask is returned, but that the value of\n      taskToken is an empty string.</p>\n         <important>\n            <p>Deciders should set their client side socket timeout to at least 70 seconds (10\n        seconds higher than the timeout).</p>\n         </important>\n         <important>\n            <p>Because the number of workflow history events for a single workflow execution might\n        be very large, the result returned might be split up across a number of pages. To retrieve\n        subsequent pages, make additional calls to <code>PollForDecisionTask</code> using the\n          <code>nextPageToken</code> returned by the initial call. Note that you do\n          <i>not</i> call <code>GetWorkflowExecutionHistory</code> with this\n          <code>nextPageToken</code>. Instead, call <code>PollForDecisionTask</code>\n        again.</p>\n         </important>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the <code>taskList.name</code> parameter by using a\n            <code>Condition</code> element with the <code>swf:taskList.name</code> key to allow the\n          action to access only certain task lists.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "nextPageToken",
+          "outputToken": "nextPageToken",
+          "items": "events",
+          "pageSize": "maximumPageSize"
+        }
+      }
+    },
+    "com.amazonaws.swf#PollForDecisionTaskInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the task lists to poll.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the task list to poll for decision tasks.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "identity": {
+          "target": "com.amazonaws.swf#Identity",
+          "traits": {
+            "smithy.api#documentation": "<p>Identity of the decider making the request, which is recorded in the\n      DecisionTaskStarted event in the workflow history. This enables diagnostic tracing when\n      problems arise. The form of this identity is user defined.</p>"
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextPageToken</code> is returned there are more results\n      available.  The value of <code>NextPageToken</code> is a unique pagination token for each page. Make the call again using \n      the returned token to retrieve the next page. Keep all other arguments unchanged. Each pagination token expires \n      after 24 hours. Using an expired pagination token will return a <code>400</code> error: \"<code>Specified token has \n      exceeded its maximum lifetime</code>\". </p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned\n      in a single call. </p>\n         <note>\n            <p>The <code>nextPageToken</code> returned by this action cannot be used with <a>GetWorkflowExecutionHistory</a> to get the next page. You must call <a>PollForDecisionTask</a> again (with the <code>nextPageToken</code>) to retrieve\n        the next page of history records. Calling <a>PollForDecisionTask</a> with a\n          <code>nextPageToken</code> doesn't return a new decision task.</p>\n         </note>"
+          }
+        },
+        "maximumPageSize": {
+          "target": "com.amazonaws.swf#PageSize",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum number of results that are returned per call.\n  Use <code>nextPageToken</code> to obtain further pages of results. </p>\n         <p>This\n      is an upper limit only; the actual number of results returned per call may be fewer than the\n      specified maximum.</p>"
+          }
+        },
+        "reverseOrder": {
+          "target": "com.amazonaws.swf#ReverseOrder",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the events in reverse order. By default the\n      results are returned in ascending order of the <code>eventTimestamp</code> of the\n      events.</p>"
+          }
+        },
+        "startAtPreviousStartedEvent": {
+          "target": "com.amazonaws.swf#StartAtPreviousStartedEvent",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>When set to <code>true</code>, returns the events with <code>eventTimestamp</code> greater than or equal to <code>eventTimestamp</code> of the most recent <code>DecisionTaskStarted</code> event. By default, this parameter is set to <code>false</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RecordActivityTaskHeartbeat": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RecordActivityTaskHeartbeatInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#ActivityTaskStatus"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by activity workers to report to the service that the <a>ActivityTask</a> represented by the specified <code>taskToken</code> is still making progress. The worker\n      can also specify details of the progress, for example percent complete, using the\n        <code>details</code> parameter. This action can also be used by the worker as a mechanism to\n      check if cancellation is being requested for the activity task. If a cancellation is being\n      attempted for the specified task, then the boolean <code>cancelRequested</code> flag returned\n      by the service is set to <code>true</code>.</p>\n         <p>This action resets the <code>taskHeartbeatTimeout</code> clock. The\n        <code>taskHeartbeatTimeout</code> is specified in <a>RegisterActivityType</a>.</p>\n         <p>This action doesn't in itself create an event in the workflow execution history.\n      However, if the task times out, the workflow execution history contains a\n        <code>ActivityTaskTimedOut</code> event that contains the information from the last\n      heartbeat generated by the activity worker.</p>\n         <note>\n            <p>The <code>taskStartToCloseTimeout</code> of an activity type is the maximum duration\n        of an activity task, regardless of the number of <a>RecordActivityTaskHeartbeat</a> requests received. The <code>taskStartToCloseTimeout</code> is also specified in <a>RegisterActivityType</a>.</p>\n         </note>\n         <note>\n            <p>This operation is only useful for long-lived activities to report liveliness of the\n        task and to determine if a cancellation is being attempted.</p>\n         </note>\n         <important>\n            <p>If the <code>cancelRequested</code> flag returns <code>true</code>, a cancellation is\n        being attempted. If the worker can cancel the activity, it should respond with <a>RespondActivityTaskCanceled</a>. Otherwise, it should ignore the cancellation\n        request.</p>\n         </important>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RecordActivityTaskHeartbeatInput": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>taskToken</code> of the <a>ActivityTask</a>.</p>\n         <important>\n            <p>\n               <code>taskToken</code> is generated by the service and should be treated as an opaque value.\n        If the task is passed to another process, its <code>taskToken</code> must also be passed.\n        This enables it to provide its progress and respond with results. </p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#LimitedData",
+          "traits": {
+            "smithy.api#documentation": "<p>If specified, contains details about the progress of the task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RecordMarkerDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "markerName": {
+          "target": "com.amazonaws.swf#MarkerName",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The name of the marker.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The details of the marker.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RecordMarker</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RecordMarkerFailedCause": {
+      "type": "enum",
+      "members": {
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#RecordMarkerFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "markerName": {
+          "target": "com.amazonaws.swf#MarkerName",
+          "traits": {
+            "smithy.api#documentation": "<p>The marker's name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#RecordMarkerFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>RecordMarkerFailed</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RecordMarkerFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#RegisterActivityType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RegisterActivityTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeAlreadyExistsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Registers a new <i>activity type</i> along with its configuration\n      settings in the specified domain.</p>\n         <important>\n            <p>A <code>TypeAlreadyExists</code> fault is returned if the type already exists in the\n        domain. You cannot change any configuration settings of the type after its registration, and\n        it must be registered as a new version.</p>\n         </important>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>defaultTaskList.name</code>: String constraint. The key is\n                <code>swf:defaultTaskList.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>name</code>: String constraint. The key is <code>swf:name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>version</code>: String constraint. The key is\n              <code>swf:version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RegisterActivityTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which this activity is to be registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the activity type within the domain.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.swf#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the activity type.</p>\n         <note>\n            <p>The activity type consists of the name and version, the combination of which must be\n        unique within the domain.</p>\n         </note>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.swf#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A textual description of the activity type.</p>"
+          }
+        },
+        "defaultTaskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default maximum duration that a worker can take to process tasks\n      of this activity type. This default can be overridden when scheduling an activity task using\n      the <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to\n        <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskHeartbeatTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default maximum time before which a worker processing a task of\n      this type must report progress by calling <a>RecordActivityTaskHeartbeat</a>. If\n      the timeout is exceeded, the activity task is automatically timed out. This default can be\n      overridden when scheduling an activity task using the <code>ScheduleActivityTask</code>\n            <a>Decision</a>. If the activity worker subsequently attempts to record a heartbeat\n      or returns a result, the activity worker receives an <code>UnknownResource</code> fault. In\n      this case, Amazon SWF no longer considers the activity task to be valid; the activity worker should\n      clean up the activity task.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to\n        <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default task list to use for scheduling tasks of this activity\n      type. This default task list is used if a task list isn't provided when a task is scheduled\n      through the <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>"
+          }
+        },
+        "defaultTaskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The default task priority to assign to the activity type. If not assigned, then\n        <code>0</code> is used. Valid values are integers that range from Java's\n        <code>Integer.MIN_VALUE</code> (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647).\n      Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task\n        Priority</a> in the <i>in the\n      <i>Amazon SWF Developer Guide</i>.</i>.</p>"
+          }
+        },
+        "defaultTaskScheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default maximum duration that a task of this activity type can\n      wait before being assigned to a worker. This default can be overridden when scheduling an\n      activity task using the <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to\n        <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskScheduleToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default maximum duration for a task of this activity type. This\n      default can be overridden when scheduling an activity task using the\n        <code>ScheduleActivityTask</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to\n        <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RegisterDomain": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RegisterDomainInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#DomainAlreadyExistsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TooManyTagsFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Registers a new domain.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>You cannot use an IAM policy to control domain access for this action. The name of\n          the domain being registered is available as the resource of this action.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RegisterDomainInput": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the domain to register. The name must be unique in the region that the domain\n      is registered in.</p>\n         <p>The specified string must not start or end with whitespace. It must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.swf#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A text description of the domain.</p>"
+          }
+        },
+        "workflowExecutionRetentionPeriodInDays": {
+          "target": "com.amazonaws.swf#DurationInDays",
+          "traits": {
+            "smithy.api#documentation": "<p>The duration (in days) that records and histories of workflow executions on the domain\n      should be kept by the service. After the retention period, the workflow execution isn't\n      available in the results of visibility calls.</p>\n         <p>If you pass the value <code>NONE</code> or <code>0</code> (zero), then the workflow\n      execution history isn't retained. As soon as the workflow execution completes, the execution\n      record and its history are deleted.</p>\n         <p>The maximum workflow execution retention period is 90 days. For more information about\n      Amazon SWF service limits, see: <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-limits.html\">Amazon SWF Service Limits</a> in the\n        <i>Amazon SWF Developer Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.swf#ResourceTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to be added when registering a domain.</p>\n         <p>Tags may only contain unicode letters, digits, whitespace, or these symbols: <code>_ . : / = + - @</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RegisterWorkflowType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RegisterWorkflowTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeAlreadyExistsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Registers a new <i>workflow type</i> and its configuration settings in\n      the specified domain.</p>\n         <p>The retention period for the workflow history is set by the <a>RegisterDomain</a> action.</p>\n         <important>\n            <p>If the type already exists, then a <code>TypeAlreadyExists</code> fault is returned.\n        You cannot change the configuration settings of a workflow type once it is registered and it\n        must be registered as a new version.</p>\n         </important>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>defaultTaskList.name</code>: String constraint. The key is\n                <code>swf:defaultTaskList.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>name</code>: String constraint. The key is <code>swf:name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>version</code>: String constraint. The key is\n              <code>swf:version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RegisterWorkflowTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which to register the workflow type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the workflow type.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.swf#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the workflow type.</p>\n         <note>\n            <p>The workflow type consists of the name and version, the combination of which must be\n        unique within the domain. To get a list of all currently registered workflow types, use the\n          <a>ListWorkflowTypes</a> action.</p>\n         </note>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.swf#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>Textual description of the workflow type.</p>"
+          }
+        },
+        "defaultTaskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default maximum duration of decision tasks for this workflow\n      type. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to\n        <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultExecutionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default maximum duration for executions of this workflow type.\n      You can override this default when starting an execution through the <a>StartWorkflowExecution</a> Action or <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds; an integer greater than or equal to 0. Unlike\n      some of the other timeout parameters in Amazon SWF, you cannot specify a value of \"NONE\" for\n        <code>defaultExecutionStartToCloseTimeout</code>; there is a one-year max limit on the time\n      that a workflow execution can run. Exceeding this limit always causes the workflow execution\n      to time out.</p>"
+          }
+        },
+        "defaultTaskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default task list to use for scheduling decision tasks for\n      executions of this workflow type. This default is used only if a task list isn't provided when\n      starting the execution through the <a>StartWorkflowExecution</a> Action or\n        <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>"
+          }
+        },
+        "defaultTaskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The default task priority to assign to the workflow type. If not assigned, then\n        <code>0</code> is used. Valid values are integers that range from Java's\n        <code>Integer.MIN_VALUE</code> (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647).\n      Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task\n        Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "defaultChildPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the default policy to use for the child workflow executions when a\n      workflow execution of this type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This\n      default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n          execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its\n          history. It is up to the decider to take appropriate actions when it receives an execution\n          history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to\n          run.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "defaultLambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The default IAM role attached to this workflow type.</p>\n         <note>\n            <p>Executions of this workflow type need IAM roles to invoke Lambda functions. If you\n        don't specify an IAM role when you start this workflow type, the default Lambda role is\n        attached to the execution. For more information, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html\">https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html</a> in the\n          <i>Amazon SWF Developer Guide</i>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RegistrationStatus": {
+      "type": "enum",
+      "members": {
+        "REGISTERED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REGISTERED"
+          }
+        },
+        "DEPRECATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEPRECATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#RequestCancelActivityTaskDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>activityId</code> of the activity task to be canceled.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelActivityTask</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n  <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RequestCancelActivityTaskFailedCause": {
+      "type": "enum",
+      "members": {
+        "ACTIVITY_ID_UNKNOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVITY_ID_UNKNOWN"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#RequestCancelActivityTaskFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>The activityId provided in the <code>RequestCancelActivityTask</code> decision that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#RequestCancelActivityTaskFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>RequestCancelActivityTask</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelActivityTaskFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The <code>workflowId</code> of the external workflow execution to cancel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the external workflow execution to cancel.</p>"
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelExternalWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+          }
+        },
+        "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>workflowId</code> of the external workflow to which the cancel request was to be delivered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the external workflow execution.</p>"
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event corresponding to the\n      <code>RequestCancelExternalWorkflowExecution</code> decision to cancel this external workflow execution. This\n      information can be useful for diagnosing problems by tracing back the chain of events leading up to this\n      event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>RequestCancelExternalWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that the decider can use in subsequent workflow tasks.\n      This data isn't sent to the workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#RequestCancelExternalWorkflowExecutionInitiatedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>workflowId</code> of the external workflow execution to be canceled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the external workflow execution to be canceled.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>RequestCancelExternalWorkflowExecution</code> decision for this cancellation request.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#RequestCancelWorkflowExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RequestCancelWorkflowExecutionInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Records a <code>WorkflowExecutionCancelRequested</code> event in the currently running\n      workflow execution identified by the given domain, workflowId, and runId. This logically\n      requests the cancellation of the workflow execution as a whole. It is up to the decider to\n      take appropriate actions when it receives an execution history with this event.</p>\n         <note>\n            <p>If the runId isn't specified, the <code>WorkflowExecutionCancelRequested</code> event\n        is recorded in the history of the current open workflow execution with the specified\n        workflowId in the domain.</p>\n         </note>\n         <note>\n            <p>Because this action allows the workflow to properly clean up and gracefully close, it\n        should be used instead of <a>TerminateWorkflowExecution</a> when\n        possible.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RequestCancelWorkflowExecutionInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the workflow execution to cancel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflowId of the workflow execution to cancel.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The runId of the workflow execution to cancel.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ResourceTag": {
+      "type": "structure",
+      "members": {
+        "key": {
+          "target": "com.amazonaws.swf#ResourceTagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The key of a tag.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "value": {
+          "target": "com.amazonaws.swf#ResourceTagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of a tag.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Tags are key-value pairs that can be associated with Amazon SWF state machines and\n      activities.</p>\n         <p>Tags may only contain unicode letters, digits, whitespace, or these symbols: <code>_ . : / = + - @</code>.</p>"
+      }
+    },
+    "com.amazonaws.swf#ResourceTagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.swf#ResourceTagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#ResourceTagKey"
+      }
+    },
+    "com.amazonaws.swf#ResourceTagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#ResourceTag"
+      }
+    },
+    "com.amazonaws.swf#ResourceTagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#RespondActivityTaskCanceled": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RespondActivityTaskCanceledInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by workers to tell the service that the <a>ActivityTask</a> identified\n      by the <code>taskToken</code> was successfully canceled. Additional <code>details</code> can\n      be provided using the <code>details</code> argument.</p>\n         <p>These <code>details</code> (if provided) appear in the\n        <code>ActivityTaskCanceled</code> event added to the workflow history.</p>\n         <important>\n            <p>Only use this operation if the <code>canceled</code> flag of a <a>RecordActivityTaskHeartbeat</a> request returns <code>true</code> and if the\n        activity can be safely undone or abandoned.</p>\n         </important>\n         <p>A task is considered open from the time that it is scheduled until it is closed.\n      Therefore a task is reported as open while a worker is processing it. A task is closed after\n      it has been specified in a call to <a>RespondActivityTaskCompleted</a>,\n      RespondActivityTaskCanceled, <a>RespondActivityTaskFailed</a>, or the task has\n        <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-basic.html#swf-dev-timeout-types\">timed\n        out</a>.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RespondActivityTaskCanceledInput": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>taskToken</code> of the <a>ActivityTask</a>.</p>\n         <important>\n            <p>\n               <code>taskToken</code> is generated by the service and should be treated as an opaque value.\n        If the task is passed to another process, its <code>taskToken</code> must also be passed.\n        This enables it to provide its progress and respond with results.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p> Information about the cancellation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RespondActivityTaskCompleted": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RespondActivityTaskCompletedInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by workers to tell the service that the <a>ActivityTask</a> identified\n      by the <code>taskToken</code> completed successfully with a <code>result</code> (if provided).\n      The <code>result</code> appears in the <code>ActivityTaskCompleted</code> event in the\n      workflow history.</p>\n         <important>\n            <p>If the requested task doesn't complete successfully, use <a>RespondActivityTaskFailed</a> instead. If the worker finds that the task is\n        canceled through the <code>canceled</code> flag returned by <a>RecordActivityTaskHeartbeat</a>, it should cancel the task, clean up and then call\n          <a>RespondActivityTaskCanceled</a>.</p>\n         </important>\n         <p>A task is considered open from the time that it is scheduled until it is closed.\n      Therefore a task is reported as open while a worker is processing it. A task is closed after\n      it has been specified in a call to RespondActivityTaskCompleted, <a>RespondActivityTaskCanceled</a>, <a>RespondActivityTaskFailed</a>, or the\n      task has <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-basic.html#swf-dev-timeout-types\">timed\n        out</a>.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RespondActivityTaskCompletedInput": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>taskToken</code> of the <a>ActivityTask</a>.</p>\n         <important>\n            <p>\n               <code>taskToken</code> is generated by the service and should be treated as an opaque value.\n        If the task is passed to another process, its <code>taskToken</code> must also be passed.\n        This enables it to provide its progress and respond with results.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "result": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The result of the activity task. It is a free form string that is implementation\n      specific.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RespondActivityTaskFailed": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RespondActivityTaskFailedInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by workers to tell the service that the <a>ActivityTask</a> identified\n      by the <code>taskToken</code> has failed with <code>reason</code> (if specified). The\n        <code>reason</code> and <code>details</code> appear in the <code>ActivityTaskFailed</code>\n      event added to the workflow history.</p>\n         <p>A task is considered open from the time that it is scheduled until it is closed.\n      Therefore a task is reported as open while a worker is processing it. A task is closed after\n      it has been specified in a call to <a>RespondActivityTaskCompleted</a>, <a>RespondActivityTaskCanceled</a>, RespondActivityTaskFailed, or the task has <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-basic.html#swf-dev-timeout-types\">timed\n        out</a>.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RespondActivityTaskFailedInput": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>taskToken</code> of the <a>ActivityTask</a>.</p>\n         <important>\n            <p>\n               <code>taskToken</code> is generated by the service and should be treated as an opaque value.\n        If the task is passed to another process, its <code>taskToken</code> must also be passed.\n        This enables it to provide its progress and respond with results.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.swf#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>Description of the error that may assist in diagnostics.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p> Detailed information about the failure.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#RespondDecisionTaskCompleted": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#RespondDecisionTaskCompletedInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Used by deciders to tell the service that the <a>DecisionTask</a> identified\n      by the <code>taskToken</code> has successfully completed. The <code>decisions</code> argument\n      specifies the list of decisions made while processing the task.</p>\n         <p>A <code>DecisionTaskCompleted</code> event is added to the workflow history. The\n        <code>executionContext</code> specified is attached to the event in the workflow execution\n      history.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>If an IAM policy grants permission to use <code>RespondDecisionTaskCompleted</code>, it\n      can express permissions for the list of decisions in the <code>decisions</code> parameter.\n      Each of the decisions has one or more parameters, much like a regular API call. To allow for\n      policies to be as readable as possible, you can express permissions on decisions as if they\n      were actual API calls, including applying conditions to some parameters. For more information,\n      see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using\n        IAM to Manage Access to Amazon SWF Workflows</a> in the\n      <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#RespondDecisionTaskCompletedInput": {
+      "type": "structure",
+      "members": {
+        "taskToken": {
+          "target": "com.amazonaws.swf#TaskToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>taskToken</code> from the <a>DecisionTask</a>.</p>\n         <important>\n            <p>\n               <code>taskToken</code> is generated by the service and should be treated as an opaque value.\n        If the task is passed to another process, its <code>taskToken</code> must also be passed.\n        This enables it to provide its progress and respond with results.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisions": {
+          "target": "com.amazonaws.swf#DecisionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of decisions (possibly empty) made by the decider while processing this\n      decision task. See the docs for the <a>Decision</a> structure for\n      details.</p>"
+          }
+        },
+        "executionContext": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>User defined context to add to workflow execution.</p>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The task list to use for the future decision tasks of this workflow execution. This list overrides the original task list you specified while starting the workflow execution. </p>"
+          }
+        },
+        "taskListScheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a timeout (in seconds) for the task list override. When this parameter is missing, the task list override is permanent. This parameter makes it possible to temporarily override the task list. If a decision task scheduled on the override task list is not started within the timeout, the decision task will time out. Amazon SWF will revert the override and schedule a new decision task to the original task list.</p>\n         <p>If a decision task scheduled on the override task list is started within the timeout, but not completed within the start-to-close timeout, Amazon SWF will also revert the override and schedule a new decision task to the original task list.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Input data for a TaskCompleted response to a decision task.</p>",
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#ReverseOrder": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.swf#Run": {
+      "type": "structure",
+      "members": {
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of a workflow execution. This ID is generated by the service and\n      can be used to uniquely identify the workflow execution within a domain.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the <code>runId</code> of a workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#ScheduleActivityTaskDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The type of the activity task to schedule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The <code>activityId</code> of the activity task.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that can be used by the decider in subsequent workflow tasks. This data isn't sent to the activity.</p>"
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the activity task.</p>"
+          }
+        },
+        "scheduleToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration for this activity task.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>A schedule-to-close timeout for this activity task must be specified either as a default for the activity type or through this field. If neither this field is set nor a default schedule-to-close timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the name of the task list in which to schedule the activity task. If not specified, the\n      <code>defaultTaskList</code> registered with the activity type is used.</p>\n         <note>\n            <p>A task list for this activity task must be specified either as a default for the activity type or through this field. If neither this field is set nor a default task list was specified at registration time then a fault is returned.</p>\n         </note>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>"
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         If set, specifies the priority with which the activity task is to be assigned to a worker. This\n      overrides the defaultTaskPriority specified when registering the activity type using <a>RegisterActivityType</a>.\n      Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a>  in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "scheduleToStartTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         If set, specifies the maximum duration the activity task can wait to be assigned to a worker.\n      This overrides the default schedule-to-start timeout specified when registering the activity type using\n      <a>RegisterActivityType</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>A schedule-to-start timeout for this activity task must be specified either as a default for the activity type or through this field. If neither this field is set nor a default schedule-to-start timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "startToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the maximum duration a worker may take to process this activity task. This overrides the\n      default start-to-close timeout specified when registering the activity type using <a>RegisterActivityType</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>A start-to-close timeout for this activity task must be specified either as a default for the activity type or through this field. If neither this field is set nor a default start-to-close timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "heartbeatTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the maximum time before which a worker processing a task of this type must report progress by\n      calling <a>RecordActivityTaskHeartbeat</a>. If the timeout is exceeded, the activity task is automatically timed\n      out. If the worker subsequently attempts to record a heartbeat or returns a result, it is ignored. This\n      overrides the default heartbeat timeout specified when registering the activity type using\n      <a>RegisterActivityType</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ScheduleActivityTask</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with the\n  appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>activityType.name</code> \u2013 String constraint. The key is <code>swf:activityType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>activityType.version</code> \u2013 String constraint. The key is <code>swf:activityType.version</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>taskList</code> \u2013 String constraint. The key is <code>swf:taskList.name</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n  <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#ScheduleActivityTaskFailedCause": {
+      "type": "enum",
+      "members": {
+        "ACTIVITY_TYPE_DEPRECATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVITY_TYPE_DEPRECATED"
+          }
+        },
+        "ACTIVITY_TYPE_DOES_NOT_EXIST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVITY_TYPE_DOES_NOT_EXIST"
+          }
+        },
+        "ACTIVITY_ID_ALREADY_IN_USE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVITY_ID_ALREADY_IN_USE"
+          }
+        },
+        "OPEN_ACTIVITIES_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN_ACTIVITIES_LIMIT_EXCEEDED"
+          }
+        },
+        "ACTIVITY_CREATION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVITY_CREATION_RATE_EXCEEDED"
+          }
+        },
+        "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_TASK_LIST_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_TASK_LIST_UNDEFINED"
+          }
+        },
+        "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ScheduleActivityTaskFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The activity type provided in the <code>ScheduleActivityTask</code> decision that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityId": {
+          "target": "com.amazonaws.swf#ActivityId",
+          "traits": {
+            "smithy.api#documentation": "<p>The activityId provided in the <code>ScheduleActivityTask</code> decision that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#ScheduleActivityTaskFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision that resulted in the\n      scheduling of this activity task. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ScheduleActivityTaskFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#ScheduleLambdaFunctionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "com.amazonaws.swf#FunctionId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that identifies the Lambda function execution in the event history.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#FunctionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name, or ARN, of the Lambda function to schedule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that the decider can use in subsequent workflow tasks.\n      This data isn't sent to the Lambda task.</p>"
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#FunctionInput",
+          "traits": {
+            "smithy.api#documentation": "<p>The optional input data to be supplied to the Lambda function.</p>"
+          }
+        },
+        "startToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The timeout value, in seconds, after which the Lambda function is considered to be\n            failed once it has started. This can be any integer from 1-900 (1s-15m).</p>\n         <p>If no value is supplied, then a default value of 900s is assumed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Decision attributes specified in <code>scheduleLambdaFunctionDecisionAttributes</code> within the list of\n      decisions <code>decisions</code> passed to <a>RespondDecisionTaskCompleted</a>.</p>"
+      }
+    },
+    "com.amazonaws.swf#ScheduleLambdaFunctionFailedCause": {
+      "type": "enum",
+      "members": {
+        "ID_ALREADY_IN_USE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ID_ALREADY_IN_USE"
+          }
+        },
+        "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED"
+          }
+        },
+        "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED"
+          }
+        },
+        "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#ScheduleLambdaFunctionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "com.amazonaws.swf#FunctionId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID provided in the <code>ScheduleLambdaFunction</code> decision that failed.\n    </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "com.amazonaws.swf#FunctionName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Lambda function.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#ScheduleLambdaFunctionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision\n        failed because it lacked sufficient permissions. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using\n          IAM to Manage Access to Amazon SWF Workflows</a> in the\n          <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>LambdaFunctionCompleted</code> event corresponding to the decision\n      that resulted in scheduling this Lambda task. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>ScheduleLambdaFunctionFailed</code> event. It isn't\n      set for other event types.</p>"
+      }
+    },
+    "com.amazonaws.swf#SignalExternalWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The <code>workflowId</code> of the workflow execution to be signaled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the workflow execution to be signaled.</p>"
+          }
+        },
+        "signalName": {
+          "target": "com.amazonaws.swf#SignalName",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The name of the signal.The target workflow execution uses the signal name and input to\n      process the signal.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The input data to be provided with the signal. The target workflow execution uses the signal\n      name and input data to process the signal.</p>"
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that can be used by the decider in subsequent decision tasks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>SignalExternalWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#SignalExternalWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+          }
+        },
+        "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#SignalExternalWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>workflowId</code> of the external workflow execution that the signal was being delivered to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the external workflow execution that the signal was being delivered to.</p>"
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#SignalExternalWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the\n      <code>SignalExternalWorkflowExecution</code> decision to request this signal. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>SignalExternalWorkflowExecution</code> decision for this signal. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that the decider can use in subsequent workflow tasks.\n      This data isn't sent to the workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#SignalExternalWorkflowExecutionInitiatedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>workflowId</code> of the external workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the external workflow execution to send the signal to.</p>"
+          }
+        },
+        "signalName": {
+          "target": "com.amazonaws.swf#SignalName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the signal.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the signal.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>SignalExternalWorkflowExecution</code> decision for this signal. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that can be used by the decider in subsequent decision tasks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>SignalExternalWorkflowExecutionInitiated</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#SignalName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#SignalWorkflowExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#SignalWorkflowExecutionInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Records a <code>WorkflowExecutionSignaled</code> event in the workflow execution\n      history and creates a decision task for the workflow execution identified by the given domain,\n      workflowId and runId. The event is recorded with the specified user defined signalName and\n      input (if provided).</p>\n         <note>\n            <p>If a runId isn't specified, then the <code>WorkflowExecutionSignaled</code> event is\n        recorded in the history of the current open workflow with the matching workflowId in the\n        domain.</p>\n         </note>\n         <note>\n            <p>If the specified workflow execution isn't open, this method fails with\n          <code>UnknownResource</code>.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#SignalWorkflowExecutionInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain containing the workflow execution to signal.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflowId of the workflow execution to signal.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The runId of the workflow execution to signal.</p>"
+          }
+        },
+        "signalName": {
+          "target": "com.amazonaws.swf#SignalName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the signal. This name must be meaningful to the target workflow.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data to attach to the <code>WorkflowExecutionSignaled</code> event in the target\n      workflow execution's history.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#SimpleWorkflowService": {
+      "type": "service",
+      "version": "2012-01-25",
+      "operations": [
+        {
+          "target": "com.amazonaws.swf#CountClosedWorkflowExecutions"
+        },
+        {
+          "target": "com.amazonaws.swf#CountOpenWorkflowExecutions"
+        },
+        {
+          "target": "com.amazonaws.swf#CountPendingActivityTasks"
+        },
+        {
+          "target": "com.amazonaws.swf#CountPendingDecisionTasks"
+        },
+        {
+          "target": "com.amazonaws.swf#DeleteActivityType"
+        },
+        {
+          "target": "com.amazonaws.swf#DeleteWorkflowType"
+        },
+        {
+          "target": "com.amazonaws.swf#DeprecateActivityType"
+        },
+        {
+          "target": "com.amazonaws.swf#DeprecateDomain"
+        },
+        {
+          "target": "com.amazonaws.swf#DeprecateWorkflowType"
+        },
+        {
+          "target": "com.amazonaws.swf#DescribeActivityType"
+        },
+        {
+          "target": "com.amazonaws.swf#DescribeDomain"
+        },
+        {
+          "target": "com.amazonaws.swf#DescribeWorkflowExecution"
+        },
+        {
+          "target": "com.amazonaws.swf#DescribeWorkflowType"
+        },
+        {
+          "target": "com.amazonaws.swf#GetWorkflowExecutionHistory"
+        },
+        {
+          "target": "com.amazonaws.swf#ListActivityTypes"
+        },
+        {
+          "target": "com.amazonaws.swf#ListClosedWorkflowExecutions"
+        },
+        {
+          "target": "com.amazonaws.swf#ListDomains"
+        },
+        {
+          "target": "com.amazonaws.swf#ListOpenWorkflowExecutions"
+        },
+        {
+          "target": "com.amazonaws.swf#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.swf#ListWorkflowTypes"
+        },
+        {
+          "target": "com.amazonaws.swf#PollForActivityTask"
+        },
+        {
+          "target": "com.amazonaws.swf#PollForDecisionTask"
+        },
+        {
+          "target": "com.amazonaws.swf#RecordActivityTaskHeartbeat"
+        },
+        {
+          "target": "com.amazonaws.swf#RegisterActivityType"
+        },
+        {
+          "target": "com.amazonaws.swf#RegisterDomain"
+        },
+        {
+          "target": "com.amazonaws.swf#RegisterWorkflowType"
+        },
+        {
+          "target": "com.amazonaws.swf#RequestCancelWorkflowExecution"
+        },
+        {
+          "target": "com.amazonaws.swf#RespondActivityTaskCanceled"
+        },
+        {
+          "target": "com.amazonaws.swf#RespondActivityTaskCompleted"
+        },
+        {
+          "target": "com.amazonaws.swf#RespondActivityTaskFailed"
+        },
+        {
+          "target": "com.amazonaws.swf#RespondDecisionTaskCompleted"
+        },
+        {
+          "target": "com.amazonaws.swf#SignalWorkflowExecution"
+        },
+        {
+          "target": "com.amazonaws.swf#StartWorkflowExecution"
+        },
+        {
+          "target": "com.amazonaws.swf#TagResource"
+        },
+        {
+          "target": "com.amazonaws.swf#TerminateWorkflowExecution"
+        },
+        {
+          "target": "com.amazonaws.swf#UndeprecateActivityType"
+        },
+        {
+          "target": "com.amazonaws.swf#UndeprecateDomain"
+        },
+        {
+          "target": "com.amazonaws.swf#UndeprecateWorkflowType"
+        },
+        {
+          "target": "com.amazonaws.swf#UntagResource"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "SWF",
+          "arnNamespace": "swf",
+          "cloudFormationName": "SWF",
+          "cloudTrailEventSource": "swf.amazonaws.com",
+          "endpointPrefix": "swf"
+        },
+        "aws.auth#sigv4": {
+          "name": "swf"
+        },
+        "aws.protocols#awsJson1_0": {},
+        "smithy.api#documentation": "<fullname>Amazon Simple Workflow Service</fullname>\n         <p>The Amazon Simple Workflow Service (Amazon SWF) makes it easy to build applications that use Amazon's cloud to\n      coordinate work across distributed components. In Amazon SWF, a <i>task</i>\n      represents a logical unit of work that is performed by a component of your workflow.\n      Coordinating tasks in a workflow involves managing intertask dependencies, scheduling, and \n      concurrency in accordance with the logical flow of the application.</p>\n         <p>Amazon SWF gives you full control over implementing tasks and coordinating them without\n      worrying about underlying complexities such as tracking their progress and maintaining their\n      state.</p>\n         <p>This documentation serves as reference only. For a broader overview of the Amazon SWF\n      programming model, see the <i>\n               <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/\">Amazon SWF Developer Guide</a>\n            </i>.</p>",
+        "smithy.api#title": "Amazon Simple Workflow Service",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://swf.amazonaws.com/doc/2012-01-25"
+        },
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            },
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://swf.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://swf-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://swf-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://swf.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 15,
+          "nodes": "/////wAAAAH/////AAAAAAAAAA4AAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAkAAAAGAAAABAAAAAcF9eEEAAAABQX14QUAAAAIAAAABwX14QkF9eEKAAAABAAAAAwAAAAKAAAABQX14QQAAAALAAAABgX14QcF9eEIAAAABgAAAA0F9eEGAAAABwX14QUF9eEGAAAAAwX14QEAAAAPAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            },
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                      "type": "error"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": {
+                          "ref": "Endpoint"
+                        },
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "aws.partition",
+                          "argv": [
+                            {
+                              "ref": "Region"
+                            }
+                          ],
+                          "assign": "PartitionResult"
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "stringEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "name"
+                                  ]
+                                },
+                                "aws-us-gov"
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseFIPS"
+                                },
+                                true
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseDualStack"
+                                },
+                                false
+                              ]
+                            }
+                          ],
+                          "endpoint": {
+                            "url": "https://swf.{Region}.{PartitionResult#dnsSuffix}",
+                            "properties": {},
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        },
+                        {
+                          "conditions": [
+                            {
+                              "fn": "stringEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "name"
+                                  ]
+                                },
+                                "aws-us-gov"
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseFIPS"
+                                },
+                                false
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseDualStack"
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "endpoint": {
+                            "url": "https://swf-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                            "properties": {},
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        },
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseFIPS"
+                                },
+                                true
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseDualStack"
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    true,
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    true,
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "rules": [
+                                {
+                                  "conditions": [],
+                                  "endpoint": {
+                                    "url": "https://swf-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                    "properties": {},
+                                    "headers": {}
+                                  },
+                                  "type": "endpoint"
+                                }
+                              ],
+                              "type": "tree"
+                            },
+                            {
+                              "conditions": [],
+                              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                              "type": "error"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseFIPS"
+                                },
+                                true
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseDualStack"
+                                },
+                                false
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                      ]
+                                    },
+                                    true
+                                  ]
+                                }
+                              ],
+                              "rules": [
+                                {
+                                  "conditions": [],
+                                  "endpoint": {
+                                    "url": "https://swf-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                    "properties": {},
+                                    "headers": {}
+                                  },
+                                  "type": "endpoint"
+                                }
+                              ],
+                              "type": "tree"
+                            },
+                            {
+                              "conditions": [],
+                              "error": "FIPS is enabled but this partition does not support FIPS",
+                              "type": "error"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseFIPS"
+                                },
+                                false
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "ref": "UseDualStack"
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    true,
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "rules": [
+                                {
+                                  "conditions": [],
+                                  "endpoint": {
+                                    "url": "https://swf.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                    "properties": {},
+                                    "headers": {}
+                                  },
+                                  "type": "endpoint"
+                                }
+                              ],
+                              "type": "tree"
+                            },
+                            {
+                              "conditions": [],
+                              "error": "DualStack is enabled but this partition does not support DualStack",
+                              "type": "error"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "endpoint": {
+                            "url": "https://swf.{Region}.{PartitionResult#dnsSuffix}",
+                            "properties": {},
+                            "headers": {}
+                          },
+                          "type": "endpoint"
+                        }
+                      ],
+                      "type": "tree"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "Invalid Configuration: Missing Region",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Endpoint": "https://example.com",
+                "UseFIPS": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Endpoint": "https://example.com",
+                "UseFIPS": true
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Endpoint": "https://example.com",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.cn-northwest-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.cn-northwest-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eusc-de-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.eusc-de-east-1.amazonaws.eu"
+                }
+              },
+              "params": {
+                "Region": "eusc-de-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eusc-de-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.eusc-de-east-1.amazonaws.eu"
+                }
+              },
+              "params": {
+                "Region": "eusc-de-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-isoe-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.eu-isoe-west-1.cloud.adc-e.uk"
+                }
+              },
+              "params": {
+                "Region": "eu-isoe-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-isoe-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.eu-isoe-west-1.cloud.adc-e.uk"
+                }
+              },
+              "params": {
+                "Region": "eu-isoe-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isof-south-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-isof-south-1.csp.hci.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isof-south-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isof-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-isof-south-1.csp.hci.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isof-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-gov-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf-fips.us-gov-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://swf.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.swf#StartAtPreviousStartedEvent": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.swf#StartChildWorkflowExecutionDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The type of the workflow execution to be started.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The <code>workflowId</code> of the workflow execution.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that can be used by the decider in subsequent workflow tasks. This data isn't sent to the child workflow execution.</p>"
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input to be provided to the workflow execution.</p>"
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The total duration for this workflow execution. This overrides the defaultExecutionStartToCloseTimeout specified when registering the workflow type.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>An execution start-to-close timeout for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default execution start-to-close timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list to be used for decision tasks of the child workflow execution.</p>\n         <note>\n            <p>A task list for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default task list was specified at registration time then a fault is returned.</p>\n         </note>\n         <p>The specified string must not start or end with whitespace. It must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>"
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         A task priority that, if set, specifies the priority for a decision task of this workflow\n      execution. This overrides the defaultTaskPriority specified when registering the workflow type.\n      Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the maximum duration of decision tasks for this workflow execution. This parameter overrides the\n      <code>defaultTaskStartToCloseTimout</code> specified when registering the workflow type using\n      <a>RegisterWorkflowType</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>A task start-to-close timeout for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default task start-to-close timeout was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         If set, specifies the policy to use for the child workflow executions if the workflow execution\n      being started is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an\n      expired timeout. This policy overrides the default child policy specified when registering the workflow type using\n      <a>RegisterWorkflowType</a>.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>\n         <note>\n            <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags to associate with the child workflow execution. A maximum of 5 tags can be specified. You can\n      list workflow executions with a specific tag by calling <a>ListOpenWorkflowExecutions</a> or\n      <a>ListClosedWorkflowExecutions</a> and specifying a <a>TagFilter</a>.</p>"
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role attached to the child workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>StartChildWorkflowExecution</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with the\n             appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tagList.member.N</code> \u2013 The key is \"swf:tagList.N\" where N is the tag number from 0 to 4,\n            inclusive.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>taskList</code> \u2013 String constraint. The key is <code>swf:taskList.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.name</code> \u2013 String constraint. The key is <code>swf:workflowType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code> \u2013 String constraint. The key is <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartChildWorkflowExecutionFailedCause": {
+      "type": "enum",
+      "members": {
+        "WORKFLOW_TYPE_DOES_NOT_EXIST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORKFLOW_TYPE_DOES_NOT_EXIST"
+          }
+        },
+        "WORKFLOW_TYPE_DEPRECATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORKFLOW_TYPE_DEPRECATED"
+          }
+        },
+        "OPEN_CHILDREN_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN_CHILDREN_LIMIT_EXCEEDED"
+          }
+        },
+        "OPEN_WORKFLOWS_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN_WORKFLOWS_LIMIT_EXCEEDED"
+          }
+        },
+        "CHILD_CREATION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHILD_CREATION_RATE_EXCEEDED"
+          }
+        },
+        "WORKFLOW_ALREADY_RUNNING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORKFLOW_ALREADY_RUNNING"
+          }
+        },
+        "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_TASK_LIST_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_TASK_LIST_UNDEFINED"
+          }
+        },
+        "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
+          }
+        },
+        "DEFAULT_CHILD_POLICY_UNDEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEFAULT_CHILD_POLICY_UNDEFINED"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#StartChildWorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type provided in the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#StartChildWorkflowExecutionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>When <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision fails because it lacks sufficient permissions. \n              For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">\n                  Using IAM to Manage Access to Amazon SWF Workflows</a>  in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>workflowId</code> of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "initiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>When the <code>cause</code> is <code>WORKFLOW_ALREADY_RUNNING</code>, <code>initiatedEventId</code> is the ID of the <code>StartChildWorkflowExecutionInitiated</code>\n          event that corresponds to the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start the workflow execution. You can use this information to diagnose\n          problems by tracing back the chain of events leading up to this event.</p>\n         <p>When the <code>cause</code> isn't <code>WORKFLOW_ALREADY_RUNNING</code>, <code>initiatedEventId</code> is set to <code>0</code> because the \n          <code>StartChildWorkflowExecutionInitiated</code> event doesn't exist.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to request this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that the decider can use in subsequent workflow tasks.\n      This data isn't sent to the child workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartChildWorkflowExecutionInitiatedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>workflowId</code> of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that can be used by the decider in subsequent decision tasks. This data isn't sent to the activity.</p>"
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The inputs provided to the child workflow execution.</p>"
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration for the child workflow execution. If the workflow execution isn't closed within this duration, it is timed out and force-terminated.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list used for the decision tasks of the child workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The priority assigned for the decision tasks for this workflow execution.\n      Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to request this child workflow execution. This\n      information can be useful for diagnosing problems by tracing back the cause of events.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy to use for the child workflow executions if this execution gets terminated by explicitly calling the\n      <a>TerminateWorkflowExecution</a> action or due to an expired timeout.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration allowed for the decision tasks for this workflow execution.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags to associated with the child workflow execution.</p>"
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role to attach to the child workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>StartChildWorkflowExecutionInitiated</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartLambdaFunctionFailedCause": {
+      "type": "enum",
+      "members": {
+        "ASSUME_ROLE_FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSUME_ROLE_FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#StartLambdaFunctionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "scheduledEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>ActivityTaskScheduled</code> event that was recorded when this\n      activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>"
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#StartLambdaFunctionFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision\n        failed because the IAM role attached to the execution lacked sufficient permissions. For\n        details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html\">Lambda Tasks</a> in the\n          <i>Amazon SWF Developer Guide</i>.</p>\n         </note>"
+          }
+        },
+        "message": {
+          "target": "com.amazonaws.swf#CauseMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that can help diagnose the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>StartLambdaFunctionFailed</code> event. It isn't set\n      for other event types.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartTimerDecisionAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The unique ID of the timer.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"
+          }
+        },
+        "startToFireTimeout": {
+          "target": "com.amazonaws.swf#DurationInSeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The duration to wait before firing the timer.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>StartTimer</code> decision.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to only\n  specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n  parameter values fall outside the specified constraints, the action fails. The associated event attribute's\n          <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see\n          <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartTimerFailedCause": {
+      "type": "enum",
+      "members": {
+        "TIMER_ID_ALREADY_IN_USE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMER_ID_ALREADY_IN_USE"
+          }
+        },
+        "OPEN_TIMERS_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPEN_TIMERS_LIMIT_EXCEEDED"
+          }
+        },
+        "TIMER_CREATION_RATE_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMER_CREATION_RATE_EXCEEDED"
+          }
+        },
+        "OPERATION_NOT_PERMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATION_NOT_PERMITTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#StartTimerFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>The timerId provided in the <code>StartTimer</code> decision that failed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#StartTimerFailedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p>\n         <note>\n            <p>If <code>cause</code> is set to <code>OPERATION_NOT_PERMITTED</code>, the decision failed\n  because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>\n          in the <i>Amazon SWF Developer Guide</i>.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>StartTimer</code> decision for this activity task. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>StartTimerFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartWorkflowExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#StartWorkflowExecutionInput"
+      },
+      "output": {
+        "target": "com.amazonaws.swf#Run"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#DefaultUndefinedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeDeprecatedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        },
+        {
+          "target": "com.amazonaws.swf#WorkflowExecutionAlreadyStartedFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an execution of the workflow type in the specified domain using the provided\n        <code>workflowId</code> and input data.</p>\n         <p>This action returns the newly started workflow execution.</p>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>tagList.member.0</code>: The key is <code>swf:tagList.member.0</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>tagList.member.1</code>: The key is <code>swf:tagList.member.1</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>tagList.member.2</code>: The key is <code>swf:tagList.member.2</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>tagList.member.3</code>: The key is <code>swf:tagList.member.3</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>tagList.member.4</code>: The key is <code>swf:tagList.member.4</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>taskList</code>: String constraint. The key is\n              <code>swf:taskList.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.name</code>: String constraint. The key is\n                <code>swf:workflowType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code>: String constraint. The key is\n                <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#StartWorkflowExecutionInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain in which the workflow execution is created.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The user defined identifier associated with the workflow execution. You can use this to\n      associate a custom identifier with the workflow execution. You may specify the same identifier\n      if a workflow execution is logically a <i>restart</i> of a previous execution.\n      You cannot have two open workflow executions with the same <code>workflowId</code> at the same\n      time within the same domain.</p>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the workflow to start.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The task list to use for the decision tasks generated for this workflow execution. This\n      overrides the <code>defaultTaskList</code> specified when registering the workflow\n      type.</p>\n         <note>\n            <p>A task list for this workflow execution must be specified either as a default for the\n        workflow type or through this parameter. If neither this parameter is set nor a default task\n        list was specified at registration time then a fault is returned.</p>\n         </note>\n         <p>The specified string must not contain a\n        <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any\n      control characters (<code>\\u0000-\\u001f</code> | <code>\\u007f-\\u009f</code>). Also, it must\n      <i>not</i> be the literal string <code>arn</code>.</p>"
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The task priority to use for this workflow execution. This overrides any default\n      priority that was assigned when the workflow type was registered. If not set, then the default\n      task priority for the workflow type is used. Valid values are integers that range from Java's\n        <code>Integer.MIN_VALUE</code> (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647).\n      Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task\n        Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input for the workflow execution. This is a free form string which should be\n      meaningful to the workflow you are starting. This <code>input</code> is made available to the\n      new workflow execution in the <code>WorkflowExecutionStarted</code> history event.</p>"
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The total duration for this workflow execution. This overrides the\n      defaultExecutionStartToCloseTimeout specified when registering the workflow type.</p>\n         <p>The duration is specified in seconds; an integer greater than or equal to\n        <code>0</code>. Exceeding this limit causes the workflow execution to time out. Unlike some\n      of the other timeout parameters in Amazon SWF, you cannot specify a value of \"NONE\" for this\n      timeout; there is a one-year max limit on the time that a workflow execution can\n      run.</p>\n         <note>\n            <p>An execution start-to-close timeout must be specified either through this parameter\n        or as a default when the workflow type is registered. If neither this parameter nor a\n        default execution start-to-close timeout is specified, a fault is returned.</p>\n         </note>"
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags to associate with the workflow execution. You can specify a maximum of\n      5 tags. You can list workflow executions with a specific tag by calling <a>ListOpenWorkflowExecutions</a> or <a>ListClosedWorkflowExecutions</a> and\n      specifying a <a>TagFilter</a>.</p>"
+          }
+        },
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the maximum duration of decision tasks for this workflow execution. This\n      parameter overrides the <code>defaultTaskStartToCloseTimout</code> specified when registering\n      the workflow type using <a>RegisterWorkflowType</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to\n        <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>\n         <note>\n            <p>A task start-to-close timeout for this workflow execution must be specified either as\n        a default for the workflow type or through this parameter. If neither this parameter is set\n        nor a default task start-to-close timeout was specified at registration time then a fault is\n        returned.</p>\n         </note>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the policy to use for the child workflow executions of this workflow\n      execution if it is terminated, by calling the <a>TerminateWorkflowExecution</a>\n      action explicitly or due to an expired timeout. This policy overrides the default child policy\n      specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n          execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its\n          history. It is up to the decider to take appropriate actions when it receives an execution\n          history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to\n          run.</p>\n            </li>\n         </ul>\n         <note>\n            <p>A child policy for this workflow execution must be specified either as a default for\n        the workflow type or through this parameter. If neither this parameter is set nor a default\n        child policy was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role to attach to this workflow execution.</p>\n         <note>\n            <p>Executions of this workflow type need IAM roles to invoke Lambda functions. If you\n        don't attach an IAM role, any attempt to schedule a Lambda task fails. This results in a\n          <code>ScheduleLambdaFunctionFailed</code> history event. For more information, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html\">https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html</a> in the\n          <i>Amazon SWF Developer Guide</i>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#Tag": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#TagFilter": {
+      "type": "structure",
+      "members": {
+        "tag": {
+          "target": "com.amazonaws.swf#Tag",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Specifies the tag that must be associated with the execution for it to meet the filter\n      criteria.</p>\n         <p>Tags may only contain unicode letters, digits, whitespace, or these symbols: <code>_ . : / = + - @</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to filter the workflow executions in visibility APIs based on a tag.</p>"
+      }
+    },
+    "com.amazonaws.swf#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.swf#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#TagResourceInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TooManyTagsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Add a tag to a Amazon SWF domain.</p>\n         <note>\n            <p>Amazon SWF supports a maximum of 50 tags per resource.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.swf#TagResourceInput": {
+      "type": "structure",
+      "members": {
+        "resourceArn": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the Amazon SWF domain.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tags": {
+          "target": "com.amazonaws.swf#ResourceTagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags to add to a domain. </p>\n         <p>Tags may only contain unicode letters, digits, whitespace, or these symbols: <code>_ . : / = + - @</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#TaskList": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a task list.</p>"
+      }
+    },
+    "com.amazonaws.swf#TaskPriority": {
+      "type": "string"
+    },
+    "com.amazonaws.swf#TaskToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        }
+      }
+    },
+    "com.amazonaws.swf#TerminateReason": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#TerminateWorkflowExecution": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#TerminateWorkflowExecutionInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Records a <code>WorkflowExecutionTerminated</code> event and forces closure of the\n      workflow execution identified by the given domain, runId, and workflowId. The child policy,\n      registered with the workflow type or specified when starting this execution, is applied to any\n      open child workflow executions of this workflow execution.</p>\n         <important>\n            <p>If the identified workflow execution was in progress, it is terminated\n        immediately.</p>\n         </important>\n         <note>\n            <p>If a runId isn't specified, then the <code>WorkflowExecutionTerminated</code> event\n        is recorded in the history of the current open workflow with the matching workflowId in the\n        domain.</p>\n         </note>\n         <note>\n            <p>You should consider using <a>RequestCancelWorkflowExecution</a> action\n        instead because it allows the workflow to gracefully close while <a>TerminateWorkflowExecution</a> doesn't.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#TerminateWorkflowExecutionInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The domain of the workflow execution to terminate.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflowId of the workflow execution to terminate.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The runId of the workflow execution to terminate.</p>"
+          }
+        },
+        "reason": {
+          "target": "com.amazonaws.swf#TerminateReason",
+          "traits": {
+            "smithy.api#documentation": "<p> A descriptive reason for terminating the workflow execution.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p> Details for terminating the workflow execution.</p>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, specifies the policy to use for the child workflow executions of the workflow\n      execution being terminated. This policy overrides the child policy specified for the workflow\n      execution at registration time or when starting the execution.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n          execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its\n          history. It is up to the decider to take appropriate actions when it receives an execution\n          history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to\n          run.</p>\n            </li>\n         </ul>\n         <note>\n            <p>A child policy for this workflow execution must be specified either as a default for\n        the workflow type or through this parameter. If neither this parameter is set nor a default\n        child policy was specified at registration time then a fault is returned.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#TimerCanceledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the timer that was canceled.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>TimerStarted</code> event that was recorded when this timer was started.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>CancelTimer</code> decision to cancel this timer. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n      Provides the details of the <code>TimerCanceled</code> event.\n   </p>"
+      }
+    },
+    "com.amazonaws.swf#TimerFiredEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the timer that fired.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>TimerStarted</code> event that was recorded when this timer was started.\n      This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>TimerFired</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#TimerId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#TimerStartedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timerId": {
+          "target": "com.amazonaws.swf#TimerId",
+          "traits": {
+            "smithy.api#documentation": "<p>The unique ID of the timer that was started.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "control": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>"
+          }
+        },
+        "startToFireTimeout": {
+          "target": "com.amazonaws.swf#DurationInSeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The duration of time after which the timer fires.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>StartTimer</code> decision for this activity task. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>TimerStarted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#Timestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.swf#TooManyTagsFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You've exceeded the number of tags allowed for a domain.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.swf#Truncated": {
+      "type": "boolean",
+      "traits": {
+        "smithy.api#default": false
+      }
+    },
+    "com.amazonaws.swf#TypeAlreadyExistsFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned if the type already exists in the specified domain. You may get this fault if you are registering a type that is either already registered or deprecated, or if you undeprecate a type that is currently registered.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#TypeDeprecatedFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned when the specified activity or workflow type was already deprecated.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#TypeNotDeprecatedFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned when the resource type has not been deprecated.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#UndeprecateActivityType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#UndeprecateActivityTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeAlreadyExistsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Undeprecates a previously deprecated <i>activity type</i>. After an activity type has\n      been undeprecated, you can create new tasks of that activity type.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>activityType.name</code>: String constraint. The key is\n              <code>swf:activityType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>activityType.version</code>: String constraint. The key is\n              <code>swf:activityType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#UndeprecateActivityTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain of the deprecated activity type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "activityType": {
+          "target": "com.amazonaws.swf#ActivityType",
+          "traits": {
+            "smithy.api#documentation": "<p>The activity type to undeprecate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#UndeprecateDomain": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#UndeprecateDomainInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#DomainAlreadyExistsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Undeprecates a previously deprecated domain. After a domain has been undeprecated it can be used\n      to create new workflow executions or register new types.</p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>You cannot use an IAM policy to constrain this action's parameters.</p>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#UndeprecateDomainInput": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain of the deprecated workflow type.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#UndeprecateWorkflowType": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#UndeprecateWorkflowTypeInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#TypeAlreadyExistsFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Undeprecates a previously deprecated <i>workflow type</i>. After a workflow type has\n      been undeprecated, you can create new executions of that type. </p>\n         <note>\n            <p>This operation is eventually consistent. The results are best effort and may not\n        exactly reflect recent updates and changes.</p>\n         </note>\n         <p>\n            <b>Access Control</b>\n         </p>\n         <p>You can use IAM policies to control this action's access to Amazon SWF resources as\n      follows:</p>\n         <ul>\n            <li>\n               <p>Use a <code>Resource</code> element with the domain name to limit the action to\n          only specified domains.</p>\n            </li>\n            <li>\n               <p>Use an <code>Action</code> element to allow or deny permission to call this\n          action.</p>\n            </li>\n            <li>\n               <p>Constrain the following parameters by using a <code>Condition</code> element with\n          the appropriate keys.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>workflowType.name</code>: String constraint. The key is\n              <code>swf:workflowType.name</code>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>workflowType.version</code>: String constraint. The key is\n              <code>swf:workflowType.version</code>.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If the caller doesn't have sufficient permissions to invoke the action, or the\n      parameter values fall outside the specified constraints, the action fails. The associated\n      event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>.\n      For details and example IAM policies, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF\n        Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.swf#UndeprecateWorkflowTypeInput": {
+      "type": "structure",
+      "members": {
+        "domain": {
+          "target": "com.amazonaws.swf#DomainName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain of the deprecated workflow type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the domain of the deprecated workflow type.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#UnknownResourceFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned when the named resource cannot be found with in the scope of this operation (region or domain). This could happen if the named resource was never created or is no longer available for this operation.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.swf#UntagResourceInput"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.swf#LimitExceededFault"
+        },
+        {
+          "target": "com.amazonaws.swf#OperationNotPermittedFault"
+        },
+        {
+          "target": "com.amazonaws.swf#UnknownResourceFault"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Remove a tag from a Amazon SWF domain.</p>"
+      }
+    },
+    "com.amazonaws.swf#UntagResourceInput": {
+      "type": "structure",
+      "members": {
+        "resourceArn": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for the Amazon SWF domain.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tagKeys": {
+          "target": "com.amazonaws.swf#ResourceTagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags to remove from the Amazon SWF domain.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.swf#Version": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.swf#VersionOptional": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecution": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The user defined identifier associated with the workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "runId": {
+          "target": "com.amazonaws.swf#WorkflowRunId",
+          "traits": {
+            "smithy.api#documentation": "<p>A system-generated unique identifier for the workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionAlreadyStartedFault": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.swf#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A description that may help with diagnosing the cause of the fault.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned by <a>StartWorkflowExecution</a> when an open execution with the same workflowId is already running in\n      the specified domain.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionCancelRequestedCause": {
+      "type": "enum",
+      "members": {
+        "CHILD_POLICY_APPLIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHILD_POLICY_APPLIED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionCancelRequestedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "externalWorkflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The external workflow execution for which the cancellation was requested.</p>"
+          }
+        },
+        "externalInitiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event corresponding to the\n      <code>RequestCancelExternalWorkflowExecution</code> decision to cancel this workflow execution.The source event\n      with this ID can be found in the history of the source workflow execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>"
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#WorkflowExecutionCancelRequestedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, indicates that the request to cancel the workflow execution was automatically generated, and specifies the cause. This happens if the parent workflow execution times out or is terminated, and the child policy is set to cancel child executions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionCancelRequested</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionCanceledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the cancellation.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionCanceled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionCompletedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The result produced by the workflow execution upon successful completion.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>CompleteWorkflowExecution</code> decision to complete this execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionCompleted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionConfiguration": {
+      "type": "structure",
+      "members": {
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration allowed for decision tasks for this workflow execution.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The total duration for this workflow execution.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The task list used for the decision tasks generated for this workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The priority assigned to decision tasks for this workflow execution. Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the\n      <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role attached to the child workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration settings for a workflow execution including timeout values, tasklist etc. These configuration settings are determined from the defaults specified when registering the workflow type and those specified when starting the workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionContinuedAsNewEventAttributes": {
+      "type": "structure",
+      "members": {
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the new workflow execution.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>ContinueAsNewWorkflowExecution</code> decision that started this execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "newExecutionRunId": {
+          "target": "com.amazonaws.swf#WorkflowRunId",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>runId</code> of the new workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The total duration allowed for the new workflow execution.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The task list to use for the decisions of the new (continued) workflow\n      execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The priority of the task to use for the decisions of the new (continued) workflow\n      execution.</p>"
+          }
+        },
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration of decision tasks for the new workflow execution.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy to use for the child workflow executions of the new execution if it is terminated by calling the\n      <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags associated with the new workflow execution.</p>"
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type of this execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role to attach to the new (continued) workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionContinuedAsNew</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionCount": {
+      "type": "structure",
+      "members": {
+        "count": {
+          "target": "com.amazonaws.swf#Count",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of workflow executions.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "truncated": {
+          "target": "com.amazonaws.swf#Truncated",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>If set to true, indicates that the actual count was more than the maximum supported by this API and the count returned is the truncated value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the count of workflow executions returned from <a>CountOpenWorkflowExecutions</a> or\n      <a>CountClosedWorkflowExecutions</a>\n         </p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionDetail": {
+      "type": "structure",
+      "members": {
+        "executionInfo": {
+          "target": "com.amazonaws.swf#WorkflowExecutionInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "executionConfiguration": {
+          "target": "com.amazonaws.swf#WorkflowExecutionConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The configuration settings for this workflow execution including timeout values, tasklist etc.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "openCounts": {
+          "target": "com.amazonaws.swf#WorkflowExecutionOpenCounts",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of tasks for this workflow execution. This includes open and closed tasks of all types.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "latestActivityTaskTimestamp": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the last activity task was scheduled for this workflow execution. You can use this information to determine if the workflow has not made progress for an unusually long period of time and might require a corrective action.</p>"
+          }
+        },
+        "latestExecutionContext": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The latest executionContext provided by the decider for this workflow execution. A decider can provide an\n      executionContext (a free-form string) when closing a decision task using <a>RespondDecisionTaskCompleted</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains details about a workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionFailedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "reason": {
+          "target": "com.amazonaws.swf#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The descriptive reason provided for the failure.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details of the failure.</p>"
+          }
+        },
+        "decisionTaskCompletedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the\n      <code>FailWorkflowExecution</code> decision to fail this execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionFailed</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionFilter": {
+      "type": "structure",
+      "members": {
+        "workflowId": {
+          "target": "com.amazonaws.swf#WorkflowId",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflowId to pass of match the criteria of this filter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to filter the workflow executions in visibility APIs by their <code>workflowId</code>.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionInfo": {
+      "type": "structure",
+      "members": {
+        "execution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow execution this information is about.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "startTimestamp": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the execution was started.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "closeTimestamp": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the workflow execution was closed. Set only if the execution status is CLOSED.</p>"
+          }
+        },
+        "executionStatus": {
+          "target": "com.amazonaws.swf#ExecutionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "closeStatus": {
+          "target": "com.amazonaws.swf#CloseStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>If the execution status is closed then this specifies how the execution was closed:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>COMPLETED</code> \u2013 the execution was successfully completed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CANCELED</code> \u2013 the execution was canceled.Cancellation allows the implementation to gracefully clean\n        up before the execution is closed.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TERMINATED</code> \u2013 the execution was force terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> \u2013 the execution failed to complete.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TIMED_OUT</code> \u2013 the execution did not complete in the alloted time and was automatically timed\n        out.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CONTINUED_AS_NEW</code> \u2013 the execution is logically continued. This means the current execution was\n        completed and a new execution was started to carry on the workflow.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "parent": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>If this workflow execution is a child of another execution then contains the workflow execution that started this execution.</p>"
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags associated with the workflow execution. Tags can be used to identify and list workflow executions of interest through the visibility APIs. A workflow execution can have a maximum of 5 tags.</p>"
+          }
+        },
+        "cancelRequested": {
+          "target": "com.amazonaws.swf#Canceled",
+          "traits": {
+            "smithy.api#default": false,
+            "smithy.api#documentation": "<p>Set to true if a cancellation is requested for this workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#WorkflowExecutionInfo"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionInfos": {
+      "type": "structure",
+      "members": {
+        "executionInfos": {
+          "target": "com.amazonaws.swf#WorkflowExecutionInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of workflow information structures.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If a <code>NextPageToken</code> was returned by a previous call, there are more\n  results available. To retrieve the next page of results, make the call again using the returned token in\n  <code>nextPageToken</code>. Keep all other arguments unchanged.</p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains a paginated list of information about workflow executions.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionOpenCounts": {
+      "type": "structure",
+      "members": {
+        "openActivityTasks": {
+          "target": "com.amazonaws.swf#Count",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The count of activity tasks whose status is <code>OPEN</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "openDecisionTasks": {
+          "target": "com.amazonaws.swf#OpenDecisionTasksCount",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The count of decision tasks whose status is OPEN. A workflow execution can have at most one open decision task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "openTimers": {
+          "target": "com.amazonaws.swf#Count",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The count of timers started by this workflow execution that have not fired yet.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "openChildWorkflowExecutions": {
+          "target": "com.amazonaws.swf#Count",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The count of child workflow executions whose status is <code>OPEN</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "openLambdaFunctions": {
+          "target": "com.amazonaws.swf#Count",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The count of Lambda tasks whose status is <code>OPEN</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the counts of open tasks, child workflow executions and timers for a workflow execution.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionSignaledEventAttributes": {
+      "type": "structure",
+      "members": {
+        "signalName": {
+          "target": "com.amazonaws.swf#SignalName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the signal received. The decider can use the signal name and inputs to determine how to the process the signal.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The inputs provided with the signal. The decider can use the signal name and inputs to determine how to process the signal.</p>"
+          }
+        },
+        "externalWorkflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow execution that sent the signal. This is set only of the signal was sent by another workflow execution.</p>"
+          }
+        },
+        "externalInitiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the\n      <code>SignalExternalWorkflow</code> decision to signal this workflow execution.The source event with this ID can\n      be found in the history of the source workflow execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event. This field is set only if\n      the signal was initiated by another workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionSignaled</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionStartedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "input": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The input provided to the workflow execution.</p>"
+          }
+        },
+        "executionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration for this workflow execution.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "taskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum duration of decision tasks for this workflow type.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the\n      <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the task list for scheduling the decision tasks for this workflow execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "taskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>The priority of the decision tasks in the workflow execution.</p>"
+          }
+        },
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type of this execution.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "tagList": {
+          "target": "com.amazonaws.swf#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tags associated with this workflow execution. An execution can have up to 5 tags.</p>"
+          }
+        },
+        "continuedExecutionRunId": {
+          "target": "com.amazonaws.swf#WorkflowRunIdOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>If this workflow execution was started due to a <code>ContinueAsNewWorkflowExecution</code> decision, then it\n      contains the <code>runId</code> of the previous workflow execution that was closed and continued as this\n      execution.</p>"
+          }
+        },
+        "parentWorkflowExecution": {
+          "target": "com.amazonaws.swf#WorkflowExecution",
+          "traits": {
+            "smithy.api#documentation": "<p>The source workflow execution that started this workflow execution. The member isn't set if the workflow execution was not started by a workflow.</p>"
+          }
+        },
+        "parentInitiatedEventId": {
+          "target": "com.amazonaws.swf#EventId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the\n      <code>StartChildWorkflowExecution</code>\n            <a>Decision</a> to start this workflow execution. The source event with\n      this ID can be found in the history of the source workflow execution. This information can be useful for diagnosing problems by tracing back the chain of\n  events leading up to this event.</p>"
+          }
+        },
+        "lambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The IAM role attached to the workflow execution.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides details of <code>WorkflowExecutionStarted</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionTerminatedCause": {
+      "type": "enum",
+      "members": {
+        "CHILD_POLICY_APPLIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHILD_POLICY_APPLIED"
+          }
+        },
+        "EVENT_LIMIT_EXCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EVENT_LIMIT_EXCEEDED"
+          }
+        },
+        "OPERATOR_INITIATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPERATOR_INITIATED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionTerminatedEventAttributes": {
+      "type": "structure",
+      "members": {
+        "reason": {
+          "target": "com.amazonaws.swf#TerminateReason",
+          "traits": {
+            "smithy.api#documentation": "<p>The reason provided for the termination.</p>"
+          }
+        },
+        "details": {
+          "target": "com.amazonaws.swf#Data",
+          "traits": {
+            "smithy.api#documentation": "<p>The details provided for the termination.</p>"
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy used for the child workflow executions of this workflow execution.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "cause": {
+          "target": "com.amazonaws.swf#WorkflowExecutionTerminatedCause",
+          "traits": {
+            "smithy.api#documentation": "<p>If set, indicates that the workflow execution was automatically terminated, and specifies the cause. This happens if the parent workflow execution times out or is terminated and the child policy is set to terminate child executions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionTerminated</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionTimedOutEventAttributes": {
+      "type": "structure",
+      "members": {
+        "timeoutType": {
+          "target": "com.amazonaws.swf#WorkflowExecutionTimeoutType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of timeout that caused this event.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "childPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy used for the child workflow executions of this workflow execution.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the details of the <code>WorkflowExecutionTimedOut</code> event.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowExecutionTimeoutType": {
+      "type": "enum",
+      "members": {
+        "START_TO_CLOSE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "START_TO_CLOSE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowRunId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowRunIdOptional": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 64
+        }
+      }
+    },
+    "com.amazonaws.swf#WorkflowType": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The name of the workflow type.</p>\n         <note>\n            <p>The combination of workflow type name and version must be unique with in a domain.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.swf#Version",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The version of the workflow type.</p>\n         <note>\n            <p>The combination of workflow type name and version must be unique with in a domain.</p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a workflow type.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowTypeConfiguration": {
+      "type": "structure",
+      "members": {
+        "defaultTaskStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default maximum duration, specified when registering the workflow type, that a decision task\n      for executions of this workflow type might take before returning completion or failure. If the task doesn'tdo  close\n      in the specified time then the task is automatically timed out and rescheduled. If the decider eventually reports\n      a completion or failure, it is ignored. This default can be overridden when starting a workflow execution using\n      the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultExecutionStartToCloseTimeout": {
+          "target": "com.amazonaws.swf#DurationInSecondsOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default maximum duration, specified when registering the workflow type, for executions of\n      this workflow type. This default can be overridden when starting a workflow execution using the\n      <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>\n         <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>"
+          }
+        },
+        "defaultTaskList": {
+          "target": "com.amazonaws.swf#TaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default task list, specified when registering the workflow type, for decisions tasks\n      scheduled for workflow executions of this type. This default can be overridden when starting a workflow execution\n      using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>"
+          }
+        },
+        "defaultTaskPriority": {
+          "target": "com.amazonaws.swf#TaskPriority",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default task priority, specified when registering the workflow type, for all decision tasks\n      of this workflow type. This default can be overridden when starting a workflow execution using the\n      <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code> decision.</p>\n         <p>Valid values are integers that range from Java's <code>Integer.MIN_VALUE</code>\n  (-2147483648) to <code>Integer.MAX_VALUE</code> (2147483647). Higher numbers indicate higher priority.</p>\n         <p>For more information about setting task priority, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html\">Setting Task Priority</a> in the <i>Amazon SWF Developer Guide</i>.</p>"
+          }
+        },
+        "defaultChildPolicy": {
+          "target": "com.amazonaws.swf#ChildPolicy",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         The default policy to use for the child workflow executions when a workflow execution of this\n      type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired\n      timeout. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a>\n      action or the <code>StartChildWorkflowExecution</code>\n            <a>Decision</a>.</p>\n         <p>The supported child policies are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TERMINATE</code> \u2013 The child executions are terminated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REQUEST_CANCEL</code> \u2013 A request to cancel is attempted for each child\n  execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider\n  to take appropriate actions when it receives an execution history with this event.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ABANDON</code> \u2013 No action is taken. The child executions continue to run.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "defaultLambdaRole": {
+          "target": "com.amazonaws.swf#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The default IAM role attached to this workflow type.</p>\n         <note>\n            <p>Executions of this workflow type need IAM roles to invoke Lambda functions. If you\n        don't specify an IAM role when starting this workflow type, the default Lambda role is\n        attached to the execution. For more information, see <a href=\"https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html\">https://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html</a> in the\n          <i>Amazon SWF Developer Guide</i>.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration settings of a workflow type.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowTypeDetail": {
+      "type": "structure",
+      "members": {
+        "typeInfo": {
+          "target": "com.amazonaws.swf#WorkflowTypeInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>General information about the workflow type.</p>\n         <p>The status of the workflow type (returned in the WorkflowTypeInfo structure) can be one of the following.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>REGISTERED</code> \u2013 The type is registered and available. Workers supporting this type should be running.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DEPRECATED</code> \u2013 The type was deprecated using <a>DeprecateWorkflowType</a>, but is still in use. You should\n        keep workers supporting this type running. You cannot create new workflow executions of this type.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        },
+        "configuration": {
+          "target": "com.amazonaws.swf#WorkflowTypeConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration settings of the workflow type registered through <a>RegisterWorkflowType</a>\n         </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains details about a workflow type.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowTypeFilter": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "com.amazonaws.swf#Name",
+          "traits": {
+            "smithy.api#documentation": "<p>\n         Name of the workflow type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "version": {
+          "target": "com.amazonaws.swf#VersionOptional",
+          "traits": {
+            "smithy.api#documentation": "<p>Version of the workflow type.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to filter workflow execution query results by type. Each parameter, if specified, defines a rule that must be satisfied by each returned result.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowTypeInfo": {
+      "type": "structure",
+      "members": {
+        "workflowType": {
+          "target": "com.amazonaws.swf#WorkflowType",
+          "traits": {
+            "smithy.api#documentation": "<p>The workflow type this information is about.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "status": {
+          "target": "com.amazonaws.swf#RegistrationStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the workflow type.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "description": {
+          "target": "com.amazonaws.swf#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the type registered through <a>RegisterWorkflowType</a>.</p>"
+          }
+        },
+        "creationDate": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date when this type was registered.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "deprecationDate": {
+          "target": "com.amazonaws.swf#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>If the type is in deprecated state, then it is set to the date when the type was deprecated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a workflow type.</p>"
+      }
+    },
+    "com.amazonaws.swf#WorkflowTypeInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.swf#WorkflowTypeInfo"
+      }
+    },
+    "com.amazonaws.swf#WorkflowTypeInfos": {
+      "type": "structure",
+      "members": {
+        "typeInfos": {
+          "target": "com.amazonaws.swf#WorkflowTypeInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of workflow type information.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "nextPageToken": {
+          "target": "com.amazonaws.swf#PageToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If a <code>NextPageToken</code> was returned by a previous call, there are more\n  results available. To retrieve the next page of results, make the call again using the returned token in\n  <code>nextPageToken</code>. Keep all other arguments unchanged.</p>\n         <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains a paginated list of information structures about workflow types.</p>"
+      }
+    }
+  }
+}

--- a/crates/fakecloud-swf/src/validate.rs
+++ b/crates/fakecloud-swf/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored SWF Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/swf.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 /// The embedded model parses to exactly this many operations; a mismatch means
 /// the vendored model drifted from the implemented surface.

--- a/crates/fakecloud-textract/model.json
+++ b/crates/fakecloud-textract/model.json
@@ -1,0 +1,6090 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.textract#AccessDeniedException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You aren't authorized to perform the action. Use the Amazon Resource Name (ARN) \n            of an authorized user or IAM role to perform the operation.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#Adapter": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the adapter resource.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Pages": {
+          "target": "com.amazonaws.textract#AdapterPages",
+          "traits": {
+            "smithy.api#documentation": "<p>Pages is a parameter that the user inputs to specify which pages to apply an adapter to. The following is a \n         list of rules for using this parameter.</p>\n         <ul>\n            <li>\n               <p>If a page is not specified, it is set to <code>[\"1\"]</code> by default.</p>\n            </li>\n            <li>\n               <p>The following characters are allowed in the parameter's string: \n               <code>0 1 2 3 4 5 6 7 8 9 - *</code>. No whitespace is allowed.</p>\n            </li>\n            <li>\n               <p>When using * to indicate all pages, it must be the only element in the list.</p>\n            </li>\n            <li>\n               <p>You can use page intervals, such as <code>[\"1-3\", \"1-1\", \"4-*\"]</code>. Where <code>*</code> indicates last page of \n               document.</p>\n            </li>\n            <li>\n               <p>Specified pages must be greater than 0 and less than or equal to the number of pages in the document.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.textract#AdapterVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that identifies the version of the adapter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An adapter selected for use when analyzing documents. Contains an adapter ID and a version number. \n         Contains information on pages selected for analysis when analyzing documents asychronously.</p>"
+      }
+    },
+    "com.amazonaws.textract#AdapterDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9\\s!\"\\#\\$%'&\\(\\)\\*\\+\\,\\-\\./:;=\\?@\\[\\\\\\]\\^_`\\{\\|\\}~><]+$"
+      }
+    },
+    "com.amazonaws.textract#AdapterId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 12,
+          "max": 1011
+        }
+      }
+    },
+    "com.amazonaws.textract#AdapterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#AdapterOverview"
+      }
+    },
+    "com.amazonaws.textract#AdapterName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-_]+$"
+      }
+    },
+    "com.amazonaws.textract#AdapterOverview": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the adapter resource.</p>"
+          }
+        },
+        "AdapterName": {
+          "target": "com.amazonaws.textract#AdapterName",
+          "traits": {
+            "smithy.api#documentation": "<p>A string naming the adapter resource.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the adapter was created.</p>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The feature types that the adapter is operating on.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information on the adapter, including the adapter ID, Name, Creation time, and feature types.</p>"
+      }
+    },
+    "com.amazonaws.textract#AdapterPage": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 9
+        },
+        "smithy.api#pattern": "^[0-9\\*\\-]+$"
+      }
+    },
+    "com.amazonaws.textract#AdapterPages": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#AdapterPage"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.textract#AdapterVersion": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionDatasetConfig": {
+      "type": "structure",
+      "members": {
+        "ManifestS3Object": {
+          "target": "com.amazonaws.textract#S3Object"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The dataset configuration options for a given version of an adapter. \n         Can include an Amazon S3 bucket if specified.</p>"
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionEvaluationMetric": {
+      "type": "structure",
+      "members": {
+        "Baseline": {
+          "target": "com.amazonaws.textract#EvaluationMetric",
+          "traits": {
+            "smithy.api#documentation": "<p>The F1 score, precision, and recall metrics for the baseline model.</p>"
+          }
+        },
+        "AdapterVersion": {
+          "target": "com.amazonaws.textract#EvaluationMetric",
+          "traits": {
+            "smithy.api#documentation": "<p>The F1 score, precision, and recall metrics for the baseline model.</p>"
+          }
+        },
+        "FeatureType": {
+          "target": "com.amazonaws.textract#FeatureType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the feature type being analyzed by a given adapter version.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information on the metrics used to evalute the peformance of a given adapter version. Includes data for \n         baseline model performance and individual adapter version perfromance.</p>"
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionEvaluationMetrics": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#AdapterVersionEvaluationMetric"
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#AdapterVersionOverview"
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionOverview": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the adapter associated with a given adapter version.</p>"
+          }
+        },
+        "AdapterVersion": {
+          "target": "com.amazonaws.textract#AdapterVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>An identified for a given adapter version.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that a given adapter version was created.</p>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The feature types that the adapter version is operating on.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.textract#AdapterVersionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains information on the status of a given adapter version.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#AdapterVersionStatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A message explaining the status of a given adapter vesion.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Summary info for an adapter version. Contains information on the AdapterId, AdapterVersion, CreationTime, FeatureTypes, and Status.</p>"
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionStatus": {
+      "type": "enum",
+      "members": {
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "AT_RISK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AT_RISK"
+          }
+        },
+        "DEPRECATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEPRECATED"
+          }
+        },
+        "CREATION_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATION_ERROR"
+          }
+        },
+        "CREATION_IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATION_IN_PROGRESS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#AdapterVersionStatusMessage": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9\\s!\"\\#\\$%'&\\(\\)\\*\\+\\,\\-\\./:;=\\?@\\[\\\\\\]\\^_`\\{\\|\\}~><]+$"
+      }
+    },
+    "com.amazonaws.textract#Adapters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Adapter"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.textract#AdaptersConfig": {
+      "type": "structure",
+      "members": {
+        "Adapters": {
+          "target": "com.amazonaws.textract#Adapters",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of adapters to be used when analyzing the specified document.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about adapters used when analyzing a document, \n         with each adapter specified using an AdapterId and version</p>"
+      }
+    },
+    "com.amazonaws.textract#AmazonResourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1011
+        }
+      }
+    },
+    "com.amazonaws.textract#AnalyzeDocument": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#AnalyzeDocumentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#AnalyzeDocumentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#HumanLoopQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Analyzes an input document for relationships between detected items. </p>\n         <p>The types of information returned are as follows: </p>\n         <ul>\n            <li>\n               <p>Form data (key-value pairs). The related information is returned in two <a>Block</a> objects, each of type <code>KEY_VALUE_SET</code>: a KEY\n                  <code>Block</code> object and a VALUE <code>Block</code> object. For example,\n                  <i>Name: Ana Silva Carolina</i> contains a key and value.\n                  <i>Name:</i> is the key. <i>Ana Silva Carolina</i> is\n               the value.</p>\n            </li>\n            <li>\n               <p>Table and table cell data. A TABLE <code>Block</code> object contains information\n               about a detected table. A CELL <code>Block</code> object is returned for each cell in\n               a table.</p>\n            </li>\n            <li>\n               <p>Lines and words of text. A LINE <code>Block</code> object contains one or more\n               WORD <code>Block</code> objects. All lines and words that are detected in the\n               document are returned (including text that doesn't have a relationship with the value\n               of <code>FeatureTypes</code>). </p>\n            </li>\n            <li>\n               <p>Signatures. A SIGNATURE <code>Block</code> object contains the location information\n               of a signature in a document. If used in conjunction with forms or tables, a signature\n               can be given a Key-Value pairing or be detected in the cell of a table.</p>\n            </li>\n            <li>\n               <p>Query. A QUERY Block object contains the query text, alias and link to the\n               associated Query results block object.</p>\n            </li>\n            <li>\n               <p>Query Result. A QUERY_RESULT Block object contains the answer to the query and an\n               ID that connects it to the query asked. This Block also contains a confidence\n               score.</p>\n            </li>\n         </ul>\n         <p>Selection elements such as check boxes and option buttons (radio buttons) can be\n         detected in form data and in tables. A SELECTION_ELEMENT <code>Block</code> object contains\n         information about a selection element, including the selection status.</p>\n         <p>You can choose which type of analysis to perform by specifying the\n            <code>FeatureTypes</code> list. </p>\n         <p>The output is returned in a list of <code>Block</code> objects.</p>\n         <p>\n            <code>AnalyzeDocument</code> is a synchronous operation. To analyze documents\n         asynchronously, use <a>StartDocumentAnalysis</a>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works-analyzing.html\">Document Text\n         Analysis</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#AnalyzeDocumentRequest": {
+      "type": "structure",
+      "members": {
+        "Document": {
+          "target": "com.amazonaws.textract#Document",
+          "traits": {
+            "smithy.api#documentation": "<p>The input document as base64-encoded bytes or an Amazon S3 object. If you use the AWS\n         CLI to call Amazon Textract operations, you can't pass image bytes. The document must be an\n         image in JPEG, PNG, PDF, or TIFF format.</p>\n         <p>If you're using an AWS SDK to call Amazon Textract, you might not need to base64-encode\n         image bytes that are passed using the <code>Bytes</code> field. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the types of analysis to perform. Add TABLES to the list to return information\n         about the tables that are detected in the input document. Add FORMS to return detected form\n         data. Add SIGNATURES to return the locations of detected signatures. Add LAYOUT to the list\n         to return information about the layout of the document.  All lines and words detected in the document are included in the response (including\n         text that isn't related to the value of <code>FeatureTypes</code>). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "HumanLoopConfig": {
+          "target": "com.amazonaws.textract#HumanLoopConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets the configuration for the human in the loop workflow for analyzing\n         documents.</p>"
+          }
+        },
+        "QueriesConfig": {
+          "target": "com.amazonaws.textract#QueriesConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains Queries and the alias for those Queries, as determined by the input. </p>"
+          }
+        },
+        "AdaptersConfig": {
+          "target": "com.amazonaws.textract#AdaptersConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the adapter to be used when analyzing a document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#AnalyzeDocumentResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Metadata about the analyzed document. An example is the number of pages.</p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.textract#BlockList",
+          "traits": {
+            "smithy.api#documentation": "<p>The items that are detected and analyzed by <code>AnalyzeDocument</code>.</p>"
+          }
+        },
+        "HumanLoopActivationOutput": {
+          "target": "com.amazonaws.textract#HumanLoopActivationOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>Shows the results of the human in the loop evaluation.</p>"
+          }
+        },
+        "AnalyzeDocumentModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the model used to analyze the document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#AnalyzeExpense": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#AnalyzeExpenseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#AnalyzeExpenseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>\n            <code>AnalyzeExpense</code> synchronously analyzes an input document for financially\n         related relationships between text.</p>\n         <p>Information is returned as <code>ExpenseDocuments</code> and seperated as\n         follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>LineItemGroups</code>- A data set containing <code>LineItems</code> which\n               store information about the lines of text, such as an item purchased and its price on\n               a receipt.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SummaryFields</code>- Contains all other information a receipt, such as\n               header information or the vendors name.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.textract#AnalyzeExpenseRequest": {
+      "type": "structure",
+      "members": {
+        "Document": {
+          "target": "com.amazonaws.textract#Document",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#AnalyzeExpenseResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata"
+        },
+        "ExpenseDocuments": {
+          "target": "com.amazonaws.textract#ExpenseDocumentList",
+          "traits": {
+            "smithy.api#documentation": "<p>The expenses detected by Amazon Textract.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#AnalyzeID": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#AnalyzeIDRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#AnalyzeIDResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Analyzes identity documents for relevant information. This information is extracted and\n         returned as <code>IdentityDocumentFields</code>, which records both the normalized field\n         and value of the extracted text. Unlike other Amazon Textract operations,\n            <code>AnalyzeID</code> doesn't return any Geometry data.</p>"
+      }
+    },
+    "com.amazonaws.textract#AnalyzeIDDetections": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Text of either the normalized field or value associated with it.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NormalizedValue": {
+          "target": "com.amazonaws.textract#NormalizedValue",
+          "traits": {
+            "smithy.api#documentation": "<p>Only returned for dates, returns the type of value detected and the date\n         written in a more machine readable way.</p>"
+          }
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score of the detected text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Used to contain the information detected by an AnalyzeID operation.</p>"
+      }
+    },
+    "com.amazonaws.textract#AnalyzeIDRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentPages": {
+          "target": "com.amazonaws.textract#DocumentPages",
+          "traits": {
+            "smithy.api#documentation": "<p>The document being passed to AnalyzeID.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#AnalyzeIDResponse": {
+      "type": "structure",
+      "members": {
+        "IdentityDocuments": {
+          "target": "com.amazonaws.textract#IdentityDocumentList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of documents processed by AnalyzeID. Includes a number denoting their place in\n         the list and the response structure for the document.</p>"
+          }
+        },
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata"
+        },
+        "AnalyzeIDModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The version of the AnalyzeIdentity API being used to process documents.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#Angle": {
+      "type": "float"
+    },
+    "com.amazonaws.textract#AutoUpdate": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#BadDocumentException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Textract isn't able to read the document. For more information on the document\n         limits in Amazon Textract, see <a>limits</a>.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#Block": {
+      "type": "structure",
+      "members": {
+        "BlockType": {
+          "target": "com.amazonaws.textract#BlockType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of text item that's recognized. In operations for text detection, the following\n         types are returned:</p>\n         <ul>\n            <li>\n               <p>\n                  <i>PAGE</i> - Contains a list of the LINE <code>Block</code> objects\n               that are detected on a document page.</p>\n            </li>\n            <li>\n               <p>\n                  <i>WORD</i> - A word detected on a document page. A word is one or\n               more ISO basic Latin script characters that aren't separated by spaces.</p>\n            </li>\n            <li>\n               <p>\n                  <i>LINE</i> - A string of space-delimited, contiguous words that are\n               detected on a document page.</p>\n            </li>\n         </ul>\n         <p>In text analysis operations, the following types are returned:</p>\n         <ul>\n            <li>\n               <p>\n                  <i>PAGE</i> - Contains a list of child <code>Block</code> objects\n               that are detected on a document page.</p>\n            </li>\n            <li>\n               <p>\n                  <i>KEY_VALUE_SET</i> - Stores the KEY and VALUE <code>Block</code>\n               objects for linked text that's detected on a document page. Use the\n                  <code>EntityType</code> field to determine if a KEY_VALUE_SET object is a KEY\n                  <code>Block</code> object or a VALUE <code>Block</code> object. </p>\n            </li>\n            <li>\n               <p>\n                  <i>WORD</i> - A word that's detected on a document page. A word is\n               one or more ISO basic Latin script characters that aren't separated by spaces.</p>\n            </li>\n            <li>\n               <p>\n                  <i>LINE</i> - A string of tab-delimited, contiguous words that are\n               detected on a document page.</p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE</i> - A table that's detected on a document page. A table\n               is grid-based information with two or more rows or columns, with a cell span of one\n               row and one column each. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_TITLE</i> - The title of a table. A title is typically a\n               line of text above or below a table, or embedded as the first row of a table. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_FOOTER</i> - The footer associated with a table. A footer\n               is typically a line or lines of text below a table or embedded as the last row of a\n               table. </p>\n            </li>\n            <li>\n               <p>\n                  <i>CELL</i> - A cell within a detected table. The cell is the parent\n               of the block that contains the text in the cell.</p>\n            </li>\n            <li>\n               <p>\n                  <i>MERGED_CELL</i>  - A cell in a table whose content spans more than\n               one row or column. The <code>Relationships</code> array for this cell contain data\n               from individual cells.</p>\n            </li>\n            <li>\n               <p>\n                  <i>SELECTION_ELEMENT</i> - A selection element such as an option\n               button (radio button) or a check box that's detected on a document page. Use the\n               value of <code>SelectionStatus</code> to determine the status of the selection\n               element.</p>\n            </li>\n            <li>\n               <p>\n                  <i>SIGNATURE</i> - The location and confidence score of a signature detected on a\n               document page. Can be returned as part of a Key-Value pair or a detected cell.</p>\n            </li>\n            <li>\n               <p>\n                  <i>QUERY</i> - A question asked during the call of AnalyzeDocument. Contains an\n               alias and an ID that attaches it to its answer.</p>\n            </li>\n            <li>\n               <p>\n                  <i>QUERY_RESULT</i> - A response to a question asked during the call\n               of analyze document. Comes with an alias and ID for ease of locating in a \n               response. Also contains location and confidence score.</p>\n            </li>\n         </ul>\n         <p>The following BlockTypes are only returned for Amazon Textract Layout.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>LAYOUT_TITLE</code> - The main title of the document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_HEADER</code> - Text located in the top margin of the document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_FOOTER</code> - Text located in the bottom margin of the document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_SECTION_HEADER</code> - The titles of sections within a document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_PAGE_NUMBER</code> - The page number of the documents.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_LIST</code> - Any information grouped together in list form. </p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_FIGURE</code> - Indicates the location of an image in a document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_TABLE</code> - Indicates the location of a table in the document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_KEY_VALUE</code> - Indicates the location of form key-values in a document.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LAYOUT_TEXT</code> - Text that is present typically as a part of paragraphs in documents.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score that Amazon Textract has in the accuracy of the recognized text and\n         the accuracy of the geometry points around the recognized text.</p>"
+          }
+        },
+        "Text": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The word or line of text that's recognized by Amazon Textract. </p>"
+          }
+        },
+        "TextType": {
+          "target": "com.amazonaws.textract#TextType",
+          "traits": {
+            "smithy.api#documentation": "<p>The kind of text that Amazon Textract has detected. Can check for handwritten text and\n         printed text.</p>"
+          }
+        },
+        "RowIndex": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The row in which a table cell is located. The first row position is 1.\n            <code>RowIndex</code> isn't returned by <code>DetectDocumentText</code> and\n            <code>GetDocumentTextDetection</code>.</p>"
+          }
+        },
+        "ColumnIndex": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The column in which a table cell appears. The first column position is 1.\n            <code>ColumnIndex</code> isn't returned by <code>DetectDocumentText</code> and\n            <code>GetDocumentTextDetection</code>.</p>"
+          }
+        },
+        "RowSpan": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of rows that a table cell spans. <code>RowSpan</code> isn't returned by\n            <code>DetectDocumentText</code> and <code>GetDocumentTextDetection</code>.</p>"
+          }
+        },
+        "ColumnSpan": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of columns that a table cell spans. <code>ColumnSpan</code> isn't returned by\n            <code>DetectDocumentText</code> and <code>GetDocumentTextDetection</code>. </p>"
+          }
+        },
+        "Geometry": {
+          "target": "com.amazonaws.textract#Geometry",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the recognized text on the image. It includes an axis-aligned, coarse\n         bounding box that surrounds the text, and a finer-grain polygon for more accurate spatial\n         information. </p>"
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.textract#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the recognized text. The identifier is only unique for a single\n         operation. </p>"
+          }
+        },
+        "Relationships": {
+          "target": "com.amazonaws.textract#RelationshipList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of relationship objects that describe how blocks are related to each other. For\n         example, a LINE block object contains a CHILD relationship type with the WORD blocks that\n         make up the line of text. There aren't Relationship objects in the list for relationships\n         that don't exist, such as when the current block has no child blocks.</p>"
+          }
+        },
+        "EntityTypes": {
+          "target": "com.amazonaws.textract#EntityTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of entity. </p>\n         <p>The following entity types can be returned by FORMS analysis:</p>\n         <ul>\n            <li>\n               <p>\n                  <i>KEY</i> - An identifier for a field on the document.</p>\n            </li>\n            <li>\n               <p>\n                  <i>VALUE</i> - The field text.</p>\n            </li>\n         </ul>\n         <p>The following entity types can be returned by TABLES analysis:</p>\n         <ul>\n            <li>\n               <p>\n                  <i>COLUMN_HEADER</i> - Identifies a cell that is a header of a column. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_TITLE</i> - Identifies a cell that is a title within the\n               table. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_SECTION_TITLE</i> - Identifies a cell that is a title of a\n               section within a table. A section title is a cell that typically spans an entire row\n               above a section. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_FOOTER</i> - Identifies a cell that is a footer of a table. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_SUMMARY</i> - Identifies a summary cell of a table. A\n               summary cell can be a row of a table or an additional, smaller table that contains\n               summary information for another table. </p>\n            </li>\n            <li>\n               <p>\n                  <i>STRUCTURED_TABLE </i> - Identifies a table with column headers\n               where the content of each row corresponds to the headers. </p>\n            </li>\n            <li>\n               <p>\n                  <i>SEMI_STRUCTURED_TABLE</i> - Identifies a non-structured table. </p>\n            </li>\n         </ul>\n         <p>\n            <code>EntityTypes</code> isn't returned by <code>DetectDocumentText</code> and\n            <code>GetDocumentTextDetection</code>.</p>"
+          }
+        },
+        "SelectionStatus": {
+          "target": "com.amazonaws.textract#SelectionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The selection status of a selection element, such as an option button or check box.\n      </p>"
+          }
+        },
+        "Page": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The page on which a block was detected. <code>Page</code> is returned by synchronous and\n         asynchronous operations. Page values greater than 1 are only returned for multipage\n         documents that are in PDF or TIFF format. A scanned image (JPEG/PNG) provided to an\n         asynchronous operation, even if it contains multiple document pages, is considered a\n         single-page document. This means that for scanned images the value of <code>Page</code> is\n         always 1. </p>"
+          }
+        },
+        "Query": {
+          "target": "com.amazonaws.textract#Query",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>Block</code> represents items that are recognized in a document within a group\n         of pixels close to each other. The information returned in a <code>Block</code> object\n         depends on the type of operation. In text detection for documents (for example <a>DetectDocumentText</a>), you get information about the detected words and lines\n         of text. In text analysis (for example <a>AnalyzeDocument</a>), you can also get\n         information about the fields, tables, and selection elements that are detected in the\n         document.</p>\n         <p>An array of <code>Block</code> objects is returned by both synchronous and asynchronous\n         operations. In synchronous operations, such as <a>DetectDocumentText</a>, the\n         array of <code>Block</code> objects is the entire set of results. In asynchronous\n         operations, such as <a>GetDocumentAnalysis</a>, the array is returned over one\n         or more responses.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works.html\">How Amazon Textract Works</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#BlockList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Block"
+      }
+    },
+    "com.amazonaws.textract#BlockType": {
+      "type": "enum",
+      "members": {
+        "KEY_VALUE_SET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KEY_VALUE_SET"
+          }
+        },
+        "PAGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PAGE"
+          }
+        },
+        "LINE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LINE"
+          }
+        },
+        "WORD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WORD"
+          }
+        },
+        "TABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE"
+          }
+        },
+        "CELL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CELL"
+          }
+        },
+        "SELECTION_ELEMENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SELECTION_ELEMENT"
+          }
+        },
+        "MERGED_CELL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MERGED_CELL"
+          }
+        },
+        "TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TITLE"
+          }
+        },
+        "QUERY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUERY"
+          }
+        },
+        "QUERY_RESULT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUERY_RESULT"
+          }
+        },
+        "SIGNATURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SIGNATURE"
+          }
+        },
+        "TABLE_TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_TITLE"
+          }
+        },
+        "TABLE_FOOTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_FOOTER"
+          }
+        },
+        "LAYOUT_TEXT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_TEXT"
+          }
+        },
+        "LAYOUT_TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_TITLE"
+          }
+        },
+        "LAYOUT_HEADER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_HEADER"
+          }
+        },
+        "LAYOUT_FOOTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_FOOTER"
+          }
+        },
+        "LAYOUT_SECTION_HEADER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_SECTION_HEADER"
+          }
+        },
+        "LAYOUT_PAGE_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_PAGE_NUMBER"
+          }
+        },
+        "LAYOUT_LIST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_LIST"
+          }
+        },
+        "LAYOUT_FIGURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_FIGURE"
+          }
+        },
+        "LAYOUT_TABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_TABLE"
+          }
+        },
+        "LAYOUT_KEY_VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT_KEY_VALUE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#BoundingBox": {
+      "type": "structure",
+      "members": {
+        "Width": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The width of the bounding box as a ratio of the overall document page\n         width.</p>"
+          }
+        },
+        "Height": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The height of the bounding box as a ratio of the overall document page\n         height.</p>"
+          }
+        },
+        "Left": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The left coordinate of the bounding box as a ratio of overall document page\n         width.</p>"
+          }
+        },
+        "Top": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The top coordinate of the bounding box as a ratio of overall document page\n         height.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The bounding box around the detected page, text, key-value pair, table, table cell, or\n         selection element on a document page. The <code>left</code> (x-coordinate) and\n            <code>top</code> (y-coordinate) are coordinates that represent the top and left sides of\n         the bounding box. Note that the upper-left corner of the image is the origin (0,0). </p>\n         <p>The <code>top</code> and <code>left</code> values returned are ratios of the overall\n         document page size. For example, if the input image is 700 x 200 pixels, and the top-left\n         coordinate of the bounding box is 350 x 50 pixels, the API returns a <code>left</code>\n         value of 0.5 (350/700) and a <code>top</code> value of 0.25 (50/200).</p>\n         <p>The <code>width</code> and <code>height</code> values represent the dimensions of the\n         bounding box as a ratio of the overall document page dimension. For example, if the\n         document page size is 700 x 200 pixels, and the bounding box width is 70 pixels, the width\n         returned is 0.1. </p>"
+      }
+    },
+    "com.amazonaws.textract#ClientRequestToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-_]+$"
+      }
+    },
+    "com.amazonaws.textract#ConflictException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Updating or deleting a resource can cause an inconsistent state.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#ContentClassifier": {
+      "type": "enum",
+      "members": {
+        "FREE_OF_PERSONALLY_IDENTIFIABLE_INFORMATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FreeOfPersonallyIdentifiableInformation"
+          }
+        },
+        "FREE_OF_ADULT_CONTENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FreeOfAdultContent"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#ContentClassifiers": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#ContentClassifier"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.textract#CreateAdapter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#CreateAdapterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#CreateAdapterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.textract#IdempotentParameterMismatchException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates an adapter, which can be fine-tuned for enhanced performance on user provided\n         documents. Takes an AdapterName and FeatureType. Currently the only supported feature type\n         is <code>QUERIES</code>. You can also provide a Description, Tags, and a\n         ClientRequestToken. You can choose whether or not the adapter should be AutoUpdated with\n         the AutoUpdate argument. By default, AutoUpdate is set to DISABLED.</p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.textract#CreateAdapterRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterName": {
+          "target": "com.amazonaws.textract#AdapterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name to be assigned to the adapter being created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.textract#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Idempotent token is used to recognize the request. If the same token is used with multiple \n         CreateAdapter requests, the same session is returned. \n         This token is employed to avoid unintentionally creating the same session multiple times.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.textract#AdapterDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The description to be assigned to the adapter being created.</p>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of feature that the adapter is being trained on. Currrenly, supported feature\n         types are: <code>QUERIES</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AutoUpdate": {
+          "target": "com.amazonaws.textract#AutoUpdate",
+          "traits": {
+            "smithy.api#documentation": "<p>Controls whether or not the adapter should automatically update.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.textract#TagMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags to be added to the adapter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#CreateAdapterResponse": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing the unique ID for the adapter that has been created.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#CreateAdapterVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#CreateAdapterVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#CreateAdapterVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.textract#IdempotentParameterMismatchException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates  a new version of an adapter. Operates on a provided AdapterId and a specified \n         dataset provided via the DatasetConfig argument. Requires that you \n         specify an Amazon S3 bucket with the OutputConfig argument. You can provide an optional KMSKeyId, \n         an optional ClientRequestToken, and optional tags.</p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.textract#CreateAdapterVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter that will receive a new version.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.textract#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Idempotent token is used to recognize the request. If the same token is used with multiple \n         CreateAdapterVersion requests, the same session is returned. \n         This token is employed to avoid unintentionally creating the same session multiple times.</p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "DatasetConfig": {
+          "target": "com.amazonaws.textract#AdapterVersionDatasetConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a dataset used to train a new adapter version. Takes a ManifestS3Object as the\n         value.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KMSKeyId": {
+          "target": "com.amazonaws.textract#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for your AWS Key Management Service key (AWS KMS key). Used to encrypt your documents.</p>"
+          }
+        },
+        "OutputConfig": {
+          "target": "com.amazonaws.textract#OutputConfig",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.textract#TagMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of tags (key-value pairs) that you want to attach to the adapter version. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#CreateAdapterVersionResponse": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing the unique ID for the adapter that has received a new version.</p>"
+          }
+        },
+        "AdapterVersion": {
+          "target": "com.amazonaws.textract#AdapterVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>A string describing the new version of the adapter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#DateTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.textract#DeleteAdapter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#DeleteAdapterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#DeleteAdapterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Amazon Textract adapter. Takes an AdapterId and deletes the adapter specified by the ID.</p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.textract#DeleteAdapterRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter to be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#DeleteAdapterResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#DeleteAdapterVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#DeleteAdapterVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#DeleteAdapterVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes an Amazon Textract adapter version. Requires that you specify both an AdapterId and a \n         AdapterVersion. Deletes the adapter version specified by the AdapterId and the AdapterVersion.</p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.textract#DeleteAdapterVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter version that will be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AdapterVersion": {
+          "target": "com.amazonaws.textract#AdapterVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the adapter version to be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#DeleteAdapterVersionResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#DetectDocumentText": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#DetectDocumentTextRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#DetectDocumentTextResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Detects text in the input document. Amazon Textract can detect lines of text and the\n         words that make up a line of text. The input document must be in one of the following image\n         formats:  JPEG, PNG, PDF, or TIFF. <code>DetectDocumentText</code> returns the detected\n         text in an array of <a>Block</a> objects. </p>\n         <p>Each document page has as an associated <code>Block</code> of type PAGE. Each PAGE <code>Block</code> object\n         is the parent of LINE <code>Block</code> objects that represent the lines of detected text on a page. A LINE <code>Block</code> object is\n         a parent for each word that makes up the line. Words are represented by <code>Block</code> objects of type WORD.</p>\n         <p>\n            <code>DetectDocumentText</code> is a synchronous operation. To analyze documents \n         asynchronously, use <a>StartDocumentTextDetection</a>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works-detecting.html\">Document Text Detection</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#DetectDocumentTextRequest": {
+      "type": "structure",
+      "members": {
+        "Document": {
+          "target": "com.amazonaws.textract#Document",
+          "traits": {
+            "smithy.api#documentation": "<p>The input document as base64-encoded bytes or an Amazon S3 object. If you use the AWS CLI\n         to call Amazon Textract operations, you can't pass image bytes. The document must be an image \n      in JPEG or PNG format.</p>\n         <p>If you're using an AWS SDK to call Amazon Textract, you might not need to base64-encode\n         image bytes that are passed using the <code>Bytes</code> field. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#DetectDocumentTextResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Metadata about the document. It contains the number of pages that are detected in the\n         document.</p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.textract#BlockList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of <code>Block</code> objects that contain the text that's detected in the\n         document.</p>"
+          }
+        },
+        "DetectDocumentTextModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#DetectedSignature": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The page a detected signature was found on.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that holds information regarding a detected signature on a page.</p>"
+      }
+    },
+    "com.amazonaws.textract#DetectedSignatureList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#DetectedSignature"
+      }
+    },
+    "com.amazonaws.textract#Document": {
+      "type": "structure",
+      "members": {
+        "Bytes": {
+          "target": "com.amazonaws.textract#ImageBlob",
+          "traits": {
+            "smithy.api#documentation": "<p>A blob of base64-encoded document bytes. The maximum size of a document that's provided\n         in a blob of bytes is 5 MB. The document bytes must be in PNG or JPEG format.</p>\n         <p>If you're using an AWS SDK to call Amazon Textract, you might not need to base64-encode\n         image bytes passed using the <code>Bytes</code> field. </p>"
+          }
+        },
+        "S3Object": {
+          "target": "com.amazonaws.textract#S3Object",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies an S3 object as the document source. The maximum size of a document that's\n         stored in an S3 bucket is 5 MB.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input document, either as bytes or as an S3 object.</p>\n         <p>You pass image bytes to an Amazon Textract API operation by using the <code>Bytes</code>\n         property. For example, you would use the <code>Bytes</code> property to pass a document\n         loaded from a local file system. Image bytes passed by using the <code>Bytes</code>\n         property must be base64 encoded. Your code might not need to encode document file bytes if\n         you're using an AWS SDK to call Amazon Textract API operations. </p>\n         <p>You pass images stored in an S3 bucket to an Amazon Textract API operation by using the\n            <code>S3Object</code> property. Documents stored in an S3 bucket don't need to be base64\n         encoded.</p>\n         <p>The AWS Region for the S3 bucket that contains the S3 object must match the AWS\n         Region that you use for Amazon Textract operations.</p>\n         <p>If you use the AWS CLI to call Amazon Textract operations, passing image bytes using\n         the Bytes property isn't supported. You must first upload the document to an Amazon S3\n         bucket, and then call the operation using the S3Object property.</p>\n         <p>For Amazon Textract to process an S3 object, the user must have permission\n         to access the S3 object. </p>"
+      }
+    },
+    "com.amazonaws.textract#DocumentGroup": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.textract#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of document that Amazon Textract has detected. See <a href=\"https://docs.aws.amazon.com/textract/latest/dg/lending-response-objects.html\">Analyze Lending Response Objects</a> for a list of all types returned by Textract.</p>"
+          }
+        },
+        "SplitDocuments": {
+          "target": "com.amazonaws.textract#SplitDocumentList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array that contains information about the pages of a document, defined by logical boundary.</p>"
+          }
+        },
+        "DetectedSignatures": {
+          "target": "com.amazonaws.textract#DetectedSignatureList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the detected signatures found in a document group.</p>"
+          }
+        },
+        "UndetectedSignatures": {
+          "target": "com.amazonaws.textract#UndetectedSignatureList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of any expected signatures not found in a document group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Summary information about documents grouped by the same document type.</p>"
+      }
+    },
+    "com.amazonaws.textract#DocumentGroupList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#DocumentGroup"
+      }
+    },
+    "com.amazonaws.textract#DocumentLocation": {
+      "type": "structure",
+      "members": {
+        "S3Object": {
+          "target": "com.amazonaws.textract#S3Object",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 bucket that contains the input document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon S3 bucket that contains the document to be processed. It's used by asynchronous\n         operations.</p>\n         <p>The input document can be an image file in JPEG or PNG format. It can also be a file in\n         PDF format.</p>"
+      }
+    },
+    "com.amazonaws.textract#DocumentMetadata": {
+      "type": "structure",
+      "members": {
+        "Pages": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of pages that are detected in the document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the input document.</p>"
+      }
+    },
+    "com.amazonaws.textract#DocumentPages": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Document"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.textract#DocumentTooLargeException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The document can't be processed because it's too large. The maximum document size for\n         synchronous operations 10 MB. The maximum document size for asynchronous operations is 500\n         MB for PDF files.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#EntityType": {
+      "type": "enum",
+      "members": {
+        "KEY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KEY"
+          }
+        },
+        "VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE"
+          }
+        },
+        "COLUMN_HEADER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COLUMN_HEADER"
+          }
+        },
+        "TABLE_TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_TITLE"
+          }
+        },
+        "TABLE_FOOTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_FOOTER"
+          }
+        },
+        "TABLE_SECTION_TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_SECTION_TITLE"
+          }
+        },
+        "TABLE_SUMMARY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_SUMMARY"
+          }
+        },
+        "STRUCTURED_TABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STRUCTURED_TABLE"
+          }
+        },
+        "SEMI_STRUCTURED_TABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SEMI_STRUCTURED_TABLE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#EntityTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#EntityType"
+      }
+    },
+    "com.amazonaws.textract#ErrorCode": {
+      "type": "string"
+    },
+    "com.amazonaws.textract#EvaluationMetric": {
+      "type": "structure",
+      "members": {
+        "F1Score": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The F1 score for an adapter version.</p>"
+          }
+        },
+        "Precision": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The Precision score for an adapter version.</p>"
+          }
+        },
+        "Recall": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The Recall score for an adapter version.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The evaluation metrics (F1 score, Precision, and Recall) for an adapter version.</p>"
+      }
+    },
+    "com.amazonaws.textract#ExpenseCurrency": {
+      "type": "structure",
+      "members": {
+        "Code": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Currency code for detected currency. the current supported codes are:</p>\n         <ul>\n            <li>\n               <p>USD</p>\n            </li>\n            <li>\n               <p>EUR</p>\n            </li>\n            <li>\n               <p>GBP</p>\n            </li>\n            <li>\n               <p>CAD</p>\n            </li>\n            <li>\n               <p>INR</p>\n            </li>\n            <li>\n               <p>JPY</p>\n            </li>\n            <li>\n               <p>CHF</p>\n            </li>\n            <li>\n               <p>AUD</p>\n            </li>\n            <li>\n               <p>CNY</p>\n            </li>\n            <li>\n               <p>BZR</p>\n            </li>\n            <li>\n               <p>SEK</p>\n            </li>\n            <li>\n               <p>HKD</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>Percentage confideence in the detected currency.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returns the kind of currency detected.</p>"
+      }
+    },
+    "com.amazonaws.textract#ExpenseDetection": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The word or line of text recognized by Amazon Textract</p>"
+          }
+        },
+        "Geometry": {
+          "target": "com.amazonaws.textract#Geometry"
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence in detection, as a percentage</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object used to store information about the Value or Label detected by Amazon Textract.</p>"
+      }
+    },
+    "com.amazonaws.textract#ExpenseDocument": {
+      "type": "structure",
+      "members": {
+        "ExpenseIndex": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>Denotes which invoice or receipt in the document the information is coming from. \n      First document will be 1, the second 2, and so on.</p>"
+          }
+        },
+        "SummaryFields": {
+          "target": "com.amazonaws.textract#ExpenseFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>Any information found outside of a table by Amazon Textract.</p>"
+          }
+        },
+        "LineItemGroups": {
+          "target": "com.amazonaws.textract#LineItemGroupList",
+          "traits": {
+            "smithy.api#documentation": "<p>Information detected on each table of a document, seperated into <code>LineItems</code>.</p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.textract#BlockList",
+          "traits": {
+            "smithy.api#documentation": "<p>This is a block object, the same as reported when DetectDocumentText is run on a document.\n      It provides word level recognition of text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The structure holding all the information returned by AnalyzeExpense</p>"
+      }
+    },
+    "com.amazonaws.textract#ExpenseDocumentList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#ExpenseDocument"
+      }
+    },
+    "com.amazonaws.textract#ExpenseField": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.textract#ExpenseType",
+          "traits": {
+            "smithy.api#documentation": "<p>The implied label of a detected element. Present alongside LabelDetection for explicit elements.</p>"
+          }
+        },
+        "LabelDetection": {
+          "target": "com.amazonaws.textract#ExpenseDetection",
+          "traits": {
+            "smithy.api#documentation": "<p>The explicitly stated label of a detected element.</p>"
+          }
+        },
+        "ValueDetection": {
+          "target": "com.amazonaws.textract#ExpenseDetection",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of a detected element. Present in explicit and implicit elements.</p>"
+          }
+        },
+        "PageNumber": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The page number the value was detected on.</p>"
+          }
+        },
+        "Currency": {
+          "target": "com.amazonaws.textract#ExpenseCurrency",
+          "traits": {
+            "smithy.api#documentation": "<p>Shows the kind of currency, both the code and confidence associated with any monatary value\n         detected.</p>"
+          }
+        },
+        "GroupProperties": {
+          "target": "com.amazonaws.textract#ExpenseGroupPropertyList",
+          "traits": {
+            "smithy.api#documentation": "<p>Shows which group a response object belongs to, such as whether an address line\n         belongs to the vendor's address or the recipent's address.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Breakdown of detected information, seperated into \n         the catagories Type, LabelDetection, and ValueDetection</p>"
+      }
+    },
+    "com.amazonaws.textract#ExpenseFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#ExpenseField"
+      }
+    },
+    "com.amazonaws.textract#ExpenseGroupProperty": {
+      "type": "structure",
+      "members": {
+        "Types": {
+          "target": "com.amazonaws.textract#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Informs you on whether the expense group is a name or an address.</p>"
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a group Id number, which will be the same for each in the group.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Shows the group that a certain key belongs to. This helps differentiate between\n         names and addresses for different organizations, that can be hard to determine\n         via JSON response.</p>"
+      }
+    },
+    "com.amazonaws.textract#ExpenseGroupPropertyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#ExpenseGroupProperty"
+      }
+    },
+    "com.amazonaws.textract#ExpenseType": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The word or line of text detected by Amazon Textract.</p>"
+          }
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence of accuracy, as a percentage.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An object used to store information about the Type detected by Amazon Textract.</p>"
+      }
+    },
+    "com.amazonaws.textract#Extraction": {
+      "type": "structure",
+      "members": {
+        "LendingDocument": {
+          "target": "com.amazonaws.textract#LendingDocument",
+          "traits": {
+            "smithy.api#documentation": "<p>Holds the structured data returned by AnalyzeDocument for lending documents.</p>"
+          }
+        },
+        "ExpenseDocument": {
+          "target": "com.amazonaws.textract#ExpenseDocument"
+        },
+        "IdentityDocument": {
+          "target": "com.amazonaws.textract#IdentityDocument"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information extracted by an analysis operation after using StartLendingAnalysis.</p>"
+      }
+    },
+    "com.amazonaws.textract#ExtractionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Extraction"
+      }
+    },
+    "com.amazonaws.textract#FeatureType": {
+      "type": "enum",
+      "members": {
+        "TABLES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLES"
+          }
+        },
+        "FORMS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FORMS"
+          }
+        },
+        "QUERIES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUERIES"
+          }
+        },
+        "SIGNATURES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SIGNATURES"
+          }
+        },
+        "LAYOUT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LAYOUT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#FeatureTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#FeatureType"
+      }
+    },
+    "com.amazonaws.textract#Float": {
+      "type": "float",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.textract#FlowDefinitionArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.textract#Geometry": {
+      "type": "structure",
+      "members": {
+        "BoundingBox": {
+          "target": "com.amazonaws.textract#BoundingBox",
+          "traits": {
+            "smithy.api#documentation": "<p>An axis-aligned coarse representation of the location of the recognized item on the\n         document page.</p>"
+          }
+        },
+        "Polygon": {
+          "target": "com.amazonaws.textract#Polygon",
+          "traits": {
+            "smithy.api#documentation": "<p>Within the bounding box, a fine-grained polygon around the recognized item.</p>"
+          }
+        },
+        "RotationAngle": {
+          "target": "com.amazonaws.textract#Angle",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a numerical value corresponding to the rotation of the text.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about where the following items are located on a document page: detected\n         page, text, key-value pairs, tables, table cells, and selection elements.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetAdapter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetAdapterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetAdapterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets configuration information for an adapter specified by an AdapterId, returning information on AdapterName, Description,\n         CreationTime, AutoUpdate status, and FeatureTypes.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetAdapterRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetAdapterResponse": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string identifying the adapter that information has been retrieved for.</p>"
+          }
+        },
+        "AdapterName": {
+          "target": "com.amazonaws.textract#AdapterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the requested adapter.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the requested adapter was created at.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.textract#AdapterDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The description for the requested adapter.</p>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>List of the targeted feature types for the requested adapter.</p>"
+          }
+        },
+        "AutoUpdate": {
+          "target": "com.amazonaws.textract#AutoUpdate",
+          "traits": {
+            "smithy.api#documentation": "<p>Binary value indicating if the adapter is being automatically updated or not.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.textract#TagMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of tags (key-value pairs) associated with the adapter that has been retrieved.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#GetAdapterVersion": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetAdapterVersionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetAdapterVersionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets configuration information for the specified adapter version, including: \n         AdapterId, AdapterVersion, FeatureTypes, Status, StatusMessage, DatasetConfig, \n         KMSKeyId, OutputConfig, Tags and EvaluationMetrics.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetAdapterVersionRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string specifying a unique ID for the adapter version you want to retrieve information for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AdapterVersion": {
+          "target": "com.amazonaws.textract#AdapterVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>A string specifying the adapter version you want to retrieve information for.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetAdapterVersionResponse": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter version being retrieved.</p>"
+          }
+        },
+        "AdapterVersion": {
+          "target": "com.amazonaws.textract#AdapterVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing the adapter version that has been retrieved.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the adapter version was created.</p>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>List of the targeted feature types for the requested adapter version.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.textract#AdapterVersionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the adapter version that has been requested.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#AdapterVersionStatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>A message that describes the status of the requested adapter version.</p>"
+          }
+        },
+        "DatasetConfig": {
+          "target": "com.amazonaws.textract#AdapterVersionDatasetConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies a dataset used to train a new adapter version. Takes a ManifestS3Objec as the\n         value.</p>"
+          }
+        },
+        "KMSKeyId": {
+          "target": "com.amazonaws.textract#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for your AWS Key Management Service key (AWS KMS key). Used to encrypt your documents.</p>"
+          }
+        },
+        "OutputConfig": {
+          "target": "com.amazonaws.textract#OutputConfig"
+        },
+        "EvaluationMetrics": {
+          "target": "com.amazonaws.textract#AdapterVersionEvaluationMetrics",
+          "traits": {
+            "smithy.api#documentation": "<p>The evaluation metrics (F1 score, Precision, and Recall) for the requested version, \n         grouped by baseline metrics and adapter version.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.textract#TagMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of tags (key-value pairs) that are associated with the adapter version.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#GetDocumentAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetDocumentAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetDocumentAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidJobIdException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the results for an Amazon Textract asynchronous operation that analyzes text in a\n         document.</p>\n         <p>You start asynchronous text analysis by calling <a>StartDocumentAnalysis</a>,\n         which returns a job identifier (<code>JobId</code>). When the text analysis operation\n         finishes, Amazon Textract publishes a completion status to the Amazon Simple Notification Service (Amazon SNS) topic\n         that's registered in the initial call to <code>StartDocumentAnalysis</code>. To get the\n         results of the text-detection operation, first check that the status value published to the\n         Amazon SNS topic is <code>SUCCEEDED</code>. If so, call <code>GetDocumentAnalysis</code>, and\n         pass the job identifier (<code>JobId</code>) from the initial call to\n            <code>StartDocumentAnalysis</code>.</p>\n         <p>\n            <code>GetDocumentAnalysis</code> returns an array of <a>Block</a> objects.\n         The following types of information are returned: </p>\n         <ul>\n            <li>\n               <p>Form data (key-value pairs). The related information is returned in two <a>Block</a> objects, each of type <code>KEY_VALUE_SET</code>: a KEY\n                  <code>Block</code> object and a VALUE <code>Block</code> object. For example,\n                  <i>Name: Ana Silva Carolina</i> contains a key and value.\n                  <i>Name:</i> is the key. <i>Ana Silva Carolina</i> is\n               the value.</p>\n            </li>\n            <li>\n               <p>Table and table cell data. A TABLE <code>Block</code> object contains information\n               about a detected table. A CELL <code>Block</code> object is returned for each cell in\n               a table.</p>\n            </li>\n            <li>\n               <p>Lines and words of text. A LINE <code>Block</code> object contains one or more\n               WORD <code>Block</code> objects. All lines and words that are detected in the\n               document are returned (including text that doesn't have a relationship with the value\n               of the <code>StartDocumentAnalysis</code>\n                  <code>FeatureTypes</code> input parameter). </p>\n            </li>\n            <li>\n               <p>Query. A QUERY Block object contains the query text, alias and link to the\n               associated Query results block object.</p>\n            </li>\n            <li>\n               <p>Query Results. A QUERY_RESULT Block object contains the answer to the query and an\n               ID that connects it to the query asked. This Block also contains a confidence\n               score.</p>\n            </li>\n         </ul>\n         <note>\n            <p>While processing a document with queries, look out for\n               <code>INVALID_REQUEST_PARAMETERS</code> output. This indicates that either the per\n            page query limit has been exceeded or that the operation is trying to query a page in\n            the document which doesn\u2019t exist. </p>\n         </note>\n         <p>Selection elements such as check boxes and option buttons (radio buttons) can be\n         detected in form data and in tables. A SELECTION_ELEMENT <code>Block</code> object contains\n         information about a selection element, including the selection status.</p>\n         <p>Use the <code>MaxResults</code> parameter to limit the number of blocks that are\n         returned. If there are more results than specified in <code>MaxResults</code>, the value of\n            <code>NextToken</code> in the operation response contains a pagination token for getting\n         the next set of results. To get the next page of results, call\n            <code>GetDocumentAnalysis</code>, and populate the <code>NextToken</code> request\n         parameter with the token value that's returned from the previous call to\n            <code>GetDocumentAnalysis</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works-analyzing.html\">Document Text\n         Analysis</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetDocumentAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the text-detection job. The <code>JobId</code> is returned from\n            <code>StartDocumentAnalysis</code>. A <code>JobId</code> value is only valid for 7\n         days.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.textract#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return per paginated call. The largest value that you\n         can specify is 1,000. If you specify a value greater than 1,000, a maximum of 1,000 results\n         is returned. The default value is 1,000.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the previous response was incomplete (because there are more blocks to retrieve),\n         Amazon Textract returns a pagination token in the response. You can use this pagination\n         token to retrieve the next set of blocks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetDocumentAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about a document that Amazon Textract processed.\n            <code>DocumentMetadata</code> is returned in every page of paginated responses from an\n         Amazon Textract video operation.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.textract#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the text detection job.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the response is truncated, Amazon Textract returns this token. You can use this token\n         in the subsequent request to retrieve the next set of text detection results.</p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.textract#BlockList",
+          "traits": {
+            "smithy.api#documentation": "<p>The results of the text-analysis operation.</p>"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.textract#Warnings",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of warnings that occurred during the document-analysis operation.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns if the detection job could not be completed. Contains explanation for what error\n         occured.</p>"
+          }
+        },
+        "AnalyzeDocumentModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#GetDocumentTextDetection": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetDocumentTextDetectionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetDocumentTextDetectionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidJobIdException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the results for an Amazon Textract asynchronous operation that detects text in a document. \n     Amazon Textract can detect lines of text and the words that make up a line of text.</p>\n         <p>You start asynchronous text detection by calling <a>StartDocumentTextDetection</a>, which returns a job identifier\n            (<code>JobId</code>). When the text detection operation finishes, Amazon Textract publishes a\n         completion status to the Amazon Simple Notification Service (Amazon SNS) topic that's registered in the initial call to\n            <code>StartDocumentTextDetection</code>. To get the results of the text-detection\n         operation, first check that the status value published to the Amazon SNS topic is\n            <code>SUCCEEDED</code>. If so, call <code>GetDocumentTextDetection</code>, and pass the\n         job identifier (<code>JobId</code>) from the initial call to\n            <code>StartDocumentTextDetection</code>.</p>\n         <p>\n            <code>GetDocumentTextDetection</code> returns an array of <a>Block</a>\n         objects. </p>\n         <p>Each document page has as an associated <code>Block</code> of type PAGE. Each PAGE <code>Block</code> object\n        is the parent of LINE <code>Block</code> objects that represent the lines of detected text on a page. A LINE <code>Block</code> object is\n        a parent for each word that makes up the line. Words are represented by <code>Block</code> objects of type WORD.</p>\n         <p>Use the MaxResults parameter to limit the number of blocks that are returned. If there\n         are more results than specified in <code>MaxResults</code>, the value of\n            <code>NextToken</code> in the operation response contains a pagination token for getting\n         the next set of results. To get the next page of results, call\n            <code>GetDocumentTextDetection</code>, and populate the <code>NextToken</code> request\n         parameter with the token value that's returned from the previous call to\n            <code>GetDocumentTextDetection</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works-detecting.html\">Document Text Detection</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetDocumentTextDetectionRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the text detection job. The <code>JobId</code> is returned from\n         <code>StartDocumentTextDetection</code>. A <code>JobId</code> value is only valid for 7 days.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.textract#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return per paginated call. The largest value you can\n         specify is 1,000. If you specify a value greater than 1,000, a maximum of 1,000 results is\n         returned. The default value is 1,000.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the previous response was incomplete (because there are more blocks to retrieve), Amazon Textract returns a pagination\n         token in the response. You can use this pagination token to retrieve the next set of blocks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetDocumentTextDetectionResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about a document that Amazon Textract processed. <code>DocumentMetadata</code> is\n         returned in every page of paginated responses from an Amazon Textract video operation.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.textract#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the text detection job.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the response is truncated, Amazon Textract returns this token. You can use this token in\n         the subsequent request to retrieve the next set of text-detection results.</p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.textract#BlockList",
+          "traits": {
+            "smithy.api#documentation": "<p>The results of the text-detection operation.</p>"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.textract#Warnings",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of warnings that occurred during the text-detection operation for the\n         document.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns if the detection job could not be completed. Contains explanation for what error occured. </p>"
+          }
+        },
+        "DetectDocumentTextModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#GetExpenseAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetExpenseAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetExpenseAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidJobIdException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the results for an Amazon Textract asynchronous operation that analyzes invoices and\n   receipts. Amazon Textract finds contact information, items purchased, and vendor name, from input\n   invoices and receipts.</p>\n         <p>You start asynchronous invoice/receipt analysis by calling <a>StartExpenseAnalysis</a>, which returns a job identifier (<code>JobId</code>). Upon\n   completion of the invoice/receipt analysis, Amazon Textract publishes the completion status to the\n   Amazon Simple Notification Service (Amazon SNS) topic. This topic must be registered in the initial call to\n    <code>StartExpenseAnalysis</code>. To get the results of the invoice/receipt analysis operation,\n   first ensure that the status value published to the Amazon SNS topic is <code>SUCCEEDED</code>. If so,\n   call <code>GetExpenseAnalysis</code>, and pass the job identifier (<code>JobId</code>) from the\n   initial call to <code>StartExpenseAnalysis</code>.</p>\n         <p>Use the MaxResults parameter to limit the number of blocks that are returned. If there are\n   more results than specified in <code>MaxResults</code>, the value of <code>NextToken</code> in\n   the operation response contains a pagination token for getting the next set of results. To get\n   the next page of results, call <code>GetExpenseAnalysis</code>, and populate the\n    <code>NextToken</code> request parameter with the token value that's returned from the previous\n   call to <code>GetExpenseAnalysis</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/invoices-receipts.html\">Analyzing Invoices and Receipts</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetExpenseAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the text detection job. The <code>JobId</code> is returned from\n    <code>StartExpenseAnalysis</code>. A <code>JobId</code> value is only valid for 7 days.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.textract#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return per paginated call. The largest value you can\n   specify is 20. If you specify a value greater than 20, a maximum of 20 results is\n   returned. The default value is 20.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the previous response was incomplete (because there are more blocks to retrieve), Amazon Textract returns a pagination\n   token in the response. You can use this pagination token to retrieve the next set of blocks.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetExpenseAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about a document that Amazon Textract processed. <code>DocumentMetadata</code> is\n   returned in every page of paginated responses from an Amazon Textract operation.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.textract#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current status of the text detection job.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the response is truncated, Amazon Textract returns this token. You can use this token in\n   the subsequent request to retrieve the next set of text-detection results.</p>"
+          }
+        },
+        "ExpenseDocuments": {
+          "target": "com.amazonaws.textract#ExpenseDocumentList",
+          "traits": {
+            "smithy.api#documentation": "<p>The expenses detected by Amazon Textract.</p>"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.textract#Warnings",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of warnings that occurred during the text-detection operation for the\n   document.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns if the detection job could not be completed. Contains explanation for what error occured. </p>"
+          }
+        },
+        "AnalyzeExpenseModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The current model version of AnalyzeExpense.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#GetLendingAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetLendingAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetLendingAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidJobIdException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the results for an Amazon Textract asynchronous operation that analyzes text in a\n            lending document. </p>\n         <p>You start asynchronous text analysis by calling <code>StartLendingAnalysis</code>,\n            which returns a job identifier (<code>JobId</code>). When the text analysis operation\n            finishes, Amazon Textract publishes a completion status to the Amazon Simple\n            Notification Service (Amazon SNS) topic that's registered in the initial call to\n                <code>StartLendingAnalysis</code>. </p>\n         <p>To get the results of the text analysis operation, first check that the status value\n            published to the Amazon SNS topic is SUCCEEDED. If so, call GetLendingAnalysis, and pass\n            the job identifier (<code>JobId</code>) from the initial call to\n                <code>StartLendingAnalysis</code>.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetLendingAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the lending or text-detection job. The <code>JobId</code> is\n            returned from <code>StartLendingAnalysis</code>. A <code>JobId</code> value is only\n            valid for 7 days.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.textract#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return per paginated call. The largest value that you\n            can specify is 30. If you specify a value greater than 30, a maximum of 30 results is\n            returned. The default value is 30.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the previous response was incomplete, Amazon Textract returns a pagination token in\n            the response. You can use this pagination token to retrieve the next set of lending\n            results.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetLendingAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata"
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.textract#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p> The current status of the lending analysis job.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the response is truncated, Amazon Textract returns this token. \n            You can use this token in the subsequent request to retrieve the next set of lending results.</p>"
+          }
+        },
+        "Results": {
+          "target": "com.amazonaws.textract#LendingResultList",
+          "traits": {
+            "smithy.api#documentation": "<p> Holds the information returned by one of AmazonTextract's document analysis\n            operations for the pinstripe.</p>"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.textract#Warnings",
+          "traits": {
+            "smithy.api#documentation": "<p> A list of warnings that occurred during the lending analysis operation. </p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>  Returns if the lending analysis job could not be completed. Contains explanation for\n            what error occurred. </p>"
+          }
+        },
+        "AnalyzeLendingModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p> The current model version of the Analyze Lending API.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#GetLendingAnalysisSummary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#GetLendingAnalysisSummaryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#GetLendingAnalysisSummaryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidJobIdException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets summarized results for the <code>StartLendingAnalysis</code> operation, which analyzes\n   text in a lending document. The returned summary consists of information about documents grouped\n   together by a common document type. Information like detected signatures, page numbers, and split\n   documents is returned with respect to the type of grouped document. </p>\n         <p>You start asynchronous text analysis by calling <code>StartLendingAnalysis</code>, which\n   returns a job identifier (<code>JobId</code>). When the text analysis operation finishes, Amazon\n   Textract publishes a completion status to the Amazon Simple Notification Service (Amazon SNS)\n   topic that's registered in the initial call to <code>StartLendingAnalysis</code>. </p>\n         <p>To get the results of the text analysis operation, first check that the status value\n   published to the Amazon SNS topic is SUCCEEDED. If so, call\n    <code>GetLendingAnalysisSummary</code>, and pass the job identifier (<code>JobId</code>) from\n   the initial call to <code>StartLendingAnalysis</code>.</p>"
+      }
+    },
+    "com.amazonaws.textract#GetLendingAnalysisSummaryRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p> A unique identifier for the lending or text-detection job. The <code>JobId</code> is\n   returned from StartLendingAnalysis. A <code>JobId</code> value is only valid for 7 days.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#GetLendingAnalysisSummaryResponse": {
+      "type": "structure",
+      "members": {
+        "DocumentMetadata": {
+          "target": "com.amazonaws.textract#DocumentMetadata"
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.textract#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p> The current status of the lending analysis job. </p>"
+          }
+        },
+        "Summary": {
+          "target": "com.amazonaws.textract#LendingSummary",
+          "traits": {
+            "smithy.api#documentation": "<p> Contains summary information for documents grouped by type.</p>"
+          }
+        },
+        "Warnings": {
+          "target": "com.amazonaws.textract#Warnings",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of warnings that occurred during the lending analysis operation.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.textract#StatusMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns if the lending analysis could not be completed. Contains explanation for what error\n   occurred.</p>"
+          }
+        },
+        "AnalyzeLendingModelVersion": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The current model version of the Analyze Lending API.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#HumanLoopActivationOutput": {
+      "type": "structure",
+      "members": {
+        "HumanLoopArn": {
+          "target": "com.amazonaws.textract#HumanLoopArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the HumanLoop created.</p>"
+          }
+        },
+        "HumanLoopActivationReasons": {
+          "target": "com.amazonaws.textract#HumanLoopActivationReasons",
+          "traits": {
+            "smithy.api#documentation": "<p>Shows if and why human review was needed.</p>"
+          }
+        },
+        "HumanLoopActivationConditionsEvaluationResults": {
+          "target": "com.amazonaws.textract#SynthesizedJsonHumanLoopActivationConditionsEvaluationResults",
+          "traits": {
+            "smithy.api#documentation": "<p>Shows the result of condition evaluations, including those conditions which activated a\n         human review.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Shows the results of the human in the loop evaluation. If there is no HumanLoopArn, the\n         input did not trigger human review.</p>"
+      }
+    },
+    "com.amazonaws.textract#HumanLoopActivationReason": {
+      "type": "string"
+    },
+    "com.amazonaws.textract#HumanLoopActivationReasons": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#HumanLoopActivationReason"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.textract#HumanLoopArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.textract#HumanLoopConfig": {
+      "type": "structure",
+      "members": {
+        "HumanLoopName": {
+          "target": "com.amazonaws.textract#HumanLoopName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the human workflow used for this image. This should be kept unique within a\n         region.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FlowDefinitionArn": {
+          "target": "com.amazonaws.textract#FlowDefinitionArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the flow definition.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAttributes": {
+          "target": "com.amazonaws.textract#HumanLoopDataAttributes",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets attributes of the input data.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Sets up the human review workflow the document will be sent to if one of the conditions\n         is met. You can also set certain attributes of the image before review. </p>"
+      }
+    },
+    "com.amazonaws.textract#HumanLoopDataAttributes": {
+      "type": "structure",
+      "members": {
+        "ContentClassifiers": {
+          "target": "com.amazonaws.textract#ContentClassifiers",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets whether the input image is free of personally identifiable information or adult\n         content.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Allows you to set attributes of the image. Currently, you can declare an image as free\n         of personally identifiable information and adult content. </p>"
+      }
+    },
+    "com.amazonaws.textract#HumanLoopName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[a-z0-9](-*[a-z0-9])*$"
+      }
+    },
+    "com.amazonaws.textract#HumanLoopQuotaExceededException": {
+      "type": "structure",
+      "members": {
+        "ResourceType": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The resource type.</p>"
+          }
+        },
+        "QuotaCode": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The quota code.</p>"
+          }
+        },
+        "ServiceCode": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The service code.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates you have exceeded the maximum number of active human in the loop workflows available</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
+      }
+    },
+    "com.amazonaws.textract#IdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#NonEmptyString"
+      }
+    },
+    "com.amazonaws.textract#IdempotentParameterMismatchException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A <code>ClientRequestToken</code> input parameter was reused with an operation, but at\n         least one of the other input parameters is different from the previous call to the\n         operation. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#IdentityDocument": {
+      "type": "structure",
+      "members": {
+        "DocumentIndex": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>Denotes the placement of a document in the IdentityDocument list. The first document\n         is marked 1, the second 2 and so on.</p>"
+          }
+        },
+        "IdentityDocumentFields": {
+          "target": "com.amazonaws.textract#IdentityDocumentFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>The structure used to record information extracted from identity documents.\n         Contains both normalized field and value of the extracted text.</p>"
+          }
+        },
+        "Blocks": {
+          "target": "com.amazonaws.textract#BlockList",
+          "traits": {
+            "smithy.api#documentation": "<p>Individual word recognition, as returned by document detection.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The structure that lists each document processed in an AnalyzeID operation.</p>"
+      }
+    },
+    "com.amazonaws.textract#IdentityDocumentField": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.textract#AnalyzeIDDetections"
+        },
+        "ValueDetection": {
+          "target": "com.amazonaws.textract#AnalyzeIDDetections"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Structure containing both the normalized type of the extracted information\n         and the text associated with it. These are extracted as Type and Value respectively.</p>"
+      }
+    },
+    "com.amazonaws.textract#IdentityDocumentFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#IdentityDocumentField"
+      }
+    },
+    "com.amazonaws.textract#IdentityDocumentList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#IdentityDocument"
+      }
+    },
+    "com.amazonaws.textract#ImageBlob": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10485760
+        }
+      }
+    },
+    "com.amazonaws.textract#InternalServerError": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Textract experienced a service issue. Try your call again.</p>",
+        "smithy.api#error": "server"
+      }
+    },
+    "com.amazonaws.textract#InvalidJobIdException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An invalid job identifier was passed to an asynchronous analysis operation.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#InvalidKMSKeyException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Indicates you do not have decrypt permissions with the KMS key entered, or the KMS key\n        was entered incorrectly. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#InvalidParameterException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An input parameter violated a constraint. For example, in synchronous operations, \n       an <code>InvalidParameterException</code> exception occurs\n      when neither of the <code>S3Object</code> or <code>Bytes</code> values are supplied in the <code>Document</code>\n      request parameter.\n       Validate your parameter before calling the API operation again.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#InvalidS3ObjectException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Textract is unable to access the S3 object that's specified in the request.\n         for more information, <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html\">Configure Access to Amazon S3</a>\n         For troubleshooting information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/troubleshooting.html\">Troubleshooting Amazon S3</a>\n         </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#JobId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-_]+$"
+      }
+    },
+    "com.amazonaws.textract#JobStatus": {
+      "type": "enum",
+      "members": {
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "PARTIAL_SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PARTIAL_SUCCESS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#JobTag": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9_.\\-:]+$"
+      }
+    },
+    "com.amazonaws.textract#KMSKeyId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^[A-Za-z0-9][A-Za-z0-9:_/+=,@.-]{0,2048}$"
+      }
+    },
+    "com.amazonaws.textract#LendingDetection": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The text extracted for a detected value in a lending document.</p>"
+          }
+        },
+        "SelectionStatus": {
+          "target": "com.amazonaws.textract#SelectionStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The selection status of a selection element, such as an option button or check box.</p>"
+          }
+        },
+        "Geometry": {
+          "target": "com.amazonaws.textract#Geometry"
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence level for the text of a detected value in a lending document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The results extracted for a lending document.</p>"
+      }
+    },
+    "com.amazonaws.textract#LendingDetectionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#LendingDetection"
+      }
+    },
+    "com.amazonaws.textract#LendingDocument": {
+      "type": "structure",
+      "members": {
+        "LendingFields": {
+          "target": "com.amazonaws.textract#LendingFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of LendingField objects.</p>"
+          }
+        },
+        "SignatureDetections": {
+          "target": "com.amazonaws.textract#SignatureDetectionList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of signatures detected in a lending document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Holds the structured data returned by AnalyzeDocument for lending documents.</p>"
+      }
+    },
+    "com.amazonaws.textract#LendingField": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of the lending document.</p>"
+          }
+        },
+        "KeyDetection": {
+          "target": "com.amazonaws.textract#LendingDetection"
+        },
+        "ValueDetections": {
+          "target": "com.amazonaws.textract#LendingDetectionList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of LendingDetection objects.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Holds the normalized key-value pairs returned by AnalyzeDocument, including the document type, detected text, and geometry.</p>"
+      }
+    },
+    "com.amazonaws.textract#LendingFieldList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#LendingField"
+      }
+    },
+    "com.amazonaws.textract#LendingResult": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The page number for a page, with regard to whole submission.</p>"
+          }
+        },
+        "PageClassification": {
+          "target": "com.amazonaws.textract#PageClassification",
+          "traits": {
+            "smithy.api#documentation": "<p>The classifier result for a given page.</p>"
+          }
+        },
+        "Extractions": {
+          "target": "com.amazonaws.textract#ExtractionList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of Extraction to hold structured data. e.g. normalized key value pairs instead of raw OCR detections .</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the detections for each page analyzed through the Analyze Lending API.</p>"
+      }
+    },
+    "com.amazonaws.textract#LendingResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#LendingResult"
+      }
+    },
+    "com.amazonaws.textract#LendingSummary": {
+      "type": "structure",
+      "members": {
+        "DocumentGroups": {
+          "target": "com.amazonaws.textract#DocumentGroupList",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains an array of all DocumentGroup objects.</p>"
+          }
+        },
+        "UndetectedDocumentTypes": {
+          "target": "com.amazonaws.textract#UndetectedDocumentTypeList",
+          "traits": {
+            "smithy.api#documentation": "<p>UndetectedDocumentTypes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information regarding DocumentGroups and UndetectedDocumentTypes.</p>"
+      }
+    },
+    "com.amazonaws.textract#LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An Amazon Textract service limit was exceeded. For example, if you start too many\n         asynchronous jobs concurrently, calls to start operations\n            (<code>StartDocumentTextDetection</code>, for example) raise a LimitExceededException\n         exception (HTTP status code: 400) until the number of concurrently running jobs is below\n         the Amazon Textract service limit. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#LineItemFields": {
+      "type": "structure",
+      "members": {
+        "LineItemExpenseFields": {
+          "target": "com.amazonaws.textract#ExpenseFieldList",
+          "traits": {
+            "smithy.api#documentation": "<p>ExpenseFields used to show information from detected lines on a table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure that holds information about the different lines found in a document's tables.</p>"
+      }
+    },
+    "com.amazonaws.textract#LineItemGroup": {
+      "type": "structure",
+      "members": {
+        "LineItemGroupIndex": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The number used to identify a specific table in a document. The first table encountered will have a LineItemGroupIndex of 1, the second 2, etc.</p>"
+          }
+        },
+        "LineItems": {
+          "target": "com.amazonaws.textract#LineItemList",
+          "traits": {
+            "smithy.api#documentation": "<p>The breakdown of information on a particular line of a table. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A grouping of tables which contain LineItems, with each table identified by the table's <code>LineItemGroupIndex</code>.</p>"
+      }
+    },
+    "com.amazonaws.textract#LineItemGroupList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#LineItemGroup"
+      }
+    },
+    "com.amazonaws.textract#LineItemList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#LineItemFields"
+      }
+    },
+    "com.amazonaws.textract#ListAdapterVersions": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#ListAdapterVersionsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#ListAdapterVersionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>List all version of an adapter that meet the specified filtration criteria.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "AdapterVersions",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.textract#ListAdapterVersionsRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter to match for when listing adapter versions.</p>"
+          }
+        },
+        "AfterCreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the lower bound for the ListAdapterVersions operation. \n         Ensures ListAdapterVersions returns only adapter versions created after the specified creation time.</p>"
+          }
+        },
+        "BeforeCreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the upper bound for the ListAdapterVersions operation. \n         Ensures ListAdapterVersions returns only adapter versions created after the specified creation time.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.textract#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return when listing adapter versions.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return when listing adapter versions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#ListAdapterVersionsResponse": {
+      "type": "structure",
+      "members": {
+        "AdapterVersions": {
+          "target": "com.amazonaws.textract#AdapterVersionList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adapter versions that match the filtering criteria specified when calling ListAdapters.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return when listing adapter versions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#ListAdapters": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#ListAdaptersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#ListAdaptersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all adapters that match the specified filtration criteria.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Adapters",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.textract#ListAdaptersRequest": {
+      "type": "structure",
+      "members": {
+        "AfterCreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the lower bound for the ListAdapters operation. \n         Ensures ListAdapters returns only adapters created after the specified creation time.</p>"
+          }
+        },
+        "BeforeCreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the upper bound for the ListAdapters operation. \n         Ensures ListAdapters returns only adapters created before the specified creation time.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.textract#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return when listing adapters.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return when listing adapters.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#ListAdaptersResponse": {
+      "type": "structure",
+      "members": {
+        "Adapters": {
+          "target": "com.amazonaws.textract#AdapterList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of adapters that matches the filtering criteria specified when calling ListAdapters.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.textract#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the next page of results to return when listing adapters.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all tags for an Amazon Textract resource.</p>"
+      }
+    },
+    "com.amazonaws.textract#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.textract#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that specifies the resource to list tags for.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.textract#TagMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of tags (key-value pairs) that are part of the requested resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.textract#NonEmptyString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.textract#NormalizedValue": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.textract#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the date, written as Year-Month-DayTHour:Minute:Second.</p>"
+          }
+        },
+        "ValueType": {
+          "target": "com.amazonaws.textract#ValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The normalized type of the value detected. In this case, DATE.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information relating to dates in a document, including the type\n         of value, and the value.</p>"
+      }
+    },
+    "com.amazonaws.textract#NotificationChannel": {
+      "type": "structure",
+      "members": {
+        "SNSTopicArn": {
+          "target": "com.amazonaws.textract#SNSTopicArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon SNS topic that Amazon Textract posts the completion status to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.textract#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that gives Amazon Textract publishing permissions to the Amazon SNS topic. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon Simple Notification Service (Amazon SNS) topic to which Amazon Textract publishes the completion status of\n         an asynchronous document operation. </p>"
+      }
+    },
+    "com.amazonaws.textract#OutputConfig": {
+      "type": "structure",
+      "members": {
+        "S3Bucket": {
+          "target": "com.amazonaws.textract#S3Bucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the bucket your output will go to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "S3Prefix": {
+          "target": "com.amazonaws.textract#S3ObjectName",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix of the object key that the output will be saved to. When not enabled, the\n         prefix will be \u201ctextract_output\".</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Sets whether or not your output will go to a user created bucket. Used to set the name\n         of the bucket, and the prefix on the output file.</p>\n         <p>\n            <code>OutputConfig</code> is an optional parameter which lets you adjust where your\n         output will be placed. By default, Amazon Textract will store the results internally and can\n         only be accessed by the Get API operations. With <code>OutputConfig</code> enabled, you can\n         set the name of the bucket the output will be sent to the file prefix of the results where\n         you can download your results. Additionally, you can set the <code>KMSKeyID</code>\n         parameter to a customer master key (CMK) to encrypt your output. Without this parameter set\n         Amazon Textract will encrypt server-side using the AWS managed CMK for Amazon S3.</p>\n         <p>Decryption of Customer Content is necessary for processing of the documents by Amazon Textract. If your account \n         is opted out under an AI services opt out policy then all unencrypted Customer Content is immediately and permanently deleted after \n         the Customer Content has been processed by the service. No copy of of the output is retained by Amazon Textract. For information about how to opt out, see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out.html\"> Managing AI services opt-out policy. </a>\n         </p>\n         <p>For more information on data privacy,\n         see the <a href=\"https://aws.amazon.com/compliance/data-privacy-faq/\">Data Privacy\n            FAQ</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#PageClassification": {
+      "type": "structure",
+      "members": {
+        "PageType": {
+          "target": "com.amazonaws.textract#PredictionList",
+          "traits": {
+            "smithy.api#documentation": "<p>The class, or document type, assigned to a detected Page object. The class, or document type, \n         assigned to a detected Page object.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PageNumber": {
+          "target": "com.amazonaws.textract#PredictionList",
+          "traits": {
+            "smithy.api#documentation": "<p> The page number the value was detected on, relative to Amazon Textract's starting position.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The class assigned to a Page object detected in an input document. \n         Contains information regarding the predicted type/class of a document's page and the \n         page number that the Page object was detected on.</p>"
+      }
+    },
+    "com.amazonaws.textract#PageList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#UInteger"
+      }
+    },
+    "com.amazonaws.textract#Pages": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#UInteger"
+      }
+    },
+    "com.amazonaws.textract#PaginationToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.textract#Percent": {
+      "type": "float",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.textract#Point": {
+      "type": "structure",
+      "members": {
+        "X": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The value of the X coordinate for a point on a <code>Polygon</code>.</p>"
+          }
+        },
+        "Y": {
+          "target": "com.amazonaws.textract#Float",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The value of the Y coordinate for a point on a <code>Polygon</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The X and Y coordinates of a point on a document page. The X and Y\n         values that are returned are ratios of the overall document page size. For example, if the\n         input document is 700 x 200 and the operation returns X=0.5 and Y=0.25, then the point is\n         at the (350,50) pixel coordinate on the document page.</p>\n         <p>An array of <code>Point</code> objects, <code>Polygon</code>, is returned\n         by <a>DetectDocumentText</a>. <code>Polygon</code> represents a fine-grained\n         polygon around detected text. For more information, see Geometry in the Amazon Textract\n         Developer Guide. </p>"
+      }
+    },
+    "com.amazonaws.textract#Polygon": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Point"
+      }
+    },
+    "com.amazonaws.textract#Prediction": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.textract#NonEmptyString",
+          "traits": {
+            "smithy.api#documentation": "<p>The predicted value of a detected object.</p>"
+          }
+        },
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>Amazon Textract's confidence in its predicted value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information regarding predicted values returned by Amazon Textract operations, including the \n         predicted value and the confidence in the predicted value.</p>"
+      }
+    },
+    "com.amazonaws.textract#PredictionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Prediction"
+      }
+    },
+    "com.amazonaws.textract#ProvisionedThroughputExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of requests exceeded your throughput limit. If you want to increase this limit, \n         contact Amazon Textract.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#Queries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Query"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.textract#QueriesConfig": {
+      "type": "structure",
+      "members": {
+        "Queries": {
+          "target": "com.amazonaws.textract#Queries",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.textract#Query": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.textract#QueryInput",
+          "traits": {
+            "smithy.api#documentation": "<p>Question that Amazon Textract will apply to the document. An example would be \"What is the customer's SSN?\"</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Alias": {
+          "target": "com.amazonaws.textract#QueryInput",
+          "traits": {
+            "smithy.api#documentation": "<p>Alias attached to the query, for ease of location.</p>"
+          }
+        },
+        "Pages": {
+          "target": "com.amazonaws.textract#QueryPages",
+          "traits": {
+            "smithy.api#documentation": "<p>Pages is a parameter that the user inputs to specify which pages to apply a query to. The following is a \n         list of rules for using this parameter.</p>\n         <ul>\n            <li>\n               <p>If a page is not specified, it is set to <code>[\"1\"]</code> by default.</p>\n            </li>\n            <li>\n               <p>The following characters are allowed in the parameter's string: \n               <code>0 1 2 3 4 5 6 7 8 9 - *</code>. No whitespace is allowed.</p>\n            </li>\n            <li>\n               <p>When using * to indicate all pages, it must be the only element in the list.</p>\n            </li>\n            <li>\n               <p>You can use page intervals, such as <code>[\u201c1-3\u201d, \u201c1-1\u201d, \u201c4-*\u201d]</code>. Where <code>*</code> indicates last page of \n               document.</p>\n            </li>\n            <li>\n               <p>Specified pages must be greater than 0 and less than or equal to the number of pages in the document.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Each query contains the question you want to ask in the Text and the alias you want to associate.</p>"
+      }
+    },
+    "com.amazonaws.textract#QueryInput": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9\\s!\"\\#\\$%'&\\(\\)\\*\\+\\,\\-\\./:;=\\?@\\[\\\\\\]\\^_`\\{\\|\\}~><]+$"
+      }
+    },
+    "com.amazonaws.textract#QueryPage": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 9
+        },
+        "smithy.api#pattern": "^[0-9\\*\\-]+$"
+      }
+    },
+    "com.amazonaws.textract#QueryPages": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#QueryPage"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.textract#Relationship": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.textract#RelationshipType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of relationship between the blocks in the IDs array and the current block. The\n         following list describes the relationship types that can be returned. </p>\n         <ul>\n            <li>\n               <p>\n                  <i>VALUE</i> - A list that contains the ID of the VALUE block that's associated with the\n               KEY of a key-value pair.</p>\n            </li>\n            <li>\n               <p>\n                  <i>CHILD</i> - A list of IDs that identify blocks found within the\n               current block object. For example, WORD blocks have a CHILD relationship to the LINE\n               block type.</p>\n            </li>\n            <li>\n               <p>\n                  <i>MERGED_CELL</i> - A list of IDs that identify each of the\n               MERGED_CELL block types in a table.</p>\n            </li>\n            <li>\n               <p>\n                  <i>ANSWER</i> - A list that contains the ID of the QUERY_RESULT\n               block that\u2019s associated with the corresponding QUERY block. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE</i> - A list of IDs that identify associated TABLE block\n               types. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_TITLE</i> - A list that contains the ID for the TABLE_TITLE\n               block type in a table. </p>\n            </li>\n            <li>\n               <p>\n                  <i>TABLE_FOOTER</i> - A list of IDs that identify the TABLE_FOOTER\n               block types in a table. </p>\n            </li>\n         </ul>"
+          }
+        },
+        "Ids": {
+          "target": "com.amazonaws.textract#IdList",
+          "traits": {
+            "smithy.api#documentation": "<p>An\n         array of IDs for related blocks. You can get the type of the relationship from the\n            <code>Type</code> element.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about how blocks are related to each other. A <code>Block</code> object\n         contains 0 or more <code>Relation</code> objects in a list, <code>Relationships</code>. For\n         more information, see <a>Block</a>.</p>\n         <p>The <code>Type</code> element provides the type of the relationship for all blocks in\n         the <code>IDs</code> array. </p>"
+      }
+    },
+    "com.amazonaws.textract#RelationshipList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Relationship"
+      }
+    },
+    "com.amazonaws.textract#RelationshipType": {
+      "type": "enum",
+      "members": {
+        "VALUE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VALUE"
+          }
+        },
+        "CHILD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CHILD"
+          }
+        },
+        "COMPLEX_FEATURES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLEX_FEATURES"
+          }
+        },
+        "MERGED_CELL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MERGED_CELL"
+          }
+        },
+        "TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TITLE"
+          }
+        },
+        "ANSWER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ANSWER"
+          }
+        },
+        "TABLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE"
+          }
+        },
+        "TABLE_TITLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_TITLE"
+          }
+        },
+        "TABLE_FOOTER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TABLE_FOOTER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Returned when an operation tried to access a nonexistent resource. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#RoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:([a-z\\d-]+):iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+      }
+    },
+    "com.amazonaws.textract#S3Bucket": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 255
+        },
+        "smithy.api#pattern": "^[0-9A-Za-z\\.\\-_]*$"
+      }
+    },
+    "com.amazonaws.textract#S3Object": {
+      "type": "structure",
+      "members": {
+        "Bucket": {
+          "target": "com.amazonaws.textract#S3Bucket",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the S3 bucket. Note that the # character is not valid in the file\n         name.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.textract#S3ObjectName",
+          "traits": {
+            "smithy.api#documentation": "<p>The file name of the input document. Image files may be in PDF, TIFF, JPEG, or PNG format.</p>"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.textract#S3ObjectVersion",
+          "traits": {
+            "smithy.api#documentation": "<p>If the bucket has versioning enabled, you can specify the object version. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The S3 bucket name and file name that identifies the document.</p>\n         <p>The AWS Region for the S3 bucket that contains the document must match the Region that\n         you use for Amazon Textract operations.</p>\n         <p>For Amazon Textract to process a file in an S3 bucket, the user must have\n         permission to access the S3 bucket and file.\n         \n      </p>"
+      }
+    },
+    "com.amazonaws.textract#S3ObjectName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.textract#S3ObjectVersion": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.textract#SNSTopicArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^(^arn:([a-z\\d-]+):sns:[a-zA-Z\\d-]{1,20}:\\w{12}:.+$)$"
+      }
+    },
+    "com.amazonaws.textract#SelectionStatus": {
+      "type": "enum",
+      "members": {
+        "SELECTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SELECTED"
+          }
+        },
+        "NOT_SELECTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NOT_SELECTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#ServiceQuotaExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Returned when a request cannot be completed as it would exceed a maximum service quota.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#SignatureDetection": {
+      "type": "structure",
+      "members": {
+        "Confidence": {
+          "target": "com.amazonaws.textract#Percent",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence, from 0 to 100, in the predicted values for a detected signature.</p>"
+          }
+        },
+        "Geometry": {
+          "target": "com.amazonaws.textract#Geometry"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information regarding a detected signature on a page.</p>"
+      }
+    },
+    "com.amazonaws.textract#SignatureDetectionList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#SignatureDetection"
+      }
+    },
+    "com.amazonaws.textract#SplitDocument": {
+      "type": "structure",
+      "members": {
+        "Index": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The index for a given document in a DocumentGroup of a specific Type.</p>"
+          }
+        },
+        "Pages": {
+          "target": "com.amazonaws.textract#PageList",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of page numbers for a for a given document, ordered by logical boundary.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about the pages of a document, defined by logical boundary.</p>"
+      }
+    },
+    "com.amazonaws.textract#SplitDocumentList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#SplitDocument"
+      }
+    },
+    "com.amazonaws.textract#StartDocumentAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#StartDocumentAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#StartDocumentAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#IdempotentParameterMismatchException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts the asynchronous analysis of an input document for relationships between detected\n         items such as key-value pairs, tables, and selection elements.</p>\n         <p>\n            <code>StartDocumentAnalysis</code> can analyze text in documents that are in JPEG, PNG, TIFF, and PDF format. The\n         documents are stored in an Amazon S3 bucket. Use <a>DocumentLocation</a> to specify the bucket name and file name\n         of the document.\n         </p>\n         <p>\n            <code>StartDocumentAnalysis</code> returns a job identifier\n            (<code>JobId</code>) that you use to get the results of the operation. When text\n         analysis is finished, Amazon Textract publishes a completion status to the Amazon Simple Notification Service (Amazon SNS)\n         topic that you specify in <code>NotificationChannel</code>. To get the results of the text\n         analysis operation, first check that the status value published to the Amazon SNS topic is\n            <code>SUCCEEDED</code>. If so, call <a>GetDocumentAnalysis</a>, and pass\n         the job identifier (<code>JobId</code>) from the initial call to\n            <code>StartDocumentAnalysis</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works-analyzing.html\">Document Text Analysis</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#StartDocumentAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentLocation": {
+          "target": "com.amazonaws.textract#DocumentLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the document to be processed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the types of analysis to perform. Add TABLES to the list to return information\n         about the tables that are detected in the input document. Add FORMS to return detected\n         form data. To perform both types of analysis, add TABLES\n         and FORMS to <code>FeatureTypes</code>. All lines and words detected in the document are\n         included in the response (including text that isn't related to the value of\n            <code>FeatureTypes</code>). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.textract#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The idempotent token that you use to identify the start request. If you use the same\n         token with multiple <code>StartDocumentAnalysis</code> requests, the same\n            <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same\n         job from being accidentally started more than once. For more information, see\n         <a href=\"https://docs.aws.amazon.com/textract/latest/dg/api-async.html\">Calling Amazon Textract Asynchronous Operations</a>.</p>"
+          }
+        },
+        "JobTag": {
+          "target": "com.amazonaws.textract#JobTag",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that you specify that's included in the completion notification published\n         to the Amazon SNS topic. For example, you can use <code>JobTag</code> to identify the type of\n         document that the completion notification corresponds to (such as a tax form or a\n         receipt).</p>"
+          }
+        },
+        "NotificationChannel": {
+          "target": "com.amazonaws.textract#NotificationChannel",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the\n         operation to. </p>"
+          }
+        },
+        "OutputConfig": {
+          "target": "com.amazonaws.textract#OutputConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets if the output will go to a customer defined bucket. By default, Amazon Textract will save\n         the results internally to be accessed by the GetDocumentAnalysis operation.</p>"
+          }
+        },
+        "KMSKeyId": {
+          "target": "com.amazonaws.textract#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key used to encrypt the inference results. This can be \n         in either Key ID or Key Alias format. When a KMS key is provided, the \n         KMS key will be used for server-side encryption of the objects in the \n         customer bucket. When this parameter is not enabled, the result will \n         be encrypted server side,using SSE-S3.</p>"
+          }
+        },
+        "QueriesConfig": {
+          "target": "com.amazonaws.textract#QueriesConfig"
+        },
+        "AdaptersConfig": {
+          "target": "com.amazonaws.textract#AdaptersConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the adapter to be used when analyzing a document.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#StartDocumentAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier for the document text detection job. Use <code>JobId</code> to identify\n         the job in a subsequent call to <code>GetDocumentAnalysis</code>. A <code>JobId</code> value \n         is only valid for 7 days.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#StartDocumentTextDetection": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#StartDocumentTextDetectionRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#StartDocumentTextDetectionResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#IdempotentParameterMismatchException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts the asynchronous detection of text in a document. Amazon Textract can detect lines of\n         text and the words that make up a line of text.</p>\n         <p>\n            <code>StartDocumentTextDetection</code> can analyze text in documents that are in JPEG, PNG, TIFF, and PDF format. The\n        documents are stored in an Amazon S3 bucket. Use <a>DocumentLocation</a> to specify the bucket name and file name\n        of the document.\n     </p>\n         <p>\n            <code>StartDocumentTextDetection</code> returns a job identifier\n            (<code>JobId</code>) that you use to get the results of the operation. When text\n         detection is finished, Amazon Textract publishes a completion status to the Amazon Simple Notification Service (Amazon SNS)\n         topic that you specify in <code>NotificationChannel</code>. To get the results of the text\n         detection operation, first check that the status value published to the Amazon SNS topic is\n            <code>SUCCEEDED</code>. If so, call <a>GetDocumentTextDetection</a>, and\n         pass the job identifier (<code>JobId</code>) from the initial call to\n            <code>StartDocumentTextDetection</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/how-it-works-detecting.html\">Document Text Detection</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#StartDocumentTextDetectionRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentLocation": {
+          "target": "com.amazonaws.textract#DocumentLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the document to be processed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.textract#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The idempotent token that's used to identify the start request. If you use the same\n         token with multiple <code>StartDocumentTextDetection</code> requests, the same\n            <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same\n         job from being accidentally started more than once. For more information, see\n         <a href=\"https://docs.aws.amazon.com/textract/latest/dg/api-async.html\">Calling Amazon Textract Asynchronous Operations</a>.</p>"
+          }
+        },
+        "JobTag": {
+          "target": "com.amazonaws.textract#JobTag",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that you specify that's included in the completion notification published\n         to the Amazon SNS topic. For example, you can use <code>JobTag</code> to identify the type of\n         document that the completion notification corresponds to (such as a tax form or a\n         receipt).</p>"
+          }
+        },
+        "NotificationChannel": {
+          "target": "com.amazonaws.textract#NotificationChannel",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the\n         operation to. </p>"
+          }
+        },
+        "OutputConfig": {
+          "target": "com.amazonaws.textract#OutputConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets if the output will go to a customer defined bucket. By default Amazon Textract will\n         save the results internally to be accessed with the GetDocumentTextDetection operation.</p>"
+          }
+        },
+        "KMSKeyId": {
+          "target": "com.amazonaws.textract#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key used to encrypt the inference results. This can be \n         in either Key ID or Key Alias format. When a KMS key is provided, the \n         KMS key will be used for server-side encryption of the objects in the \n         customer bucket. When this parameter is not enabled, the result will \n         be encrypted server side,using SSE-S3.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#StartDocumentTextDetectionResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the text detection job for the document. Use <code>JobId</code> to\n         identify the job in a subsequent call to <code>GetDocumentTextDetection</code>.\n         A <code>JobId</code> value is only valid for 7 days.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#StartExpenseAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#StartExpenseAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#StartExpenseAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#IdempotentParameterMismatchException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts the asynchronous analysis of invoices or receipts for data like contact information,\n   items purchased, and vendor names.</p>\n         <p>\n            <code>StartExpenseAnalysis</code> can analyze text in documents that are in JPEG, PNG, and\n   PDF format. The documents must be stored in an Amazon S3 bucket. Use the <a>DocumentLocation</a> parameter to specify the name of your S3 bucket and the name of the\n   document in that bucket. </p>\n         <p>\n            <code>StartExpenseAnalysis</code> returns a job identifier (<code>JobId</code>) that you\n   will provide to <code>GetExpenseAnalysis</code> to retrieve the results of the operation. When\n   the analysis of the input invoices/receipts is finished, Amazon Textract publishes a completion\n   status to the Amazon Simple Notification Service (Amazon SNS) topic that you provide to the <code>NotificationChannel</code>.\n   To obtain the results of the invoice and receipt analysis operation, ensure that the status value\n   published to the Amazon SNS topic is <code>SUCCEEDED</code>. If so, call <a>GetExpenseAnalysis</a>, and pass the job identifier (<code>JobId</code>) that was\n   returned by your call to <code>StartExpenseAnalysis</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/invoice-receipts.html\">Analyzing Invoices and Receipts</a>.</p>"
+      }
+    },
+    "com.amazonaws.textract#StartExpenseAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentLocation": {
+          "target": "com.amazonaws.textract#DocumentLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the document to be processed.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.textract#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The idempotent token that's used to identify the start request. If you use the same token with multiple <code>StartDocumentTextDetection</code> requests, the same <code>JobId</code> is returned. \n   Use <code>ClientRequestToken</code> to prevent the same job from being accidentally started more than once. \n   For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/api-async.html\">Calling Amazon Textract Asynchronous Operations</a>\n         </p>"
+          }
+        },
+        "JobTag": {
+          "target": "com.amazonaws.textract#JobTag",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier you specify that's included in the completion notification published\n   to the Amazon SNS topic. For example, you can use <code>JobTag</code> to identify the type of\n   document that the completion notification corresponds to (such as a tax form or a\n   receipt).</p>"
+          }
+        },
+        "NotificationChannel": {
+          "target": "com.amazonaws.textract#NotificationChannel",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the\n   operation to. </p>"
+          }
+        },
+        "OutputConfig": {
+          "target": "com.amazonaws.textract#OutputConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Sets if the output will go to a customer defined bucket. By default, Amazon Textract will\n   save the results internally to be accessed by the <code>GetExpenseAnalysis</code>\n   operation.</p>"
+          }
+        },
+        "KMSKeyId": {
+          "target": "com.amazonaws.textract#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key used to encrypt the inference results. This can be \n   in either Key ID or Key Alias format. When a KMS key is provided, the \n   KMS key will be used for server-side encryption of the objects in the \n   customer bucket. When this parameter is not enabled, the result will \n   be encrypted server side,using SSE-S3.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#StartExpenseAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the text detection job. The <code>JobId</code> is returned from\n    <code>StartExpenseAnalysis</code>. A <code>JobId</code> value is only valid for 7 days.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#StartLendingAnalysis": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#StartLendingAnalysisRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#StartLendingAnalysisResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#BadDocumentException"
+        },
+        {
+          "target": "com.amazonaws.textract#DocumentTooLargeException"
+        },
+        {
+          "target": "com.amazonaws.textract#IdempotentParameterMismatchException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidKMSKeyException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidS3ObjectException"
+        },
+        {
+          "target": "com.amazonaws.textract#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#UnsupportedDocumentException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts the classification and analysis of an input document.\n    <code>StartLendingAnalysis</code> initiates the classification and analysis of a packet of\n   lending documents. <code>StartLendingAnalysis</code> operates on a document file located in an\n   Amazon S3 bucket.</p>\n         <p>\n            <code>StartLendingAnalysis</code> can analyze text in documents that are in one of the\n   following formats: JPEG, PNG, TIFF, PDF. Use <code>DocumentLocation</code> to specify the bucket\n   name and the file name of the document. </p>\n         <p>\n            <code>StartLendingAnalysis</code> returns a job identifier (<code>JobId</code>) that you use\n   to get the results of the operation. When the text analysis is finished, Amazon Textract\n   publishes a completion status to the Amazon Simple Notification Service (Amazon SNS) topic that\n   you specify in <code>NotificationChannel</code>. To get the results of the text analysis\n   operation, first check that the status value published to the Amazon SNS topic is SUCCEEDED. If\n   the status is SUCCEEDED you can call either <code>GetLendingAnalysis</code> or\n    <code>GetLendingAnalysisSummary</code> and provide the <code>JobId</code> to obtain the results\n   of the analysis.</p>\n         <p>If using <code>OutputConfig</code> to specify an Amazon S3 bucket, the output will be contained\n   within the specified prefix in a directory labeled with the job-id. In the directory there are 3\n   sub-directories: </p>\n         <ul>\n            <li>\n               <p>detailedResponse (contains the GetLendingAnalysis response)</p>\n            </li>\n            <li>\n               <p>summaryResponse (for the GetLendingAnalysisSummary response)</p>\n            </li>\n            <li>\n               <p>splitDocuments (documents split across logical boundaries)</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.textract#StartLendingAnalysisRequest": {
+      "type": "structure",
+      "members": {
+        "DocumentLocation": {
+          "target": "com.amazonaws.textract#DocumentLocation",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "ClientRequestToken": {
+          "target": "com.amazonaws.textract#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The idempotent token that you use to identify the start request. If you use the same token\n   with multiple <code>StartLendingAnalysis</code> requests, the same <code>JobId</code> is\n   returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidentally\n   started more than once. For more information, see <a href=\"https://docs.aws.amazon.com/textract/latest/dg/api-sync.html\">Calling Amazon Textract Asynchronous Operations</a>.</p>"
+          }
+        },
+        "JobTag": {
+          "target": "com.amazonaws.textract#JobTag",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier that you specify to be included in the completion notification published to\n   the Amazon SNS topic. For example, you can use <code>JobTag</code> to identify the type of\n   document that the completion notification corresponds to (such as a tax form or a\n   receipt).</p>"
+          }
+        },
+        "NotificationChannel": {
+          "target": "com.amazonaws.textract#NotificationChannel"
+        },
+        "OutputConfig": {
+          "target": "com.amazonaws.textract#OutputConfig"
+        },
+        "KMSKeyId": {
+          "target": "com.amazonaws.textract#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key used to encrypt the inference results. This can be in either Key ID or Key\n   Alias format. When a KMS key is provided, the KMS key will be used for server-side encryption of\n   the objects in the customer bucket. When this parameter is not enabled, the result will be\n   encrypted server side, using SSE-S3. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#StartLendingAnalysisResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.textract#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the lending or text-detection job. The <code>JobId</code> is\n   returned from <code>StartLendingAnalysis</code>. A <code>JobId</code> value is only valid for 7\n   days.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#StatusMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.textract#String": {
+      "type": "string"
+    },
+    "com.amazonaws.textract#StringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#String"
+      }
+    },
+    "com.amazonaws.textract#SynthesizedJsonHumanLoopActivationConditionsEvaluationResults": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10240
+        },
+        "smithy.api#mediaType": "application/json"
+      }
+    },
+    "com.amazonaws.textract#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^(?!aws:)[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$"
+      }
+    },
+    "com.amazonaws.textract#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.textract#TagMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.textract#TagKey"
+      },
+      "value": {
+        "target": "com.amazonaws.textract#TagValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.textract#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds one or more tags to the specified resource.</p>"
+      }
+    },
+    "com.amazonaws.textract#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.textract#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that specifies the resource to be tagged.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.textract#TagMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A set of tags (key-value pairs) that you want to assign to the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
+    },
+    "com.amazonaws.textract#TextType": {
+      "type": "enum",
+      "members": {
+        "HANDWRITING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HANDWRITING"
+          }
+        },
+        "PRINTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PRINTED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#Textract": {
+      "type": "service",
+      "version": "2018-06-27",
+      "operations": [
+        {
+          "target": "com.amazonaws.textract#AnalyzeDocument"
+        },
+        {
+          "target": "com.amazonaws.textract#AnalyzeExpense"
+        },
+        {
+          "target": "com.amazonaws.textract#AnalyzeID"
+        },
+        {
+          "target": "com.amazonaws.textract#CreateAdapter"
+        },
+        {
+          "target": "com.amazonaws.textract#CreateAdapterVersion"
+        },
+        {
+          "target": "com.amazonaws.textract#DeleteAdapter"
+        },
+        {
+          "target": "com.amazonaws.textract#DeleteAdapterVersion"
+        },
+        {
+          "target": "com.amazonaws.textract#DetectDocumentText"
+        },
+        {
+          "target": "com.amazonaws.textract#GetAdapter"
+        },
+        {
+          "target": "com.amazonaws.textract#GetAdapterVersion"
+        },
+        {
+          "target": "com.amazonaws.textract#GetDocumentAnalysis"
+        },
+        {
+          "target": "com.amazonaws.textract#GetDocumentTextDetection"
+        },
+        {
+          "target": "com.amazonaws.textract#GetExpenseAnalysis"
+        },
+        {
+          "target": "com.amazonaws.textract#GetLendingAnalysis"
+        },
+        {
+          "target": "com.amazonaws.textract#GetLendingAnalysisSummary"
+        },
+        {
+          "target": "com.amazonaws.textract#ListAdapters"
+        },
+        {
+          "target": "com.amazonaws.textract#ListAdapterVersions"
+        },
+        {
+          "target": "com.amazonaws.textract#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.textract#StartDocumentAnalysis"
+        },
+        {
+          "target": "com.amazonaws.textract#StartDocumentTextDetection"
+        },
+        {
+          "target": "com.amazonaws.textract#StartExpenseAnalysis"
+        },
+        {
+          "target": "com.amazonaws.textract#StartLendingAnalysis"
+        },
+        {
+          "target": "com.amazonaws.textract#TagResource"
+        },
+        {
+          "target": "com.amazonaws.textract#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.textract#UpdateAdapter"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Textract",
+          "arnNamespace": "textract",
+          "cloudFormationName": "Textract",
+          "cloudTrailEventSource": "textract.amazonaws.com",
+          "endpointPrefix": "textract"
+        },
+        "aws.auth#sigv4": {
+          "name": "textract"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<p>Amazon Textract detects and analyzes text in documents and converts it\n         into machine-readable text. This is the API reference documentation for\n         Amazon Textract.</p>",
+        "smithy.api#title": "Amazon Textract",
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://textract-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://textract-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://textract.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://textract.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 13,
+          "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://textract-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://textract-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://textract.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://textract.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://textract.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.textract#ThrottlingException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Textract is temporarily unable to process the request. Try your call again.</p>",
+        "smithy.api#error": "server"
+      }
+    },
+    "com.amazonaws.textract#UInteger": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0
+        }
+      }
+    },
+    "com.amazonaws.textract#UndetectedDocumentTypeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#NonEmptyString"
+      }
+    },
+    "com.amazonaws.textract#UndetectedSignature": {
+      "type": "structure",
+      "members": {
+        "Page": {
+          "target": "com.amazonaws.textract#UInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The page where a signature was expected but not found.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A structure containing information about an undetected signature on a page where it was expected but not found.</p>"
+      }
+    },
+    "com.amazonaws.textract#UndetectedSignatureList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#UndetectedSignature"
+      }
+    },
+    "com.amazonaws.textract#UnsupportedDocumentException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The format of the input document isn't supported. Documents for operations can be in\n         PNG, JPEG, PDF, or TIFF format.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes any tags with the specified keys from the specified resource.</p>"
+      }
+    },
+    "com.amazonaws.textract#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.textract#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) that specifies the resource to be untagged.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.textract#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the tags to be removed from the resource specified by the ResourceARN.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#UpdateAdapter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.textract#UpdateAdapterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.textract#UpdateAdapterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.textract#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.textract#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.textract#InternalServerError"
+        },
+        {
+          "target": "com.amazonaws.textract#InvalidParameterException"
+        },
+        {
+          "target": "com.amazonaws.textract#ProvisionedThroughputExceededException"
+        },
+        {
+          "target": "com.amazonaws.textract#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.textract#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.textract#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Update the configuration for an adapter. FeatureTypes configurations cannot be updated.\n         At least one new parameter must be specified as an argument.</p>"
+      }
+    },
+    "com.amazonaws.textract#UpdateAdapterRequest": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter that will be updated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.textract#AdapterDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The new description to be applied to the adapter.</p>"
+          }
+        },
+        "AdapterName": {
+          "target": "com.amazonaws.textract#AdapterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The new name to be applied to the adapter.</p>"
+          }
+        },
+        "AutoUpdate": {
+          "target": "com.amazonaws.textract#AutoUpdate",
+          "traits": {
+            "smithy.api#documentation": "<p>The new auto-update status to be applied to the adapter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.textract#UpdateAdapterResponse": {
+      "type": "structure",
+      "members": {
+        "AdapterId": {
+          "target": "com.amazonaws.textract#AdapterId",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing a unique ID for the adapter that has been updated.</p>"
+          }
+        },
+        "AdapterName": {
+          "target": "com.amazonaws.textract#AdapterName",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing the name of the adapter that has been updated.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.textract#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>An object specifying the creation time of the the adapter that has been updated.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.textract#AdapterDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A string containing the description of the adapter that has been updated.</p>"
+          }
+        },
+        "FeatureTypes": {
+          "target": "com.amazonaws.textract#FeatureTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>List of the targeted feature types for the updated adapter.</p>"
+          }
+        },
+        "AutoUpdate": {
+          "target": "com.amazonaws.textract#AutoUpdate",
+          "traits": {
+            "smithy.api#documentation": "<p>The auto-update status of the adapter that has been updated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.textract#ValidationException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.textract#String"
+        },
+        "Code": {
+          "target": "com.amazonaws.textract#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>  Indicates that a request was not valid. Check request for proper formatting. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.textract#ValueType": {
+      "type": "enum",
+      "members": {
+        "DATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.textract#Warning": {
+      "type": "structure",
+      "members": {
+        "ErrorCode": {
+          "target": "com.amazonaws.textract#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code for the warning.</p>"
+          }
+        },
+        "Pages": {
+          "target": "com.amazonaws.textract#Pages",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of the pages that the warning applies to.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A warning about an issue that occurred during asynchronous text analysis (<a>StartDocumentAnalysis</a>) or asynchronous document text detection (<a>StartDocumentTextDetection</a>). </p>"
+      }
+    },
+    "com.amazonaws.textract#Warnings": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.textract#Warning"
+      }
+    }
+  }
+}

--- a/crates/fakecloud-textract/src/validate.rs
+++ b/crates/fakecloud-textract/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored Textract Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/textract.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 #[derive(Debug, Default)]
 struct MemberConstraint {

--- a/crates/fakecloud-timestream/model.json
+++ b/crates/fakecloud-timestream/model.json
@@ -1,0 +1,7445 @@
+{
+  "smithy": "2.0",
+  "shapes": {
+    "com.amazonaws.timestreamwrite#AccessDeniedException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You are not authorized to perform this action.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
+      }
+    },
+    "com.amazonaws.timestreamwrite#AmazonResourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1011
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadDataFormat": {
+      "type": "enum",
+      "members": {
+        "CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CSV"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadProgressReport": {
+      "type": "structure",
+      "members": {
+        "RecordsProcessed": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "RecordsIngested": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "ParseFailures": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "RecordIngestionFailures": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "FileFailures": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "BytesMetered": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about the progress of a batch load task.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadStatus": {
+      "type": "enum",
+      "members": {
+        "CREATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        },
+        "PROGRESS_STOPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROGRESS_STOPPED"
+          }
+        },
+        "PENDING_RESUME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING_RESUME"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadTask": {
+      "type": "structure",
+      "members": {
+        "TaskId": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the batch load task.</p>"
+          }
+        },
+        "TaskStatus": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status of the batch load task.</p>"
+          }
+        },
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Database name for the database into which a batch load task loads data.</p>"
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Table name for the table into which a batch load task loads data.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Timestream batch load task was created.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Timestream batch load task was last updated.</p>"
+          }
+        },
+        "ResumableUntil": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about a batch load task.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadTaskDescription": {
+      "type": "structure",
+      "members": {
+        "TaskId": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the batch load task.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "DataSourceConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#DataSourceConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration details about the data source for a batch load task.</p>"
+          }
+        },
+        "ProgressReport": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadProgressReport",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "ReportConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#ReportConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Report configuration for a batch load task. This contains details about where error\n         reports are stored.</p>"
+          }
+        },
+        "DataModelConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#DataModelConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Data model configuration for a batch load task. This contains details about where a data\n         model for a batch load task is stored.</p>"
+          }
+        },
+        "TargetDatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "TargetTableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "TaskStatus": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status of the batch load task.</p>"
+          }
+        },
+        "RecordVersion": {
+          "target": "com.amazonaws.timestreamwrite#RecordVersion",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Timestream batch load task was created.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Timestream batch load task was last updated.</p>"
+          }
+        },
+        "ResumableUntil": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details about a batch load task.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadTaskId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 32
+        },
+        "smithy.api#pattern": "^[A-Z0-9]+$"
+      }
+    },
+    "com.amazonaws.timestreamwrite#BatchLoadTaskList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#BatchLoadTask"
+      }
+    },
+    "com.amazonaws.timestreamwrite#Boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.timestreamwrite#ClientRequestToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ConflictException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Timestream was unable to process this request because it contains resource that\n         already exists.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateBatchLoadTask": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#CreateBatchLoadTaskRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#CreateBatchLoadTaskResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Creates a new Timestream batch load task. A batch load task processes data from\n         a CSV source in an S3 location and writes to a Timestream table. A mapping from\n         source to target is defined in a batch load task. Errors and events are written to a report\n         at an S3 location. For the report, if the KMS key is not specified, the\n         report will be encrypted with an S3 managed key when <code>SSE_S3</code> is the option.\n         Otherwise an error is thrown. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed\n            keys</a>. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. For\n         details, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.create-batch-load.html\">code\n            sample</a>.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateBatchLoadTaskRequest": {
+      "type": "structure",
+      "members": {
+        "ClientToken": {
+          "target": "com.amazonaws.timestreamwrite#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "DataModelConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#DataModelConfiguration"
+        },
+        "DataSourceConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#DataSourceConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Defines configuration details about the data source for a batch load task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ReportConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#ReportConfiguration",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "TargetDatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+          "traits": {
+            "smithy.api#documentation": "<p>Target Timestream database for a batch load task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetTableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+          "traits": {
+            "smithy.api#documentation": "<p>Target Timestream table for a batch load task.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RecordVersion": {
+          "target": "com.amazonaws.timestreamwrite#RecordVersion",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateBatchLoadTaskResponse": {
+      "type": "structure",
+      "members": {
+        "TaskId": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the batch load task.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateDatabase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#CreateDatabaseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#CreateDatabaseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Creates a new Timestream database. If the KMS key is not\n         specified, the database will be encrypted with a Timestream managed KMS key located in your account. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed keys</a>. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. For\n         details, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.create-db.html\">code sample</a>.\n      </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateDatabaseRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key for the database. If the KMS key is not\n         specified, the database will be encrypted with a Timestream managed KMS key located in your account. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed keys</a>.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.timestreamwrite#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p> A list of key-value pairs to label the table. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateDatabaseResponse": {
+      "type": "structure",
+      "members": {
+        "Database": {
+          "target": "com.amazonaws.timestreamwrite#Database",
+          "traits": {
+            "smithy.api#documentation": "<p>The newly created Timestream database.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateTable": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#CreateTableRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#CreateTableResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Adds a new table to an existing database in your account. In an Amazon Web Services account, table names must be at least unique within each Region if they are in the same\n         database. You might have identical table names in the same Region if the tables are in\n         separate databases. While creating the table, you must specify the table name, database\n         name, and the retention properties. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.create-table.html\">code\n            sample</a> for details. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateTableRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RetentionProperties": {
+          "target": "com.amazonaws.timestreamwrite#RetentionProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The duration for which your time-series data must be stored in the memory store and the\n         magnetic store.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.timestreamwrite#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p> A list of key-value pairs to label the table. </p>"
+          }
+        },
+        "MagneticStoreWriteProperties": {
+          "target": "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains properties to set on the table when enabling magnetic store writes.</p>"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.timestreamwrite#Schema",
+          "traits": {
+            "smithy.api#documentation": "<p> The schema of the table. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#CreateTableResponse": {
+      "type": "structure",
+      "members": {
+        "Table": {
+          "target": "com.amazonaws.timestreamwrite#Table",
+          "traits": {
+            "smithy.api#documentation": "<p>The newly created Timestream table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#CsvConfiguration": {
+      "type": "structure",
+      "members": {
+        "ColumnSeparator": {
+          "target": "com.amazonaws.timestreamwrite#StringValue1",
+          "traits": {
+            "smithy.api#documentation": "<p>Column separator can be one of comma (','), pipe ('|), semicolon (';'), tab('/t'), or\n         blank space (' '). </p>"
+          }
+        },
+        "EscapeChar": {
+          "target": "com.amazonaws.timestreamwrite#StringValue1",
+          "traits": {
+            "smithy.api#documentation": "<p>Escape character can be one of </p>"
+          }
+        },
+        "QuoteChar": {
+          "target": "com.amazonaws.timestreamwrite#StringValue1",
+          "traits": {
+            "smithy.api#documentation": "<p>Can be single quote (') or double quote (\").</p>"
+          }
+        },
+        "NullValue": {
+          "target": "com.amazonaws.timestreamwrite#StringValue256",
+          "traits": {
+            "smithy.api#documentation": "<p>Can be blank space (' ').</p>"
+          }
+        },
+        "TrimWhiteSpace": {
+          "target": "com.amazonaws.timestreamwrite#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies to trim leading and trailing white space.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A delimited data format where the column separator can be a comma and the record\n         separator is a newline character.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DataModel": {
+      "type": "structure",
+      "members": {
+        "TimeColumn": {
+          "target": "com.amazonaws.timestreamwrite#StringValue256",
+          "traits": {
+            "smithy.api#documentation": "<p>Source column to be mapped to time.</p>"
+          }
+        },
+        "TimeUnit": {
+          "target": "com.amazonaws.timestreamwrite#TimeUnit",
+          "traits": {
+            "smithy.api#documentation": "<p> The granularity of the timestamp unit. It indicates if the time value is in seconds,\n         milliseconds, nanoseconds, or other supported values. Default is <code>MILLISECONDS</code>.\n      </p>"
+          }
+        },
+        "DimensionMappings": {
+          "target": "com.amazonaws.timestreamwrite#DimensionMappings",
+          "traits": {
+            "smithy.api#documentation": "<p>Source to target mappings for dimensions.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MultiMeasureMappings": {
+          "target": "com.amazonaws.timestreamwrite#MultiMeasureMappings",
+          "traits": {
+            "smithy.api#documentation": "<p>Source to target mappings for multi-measure records.</p>"
+          }
+        },
+        "MixedMeasureMappings": {
+          "target": "com.amazonaws.timestreamwrite#MixedMeasureMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p>Source to target mappings for measures.</p>"
+          }
+        },
+        "MeasureNameColumn": {
+          "target": "com.amazonaws.timestreamwrite#StringValue256",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Data model for a batch load task.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DataModelConfiguration": {
+      "type": "structure",
+      "members": {
+        "DataModel": {
+          "target": "com.amazonaws.timestreamwrite#DataModel",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "DataModelS3Configuration": {
+          "target": "com.amazonaws.timestreamwrite#DataModelS3Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DataModelS3Configuration": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.timestreamwrite#S3BucketName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "ObjectKey": {
+          "target": "com.amazonaws.timestreamwrite#S3ObjectKey",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DataSourceConfiguration": {
+      "type": "structure",
+      "members": {
+        "DataSourceS3Configuration": {
+          "target": "com.amazonaws.timestreamwrite#DataSourceS3Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration of an S3 location for a file which contains data to load.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CsvConfiguration": {
+          "target": "com.amazonaws.timestreamwrite#CsvConfiguration"
+        },
+        "DataFormat": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>This is currently CSV.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Defines configuration details about the data source.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DataSourceS3Configuration": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.timestreamwrite#S3BucketName",
+          "traits": {
+            "smithy.api#documentation": "<p>The bucket name of the customer S3 bucket.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ObjectKeyPrefix": {
+          "target": "com.amazonaws.timestreamwrite#S3ObjectKey",
+          "traits": {
+            "smithy.api#documentation": "<p>\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n      </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#Database": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name that uniquely identifies this database.</p>"
+          }
+        },
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>"
+          }
+        },
+        "TableCount": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The total number of tables found within a Timestream database. </p>"
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier of the KMS key used to encrypt the data stored in the\n         database.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the database was created, calculated from the Unix epoch time.</p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p> The last time that this database was updated. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A top-level container for a table. Databases and tables are the fundamental management\n         concepts in Amazon Timestream. All tables in a database are encrypted with the\n         same KMS key.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DatabaseList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#Database"
+      }
+    },
+    "com.amazonaws.timestreamwrite#Date": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.timestreamwrite#DeleteDatabase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#DeleteDatabaseRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Deletes a given Timestream database. <i>This is an irreversible\n            operation. After a database is deleted, the time-series data from its tables cannot be\n            recovered.</i>\n         </p>\n         <note>\n            <p>All tables in the database must be deleted first, or a ValidationException error will\n            be thrown. </p>\n            <p>Due to the nature of distributed retries, the operation can return either success or\n            a ResourceNotFoundException. Clients should consider them equivalent.</p>\n         </note>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.delete-db.html\">code sample</a>\n         for details.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DeleteDatabaseRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database to be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DeleteTable": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#DeleteTableRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Deletes a given Timestream table. This is an irreversible operation. After a\n            Timestream database table is deleted, the time-series data stored in the table\n         cannot be recovered. </p>\n         <note>\n            <p>Due to the nature of distributed retries, the operation can return either success or\n            a ResourceNotFoundException. Clients should consider them equivalent.</p>\n         </note>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.delete-table.html\">code\n            sample</a> for details.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DeleteTableRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the database where the Timestream database is to be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table to be deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeBatchLoadTask": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Returns information about the batch load task, including configurations, mappings,\n         progress, and other details. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.describe-batch-load.html\">code\n            sample</a> for details.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskRequest": {
+      "type": "structure",
+      "members": {
+        "TaskId": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the batch load task.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskResponse": {
+      "type": "structure",
+      "members": {
+        "BatchLoadTaskDescription": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>Description of the batch load task.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeDatabase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#DescribeDatabaseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#DescribeDatabaseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Returns information about the database, including the database name, time that the\n         database was created, and the total number of tables found within the database. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service\n            quotas apply</a>. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.describe-db.html\">code sample</a>\n         for details.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeDatabaseRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeDatabaseResponse": {
+      "type": "structure",
+      "members": {
+        "Database": {
+          "target": "com.amazonaws.timestreamwrite#Database",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeEndpoints": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#DescribeEndpointsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#DescribeEndpointsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Returns a list of available endpoints to make Timestream API calls against.\n         This API operation is available through both the Write and Query APIs.</p>\n         <p>Because the Timestream SDKs are designed to transparently work with the\n         service\u2019s architecture, including the management and mapping of the service endpoints,\n            <i>we don't recommend that you use this API operation unless</i>:</p>\n         <ul>\n            <li>\n               <p>You are using <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/VPCEndpoints\">VPC endpoints (Amazon Web Services PrivateLink) with Timestream</a>\n               </p>\n            </li>\n            <li>\n               <p>Your application uses a programming language that does not yet have SDK\n               support</p>\n            </li>\n            <li>\n               <p>You require better control over the client-side implementation</p>\n            </li>\n         </ul>\n         <p>For detailed information on how and when to use and implement DescribeEndpoints, see\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/Using.API.html#Using-API.endpoint-discovery\">The\n            Endpoint Discovery Pattern</a>.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeEndpointsRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeEndpointsResponse": {
+      "type": "structure",
+      "members": {
+        "Endpoints": {
+          "target": "com.amazonaws.timestreamwrite#Endpoints",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>Endpoints</code> object is returned when a <code>DescribeEndpoints</code>\n         request is made.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeTable": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#DescribeTableRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#DescribeTableResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Returns information about the table, including the table name, database name, retention\n         duration of the memory store and the magnetic store. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.describe-table.html\">code\n            sample</a> for details. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeTableRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#DescribeTableResponse": {
+      "type": "structure",
+      "members": {
+        "Table": {
+          "target": "com.amazonaws.timestreamwrite#Table",
+          "traits": {
+            "smithy.api#documentation": "<p>The Timestream table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#Dimension": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p> Dimension represents the metadata attributes of the time series. For example, the name\n         and Availability Zone of an EC2 instance or the name of the manufacturer of a wind turbine\n         are dimensions. </p>\n         <p>For constraints on dimension names, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.naming\">Naming\n            Constraints</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.timestreamwrite#SchemaValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the dimension.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DimensionValueType": {
+          "target": "com.amazonaws.timestreamwrite#DimensionValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>The data type of the dimension for the time-series data point.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents the metadata attributes of the time series. For example, the name and\n         Availability Zone of an EC2 instance or the name of the manufacturer of a wind turbine are\n         dimensions. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DimensionMapping": {
+      "type": "structure",
+      "members": {
+        "SourceColumn": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "DestinationColumn": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#DimensionMappings": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#DimensionMapping"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#DimensionValueType": {
+      "type": "enum",
+      "members": {
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Dimensions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#Dimension"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Endpoint": {
+      "type": "structure",
+      "members": {
+        "Address": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An endpoint address.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CachePeriodInMinutes": {
+          "target": "com.amazonaws.timestreamwrite#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The TTL for the endpoint, in minutes.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an available endpoint against which to make API calls against, as well as the\n         TTL for that endpoint.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#Endpoints": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#Endpoint"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamwrite#Integer": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.timestreamwrite#InternalServerException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n         Timestream was unable to fully process this request because of an internal server\n         error.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.timestreamwrite#InvalidEndpointException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested endpoint was not valid.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 421
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListBatchLoadTasks": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#ListBatchLoadTasksRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#ListBatchLoadTasksResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Provides a list of batch load tasks, along with the name, status, when the task is\n         resumable until, and other details. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.list-batch-load-tasks.html\">code\n            sample</a> for details.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListBatchLoadTasksRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A token to specify where to start paginating. This is the NextToken from a previously\n         truncated response.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.timestreamwrite#PageLimit",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of items to return in the output. If the total number of items\n         available is more than the value specified, a NextToken is provided in the output. To\n         resume pagination, provide the NextToken value as argument of a subsequent API\n         invocation.</p>"
+          }
+        },
+        "TaskStatus": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status of the batch load task.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListBatchLoadTasksResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A token to specify where to start paginating. Provide the next\n         ListBatchLoadTasksRequest.</p>"
+          }
+        },
+        "BatchLoadTasks": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of batch load task details.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListDatabases": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#ListDatabasesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#ListDatabasesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Returns a list of your Timestream databases. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.list-db.html\">code sample</a> for\n         details. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListDatabasesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token. To resume pagination, provide the NextToken value as argument of a\n         subsequent API invocation.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.timestreamwrite#PaginationLimit",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of items to return in the output. If the total number of items\n         available is more than the value specified, a NextToken is provided in the output. To\n         resume pagination, provide the NextToken value as argument of a subsequent API\n         invocation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListDatabasesResponse": {
+      "type": "structure",
+      "members": {
+        "Databases": {
+          "target": "com.amazonaws.timestreamwrite#DatabaseList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of database names.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token. This parameter is returned when the response is truncated.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListTables": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#ListTablesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#ListTablesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Provides a list of tables, along with the name, status, and retention properties of each\n         table. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.list-table.html\">code sample</a>\n         for details. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListTablesRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The pagination token. To resume pagination, provide the NextToken value as argument of a\n         subsequent API invocation.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.timestreamwrite#PaginationLimit",
+          "traits": {
+            "smithy.api#documentation": "<p>The total number of items to return in the output. If the total number of items\n         available is more than the value specified, a NextToken is provided in the output. To\n         resume pagination, provide the NextToken value as argument of a subsequent API\n         invocation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListTablesResponse": {
+      "type": "structure",
+      "members": {
+        "Tables": {
+          "target": "com.amazonaws.timestreamwrite#TableList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tables.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A token to specify where to start paginating. This is the NextToken from a previously\n         truncated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> Lists all tags on a Timestream resource. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.timestreamwrite#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p> The Timestream resource with tags to be listed. This value is an Amazon\n         Resource Name (ARN). </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.timestreamwrite#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p> The tags currently associated with the Timestream resource. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#Long": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.timestreamwrite#MagneticStoreRejectedDataLocation": {
+      "type": "structure",
+      "members": {
+        "S3Configuration": {
+          "target": "com.amazonaws.timestreamwrite#S3Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration of an S3 location to write error reports for records rejected,\n         asynchronously, during magnetic store writes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The location to write error reports for records rejected, asynchronously, during\n         magnetic store writes.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#MagneticStoreRetentionPeriodInDays": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 73000
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties": {
+      "type": "structure",
+      "members": {
+        "EnableMagneticStoreWrites": {
+          "target": "com.amazonaws.timestreamwrite#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>A flag to enable magnetic store writes.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MagneticStoreRejectedDataLocation": {
+          "target": "com.amazonaws.timestreamwrite#MagneticStoreRejectedDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The location to write error reports for records rejected asynchronously during magnetic\n         store writes.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The set of properties on a table for configuring magnetic store writes.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#MeasureValue": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p> The name of the MeasureValue. </p>\n         <p> For constraints on MeasureValue names, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.naming\"> Naming Constraints</a> in the Amazon Timestream Developer Guide.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p> The value for the MeasureValue. For information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/writes.html#writes.data-types\">Data\n         types</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.timestreamwrite#MeasureValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the data type of the MeasureValue for the time-series data point.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Represents the data attribute of the time series. For example, the CPU utilization of\n         an EC2 instance or the RPM of a wind turbine are measures. MeasureValue has both name and\n         value. </p>\n         <p> MeasureValue is only allowed for type <code>MULTI</code>. Using <code>MULTI</code>\n         type, you can pass multiple data attributes associated with the same time series in a\n         single record </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#MeasureValueType": {
+      "type": "enum",
+      "members": {
+        "DOUBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOUBLE"
+          }
+        },
+        "BIGINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIGINT"
+          }
+        },
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        },
+        "BOOLEAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOLEAN"
+          }
+        },
+        "TIMESTAMP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMESTAMP"
+          }
+        },
+        "MULTI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#MeasureValues": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#MeasureValue"
+      }
+    },
+    "com.amazonaws.timestreamwrite#MemoryStoreRetentionPeriodInHours": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 8766
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#MixedMeasureMapping": {
+      "type": "structure",
+      "members": {
+        "MeasureName": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "SourceColumn": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "TargetMeasureName": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "MeasureValueType": {
+          "target": "com.amazonaws.timestreamwrite#MeasureValueType",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MultiMeasureAttributeMappings": {
+          "target": "com.amazonaws.timestreamwrite#MultiMeasureAttributeMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#MixedMeasureMappingList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#MixedMeasureMapping"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#MultiMeasureAttributeMapping": {
+      "type": "structure",
+      "members": {
+        "SourceColumn": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetMultiMeasureAttributeName": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "MeasureValueType": {
+          "target": "com.amazonaws.timestreamwrite#ScalarMeasureValueType",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#MultiMeasureAttributeMappingList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#MultiMeasureAttributeMapping"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#MultiMeasureMappings": {
+      "type": "structure",
+      "members": {
+        "TargetMultiMeasureName": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "MultiMeasureAttributeMappings": {
+          "target": "com.amazonaws.timestreamwrite#MultiMeasureAttributeMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#PageLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#PaginationLimit": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#PartitionKey": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.timestreamwrite#PartitionKeyType",
+          "traits": {
+            "smithy.api#documentation": "<p> The type of the partition key. Options are DIMENSION (dimension key) and MEASURE\n         (measure key). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p> The name of the attribute used for a dimension key. </p>"
+          }
+        },
+        "EnforcementInRecord": {
+          "target": "com.amazonaws.timestreamwrite#PartitionKeyEnforcementLevel",
+          "traits": {
+            "smithy.api#documentation": "<p> The level of enforcement for the specification of a dimension key in ingested records.\n         Options are REQUIRED (dimension key must be specified) and OPTIONAL (dimension key does not\n         have to be specified). </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> An attribute used in partitioning data in a table. A dimension key partitions data\n         using the values of the dimension specified by the dimension-name as partition key, while a\n         measure key partitions data using measure names (values of the 'measure_name' column).\n      </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#PartitionKeyEnforcementLevel": {
+      "type": "enum",
+      "members": {
+        "REQUIRED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REQUIRED"
+          }
+        },
+        "OPTIONAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OPTIONAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#PartitionKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#PartitionKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#PartitionKeyType": {
+      "type": "enum",
+      "members": {
+        "DIMENSION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DIMENSION"
+          }
+        },
+        "MEASURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MEASURE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Record": {
+      "type": "structure",
+      "members": {
+        "Dimensions": {
+          "target": "com.amazonaws.timestreamwrite#Dimensions",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the list of dimensions for time-series data points.</p>"
+          }
+        },
+        "MeasureName": {
+          "target": "com.amazonaws.timestreamwrite#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Measure represents the data attribute of the time series. For example, the CPU\n         utilization of an EC2 instance or the RPM of a wind turbine are measures. </p>"
+          }
+        },
+        "MeasureValue": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p> Contains the measure value for the time-series data point. </p>"
+          }
+        },
+        "MeasureValueType": {
+          "target": "com.amazonaws.timestreamwrite#MeasureValueType",
+          "traits": {
+            "smithy.api#documentation": "<p> Contains the data type of the measure value for the time-series data point. Default\n         type is <code>DOUBLE</code>. For more information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/writes.html#writes.data-types\">Data\n         types</a>.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.timestreamwrite#StringValue256",
+          "traits": {
+            "smithy.api#documentation": "<p> Contains the time at which the measure value for the data point was collected. The time\n         value plus the unit provides the time elapsed since the epoch. For example, if the time\n         value is <code>12345</code> and the unit is <code>ms</code>, then <code>12345 ms</code>\n         have elapsed since the epoch. </p>"
+          }
+        },
+        "TimeUnit": {
+          "target": "com.amazonaws.timestreamwrite#TimeUnit",
+          "traits": {
+            "smithy.api#documentation": "<p> The granularity of the timestamp unit. It indicates if the time value is in seconds,\n         milliseconds, nanoseconds, or other supported values. Default is <code>MILLISECONDS</code>.\n      </p>"
+          }
+        },
+        "Version": {
+          "target": "com.amazonaws.timestreamwrite#RecordVersion",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>64-bit attribute used for record updates. Write requests for duplicate data with a\n         higher version number will update the existing measure value and version. In cases where\n         the measure value is the same, <code>Version</code> will still be updated. Default value is\n            <code>1</code>.</p>\n         <note>\n            <p>\n               <code>Version</code> must be <code>1</code> or greater, or you will receive a\n               <code>ValidationException</code> error.</p>\n         </note>"
+          }
+        },
+        "MeasureValues": {
+          "target": "com.amazonaws.timestreamwrite#MeasureValues",
+          "traits": {
+            "smithy.api#documentation": "<p> Contains the list of MeasureValue for time-series data points. </p>\n         <p> This is only allowed for type <code>MULTI</code>. For scalar values, use\n            <code>MeasureValue</code> attribute of the record directly. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a time-series data point being written into Timestream. Each record\n         contains an array of dimensions. Dimensions represent the metadata attributes of a\n         time-series data point, such as the instance name or Availability Zone of an EC2 instance.\n         A record also contains the measure name, which is the name of the measure being collected\n         (for example, the CPU utilization of an EC2 instance). Additionally, a record contains the\n         measure value and the value type, which is the data type of the measure value. Also, the\n         record contains the timestamp of when the measure was collected and the timestamp unit,\n         which represents the granularity of the timestamp. </p>\n         <p> Records have a <code>Version</code> field, which is a 64-bit <code>long</code> that you\n         can use for updating data points. Writes of a duplicate record with the same dimension,\n         timestamp, and measure name but different measure value will only succeed if the\n            <code>Version</code> attribute of the record in the write request is higher than that of\n         the existing record. Timestream defaults to a <code>Version</code> of\n            <code>1</code> for records without the <code>Version</code> field. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#RecordIndex": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.timestreamwrite#RecordVersion": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.timestreamwrite#Records": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#Record"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#RecordsIngested": {
+      "type": "structure",
+      "members": {
+        "Total": {
+          "target": "com.amazonaws.timestreamwrite#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Total count of successfully ingested records.</p>"
+          }
+        },
+        "MemoryStore": {
+          "target": "com.amazonaws.timestreamwrite#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Count of records ingested into the memory store.</p>"
+          }
+        },
+        "MagneticStore": {
+          "target": "com.amazonaws.timestreamwrite#Integer",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Count of records ingested into the magnetic store.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information on the records ingested by this request.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#RejectedRecord": {
+      "type": "structure",
+      "members": {
+        "RecordIndex": {
+          "target": "com.amazonaws.timestreamwrite#RecordIndex",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p> The index of the record in the input request for WriteRecords. Indexes begin with 0.\n      </p>"
+          }
+        },
+        "Reason": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p> The reason why a record was not successfully inserted into Timestream.\n         Possible causes of failure include: </p>\n         <ul>\n            <li>\n               <p>Records with duplicate data where there are multiple records with the same\n               dimensions, timestamps, and measure names but: </p>\n               <ul>\n                  <li>\n                     <p>Measure values are different</p>\n                  </li>\n                  <li>\n                     <p>Version is not present in the request, <i>or</i> the value of\n                     version in the new record is equal to or lower than the existing value</p>\n                  </li>\n               </ul>\n               <p>If Timestream rejects data for this case, the\n                  <code>ExistingVersion</code> field in the <code>RejectedRecords</code> response\n               will indicate the current record\u2019s version. To force an update, you can resend the\n               request with a version for the record set to a value greater than the\n                  <code>ExistingVersion</code>.</p>\n            </li>\n            <li>\n               <p> Records with timestamps that lie outside the retention duration of the memory\n               store. </p>\n               <note>\n                  <p>When the retention window is updated, you will receive a\n                     <code>RejectedRecords</code> exception if you immediately try to ingest data\n                  within the new window. To avoid a <code>RejectedRecords</code> exception, wait\n                  until the duration of the new window to ingest new data. For further information,\n                  see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/best-practices.html#configuration\"> Best\n                     Practices for Configuring Timestream</a> and <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/storage.html\">the\n                     explanation of how storage works in Timestream</a>.</p>\n               </note>\n            </li>\n            <li>\n               <p> Records with dimensions or measures that exceed the Timestream defined\n               limits. </p>\n            </li>\n         </ul>\n         <p> For more information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Access Management</a> in the\n            Timestream Developer Guide. </p>"
+          }
+        },
+        "ExistingVersion": {
+          "target": "com.amazonaws.timestreamwrite#RecordVersion",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>The existing version of the record. This value is populated in scenarios where an\n         identical record exists with a higher version than the version in the write request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Represents records that were not successfully inserted into Timestream due to\n         data validation issues that must be resolved before reinserting time-series data into the\n         system. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#RejectedRecords": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#RejectedRecord"
+      }
+    },
+    "com.amazonaws.timestreamwrite#RejectedRecordsException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+        },
+        "RejectedRecords": {
+          "target": "com.amazonaws.timestreamwrite#RejectedRecords",
+          "traits": {
+            "smithy.api#documentation": "<p>\n      </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> WriteRecords would throw this exception in the following cases: </p>\n         <ul>\n            <li>\n               <p>Records with duplicate data where there are multiple records with the same\n               dimensions, timestamps, and measure names but: </p>\n               <ul>\n                  <li>\n                     <p>Measure values are different</p>\n                  </li>\n                  <li>\n                     <p>Version is not present in the request <i>or</i> the value of\n                     version in the new record is equal to or lower than the existing value</p>\n                  </li>\n               </ul>\n               <p> In this case, if Timestream rejects data, the\n                  <code>ExistingVersion</code> field in the <code>RejectedRecords</code> response\n               will indicate the current record\u2019s version. To force an update, you can resend the\n               request with a version for the record set to a value greater than the\n                  <code>ExistingVersion</code>.</p>\n            </li>\n            <li>\n               <p> Records with timestamps that lie outside the retention duration of the memory\n               store. </p>\n            </li>\n            <li>\n               <p> Records with dimensions or measures that exceed the Timestream defined\n               limits. </p>\n            </li>\n         </ul>\n         <p> For more information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Quotas</a> in the Amazon Timestream Developer Guide. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 419
+      }
+    },
+    "com.amazonaws.timestreamwrite#ReportConfiguration": {
+      "type": "structure",
+      "members": {
+        "ReportS3Configuration": {
+          "target": "com.amazonaws.timestreamwrite#ReportS3Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration of an S3 location to write error reports and events for a batch\n         load.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Report configuration for a batch load task. This contains details about where error\n         reports are stored.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ReportS3Configuration": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.timestreamwrite#S3BucketName",
+          "traits": {
+            "smithy.api#documentation": "<p></p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ObjectKeyPrefix": {
+          "target": "com.amazonaws.timestreamwrite#S3ObjectKeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "EncryptionOption": {
+          "target": "com.amazonaws.timestreamwrite#S3EncryptionOption",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p></p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p></p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ResourceCreateAPIName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^[a-zA-Z0-9_.-]+$"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ResourceName": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamwrite#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The operation tried to access a nonexistent resource. The resource might not be\n         specified correctly, or its status might not be ACTIVE.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.timestreamwrite#ResumeBatchLoadTask": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>\n      </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskRequest": {
+      "type": "structure",
+      "members": {
+        "TaskId": {
+          "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the batch load task to resume.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#RetentionProperties": {
+      "type": "structure",
+      "members": {
+        "MemoryStoreRetentionPeriodInHours": {
+          "target": "com.amazonaws.timestreamwrite#MemoryStoreRetentionPeriodInHours",
+          "traits": {
+            "smithy.api#documentation": "<p>The duration for which data must be stored in the memory store. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MagneticStoreRetentionPeriodInDays": {
+          "target": "com.amazonaws.timestreamwrite#MagneticStoreRetentionPeriodInDays",
+          "traits": {
+            "smithy.api#documentation": "<p>The duration for which data must be stored in the magnetic store. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Retention properties contain the duration for which your time-series data must be stored\n         in the magnetic store and the memory store. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#S3BucketName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+      }
+    },
+    "com.amazonaws.timestreamwrite#S3Configuration": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.timestreamwrite#S3BucketName",
+          "traits": {
+            "smithy.api#documentation": "<p>The bucket name of the customer S3 bucket.</p>"
+          }
+        },
+        "ObjectKeyPrefix": {
+          "target": "com.amazonaws.timestreamwrite#S3ObjectKeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>The object key preview for the customer S3 location.</p>"
+          }
+        },
+        "EncryptionOption": {
+          "target": "com.amazonaws.timestreamwrite#S3EncryptionOption",
+          "traits": {
+            "smithy.api#documentation": "<p>The encryption option for the customer S3 location. Options are S3 server-side\n         encryption with an S3 managed key or Amazon Web Services managed key.</p>"
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The KMS key ID for the customer S3 location when encrypting with an\n            Amazon Web Services managed key.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The configuration that specifies an S3 location.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#S3EncryptionOption": {
+      "type": "enum",
+      "members": {
+        "SSE_S3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSE_S3"
+          }
+        },
+        "SSE_KMS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSE_KMS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#S3ObjectKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+      }
+    },
+    "com.amazonaws.timestreamwrite#S3ObjectKeyPrefix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 928
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+      }
+    },
+    "com.amazonaws.timestreamwrite#ScalarMeasureValueType": {
+      "type": "enum",
+      "members": {
+        "DOUBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOUBLE"
+          }
+        },
+        "BIGINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIGINT"
+          }
+        },
+        "BOOLEAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOLEAN"
+          }
+        },
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        },
+        "TIMESTAMP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMESTAMP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Schema": {
+      "type": "structure",
+      "members": {
+        "CompositePartitionKey": {
+          "target": "com.amazonaws.timestreamwrite#PartitionKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>A non-empty list of partition keys defining the attributes used to partition the table\n         data. The order of the list determines the partition hierarchy. The name and type of each\n         partition key as well as the partition key order cannot be changed after the table is\n         created. However, the enforcement level of each partition key can be changed. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> A Schema specifies the expected data model of the table. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#SchemaName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#SchemaValue": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamwrite#ServiceQuotaExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The instance quota of resource exceeded for this account.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
+      }
+    },
+    "com.amazonaws.timestreamwrite#String": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamwrite#StringValue1": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#StringValue2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#StringValue256": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Table": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.timestreamwrite#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name that uniquely identifies this table.</p>"
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table.</p>"
+          }
+        },
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database that contains this table.</p>"
+          }
+        },
+        "TableStatus": {
+          "target": "com.amazonaws.timestreamwrite#TableStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The current state of the table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "RetentionProperties": {
+          "target": "com.amazonaws.timestreamwrite#RetentionProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The retention duration for the memory store and magnetic store.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Timestream table was created. </p>"
+          }
+        },
+        "LastUpdatedTime": {
+          "target": "com.amazonaws.timestreamwrite#Date",
+          "traits": {
+            "smithy.api#documentation": "<p>The time when the Timestream table was last updated.</p>"
+          }
+        },
+        "MagneticStoreWriteProperties": {
+          "target": "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains properties to set on the table when enabling magnetic store writes.</p>"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.timestreamwrite#Schema",
+          "traits": {
+            "smithy.api#documentation": "<p> The schema of the table. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a database table in Timestream. Tables contain one or more related\n         time series. You can modify the retention duration of the memory store and the magnetic\n         store for a table. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#TableList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#Table"
+      }
+    },
+    "com.amazonaws.timestreamwrite#TableStatus": {
+      "type": "enum",
+      "members": {
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "RESTORING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "RESTORING"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.timestreamwrite#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p> The key of the tag. Tag keys are case sensitive. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.timestreamwrite#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p> The value of the tag. Tag values are case-sensitive and can be null. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> A tag is a label that you assign to a Timestream database and/or table. Each\n         tag consists of a key and an optional value, both of which you define. With tags, you can\n         categorize databases and/or tables, for example, by purpose, owner, or environment. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamwrite#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> Associates a set of tags with a Timestream resource. You can then activate\n         these user-defined tags so that they appear on the Billing and Cost Management console for\n         cost allocation tracking. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.timestreamwrite#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p> Identifies the Timestream resource to which tags should be added. This value\n         is an Amazon Resource Name (ARN). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.timestreamwrite#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p> The tags to be assigned to the Timestream resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#ThrottlingException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Too many requests were made by a user and they exceeded the service quotas. The request\n         was throttled.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.timestreamwrite#TimeUnit": {
+      "type": "enum",
+      "members": {
+        "MILLISECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MILLISECONDS"
+          }
+        },
+        "SECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SECONDS"
+          }
+        },
+        "MICROSECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MICROSECONDS"
+          }
+        },
+        "NANOSECONDS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NANOSECONDS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#Timestream_20181101": {
+      "type": "service",
+      "version": "2018-11-01",
+      "operations": [
+        {
+          "target": "com.amazonaws.timestreamwrite#CreateBatchLoadTask"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#CreateDatabase"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#CreateTable"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#DeleteDatabase"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#DeleteTable"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#DescribeBatchLoadTask"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#DescribeDatabase"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#DescribeEndpoints"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#DescribeTable"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ListBatchLoadTasks"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ListDatabases"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ListTables"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResumeBatchLoadTask"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#TagResource"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#UpdateDatabase"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#UpdateTable"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#WriteRecords"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#CancelQuery"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#CreateScheduledQuery"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#DeleteScheduledQuery"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#DescribeAccountSettings"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#DescribeScheduledQuery"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ExecuteScheduledQuery"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ListScheduledQueries"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#PrepareQuery"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#Query"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#UpdateAccountSettings"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#UpdateScheduledQuery"
+        }
+      ],
+      "traits": {
+        "aws.api#clientEndpointDiscovery": {
+          "operation": "com.amazonaws.timestreamwrite#DescribeEndpoints",
+          "error": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        "aws.api#service": {
+          "sdkId": "Timestream Write",
+          "arnNamespace": "timestream",
+          "cloudFormationName": "TimestreamWrite",
+          "cloudTrailEventSource": "timestreamwrite.amazonaws.com",
+          "endpointPrefix": "ingest.timestream"
+        },
+        "aws.auth#sigv4": {
+          "name": "timestream"
+        },
+        "aws.protocols#awsJson1_0": {},
+        "smithy.api#documentation": "<fullname>Amazon Timestream Write</fullname>\n         <p>Amazon Timestream is a fast, scalable, fully managed time-series database service\n         that makes it easy to store and analyze trillions of time-series data points per day. With\n            Timestream, you can easily store and analyze IoT sensor data to derive insights\n         from your IoT applications. You can analyze industrial telemetry to streamline equipment\n         management and maintenance. You can also store and analyze log data and metrics to improve\n         the performance and availability of your applications. </p>\n         <p>Timestream is built from the ground up to effectively ingest, process, and\n         store time-series data. It organizes data to optimize query processing. It automatically\n         scales based on the volume of data ingested and on the query volume to ensure you receive\n         optimal performance while inserting and querying data. As your data grows over time,\n            Timestream\u2019s adaptive query processing engine spans across storage tiers to\n         provide fast analysis while reducing costs.</p>",
+        "smithy.api#title": "Amazon Timestream Write",
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://timestream-ingest-fips.{Region}.api.aws",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://timestream-ingest.{Region}.api.aws",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://ingest.timestream-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://ingest.timestream.{Region}.amazonaws.com",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://ingest.timestream-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://ingest.timestream.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://ingest.timestream.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 18,
+          "nodes": "/////wAAAAH/////AAAAAAAAABEAAAADAAAAAQAAAAQF9eEOAAAAAgAAAAUF9eEOAAAAAwAAAAoAAAAGAAAABAAAAAcF9eENAAAABgAAAAgF9eEMAAAABwX14QUAAAAJAAAACAX14QUF9eELAAAABAAAAA0AAAALAAAABQAAAAwF9eEKAAAACAX14QgF9eEJAAAABQAAAA4F9eEHAAAABgAAAA8F9eEHAAAABwX14QQAAAAQAAAACAX14QUF9eEGAAAAAwX14QEAAAASAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    "aws",
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://timestream-ingest-fips.{Region}.api.aws",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    "aws-us-gov",
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://timestream-ingest.{Region}.api.aws",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://ingest.timestream-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws-us-gov"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://ingest.timestream.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://ingest.timestream-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    "aws",
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://timestream-ingest.{Region}.api.aws",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    "aws-us-gov",
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://timestream-ingest.{Region}.api.aws",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://ingest.timestream.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://ingest.timestream.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.ap-northeast-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.ap-south-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.ap-southeast-2.api.aws"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.eu-central-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.eu-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-east-2.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest-fips.us-east-2.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-west-2.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest-fips.us-west-2.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-gov-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-gov-west-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://timestream-ingest.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://ingest.timestream.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.timestreamwrite#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> Removes the association of tags from a Timestream resource. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.timestreamwrite#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p> The Timestream resource that the tags will be removed from. This value is an\n         Amazon Resource Name (ARN). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.timestreamwrite#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p> A list of tags keys. Existing tags of the resource whose keys are members of this list\n         will be removed from the Timestream resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#UpdateDatabase": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#UpdateDatabaseRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#UpdateDatabaseResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> Modifies the KMS key for an existing database. While updating the\n         database, you must specify the database name and the identifier of the new KMS key to be used (<code>KmsKeyId</code>). If there are any concurrent\n            <code>UpdateDatabase</code> requests, first writer wins. </p>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.update-db.html\">code sample</a>\n         for details.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#UpdateDatabaseRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p> The name of the database. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamwrite#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p> The identifier of the new KMS key (<code>KmsKeyId</code>) to be used to\n         encrypt the data stored in the database. If the <code>KmsKeyId</code> currently registered\n         with the database is the same as the <code>KmsKeyId</code> in the request, there will not\n         be any update. </p>\n         <p>You can specify the <code>KmsKeyId</code> using any of the following:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN:\n                  <code>arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN:\n               <code>arn:aws:kms:us-east-1:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#UpdateDatabaseResponse": {
+      "type": "structure",
+      "members": {
+        "Database": {
+          "target": "com.amazonaws.timestreamwrite#Database"
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#UpdateTable": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#UpdateTableRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#UpdateTableResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Modifies the retention duration of the memory store and magnetic store for your Timestream table. Note that the change in retention duration takes effect immediately.\n         For example, if the retention period of the memory store was initially set to 2 hours and\n         then changed to 24 hours, the memory store will be capable of holding 24 hours of data, but\n         will be populated with 24 hours of data 22 hours after this change was made. Timestream does not retrieve data from the magnetic store to populate the memory store. </p>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.update-table.html\">code\n            sample</a> for details.</p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#UpdateTableRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RetentionProperties": {
+          "target": "com.amazonaws.timestreamwrite#RetentionProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The retention duration of the memory store and the magnetic store.</p>"
+          }
+        },
+        "MagneticStoreWriteProperties": {
+          "target": "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains properties to set on the table when enabling magnetic store writes.</p>"
+          }
+        },
+        "Schema": {
+          "target": "com.amazonaws.timestreamwrite#Schema",
+          "traits": {
+            "smithy.api#documentation": "<p> The schema of the table. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#UpdateTableResponse": {
+      "type": "structure",
+      "members": {
+        "Table": {
+          "target": "com.amazonaws.timestreamwrite#Table",
+          "traits": {
+            "smithy.api#documentation": "<p>The updated Timestream table.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#ValidationException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> An invalid or malformed request.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.timestreamwrite#WriteRecords": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamwrite#WriteRecordsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamwrite#WriteRecordsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#RejectedRecordsException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamwrite#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Enables you to write your time-series data into Timestream. You can specify a\n         single data point or a batch of data points to be inserted into the system. Timestream offers you a flexible schema that auto detects the column names and data\n         types for your Timestream tables based on the dimension names and data types of\n         the data points you specify when invoking writes into the database. </p>\n         <p>Timestream supports eventual consistency read semantics. This means that when\n         you query data immediately after writing a batch of data into Timestream, the\n         query results might not reflect the results of a recently completed write operation. The\n         results may also include some stale data. If you repeat the query request after a short\n         time, the results should return the latest data. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. </p>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.write.html\">code sample</a> for\n         details.</p>\n         <p>\n            <b>Upserts</b>\n         </p>\n         <p>You can use the <code>Version</code> parameter in a <code>WriteRecords</code> request to\n         update data points. Timestream tracks a version number with each record.\n            <code>Version</code> defaults to <code>1</code> when it's not specified for the record\n         in the request. Timestream updates an existing record\u2019s measure value along with\n         its <code>Version</code> when it receives a write request with a higher\n            <code>Version</code> number for that record. When it receives an update request where\n         the measure value is the same as that of the existing record, Timestream still\n         updates <code>Version</code>, if it is greater than the existing value of\n            <code>Version</code>. You can update a data point as many times as desired, as long as\n         the value of <code>Version</code> continuously increases. </p>\n         <p> For example, suppose you write a new record without indicating <code>Version</code> in\n         the request. Timestream stores this record, and set <code>Version</code> to\n            <code>1</code>. Now, suppose you try to update this record with a\n            <code>WriteRecords</code> request of the same record with a different measure value but,\n         like before, do not provide <code>Version</code>. In this case, Timestream will\n         reject this update with a <code>RejectedRecordsException</code> since the updated record\u2019s\n         version is not greater than the existing value of Version. </p>\n         <p>However, if you were to resend the update request with <code>Version</code> set to\n            <code>2</code>, Timestream would then succeed in updating the record\u2019s value,\n         and the <code>Version</code> would be set to <code>2</code>. Next, suppose you sent a\n            <code>WriteRecords</code> request with this same record and an identical measure value,\n         but with <code>Version</code> set to <code>3</code>. In this case, Timestream\n         would only update <code>Version</code> to <code>3</code>. Any further updates would need to\n         send a version number greater than <code>3</code>, or the update requests would receive a\n            <code>RejectedRecordsException</code>. </p>"
+      }
+    },
+    "com.amazonaws.timestreamwrite#WriteRecordsRequest": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamwrite#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CommonAttributes": {
+          "target": "com.amazonaws.timestreamwrite#Record",
+          "traits": {
+            "smithy.api#documentation": "<p>A record that contains the common measure, dimension, time, and version attributes\n         shared across all the records in the request. The measure and dimension attributes\n         specified will be merged with the measure and dimension attributes in the records object\n         when the data is written into Timestream. Dimensions may not overlap, or a\n            <code>ValidationException</code> will be thrown. In other words, a record must contain\n         dimensions with unique names. </p>"
+          }
+        },
+        "Records": {
+          "target": "com.amazonaws.timestreamwrite#Records",
+          "traits": {
+            "smithy.api#documentation": "<p>An array of records that contain the unique measure, dimension, time, and version\n         attributes for each time-series data point. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamwrite#WriteRecordsResponse": {
+      "type": "structure",
+      "members": {
+        "RecordsIngested": {
+          "target": "com.amazonaws.timestreamwrite#RecordsIngested",
+          "traits": {
+            "smithy.api#documentation": "<p>Information on the records ingested by this request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#AccessDeniedException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ServiceErrorMessage"
+        }
+      },
+      "traits": {
+        "aws.protocols#awsQueryError": {
+          "code": "AccessDenied",
+          "httpResponseCode": 403
+        },
+        "smithy.api#documentation": "<p>You do not have the necessary permissions to access the account settings.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 403
+      }
+    },
+    "com.amazonaws.timestreamquery#AccountSettingsNotificationConfiguration": {
+      "type": "structure",
+      "members": {
+        "SnsConfiguration": {
+          "target": "com.amazonaws.timestreamquery#SnsConfiguration"
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>An Amazon Resource Name (ARN) that grants Timestream permission to publish notifications. This field is only visible if SNS Topic is provided when updating the account settings.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration settings for notifications related to account settings.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#AmazonResourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#CancelQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#CancelQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#CancelQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> Cancels a query that has been issued. Cancellation is provided only if the query has\n            not completed running before the cancellation request was issued. Because cancellation\n            is an idempotent operation, subsequent cancellation requests will return a\n                <code>CancellationMessage</code>, indicating that the query has already been\n            canceled. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.cancel-query.html\">code\n                sample</a> for details. </p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#CancelQueryRequest": {
+      "type": "structure",
+      "members": {
+        "QueryId": {
+          "target": "com.amazonaws.timestreamquery#QueryId",
+          "traits": {
+            "smithy.api#documentation": "<p> The ID of the query that needs to be cancelled. <code>QueryID</code> is returned as\n            part of the query result. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#CancelQueryResponse": {
+      "type": "structure",
+      "members": {
+        "CancellationMessage": {
+          "target": "com.amazonaws.timestreamquery#String",
+          "traits": {
+            "smithy.api#documentation": "<p> A <code>CancellationMessage</code> is returned when a <code>CancelQuery</code>\n            request for the query specified by <code>QueryId</code> has already been issued. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ClientRequestToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 32,
+          "max": 128
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ClientToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 32,
+          "max": 128
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ColumnInfo": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#String",
+          "traits": {
+            "smithy.api#documentation": "<p> The name of the result set column. The name of the result set is available for\n            columns of all data types except for arrays. </p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.timestreamquery#Type",
+          "traits": {
+            "smithy.api#documentation": "<p>The data type of the result set column. The data type can be a scalar or complex.\n            Scalar data types are integers, strings, doubles, Booleans, and others. Complex data\n            types are types such as arrays, rows, and others. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Contains the metadata for query results such as the column names, data types, and\n            other attributes. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ColumnInfoList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#ColumnInfo"
+      }
+    },
+    "com.amazonaws.timestreamquery#ComputeMode": {
+      "type": "enum",
+      "members": {
+        "ON_DEMAND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ON_DEMAND"
+          }
+        },
+        "PROVISIONED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PROVISIONED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ConflictException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Unable to poll results for a cancelled query. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.timestreamquery#CreateScheduledQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#CreateScheduledQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#CreateScheduledQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> Create a scheduled query that will be run on your behalf at the configured schedule.\n            Timestream assumes the execution role provided as part of the\n                <code>ScheduledQueryExecutionRoleArn</code> parameter to run the query. You can use\n            the <code>NotificationConfiguration</code> parameter to configure notification for your\n            scheduled query operations.</p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#CreateScheduledQueryRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "QueryString": {
+          "target": "com.amazonaws.timestreamquery#QueryString",
+          "traits": {
+            "smithy.api#documentation": "<p>The query string to run. Parameter names can be specified in the query string\n                <code>@</code> character followed by an identifier. The named Parameter\n                <code>@scheduled_runtime</code> is reserved and can be used in the query to get the\n            time at which the query is scheduled to run.</p>\n         <p>The timestamp calculated according to the ScheduleConfiguration parameter, will be the\n            value of <code>@scheduled_runtime</code> paramater for each query run. For example,\n            consider an instance of a scheduled query executing on 2021-12-01 00:00:00. For this\n            instance, the <code>@scheduled_runtime</code> parameter is initialized to the timestamp\n            2021-12-01 00:00:00 when invoking the query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ScheduleConfiguration": {
+          "target": "com.amazonaws.timestreamquery#ScheduleConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>The schedule configuration for the query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NotificationConfiguration": {
+          "target": "com.amazonaws.timestreamquery#NotificationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Notification configuration for the scheduled query. A notification is sent by\n            Timestream when a query run finishes, when the state is updated or when you delete it.\n        </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetConfiguration": {
+          "target": "com.amazonaws.timestreamquery#TargetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration used for writing the result of a query.</p>"
+          }
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.timestreamquery#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Using a ClientToken makes the call to CreateScheduledQuery idempotent, in other words,\n            making the same request repeatedly will produce the same result. Making multiple\n            identical CreateScheduledQuery requests has the same effect as making a single request. </p>\n         <ul>\n            <li>\n               <p> If CreateScheduledQuery is called without a <code>ClientToken</code>, the\n                    Query SDK generates a <code>ClientToken</code> on your behalf.</p>\n            </li>\n            <li>\n               <p> After 8 hours, any request with the same <code>ClientToken</code> is treated\n                    as a new request. </p>\n            </li>\n         </ul>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "ScheduledQueryExecutionRoleArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN for the IAM role that Timestream will assume when running the scheduled query.\n        </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.timestreamquery#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of key-value pairs to label the scheduled query.</p>"
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamquery#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon KMS key used to encrypt the scheduled query resource, at-rest. If the\n            Amazon KMS key is not specified, the scheduled query resource will be encrypted with a\n            Timestream owned Amazon KMS key. To specify a KMS key, use the key ID, key ARN, alias\n            name, or alias ARN. When using an alias name, prefix the name with\n                <i>alias/</i>\n         </p>\n         <p>If ErrorReportConfiguration uses <code>SSE_KMS</code> as encryption type, the same\n            KmsKeyId is used to encrypt the error report at rest.</p>"
+          }
+        },
+        "ErrorReportConfiguration": {
+          "target": "com.amazonaws.timestreamquery#ErrorReportConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration for error reporting. Error reports will be generated when a problem is\n            encountered when writing the query results. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#CreateScheduledQueryResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN for the created scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#Datum": {
+      "type": "structure",
+      "members": {
+        "ScalarValue": {
+          "target": "com.amazonaws.timestreamquery#ScalarValue",
+          "traits": {
+            "smithy.api#documentation": "<p> Indicates if the data point is a scalar value such as integer, string, double, or\n            Boolean. </p>"
+          }
+        },
+        "TimeSeriesValue": {
+          "target": "com.amazonaws.timestreamquery#TimeSeriesDataPointList",
+          "traits": {
+            "smithy.api#documentation": "<p> Indicates if the data point is a timeseries data type. </p>"
+          }
+        },
+        "ArrayValue": {
+          "target": "com.amazonaws.timestreamquery#DatumList",
+          "traits": {
+            "smithy.api#documentation": "<p> Indicates if the data point is an array. </p>"
+          }
+        },
+        "RowValue": {
+          "target": "com.amazonaws.timestreamquery#Row",
+          "traits": {
+            "smithy.api#documentation": "<p> Indicates if the data point is a row. </p>"
+          }
+        },
+        "NullValue": {
+          "target": "com.amazonaws.timestreamquery#NullableBoolean",
+          "traits": {
+            "smithy.api#documentation": "<p> Indicates if the data point is null. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Datum represents a single data point in a query result. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#DatumList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#Datum"
+      }
+    },
+    "com.amazonaws.timestreamquery#DeleteScheduledQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#DeleteScheduledQueryRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Deletes a given scheduled query. This is an irreversible operation. </p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DeleteScheduledQueryRequest": {
+      "type": "structure",
+      "members": {
+        "ScheduledQueryArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the scheduled query. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeAccountSettings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#DescribeAccountSettingsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#DescribeAccountSettingsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Describes the settings for your account that include the query pricing model and the configured maximum TCUs the service can use for your query workload.</p>\n         <p>You're charged only for the duration of compute units used for your workloads.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeAccountSettingsRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeAccountSettingsResponse": {
+      "type": "structure",
+      "members": {
+        "MaxQueryTCU": {
+          "target": "com.amazonaws.timestreamquery#MaxQueryCapacity",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/tcu.html\">Timestream compute units</a> (TCUs) the service will use at any point in time to serve your queries. To run queries, you must set a minimum capacity of 4 TCU. You can set the maximum number of TCU in multiples of 4, for example, 4, 8, 16, 32, and so on. This configuration is applicable only for on-demand usage of (TCUs). \n        \n        \n        </p>"
+          }
+        },
+        "QueryPricingModel": {
+          "target": "com.amazonaws.timestreamquery#QueryPricingModel",
+          "traits": {
+            "smithy.api#documentation": "<p>The pricing model for queries in your account.</p>\n         <note>\n            <p>The <code>QueryPricingModel</code> parameter is used by several Timestream operations; however, the <code>UpdateAccountSettings</code> API operation doesn't recognize any values other than <code>COMPUTE_UNITS</code>.</p>\n         </note>"
+          }
+        },
+        "QueryCompute": {
+          "target": "com.amazonaws.timestreamquery#QueryComputeResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the usage settings for Timestream Compute Units (TCUs) in your account for the query workload. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeEndpoints": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#DescribeEndpointsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#DescribeEndpointsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>DescribeEndpoints returns a list of available endpoints to make Timestream\n            API calls against. This API is available through both Write and Query.</p>\n         <p>Because the Timestream SDKs are designed to transparently work with the\n            service\u2019s architecture, including the management and mapping of the service endpoints,\n                <i>it is not recommended that you use this API unless</i>:</p>\n         <ul>\n            <li>\n               <p>You are using <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/VPCEndpoints\">VPC endpoints (Amazon Web Services PrivateLink) with Timestream\n                    </a>\n               </p>\n            </li>\n            <li>\n               <p>Your application uses a programming language that does not yet have SDK\n                    support</p>\n            </li>\n            <li>\n               <p>You require better control over the client-side implementation</p>\n            </li>\n         </ul>\n         <p>For detailed information on how and when to use and implement DescribeEndpoints, see\n                <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/Using.API.html#Using-API.endpoint-discovery\">The Endpoint Discovery Pattern</a>.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeEndpointsRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeEndpointsResponse": {
+      "type": "structure",
+      "members": {
+        "Endpoints": {
+          "target": "com.amazonaws.timestreamquery#Endpoints",
+          "traits": {
+            "smithy.api#documentation": "<p>An <code>Endpoints</code> object is returned when a <code>DescribeEndpoints</code>\n            request is made.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeScheduledQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#DescribeScheduledQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#DescribeScheduledQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Provides detailed information about a scheduled query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeScheduledQueryRequest": {
+      "type": "structure",
+      "members": {
+        "ScheduledQueryArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DescribeScheduledQueryResponse": {
+      "type": "structure",
+      "members": {
+        "ScheduledQuery": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#DimensionMapping": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Column name from query result.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DimensionValueType": {
+          "target": "com.amazonaws.timestreamquery#DimensionValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>Type for the dimension. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This type is used to map column(s) from the query result to a dimension in the\n            destination table.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#DimensionMappingList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#DimensionMapping"
+      }
+    },
+    "com.amazonaws.timestreamquery#DimensionValueType": {
+      "type": "enum",
+      "members": {
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#Double": {
+      "type": "double",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.timestreamquery#Endpoint": {
+      "type": "structure",
+      "members": {
+        "Address": {
+          "target": "com.amazonaws.timestreamquery#String",
+          "traits": {
+            "smithy.api#documentation": "<p>An endpoint address.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CachePeriodInMinutes": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The TTL for the endpoint, in minutes.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an available endpoint against which to make API calls against, as well as\n            the TTL for that endpoint.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#Endpoints": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#Endpoint"
+      }
+    },
+    "com.amazonaws.timestreamquery#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#ErrorReportConfiguration": {
+      "type": "structure",
+      "members": {
+        "S3Configuration": {
+          "target": "com.amazonaws.timestreamquery#S3Configuration",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 configuration for the error reports.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration required for error reporting.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ErrorReportLocation": {
+      "type": "structure",
+      "members": {
+        "S3ReportLocation": {
+          "target": "com.amazonaws.timestreamquery#S3ReportLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The S3 location where error reports are written.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This contains the location of the error report for a single scheduled query call.\n        </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ExecuteScheduledQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#ExecuteScheduledQueryRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p> You can use this API to run a scheduled query manually. </p>\n         <p>If you enabled <code>QueryInsights</code>, this API also returns insights and metrics related to the query that you executed as part of an Amazon SNS notification. <code>QueryInsights</code> helps with performance tuning of your query. For more information about <code>QueryInsights</code>, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/using-query-insights.html\">Using query insights to optimize queries in Amazon Timestream</a>.</p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ExecuteScheduledQueryRequest": {
+      "type": "structure",
+      "members": {
+        "ScheduledQueryArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InvocationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp in UTC. Query will be run as if it was invoked at this timestamp.\n        </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.timestreamquery#ClientToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Not used. </p>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "QueryInsights": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryInsights",
+          "traits": {
+            "smithy.api#documentation": "<p>Encapsulates settings for enabling <code>QueryInsights</code>.</p>\n         <p>Enabling <code>QueryInsights</code> returns insights and metrics as a part of the Amazon SNS notification for the query that you executed. You can use <code>QueryInsights</code> to tune your query performance and cost.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ExecutionStats": {
+      "type": "structure",
+      "members": {
+        "ExecutionTimeInMillis": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Total time, measured in milliseconds, that was needed for the scheduled query run to\n            complete.</p>"
+          }
+        },
+        "DataWrites": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Data writes metered for records ingested in a single scheduled query run.</p>"
+          }
+        },
+        "BytesMetered": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Bytes metered for a single scheduled query run.</p>"
+          }
+        },
+        "CumulativeBytesScanned": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Bytes scanned for a single scheduled query run.</p>"
+          }
+        },
+        "RecordsIngested": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The number of records ingested for a single scheduled query run. </p>"
+          }
+        },
+        "QueryResultRows": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Number of rows present in the output from running a query before ingestion to\n            destination data source.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Statistics for a single scheduled query run.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#InternalServerException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An internal server error occurred while processing the request.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.timestreamquery#InvalidEndpointException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested endpoint is invalid.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 421
+      }
+    },
+    "com.amazonaws.timestreamquery#LastUpdate": {
+      "type": "structure",
+      "members": {
+        "TargetQueryTCU": {
+          "target": "com.amazonaws.timestreamquery#QueryTCU",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of TimeStream Compute Units (TCUs) requested in the last account settings update.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.timestreamquery#LastUpdateStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the last update. Can be either <code>PENDING</code>, <code>FAILED</code>, or <code>SUCCEEDED</code>.</p>"
+          }
+        },
+        "StatusMessage": {
+          "target": "com.amazonaws.timestreamquery#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Error message describing the last account settings update status, visible only if an error occurred.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration object that contains the most recent account settings update, visible only if settings have been updated previously.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#LastUpdateStatus": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "SUCCEEDED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUCCEEDED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ListScheduledQueries": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#ListScheduledQueriesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#ListScheduledQueriesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Gets a list of all scheduled queries in the caller's Amazon account and Region.\n                <code>ListScheduledQueries</code> is eventually consistent. </p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "ScheduledQueries",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ListScheduledQueriesRequest": {
+      "type": "structure",
+      "members": {
+        "MaxResults": {
+          "target": "com.amazonaws.timestreamquery#MaxScheduledQueriesResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of items to return in the output. If the total number of items\n            available is more than the value specified, a <code>NextToken</code> is provided in the\n            output. To resume pagination, provide the <code>NextToken</code> value as the argument\n            to the subsequent call to <code>ListScheduledQueriesRequest</code>.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamquery#NextScheduledQueriesResultsToken",
+          "traits": {
+            "smithy.api#documentation": "<p> A pagination token to resume pagination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ListScheduledQueriesResponse": {
+      "type": "structure",
+      "members": {
+        "ScheduledQueries": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of scheduled queries.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamquery#NextScheduledQueriesResultsToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token to specify where to start paginating. This is the NextToken from a previously\n            truncated response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>List all tags on a Timestream query resource.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Tags",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Timestream resource with tags to be listed. This value is an Amazon Resource Name\n            (ARN).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.timestreamquery#MaxTagsForResourceResult",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of tags to return.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamquery#NextTagsForResourceResultsToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token to resume pagination.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.timestreamquery#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags currently associated with the Timestream resource. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamquery#NextTagsForResourceResultsToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A pagination token to resume pagination with a subsequent call to\n                <code>ListTagsForResourceResponse</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#Long": {
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
+    },
+    "com.amazonaws.timestreamquery#MaxQueryCapacity": {
+      "type": "integer"
+    },
+    "com.amazonaws.timestreamquery#MaxQueryResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#MaxScheduledQueriesResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#MaxTagsForResourceResult": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#MeasureValueType": {
+      "type": "enum",
+      "members": {
+        "BIGINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIGINT"
+          }
+        },
+        "BOOLEAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOLEAN"
+          }
+        },
+        "DOUBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOUBLE"
+          }
+        },
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        },
+        "MULTI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#MixedMeasureMapping": {
+      "type": "structure",
+      "members": {
+        "MeasureName": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Refers to the value of measure_name in a result row. This field is required if\n            MeasureNameColumn is provided.</p>"
+          }
+        },
+        "SourceColumn": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>This field refers to the source column from which measure-value is to be read for\n            result materialization.</p>"
+          }
+        },
+        "TargetMeasureName": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Target measure name to be used. If not provided, the target measure name by default\n            would be measure-name if provided, or sourceColumn otherwise. </p>"
+          }
+        },
+        "MeasureValueType": {
+          "target": "com.amazonaws.timestreamquery#MeasureValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>Type of the value that is to be read from sourceColumn. If the mapping is for MULTI,\n            use MeasureValueType.MULTI.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MultiMeasureAttributeMappings": {
+          "target": "com.amazonaws.timestreamquery#MultiMeasureAttributeMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p>Required when measureValueType is MULTI. Attribute mappings for MULTI value\n            measures.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>MixedMeasureMappings are mappings that can be used to ingest data into a mixture of\n            narrow and multi measures in the derived table.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#MixedMeasureMappingList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#MixedMeasureMapping"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#MultiMeasureAttributeMapping": {
+      "type": "structure",
+      "members": {
+        "SourceColumn": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Source column from where the attribute value is to be read.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetMultiMeasureAttributeName": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Custom name to be used for attribute name in derived table. If not provided, source\n            column name would be used.</p>"
+          }
+        },
+        "MeasureValueType": {
+          "target": "com.amazonaws.timestreamquery#ScalarMeasureValueType",
+          "traits": {
+            "smithy.api#documentation": "<p>Type of the attribute to be read from the source column.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Attribute mapping for MULTI value measures.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#MultiMeasureAttributeMappingList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#MultiMeasureAttributeMapping"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#MultiMeasureMappings": {
+      "type": "structure",
+      "members": {
+        "TargetMultiMeasureName": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the target multi-measure name in the derived table. This input is required\n            when measureNameColumn is not provided. If MeasureNameColumn is provided, then value\n            from that column will be used as multi-measure name.</p>"
+          }
+        },
+        "MultiMeasureAttributeMappings": {
+          "target": "com.amazonaws.timestreamquery#MultiMeasureAttributeMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p>Required. Attribute mappings to be used for mapping query results to ingest data for\n            multi-measure attributes.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Only one of MixedMeasureMappings or MultiMeasureMappings is to be provided.\n            MultiMeasureMappings can be used to ingest data as multi measures in the derived\n            table.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#NextScheduledQueriesResultsToken": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#NextTagsForResourceResultsToken": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#NotificationConfiguration": {
+      "type": "structure",
+      "members": {
+        "SnsConfiguration": {
+          "target": "com.amazonaws.timestreamquery#SnsConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Details about the Amazon Simple Notification Service (SNS) configuration. This field is visible only when SNS Topic is provided when updating the account settings.  </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Notification configuration for a scheduled query. A notification is sent by Timestream\n            when a scheduled query is created, its state is updated or when it is deleted. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#NullableBoolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.timestreamquery#PaginationToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ParameterMapping": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Parameter name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.timestreamquery#Type",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Mapping for named parameters.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ParameterMappingList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#ParameterMapping"
+      }
+    },
+    "com.amazonaws.timestreamquery#PartitionKey": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#PartitionKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#PartitionKey"
+      }
+    },
+    "com.amazonaws.timestreamquery#PrepareQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#PrepareQueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#PrepareQueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>A synchronous operation that allows you to submit a query with parameters to be stored\n            by Timestream for later running. Timestream only supports using this operation with\n                <code>ValidateOnly</code> set to <code>true</code>. </p>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#PrepareQueryRequest": {
+      "type": "structure",
+      "members": {
+        "QueryString": {
+          "target": "com.amazonaws.timestreamquery#QueryString",
+          "traits": {
+            "smithy.api#documentation": "<p>The Timestream query string that you want to use as a prepared statement. Parameter\n            names can be specified in the query string <code>@</code> character followed by an\n            identifier. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ValidateOnly": {
+          "target": "com.amazonaws.timestreamquery#NullableBoolean",
+          "traits": {
+            "smithy.api#documentation": "<p>By setting this value to <code>true</code>, Timestream will only validate that the\n            query string is a valid Timestream query, and not store the prepared query for later\n            use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#PrepareQueryResponse": {
+      "type": "structure",
+      "members": {
+        "QueryString": {
+          "target": "com.amazonaws.timestreamquery#QueryString",
+          "traits": {
+            "smithy.api#documentation": "<p>The query string that you want prepare.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Columns": {
+          "target": "com.amazonaws.timestreamquery#SelectColumnList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of SELECT clause columns of the submitted query string. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Parameters": {
+          "target": "com.amazonaws.timestreamquery#ParameterMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of parameters used in the submitted query string. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ProvisionedCapacityRequest": {
+      "type": "structure",
+      "members": {
+        "TargetQueryTCU": {
+          "target": "com.amazonaws.timestreamquery#QueryTCU",
+          "traits": {
+            "smithy.api#documentation": "<p>The target compute capacity for querying data, specified in Timestream Compute Units (TCUs).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NotificationConfiguration": {
+          "target": "com.amazonaws.timestreamquery#AccountSettingsNotificationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration settings for notifications related to the provisioned capacity update.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to update the provisioned capacity settings for querying data.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ProvisionedCapacityResponse": {
+      "type": "structure",
+      "members": {
+        "ActiveQueryTCU": {
+          "target": "com.amazonaws.timestreamquery#QueryTCU",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of Timestream Compute Units (TCUs) provisioned in the account. This field is only visible when the compute mode is <code>PROVISIONED</code>.</p>"
+          }
+        },
+        "NotificationConfiguration": {
+          "target": "com.amazonaws.timestreamquery#AccountSettingsNotificationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains settings for notifications that are sent whenever the provisioned capacity settings are modified. This field is only visible when the compute mode is <code>PROVISIONED</code>.</p>"
+          }
+        },
+        "LastUpdate": {
+          "target": "com.amazonaws.timestreamquery#LastUpdate",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the last update to the provisioned capacity settings.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The response to a request to update the provisioned capacity settings for querying data.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#Query": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#QueryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#QueryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#QueryExecutionException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>\n            <code>Query</code> is a synchronous operation that enables you to run a query against\n            your Amazon Timestream data.</p>\n         <p>If you enabled <code>QueryInsights</code>, this API also returns insights and metrics related to the query that you executed. <code>QueryInsights</code> helps with performance tuning of your query. For more information about <code>QueryInsights</code>, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/using-query-insights.html\">Using query insights to optimize queries in Amazon Timestream</a>.</p>\n         <note>\n            <p>The maximum number of <code>Query</code> API requests you're allowed to make with <code>QueryInsights</code> enabled is 1 query per second (QPS). If you exceed this query rate, it might result in throttling.</p>\n         </note>\n         <p>\n            <code>Query</code> will time out after 60 seconds.\n            You must update the default timeout in the SDK to support a timeout of 60 seconds. See\n            the <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.run-query.html\">code\n                sample</a> for details. </p>\n         <p>Your query request will fail in the following cases:</p>\n         <ul>\n            <li>\n               <p> If you submit a <code>Query</code> request with the same client token outside\n                    of the 5-minute idempotency window. </p>\n            </li>\n            <li>\n               <p> If you submit a <code>Query</code> request with the same client token, but\n                    change other parameters, within the 5-minute idempotency window. </p>\n            </li>\n            <li>\n               <p> If the size of the row (including the query metadata) exceeds 1 MB, then the\n                    query will fail with the following error message: </p>\n               <p>\n                  <code>Query aborted as max page response size has been exceeded by the output\n                        result row</code>\n               </p>\n            </li>\n            <li>\n               <p> If the IAM principal of the query initiator and the result reader are not the\n                    same and/or the query initiator and the result reader do not have the same query\n                    string in the query requests, the query will fail with an <code>Invalid\n                        pagination token</code> error. </p>\n            </li>\n         </ul>",
+        "smithy.api#idempotent": {},
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Rows",
+          "pageSize": "MaxRows"
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryComputeRequest": {
+      "type": "structure",
+      "members": {
+        "ComputeMode": {
+          "target": "com.amazonaws.timestreamquery#ComputeMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode in which Timestream Compute Units (TCUs) are allocated and utilized within an account. Note that in the Asia Pacific (Mumbai)  region, the API operation only recognizes the value <code>PROVISIONED</code>.</p>"
+          }
+        },
+        "ProvisionedCapacity": {
+          "target": "com.amazonaws.timestreamquery#ProvisionedCapacityRequest",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration object that contains settings for provisioned Timestream Compute Units (TCUs) in your account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A request to retrieve or update the compute capacity settings for querying data.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryComputeResponse": {
+      "type": "structure",
+      "members": {
+        "ComputeMode": {
+          "target": "com.amazonaws.timestreamquery#ComputeMode",
+          "traits": {
+            "smithy.api#documentation": "<p>The mode in which Timestream Compute Units (TCUs) are allocated and utilized within an account. Note that in the Asia Pacific (Mumbai)  region, the API operation only recognizes the value <code>PROVISIONED</code>.</p>"
+          }
+        },
+        "ProvisionedCapacity": {
+          "target": "com.amazonaws.timestreamquery#ProvisionedCapacityResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration object that contains settings for provisioned Timestream Compute Units (TCUs) in your account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The response to a request to retrieve or update the compute capacity settings for querying data.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryExecutionException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n            Timestream was unable to run the query successfully. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryInsights": {
+      "type": "structure",
+      "members": {
+        "Mode": {
+          "target": "com.amazonaws.timestreamquery#QueryInsightsMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the following modes to enable <code>QueryInsights</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED_WITH_RATE_CONTROL</code> \u2013 Enables <code>QueryInsights</code> for the queries being processed. This mode also includes a rate control mechanism, which limits the <code>QueryInsights</code> feature to 1 query per second (QPS).</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Disables <code>QueryInsights</code>.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>\n            <code>QueryInsights</code> is a performance tuning feature that helps you optimize your queries, reducing costs and improving performance. With <code>QueryInsights</code>, you can assess the pruning efficiency of your queries and identify areas for improvement to enhance query performance. With <code>QueryInsights</code>, you can also analyze the effectiveness of your queries in terms of temporal and spatial pruning, and identify opportunities to improve performance. Specifically, you can evaluate how well your queries use time-based and partition key-based indexing strategies to optimize data retrieval. To optimize query performance, it's essential that you fine-tune both the temporal and spatial parameters that govern query execution.</p>\n         <p>The key metrics provided by <code>QueryInsights</code> are <code>QuerySpatialCoverage</code> and <code>QueryTemporalRange</code>. <code>QuerySpatialCoverage</code> indicates how much of the spatial axis the query scans, with lower values being more efficient. <code>QueryTemporalRange</code> shows the time range scanned, with narrower ranges being more performant.</p>\n         <p>\n            <b>Benefits of QueryInsights</b>\n         </p>\n         <p>The following are the key benefits of using <code>QueryInsights</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Identifying inefficient queries</b> \u2013 <code>QueryInsights</code> provides information on the time-based and attribute-based pruning of the tables accessed by the query. This information helps you identify the tables that are sub-optimally accessed.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Optimizing your data model and partitioning</b> \u2013 You can use the <code>QueryInsights</code> information to access and fine-tune your data model and partitioning strategy.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Tuning queries</b> \u2013 <code>QueryInsights</code> highlights opportunities to use indexes more effectively.</p>\n            </li>\n         </ul>\n         <note>\n            <p>The maximum number of <code>Query</code> API requests you're allowed to make with <code>QueryInsights</code> enabled is 1 query per second (QPS). If you exceed this query rate, it might result in throttling.</p>\n         </note>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryInsightsMode": {
+      "type": "enum",
+      "members": {
+        "ENABLED_WITH_RATE_CONTROL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED_WITH_RATE_CONTROL"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryInsightsResponse": {
+      "type": "structure",
+      "members": {
+        "QuerySpatialCoverage": {
+          "target": "com.amazonaws.timestreamquery#QuerySpatialCoverage",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides insights into the spatial coverage of the query, including the table with sub-optimal (max) spatial pruning. This information can help you identify areas for improvement in your partitioning strategy to enhance spatial pruning. </p>"
+          }
+        },
+        "QueryTemporalRange": {
+          "target": "com.amazonaws.timestreamquery#QueryTemporalRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides insights into the temporal range of the query, including the table with the largest (max) time range. Following are some of the potential options for optimizing time-based pruning:</p>\n         <ul>\n            <li>\n               <p>Add missing time-predicates.</p>\n            </li>\n            <li>\n               <p>Remove functions around the time predicates.</p>\n            </li>\n            <li>\n               <p>Add time predicates to all the sub-queries.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "QueryTableCount": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the number of tables in the query.</p>"
+          }
+        },
+        "OutputRows": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the total number of rows returned as part of the query result set. You can use this data to validate if the number of rows in the result set have changed as part of the query tuning exercise.</p>"
+          }
+        },
+        "OutputBytes": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the size of query result set in bytes. You can use this data to validate if the result set has changed as part of the query tuning exercise.</p>"
+          }
+        },
+        "UnloadPartitionCount": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the partitions created by the <code>Unload</code> operation.</p>"
+          }
+        },
+        "UnloadWrittenRows": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the rows written by the <code>Unload</code> query.</p>"
+          }
+        },
+        "UnloadWrittenBytes": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the size, in bytes, written by the <code>Unload</code> operation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides various insights and metrics related to the query that you executed.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryPricingModel": {
+      "type": "enum",
+      "members": {
+        "BYTES_SCANNED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BYTES_SCANNED"
+          }
+        },
+        "COMPUTE_UNITS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPUTE_UNITS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryRequest": {
+      "type": "structure",
+      "members": {
+        "QueryString": {
+          "target": "com.amazonaws.timestreamquery#QueryString",
+          "traits": {
+            "smithy.api#documentation": "<p> The query to be run by Timestream. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.timestreamquery#ClientRequestToken",
+          "traits": {
+            "smithy.api#documentation": "<p> Unique, case-sensitive string of up to 64 ASCII characters specified when a\n                <code>Query</code> request is made. Providing a <code>ClientToken</code> makes the\n            call to <code>Query</code>\n            <i>idempotent</i>. This means that running the same query repeatedly will\n            produce the same result. In other words, making multiple identical <code>Query</code>\n            requests has the same effect as making a single request. When using\n                <code>ClientToken</code> in a query, note the following: </p>\n         <ul>\n            <li>\n               <p> If the Query API is instantiated without a <code>ClientToken</code>, the\n                    Query SDK generates a <code>ClientToken</code> on your behalf.</p>\n            </li>\n            <li>\n               <p>If the <code>Query</code> invocation only contains the\n                        <code>ClientToken</code> but does not include a <code>NextToken</code>, that\n                    invocation of <code>Query</code> is assumed to be a new query run.</p>\n            </li>\n            <li>\n               <p>If the invocation contains <code>NextToken</code>, that particular invocation\n                    is assumed to be a subsequent invocation of a prior call to the Query API, and a\n                    result set is returned.</p>\n            </li>\n            <li>\n               <p> After 4 hours, any request with the same <code>ClientToken</code> is treated\n                    as a new request. </p>\n            </li>\n         </ul>",
+            "smithy.api#idempotencyToken": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamquery#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p> A pagination token used to return a set of results. When the <code>Query</code> API\n            is invoked using <code>NextToken</code>, that particular invocation is assumed to be a\n            subsequent invocation of a prior call to <code>Query</code>, and a result set is\n            returned. However, if the <code>Query</code> invocation only contains the\n                <code>ClientToken</code>, that invocation of <code>Query</code> is assumed to be a\n            new query run. </p>\n         <p>Note the following when using NextToken in a query:</p>\n         <ul>\n            <li>\n               <p>A pagination token can be used for up to five <code>Query</code> invocations,\n                    OR for a duration of up to 1 hour \u2013 whichever comes first.</p>\n            </li>\n            <li>\n               <p>Using the same <code>NextToken</code> will return the same set of records. To\n                    keep paginating through the result set, you must to use the most recent\n                        <code>nextToken</code>.</p>\n            </li>\n            <li>\n               <p>Suppose a <code>Query</code> invocation returns two <code>NextToken</code>\n                    values, <code>TokenA</code> and <code>TokenB</code>. If <code>TokenB</code> is\n                    used in a subsequent <code>Query</code> invocation, then <code>TokenA</code> is\n                    invalidated and cannot be reused.</p>\n            </li>\n            <li>\n               <p>To request a previous result set from a query after pagination has begun, you\n                    must re-invoke the Query API.</p>\n            </li>\n            <li>\n               <p>The latest <code>NextToken</code> should be used to paginate until\n                        <code>null</code> is returned, at which point a new <code>NextToken</code>\n                    should be used.</p>\n            </li>\n            <li>\n               <p> If the IAM principal of the query initiator and the result reader are not the\n                    same and/or the query initiator and the result reader do not have the same query\n                    string in the query requests, the query will fail with an <code>Invalid\n                        pagination token</code> error. </p>\n            </li>\n         </ul>"
+          }
+        },
+        "MaxRows": {
+          "target": "com.amazonaws.timestreamquery#MaxQueryResults",
+          "traits": {
+            "smithy.api#documentation": "<p> The total number of rows to be returned in the <code>Query</code> output. The initial\n            run of <code>Query</code> with a <code>MaxRows</code> value specified will return the\n            result set of the query in two cases: </p>\n         <ul>\n            <li>\n               <p>The size of the result is less than <code>1MB</code>.</p>\n            </li>\n            <li>\n               <p>The number of rows in the result set is less than the value of\n                        <code>maxRows</code>.</p>\n            </li>\n         </ul>\n         <p>Otherwise, the initial invocation of <code>Query</code> only returns a\n                <code>NextToken</code>, which can then be used in subsequent calls to fetch the\n            result set. To resume pagination, provide the <code>NextToken</code> value in the\n            subsequent command.</p>\n         <p>If the row size is large (e.g. a row has many columns), Timestream may return\n            fewer rows to keep the response size from exceeding the 1 MB limit. If\n                <code>MaxRows</code> is not provided, Timestream will send the necessary\n            number of rows to meet the 1 MB limit.</p>"
+          }
+        },
+        "QueryInsights": {
+          "target": "com.amazonaws.timestreamquery#QueryInsights",
+          "traits": {
+            "smithy.api#documentation": "<p>Encapsulates settings for enabling <code>QueryInsights</code>.</p>\n         <p>Enabling <code>QueryInsights</code> returns insights and metrics in addition to query results for the query that you executed. You can use <code>QueryInsights</code> to tune your query performance.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryResponse": {
+      "type": "structure",
+      "members": {
+        "QueryId": {
+          "target": "com.amazonaws.timestreamquery#QueryId",
+          "traits": {
+            "smithy.api#documentation": "<p> A unique ID for the given query. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.timestreamquery#PaginationToken",
+          "traits": {
+            "smithy.api#documentation": "<p> A pagination token that can be used again on a <code>Query</code> call to get the\n            next set of results. </p>"
+          }
+        },
+        "Rows": {
+          "target": "com.amazonaws.timestreamquery#RowList",
+          "traits": {
+            "smithy.api#documentation": "<p> The result set rows returned by the query. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ColumnInfo": {
+          "target": "com.amazonaws.timestreamquery#ColumnInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p> The column data types of the returned result set. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "QueryStatus": {
+          "target": "com.amazonaws.timestreamquery#QueryStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Information about the status of the query, including progress and bytes\n            scanned.</p>"
+          }
+        },
+        "QueryInsightsResponse": {
+          "target": "com.amazonaws.timestreamquery#QueryInsightsResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>Encapsulates <code>QueryInsights</code> containing insights and metrics related to the query that you executed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#QuerySpatialCoverage": {
+      "type": "structure",
+      "members": {
+        "Max": {
+          "target": "com.amazonaws.timestreamquery#QuerySpatialCoverageMax",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides insights into the spatial coverage of the executed query and the table with the most inefficient spatial pruning.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Value</code> \u2013 The maximum ratio of spatial coverage.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TableArn</code> \u2013 The Amazon Resource Name (ARN) of the table with sub-optimal spatial pruning.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PartitionKey</code> \u2013 The partition key used for partitioning, which can be a default <code>measure_name</code> or a CDPK.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides insights into the spatial coverage of the query, including the table with sub-optimal (max) spatial pruning. This information can help you identify areas for improvement in your partitioning strategy to enhance spatial pruning</p>\n         <p>For example, you can do the following with the <code>QuerySpatialCoverage</code> information:</p>\n         <ul>\n            <li>\n               <p>Add measure_name or use <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys.html\">customer-defined partition key</a> (CDPK) predicates.</p>\n            </li>\n            <li>\n               <p>If you've already done the preceding action, remove functions around them or clauses, such as <code>LIKE</code>.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QuerySpatialCoverageMax": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.timestreamquery#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum ratio of spatial coverage.</p>"
+          }
+        },
+        "TableArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the table with the most sub-optimal spatial pruning.</p>"
+          }
+        },
+        "PartitionKey": {
+          "target": "com.amazonaws.timestreamquery#PartitionKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The partition key used for partitioning, which can be a default <code>measure_name</code> or a <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys.html\">customer defined partition key</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides insights into the table with the most sub-optimal spatial range scanned by your query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryStatus": {
+      "type": "structure",
+      "members": {
+        "ProgressPercentage": {
+          "target": "com.amazonaws.timestreamquery#Double",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The progress of the query, expressed as a percentage.</p>"
+          }
+        },
+        "CumulativeBytesScanned": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The amount of data scanned by the query in bytes. This is a cumulative sum and\n            represents the total amount of bytes scanned since the query was started. </p>"
+          }
+        },
+        "CumulativeBytesMetered": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The amount of data scanned by the query in bytes that you will be charged for. This is\n            a cumulative sum and represents the total amount of data that you will be charged for\n            since the query was started. The charge is applied only once and is either applied when\n            the query completes running or when the query is cancelled. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the status of the query, including progress and bytes\n            scanned.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 262144
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryTCU": {
+      "type": "integer"
+    },
+    "com.amazonaws.timestreamquery#QueryTemporalRange": {
+      "type": "structure",
+      "members": {
+        "Max": {
+          "target": "com.amazonaws.timestreamquery#QueryTemporalRangeMax",
+          "traits": {
+            "smithy.api#documentation": "<p>Encapsulates the following properties that provide insights into the most sub-optimal performing table on the temporal axis:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Value</code> \u2013 The maximum duration in nanoseconds between the start and end of the query.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TableArn</code> \u2013 The Amazon Resource Name (ARN) of the table which is queried with the largest time range.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides insights into the temporal range of the query, including the table with the largest (max) time range.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#QueryTemporalRangeMax": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>The maximum duration in nanoseconds between the start and end of the query.</p>"
+          }
+        },
+        "TableArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the table which is queried with the largest time range.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides insights into the table with the most sub-optimal temporal pruning scanned by your query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ResourceName": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        },
+        "ScheduledQueryArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the scheduled query.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The requested resource could not be found.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.timestreamquery#Row": {
+      "type": "structure",
+      "members": {
+        "Data": {
+          "target": "com.amazonaws.timestreamquery#DatumList",
+          "traits": {
+            "smithy.api#documentation": "<p>List of data points in a single row of the result set.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a single row in the query results.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#RowList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#Row"
+      }
+    },
+    "com.amazonaws.timestreamquery#S3BucketName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 3,
+          "max": 63
+        },
+        "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+      }
+    },
+    "com.amazonaws.timestreamquery#S3Configuration": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.timestreamquery#S3BucketName",
+          "traits": {
+            "smithy.api#documentation": "<p> Name of the S3 bucket under which error reports will be created.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ObjectKeyPrefix": {
+          "target": "com.amazonaws.timestreamquery#S3ObjectKeyPrefix",
+          "traits": {
+            "smithy.api#documentation": "<p> Prefix for the error report key. Timestream by default adds the following prefix to\n            the error report path. </p>"
+          }
+        },
+        "EncryptionOption": {
+          "target": "com.amazonaws.timestreamquery#S3EncryptionOption",
+          "traits": {
+            "smithy.api#documentation": "<p> Encryption at rest options for the error reports. If no encryption option is\n            specified, Timestream will choose SSE_S3 as default. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details on S3 location for error reports that result from running a query. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#S3EncryptionOption": {
+      "type": "enum",
+      "members": {
+        "SSE_S3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSE_S3"
+          }
+        },
+        "SSE_KMS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSE_KMS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#S3ObjectKey": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#S3ObjectKeyPrefix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 896
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+      }
+    },
+    "com.amazonaws.timestreamquery#S3ReportLocation": {
+      "type": "structure",
+      "members": {
+        "BucketName": {
+          "target": "com.amazonaws.timestreamquery#S3BucketName",
+          "traits": {
+            "smithy.api#documentation": "<p> S3 bucket name. </p>"
+          }
+        },
+        "ObjectKey": {
+          "target": "com.amazonaws.timestreamquery#S3ObjectKey",
+          "traits": {
+            "smithy.api#documentation": "<p>S3 key. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> S3 report location for the scheduled query run.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScalarMeasureValueType": {
+      "type": "enum",
+      "members": {
+        "BIGINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIGINT"
+          }
+        },
+        "BOOLEAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOLEAN"
+          }
+        },
+        "DOUBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOUBLE"
+          }
+        },
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        },
+        "TIMESTAMP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMESTAMP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ScalarType": {
+      "type": "enum",
+      "members": {
+        "VARCHAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "VARCHAR"
+          }
+        },
+        "BOOLEAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BOOLEAN"
+          }
+        },
+        "BIGINT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIGINT"
+          }
+        },
+        "DOUBLE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DOUBLE"
+          }
+        },
+        "TIMESTAMP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIMESTAMP"
+          }
+        },
+        "DATE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATE"
+          }
+        },
+        "TIME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TIME"
+          }
+        },
+        "INTERVAL_DAY_TO_SECOND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERVAL_DAY_TO_SECOND"
+          }
+        },
+        "INTERVAL_YEAR_TO_MONTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTERVAL_YEAR_TO_MONTH"
+          }
+        },
+        "UNKNOWN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNKNOWN"
+          }
+        },
+        "INTEGER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INTEGER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ScalarValue": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#ScheduleConfiguration": {
+      "type": "structure",
+      "members": {
+        "ScheduleExpression": {
+          "target": "com.amazonaws.timestreamquery#ScheduleExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>An expression that denotes when to trigger the scheduled query run. This can be a cron\n            expression or a rate expression. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration of the schedule of the query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduleExpression": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQuery": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>The creation time of the scheduled query.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryState",
+          "traits": {
+            "smithy.api#documentation": "<p>State of scheduled query. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PreviousInvocationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>The last time the scheduled query was run.</p>"
+          }
+        },
+        "NextInvocationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>The next time the scheduled query is to be run.</p>"
+          }
+        },
+        "ErrorReportConfiguration": {
+          "target": "com.amazonaws.timestreamquery#ErrorReportConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration for scheduled query error reporting.</p>"
+          }
+        },
+        "TargetDestination": {
+          "target": "com.amazonaws.timestreamquery#TargetDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>Target data source where final scheduled query result will be written.</p>"
+          }
+        },
+        "LastRunStatus": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryRunStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Status of the last scheduled query run.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Scheduled Query</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryDescription": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Scheduled query ARN.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the scheduled query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "QueryString": {
+          "target": "com.amazonaws.timestreamquery#QueryString",
+          "traits": {
+            "smithy.api#documentation": "<p>The query to be run.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>Creation time of the scheduled query.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryState",
+          "traits": {
+            "smithy.api#documentation": "<p>State of the scheduled query. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PreviousInvocationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>Last time the query was run.</p>"
+          }
+        },
+        "NextInvocationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>The next time the scheduled query is scheduled to run.</p>"
+          }
+        },
+        "ScheduleConfiguration": {
+          "target": "com.amazonaws.timestreamquery#ScheduleConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Schedule configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "NotificationConfiguration": {
+          "target": "com.amazonaws.timestreamquery#NotificationConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Notification configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetConfiguration": {
+          "target": "com.amazonaws.timestreamquery#TargetConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Scheduled query target store configuration.</p>"
+          }
+        },
+        "ScheduledQueryExecutionRoleArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>IAM role that Timestream uses to run the schedule query.</p>"
+          }
+        },
+        "KmsKeyId": {
+          "target": "com.amazonaws.timestreamquery#StringValue2048",
+          "traits": {
+            "smithy.api#documentation": "<p>A customer provided KMS key used to encrypt the scheduled query resource.</p>"
+          }
+        },
+        "ErrorReportConfiguration": {
+          "target": "com.amazonaws.timestreamquery#ErrorReportConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Error-reporting configuration for the scheduled query.</p>"
+          }
+        },
+        "LastRunSummary": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryRunSummary",
+          "traits": {
+            "smithy.api#documentation": "<p>Runtime summary for the last scheduled query run. </p>"
+          }
+        },
+        "RecentlyFailedRuns": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryRunSummaryList",
+          "traits": {
+            "smithy.api#documentation": "<p>Runtime summary for the last five failed scheduled query runs.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Structure that describes scheduled query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryInsights": {
+      "type": "structure",
+      "members": {
+        "Mode": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryInsightsMode",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the following modes to enable <code>ScheduledQueryInsights</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED_WITH_RATE_CONTROL</code> \u2013 Enables <code>ScheduledQueryInsights</code> for the queries being processed. This mode also includes a rate control mechanism, which limits the <code>QueryInsights</code> feature to 1 query per second (QPS).</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> \u2013 Disables <code>ScheduledQueryInsights</code>.</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Encapsulates settings for enabling <code>QueryInsights</code> on an <code>ExecuteScheduledQueryRequest</code>.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryInsightsMode": {
+      "type": "enum",
+      "members": {
+        "ENABLED_WITH_RATE_CONTROL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED_WITH_RATE_CONTROL"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryInsightsResponse": {
+      "type": "structure",
+      "members": {
+        "QuerySpatialCoverage": {
+          "target": "com.amazonaws.timestreamquery#QuerySpatialCoverage",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides insights into the spatial coverage of the query, including the table with sub-optimal (max) spatial pruning. This information can help you identify areas for improvement in your partitioning strategy to enhance spatial pruning.</p>"
+          }
+        },
+        "QueryTemporalRange": {
+          "target": "com.amazonaws.timestreamquery#QueryTemporalRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides insights into the temporal range of the query, including the table with the largest (max) time range. Following are some of the potential options for optimizing time-based pruning:</p>\n         <ul>\n            <li>\n               <p>Add missing time-predicates.</p>\n            </li>\n            <li>\n               <p>Remove functions around the time predicates.</p>\n            </li>\n            <li>\n               <p>Add time predicates to all the sub-queries.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "QueryTableCount": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the number of tables in the query.</p>"
+          }
+        },
+        "OutputRows": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the total number of rows returned as part of the query result set. You can use this data to validate if the number of rows in the result set have changed as part of the query tuning exercise.</p>"
+          }
+        },
+        "OutputBytes": {
+          "target": "com.amazonaws.timestreamquery#Long",
+          "traits": {
+            "smithy.api#default": null,
+            "smithy.api#documentation": "<p>Indicates the size of query result set in bytes. You can use this data to validate if the result set has changed as part of the query tuning exercise.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides various insights and metrics related to the <code>ExecuteScheduledQueryRequest</code> that was executed.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#ScheduledQuery"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryRunStatus": {
+      "type": "enum",
+      "members": {
+        "AUTO_TRIGGER_SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO_TRIGGER_SUCCESS"
+          }
+        },
+        "AUTO_TRIGGER_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTO_TRIGGER_FAILURE"
+          }
+        },
+        "MANUAL_TRIGGER_SUCCESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANUAL_TRIGGER_SUCCESS"
+          }
+        },
+        "MANUAL_TRIGGER_FAILURE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANUAL_TRIGGER_FAILURE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryRunSummary": {
+      "type": "structure",
+      "members": {
+        "InvocationTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>InvocationTime for this run. This is the time at which the query is scheduled to run.\n            Parameter <code>@scheduled_runtime</code> can be used in the query to get the value.\n        </p>"
+          }
+        },
+        "TriggerTime": {
+          "target": "com.amazonaws.timestreamquery#Time",
+          "traits": {
+            "smithy.api#documentation": "<p>The actual time when the query was run.</p>"
+          }
+        },
+        "RunStatus": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryRunStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of a scheduled query run.</p>"
+          }
+        },
+        "ExecutionStats": {
+          "target": "com.amazonaws.timestreamquery#ExecutionStats",
+          "traits": {
+            "smithy.api#documentation": "<p>Runtime statistics for a scheduled run.</p>"
+          }
+        },
+        "QueryInsightsResponse": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryInsightsResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides various insights and metrics related to the run summary of the scheduled query.</p>"
+          }
+        },
+        "ErrorReportLocation": {
+          "target": "com.amazonaws.timestreamquery#ErrorReportLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>S3 location for error report.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>Error message for the scheduled query in case of failure. You might have to look at\n            the error report to get more detailed error reasons. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Run summary for the scheduled query</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryRunSummaryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#ScheduledQueryRunSummary"
+      }
+    },
+    "com.amazonaws.timestreamquery#ScheduledQueryState": {
+      "type": "enum",
+      "members": {
+        "ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENABLED"
+          }
+        },
+        "DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DISABLED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#SchemaName": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#SelectColumn": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.timestreamquery#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the column.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.timestreamquery#Type"
+        },
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamquery#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p> Database that has this column.</p>"
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamquery#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Table within the database that has this column. </p>"
+          }
+        },
+        "Aliased": {
+          "target": "com.amazonaws.timestreamquery#NullableBoolean",
+          "traits": {
+            "smithy.api#documentation": "<p>True, if the column name was aliased by the query. False otherwise.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details of the column that is returned by the query. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#SelectColumnList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#SelectColumn"
+      }
+    },
+    "com.amazonaws.timestreamquery#ServiceErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#ServiceQuotaExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have exceeded the service quota.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 402
+      }
+    },
+    "com.amazonaws.timestreamquery#SnsConfiguration": {
+      "type": "structure",
+      "members": {
+        "TopicArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>SNS topic ARN that the scheduled query status notifications will be sent to.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Details on SNS that are required to send the notification.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#String": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#StringValue2048": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.timestreamquery#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The key of the tag. Tag keys are case sensitive. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.timestreamquery#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the tag. Tag values are case sensitive and can be null. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A tag is a label that you assign to a Timestream database and/or table. Each tag\n            consists of a key and an optional value, both of which you define. Tags enable you to\n            categorize databases and/or tables, for example, by purpose, owner, or environment.\n        </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ServiceQuotaExceededException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Associate a set of tags with a Timestream resource. You can then activate these\n            user-defined tags so that they appear on the Billing and Cost Management console for\n            cost allocation tracking. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Identifies the Timestream resource to which tags should be added. This value is an\n            Amazon Resource Name (ARN).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.timestreamquery#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags to be assigned to the Timestream resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.timestreamquery#TargetConfiguration": {
+      "type": "structure",
+      "members": {
+        "TimestreamConfiguration": {
+          "target": "com.amazonaws.timestreamquery#TimestreamConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Configuration needed to write data into the Timestream database and table.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Configuration used for writing the output of a query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#TargetDestination": {
+      "type": "structure",
+      "members": {
+        "TimestreamDestination": {
+          "target": "com.amazonaws.timestreamquery#TimestreamDestination",
+          "traits": {
+            "smithy.api#documentation": "<p>Query result destination details for Timestream data source.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Destination details to write data for a target data source. Current supported data\n            source is Timestream.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#ThrottlingException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The request was throttled due to excessive requests.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.timestreamquery#Time": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.timestreamquery#TimeSeriesDataPoint": {
+      "type": "structure",
+      "members": {
+        "Time": {
+          "target": "com.amazonaws.timestreamquery#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The timestamp when the measure value was collected.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.timestreamquery#Datum",
+          "traits": {
+            "smithy.api#documentation": "<p>The measure value for the data point.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The timeseries data type represents the values of a measure over time. A time series\n            is an array of rows of timestamps and measure values, with rows sorted in ascending\n            order of time. A TimeSeriesDataPoint is a single data point in the time series. It\n            represents a tuple of (time, measure value) in a time series. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#TimeSeriesDataPointList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.timestreamquery#TimeSeriesDataPoint"
+      }
+    },
+    "com.amazonaws.timestreamquery#Timestamp": {
+      "type": "string"
+    },
+    "com.amazonaws.timestreamquery#TimestreamConfiguration": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamquery#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of Timestream database to which the query result will be written.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamquery#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of Timestream table that the query result will be written to. The table should be\n            within the same database that is provided in Timestream configuration.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TimeColumn": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Column from query result that should be used as the time column in destination table.\n            Column type for this should be TIMESTAMP.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DimensionMappings": {
+          "target": "com.amazonaws.timestreamquery#DimensionMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p> This is to allow mapping column(s) from the query result to the dimension in the\n            destination table. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MultiMeasureMappings": {
+          "target": "com.amazonaws.timestreamquery#MultiMeasureMappings",
+          "traits": {
+            "smithy.api#documentation": "<p>Multi-measure mappings.</p>"
+          }
+        },
+        "MixedMeasureMappings": {
+          "target": "com.amazonaws.timestreamquery#MixedMeasureMappingList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies how to map measures to multi-measure records.</p>"
+          }
+        },
+        "MeasureNameColumn": {
+          "target": "com.amazonaws.timestreamquery#SchemaName",
+          "traits": {
+            "smithy.api#documentation": "<p>Name of the measure column.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Configuration to write data into Timestream database and table. This configuration\n            allows the user to map the query result select columns into the destination table\n            columns. </p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#TimestreamDestination": {
+      "type": "structure",
+      "members": {
+        "DatabaseName": {
+          "target": "com.amazonaws.timestreamquery#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Timestream database name. </p>"
+          }
+        },
+        "TableName": {
+          "target": "com.amazonaws.timestreamquery#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>Timestream table name. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Destination for scheduled query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#Type": {
+      "type": "structure",
+      "members": {
+        "ScalarType": {
+          "target": "com.amazonaws.timestreamquery#ScalarType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the column is of type string, integer, Boolean, double, timestamp, date,\n            time. For more information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/supported-data-types.html\">Supported data\n                types</a>.</p>"
+          }
+        },
+        "ArrayColumnInfo": {
+          "target": "com.amazonaws.timestreamquery#ColumnInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the column is an array.</p>"
+          }
+        },
+        "TimeSeriesMeasureValueColumnInfo": {
+          "target": "com.amazonaws.timestreamquery#ColumnInfo",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the column is a timeseries data type.</p>"
+          }
+        },
+        "RowColumnInfo": {
+          "target": "com.amazonaws.timestreamquery#ColumnInfoList",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates if the column is a row.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the data type of a column in a query result set. The data type can be scalar\n            or complex. The supported scalar data types are integers, Boolean, string, double,\n            timestamp, date, time, and intervals. The supported complex data types are arrays, rows,\n            and timeseries.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Removes the association of tags from a Timestream query resource.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Timestream resource that the tags will be removed from. This value is an Amazon\n            Resource Name (ARN). </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.timestreamquery#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list of tags keys. Existing tags of the resource whose keys are members of this list\n            will be removed from the Timestream resource. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#UpdateAccountSettings": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#UpdateAccountSettingsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.timestreamquery#UpdateAccountSettingsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Transitions your account to use TCUs for query pricing and modifies the maximum query compute units that you've configured. If you reduce the value of <code>MaxQueryTCU</code> to a desired configuration, the new value can take up to 24 hours to be effective.</p>\n         <note>\n            <p>After you've transitioned your account to use TCUs for query pricing, you can't transition to using bytes scanned for query pricing.</p>\n         </note>",
+        "smithy.api#idempotent": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#UpdateAccountSettingsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxQueryTCU": {
+          "target": "com.amazonaws.timestreamquery#MaxQueryCapacity",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of compute units the service will use at any point in time to serve your queries. To run queries, you must set a minimum capacity of 4 TCU. You can set the maximum number of TCU in multiples of 4, for example, 4, 8, 16, 32, and so on. The maximum value supported for <code>MaxQueryTCU</code> is 1000. To request an increase to this soft limit, contact Amazon Web Services Support. For information about the default quota for maxQueryTCU, see Default quotas. This configuration is applicable only for on-demand usage of Timestream Compute Units (TCUs).</p>\n         <p>The maximum value supported for <code>MaxQueryTCU</code> is 1000. To request an increase to this soft limit, contact Amazon Web Services Support. For information about the default quota for <code>maxQueryTCU</code>, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.default\">Default quotas</a>.</p>"
+          }
+        },
+        "QueryPricingModel": {
+          "target": "com.amazonaws.timestreamquery#QueryPricingModel",
+          "traits": {
+            "smithy.api#documentation": "<p>The pricing model for queries in an account.</p>\n         <note>\n            <p>The <code>QueryPricingModel</code> parameter is used by several Timestream operations; however, the <code>UpdateAccountSettings</code> API operation doesn't recognize any values other than <code>COMPUTE_UNITS</code>.</p>\n         </note>"
+          }
+        },
+        "QueryCompute": {
+          "target": "com.amazonaws.timestreamquery#QueryComputeRequest",
+          "traits": {
+            "smithy.api#documentation": "<p>Modifies the query compute settings configured in your account, including the query pricing model and provisioned Timestream Compute Units (TCUs) in your account.</p>\n         <note>\n            <p>This API is idempotent, meaning that making the same request multiple times will have the same effect as making the request once.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#UpdateAccountSettingsResponse": {
+      "type": "structure",
+      "members": {
+        "MaxQueryTCU": {
+          "target": "com.amazonaws.timestreamquery#MaxQueryCapacity",
+          "traits": {
+            "smithy.api#documentation": "<p>The configured maximum number of compute units the service will use at any point in time to serve your queries.</p>"
+          }
+        },
+        "QueryPricingModel": {
+          "target": "com.amazonaws.timestreamquery#QueryPricingModel",
+          "traits": {
+            "smithy.api#documentation": "<p>The pricing model for an account.</p>"
+          }
+        },
+        "QueryCompute": {
+          "target": "com.amazonaws.timestreamquery#QueryComputeResponse",
+          "traits": {
+            "smithy.api#documentation": "<p>Confirms the updated account settings for querying data in your account.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#UpdateScheduledQuery": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.timestreamquery#UpdateScheduledQueryRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ThrottlingException"
+        },
+        {
+          "target": "com.amazonaws.timestreamquery#ValidationException"
+        }
+      ],
+      "traits": {
+        "aws.api#clientDiscoveredEndpoint": {
+          "required": true
+        },
+        "smithy.api#documentation": "<p>Update a scheduled query.</p>"
+      }
+    },
+    "com.amazonaws.timestreamquery#UpdateScheduledQueryRequest": {
+      "type": "structure",
+      "members": {
+        "ScheduledQueryArn": {
+          "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>ARN of the scheuled query.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.timestreamquery#ScheduledQueryState",
+          "traits": {
+            "smithy.api#documentation": "<p>State of the scheduled query. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.timestreamquery#ValidationException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.timestreamquery#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> Invalid or malformed request. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    }
+  }
+}

--- a/crates/fakecloud-timestream/src/validate.rs
+++ b/crates/fakecloud-timestream/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored combined Timestream Smithy model (write + query merged under a
 /// single service shape), embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/timestream.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 /// The embedded model parses to exactly this many distinct operations (keyed by
 /// short name; the four ops shared between write and query dedup to one). A

--- a/crates/fakecloud-transcribe/model.json
+++ b/crates/fakecloud-transcribe/model.json
@@ -1,0 +1,8873 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.transcribe#AbsoluteTimeRange": {
+      "type": "structure",
+      "members": {
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#TimestampMilliseconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in milliseconds, when Amazon Transcribe starts searching for the specified\n            criteria in your audio. If you include <code>StartTime</code> in your request, you must\n            also include <code>EndTime</code>.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.transcribe#TimestampMilliseconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in milliseconds, when Amazon Transcribe stops searching for the specified\n            criteria in your audio. If you include <code>EndTime</code> in your request, you must\n            also include <code>StartTime</code>.</p>"
+          }
+        },
+        "First": {
+          "target": "com.amazonaws.transcribe#TimestampMilliseconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in milliseconds, from the start of your media file until the specified value. \n            Amazon Transcribe searches for your specified criteria in this time segment.</p>"
+          }
+        },
+        "Last": {
+          "target": "com.amazonaws.transcribe#TimestampMilliseconds",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in milliseconds, from the specified value until the end of your media file.\n            Amazon Transcribe searches for your specified criteria in this time segment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A time range, in milliseconds, between two points in your media file.</p>\n         <p>You can use <code>StartTime</code> and <code>EndTime</code> to search a custom\n            segment. For example, setting <code>StartTime</code> to 10000 and <code>EndTime</code>\n            to 50000 only searches for your specified criteria in the audio contained between the\n            10,000 millisecond mark and the 50,000 millisecond mark of your media file. You must use\n                <code>StartTime</code> and <code>EndTime</code> as a set; that is, if you include\n            one, you must include both.</p>\n         <p>You can use also <code>First</code> to search from the start of the audio until the\n            time that  you specify, or <code>Last</code> to search from the time that you specify\n            until the end of the audio. For example, setting <code>First</code> to 50000 only\n            searches for your specified criteria in the audio contained between the start of the\n            media file to the 50,000 millisecond mark. You can use <code>First</code> and\n                <code>Last</code> independently of each other.</p>\n         <p>If you prefer to use percentage instead of milliseconds, see .</p>"
+      }
+    },
+    "com.amazonaws.transcribe#BadRequestException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.transcribe#FailureReason"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Your request didn't pass one or more validation tests. This can occur when the entity\n            you're trying to delete doesn't exist or if it's in a non-terminal state (such as\n                <code>IN PROGRESS</code>). See the exception message field for more\n            information.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.transcribe#BaseModelName": {
+      "type": "enum",
+      "members": {
+        "NARROW_BAND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NarrowBand"
+          }
+        },
+        "WIDE_BAND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "WideBand"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.transcribe#CLMLanguageCode": {
+      "type": "enum",
+      "members": {
+        "EN_US": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-US"
+          }
+        },
+        "HI_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "hi-IN"
+          }
+        },
+        "ES_US": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es-US"
+          }
+        },
+        "EN_GB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-GB"
+          }
+        },
+        "EN_AU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-AU"
+          }
+        },
+        "DE_DE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "de-DE"
+          }
+        },
+        "JA_JP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ja-JP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsFeature": {
+      "type": "enum",
+      "members": {
+        "GENERATIVE_SUMMARIZATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GENERATIVE_SUMMARIZATION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJob": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJobName": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics job. Job names are case sensitive and must be unique\n            within an Amazon Web Services account.</p>"
+          }
+        },
+        "CallAnalyticsJobStatus": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the specified Call Analytics job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>TranscriptFileUri</code> (or\n                <code>RedactedTranscriptFileUri</code>, if you requested transcript redaction). If\n            the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why\n            your transcription job failed.</p>"
+          }
+        },
+        "CallAnalyticsJobDetails": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about a call analytics job, including information about skipped analytics features.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your Call Analytics job. For a list of supported\n            languages and their associated language codes, refer to the <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a>\n            table.</p>\n         <p>If you do not know the language spoken in your media file, you can omit this field and\n            let Amazon Transcribe automatically identify the language of your media. To improve the\n            accuracy of language identification, you can include several language codes and Amazon Transcribe chooses the closest match for your transcription.</p>"
+          }
+        },
+        "MediaSampleRateHertz": {
+          "target": "com.amazonaws.transcribe#MediaSampleRateHertz",
+          "traits": {
+            "smithy.api#documentation": "<p>The sample rate, in hertz, of the audio track in your input media file.</p>"
+          }
+        },
+        "MediaFormat": {
+          "target": "com.amazonaws.transcribe#MediaFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of the input media file.</p>"
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the Amazon S3 location of the media file you used in your Call\n            Analytics request.</p>"
+          }
+        },
+        "Transcript": {
+          "target": "com.amazonaws.transcribe#Transcript"
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:33:13.922000-07:00</code> represents a transcription job\n            that started processing at 12:33 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>CallAnalyticsJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the Call Analytics job\n            request failed.</p>\n         <p>The <code>FailureReason</code> field contains one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Unsupported media format</code>.</p>\n               <p>The media format specified in <code>MediaFormat</code> isn't valid. Refer to\n                    refer to the <code>MediaFormat</code> parameter for a list of supported\n                    formats.</p>\n            </li>\n            <li>\n               <p>\n                  <code>The media format provided does not match the detected media\n                        format</code>.</p>\n               <p>The media format specified in <code>MediaFormat</code> doesn't match the\n                    format of the input file. Check the media format of your media file and correct\n                    the specified value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid sample rate for audio file</code>.</p>\n               <p>The sample rate specified in <code>MediaSampleRateHertz</code> isn't valid.\n                    The sample rate must be between 8,000 and 48,000 hertz.</p>\n            </li>\n            <li>\n               <p>\n                  <code>The sample rate provided does not match the detected sample\n                    rate</code>.</p>\n               <p>The sample rate specified in <code>MediaSampleRateHertz</code> doesn't match\n                    the sample rate detected in your input media file. Check the sample rate of your\n                    media file and correct the specified value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid file size: file size too large</code>.</p>\n               <p>The size of your media file is larger than what Amazon Transcribe can\n                    process. For more information, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html#limits-amazon-transcribe\">Service \n                        quotas</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid number of channels: number of channels too large</code>.</p>\n               <p>Your audio contains more channels than Amazon Transcribe is able to process.\n                    For more information, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html#limits-amazon-transcribe\">Service \n                        quotas</a>.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) you included in your request.</p>"
+          }
+        },
+        "IdentifiedLanguageScore": {
+          "target": "com.amazonaws.transcribe#IdentifiedLanguageScore",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score associated with the language identified in your media\n            file.</p>\n         <p>Confidence scores are values between 0 and 1; a larger value indicates a higher\n            probability that the identified language correctly matches the language spoken in your\n            media.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information on any additional settings that were included in your request.\n            Additional settings include content redaction and language identification\n            settings.</p>"
+          }
+        },
+        "ChannelDefinitions": {
+          "target": "com.amazonaws.transcribe#ChannelDefinitions",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates which speaker is on which channel.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags, each in the form of a key:value pair, assigned to the specified\n            call analytics job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a Call Analytics job.</p>\n         <p>To view the job's status, refer to <code>CallAnalyticsJobStatus</code>. If the status\n            is <code>COMPLETED</code>, the job is finished. You can find your completed transcript\n            at the URI specified in <code>TranscriptFileUri</code>. If the status is\n                <code>FAILED</code>, <code>FailureReason</code> provides details on why your\n            transcription job failed.</p>\n         <p>If you enabled personally identifiable information (PII) redaction, the redacted\n            transcript appears at the location specified in\n            <code>RedactedTranscriptFileUri</code>.</p>\n         <p>If you chose to redact the audio in your media file, you can find your redacted media\n            file at the location specified in the <code>RedactedMediaFileUri</code> field of your\n            response.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJobDetails": {
+      "type": "structure",
+      "members": {
+        "Skipped": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsSkippedFeatureList",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains information about any skipped analytics features during the analysis of a call analytics job.</p>\n         <p>This array lists all the analytics features that were skipped, along with their corresponding reason code and message.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains details about a call analytics job, including information about skipped analytics features.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJobName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJobSettings": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to include in your Call Analytics\n            transcription request. Custom vocabulary names are case sensitive.</p>"
+          }
+        },
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want to include in your Call Analytics\n            transcription request. Custom vocabulary filter names are case sensitive.</p>\n         <p>Note that if you include <code>VocabularyFilterName</code> in your request, you must\n            also include <code>VocabularyFilterMethod</code>.</p>"
+          }
+        },
+        "VocabularyFilterMethod": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterMethod",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify how you want your custom vocabulary filter applied to your transcript.</p>\n         <p>To replace words with <code>***</code>, choose <code>mask</code>.</p>\n         <p>To delete words, choose <code>remove</code>.</p>\n         <p>To flag words without changing them, choose <code>tag</code>.</p>"
+          }
+        },
+        "LanguageModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom language model you want to use when processing your Call\n            Analytics job. Note that custom language model names are case sensitive.</p>\n         <p>The language of the specified custom language model must match the language code that\n            you specify in your transcription request. If the languages do not match, the custom\n            language model isn't applied. There are no errors or warnings associated with a language\n            mismatch.</p>"
+          }
+        },
+        "ContentRedaction": {
+          "target": "com.amazonaws.transcribe#ContentRedaction"
+        },
+        "LanguageOptions": {
+          "target": "com.amazonaws.transcribe#LanguageOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>You can specify two or more language codes that represent the languages you think may\n            be present in your media. Including more than five is not recommended. If you're unsure\n            what languages are present, do not include this parameter.</p>\n         <p>Including language options can improve the accuracy of language identification.</p>\n         <p>For a list of languages supported with Call Analytics, refer to the <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported\n                languages</a> table.</p>\n         <p>To transcribe speech in Modern Standard Arabic (<code>ar-SA</code>) in Amazon Web Services GovCloud (US) (US-West, us-gov-west-1), Amazon Web Services GovCloud (US) (US-East, us-gov-east-1), Canada (Calgary) ca-west-1 and Africa (Cape Town) af-south-1, your media file\n            must be encoded at a sample rate of 16,000 Hz or higher.</p>"
+          }
+        },
+        "LanguageIdSettings": {
+          "target": "com.amazonaws.transcribe#LanguageIdSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>If using automatic language identification in your request and you want to apply a\n            custom language model, a custom vocabulary, or a custom vocabulary filter, include\n                <code>LanguageIdSettings</code> with the relevant sub-parameters\n                (<code>VocabularyName</code>, <code>LanguageModelName</code>, and\n                <code>VocabularyFilterName</code>).</p>\n         <p>\n            <code>LanguageIdSettings</code> supports two to five language codes. Each language\n            code you include can have an associated custom language model, custom vocabulary, and\n            custom vocabulary filter. The language codes that you specify must match the languages\n            of the associated custom language models, custom vocabularies, and custom vocabulary\n            filters.</p>\n         <p>It's recommended that you include <code>LanguageOptions</code> when using\n                <code>LanguageIdSettings</code> to ensure that the correct language dialect is\n            identified. For example, if you specify a custom vocabulary that is in\n                <code>en-US</code> but Amazon Transcribe determines that the language spoken in\n            your media is <code>en-AU</code>, your custom vocabulary <i>is not</i>\n            applied to your transcription. If you include <code>LanguageOptions</code> and include\n                <code>en-US</code> as the only English language dialect, your custom vocabulary\n                <i>is</i> applied to your transcription.</p>\n         <p>If you want to include a custom language model, custom vocabulary, or custom\n            vocabulary filter with your request but <b>do not</b> want to\n            use automatic language identification, use instead the <code></code> parameter with the\n                <code>LanguageModelName</code>, <code>VocabularyName</code>, or\n                <code>VocabularyFilterName</code> sub-parameters.</p>\n         <p>For a list of languages supported with Call Analytics, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages and \n            language-specific features</a>.</p>"
+          }
+        },
+        "Summarization": {
+          "target": "com.amazonaws.transcribe#Summarization",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains <code>GenerateAbstractiveSummary</code>, which is a required parameter if you \n\t    want to enable Generative call summarization in your Call Analytics request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides additional optional settings for your  request, including content redaction,\n            automatic language identification; allows you to apply custom language models, custom\n            vocabulary filters, and custom vocabularies.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJobStatus": {
+      "type": "enum",
+      "members": {
+        "QUEUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUEUED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJobSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#CallAnalyticsJobSummary"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsJobSummary": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJobName": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics job. Job names are case sensitive and must be unique\n            within an Amazon Web Services account.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time your Call Analytics job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:33:13.922000-07:00</code> represents a transcription job\n            that started processing at 12:33 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your Call Analytics transcription.</p>"
+          }
+        },
+        "CallAnalyticsJobStatus": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of your Call Analytics job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>TranscriptFileUri</code> (or\n                <code>RedactedTranscriptFileUri</code>, if you requested transcript redaction). If\n            the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why\n            your transcription job failed.</p>"
+          }
+        },
+        "CallAnalyticsJobDetails": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about a call analytics job, including information about skipped analytics features.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>CallAnalyticsJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the Call Analytics job\n            failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a specific Call Analytics job.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsSkippedFeature": {
+      "type": "structure",
+      "members": {
+        "Feature": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsFeature",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates the type of analytics feature that was skipped during the analysis of a call analytics job.</p>"
+          }
+        },
+        "ReasonCode": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsSkippedReasonCode",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a code indicating the reason why a specific analytics feature was skipped during the analysis of a call analytics job.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.transcribe#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains additional information or a message explaining why a specific analytics feature was skipped during the analysis of a call analytics job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a skipped analytics feature during the analysis of a call analytics job.</p>\n         <p>The <code>Feature</code> field indicates the type of analytics feature that was skipped.</p>\n         <p>The <code>Message</code> field contains additional information or a message explaining why the analytics feature was skipped.</p>\n         <p>The <code>ReasonCode</code> field provides a code indicating the reason why the analytics feature was skipped.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsSkippedFeatureList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#CallAnalyticsSkippedFeature"
+      }
+    },
+    "com.amazonaws.transcribe#CallAnalyticsSkippedReasonCode": {
+      "type": "enum",
+      "members": {
+        "INSUFFICIENT_CONVERSATION_CONTENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INSUFFICIENT_CONVERSATION_CONTENT"
+          }
+        },
+        "FAILED_SAFETY_GUIDELINES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED_SAFETY_GUIDELINES"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CategoryName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#CategoryProperties": {
+      "type": "structure",
+      "members": {
+        "CategoryName": {
+          "target": "com.amazonaws.transcribe#CategoryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics category. Category names are case sensitive and must be\n            unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "Rules": {
+          "target": "com.amazonaws.transcribe#RuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>The rules used to define a Call Analytics category. Each category can have between 1\n            and 20 rules.</p>"
+          }
+        },
+        "CreateTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics category was created.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "LastUpdateTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Call Analytics category was last updated.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-05T12:45:32.691000-07:00</code> represents 12:45 PM UTC-7 on May\n            5, 2022.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags, each in the form of a key:value pair, assigned to the specified\n            call analytics category.</p>"
+          }
+        },
+        "InputType": {
+          "target": "com.amazonaws.transcribe#InputType",
+          "traits": {
+            "smithy.api#documentation": "<p>The input type associated with the specified category. <code>POST_CALL</code> \n            refers to a category that is applied to batch transcriptions; <code>REAL_TIME</code> \n            refers to a category that is applied to streaming transcriptions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides you with the properties of the Call Analytics category you specified in your\n            request. This includes the list of rules that define the specified category.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CategoryPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#CategoryProperties"
+      }
+    },
+    "com.amazonaws.transcribe#ChannelDefinition": {
+      "type": "structure",
+      "members": {
+        "ChannelId": {
+          "target": "com.amazonaws.transcribe#ChannelId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Specify the audio channel you want to define.</p>"
+          }
+        },
+        "ParticipantRole": {
+          "target": "com.amazonaws.transcribe#ParticipantRole",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the speaker you want to define. Omitting this parameter is equivalent to\n            specifying both participants.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Makes it possible to specify which speaker is on which channel. For example, if your\n            agent is the first participant to speak, you would set <code>ChannelId</code> to\n                <code>0</code> (to indicate the first channel) and <code>ParticipantRole</code> to\n                <code>AGENT</code> (to indicate that it's the agent speaking).</p>"
+      }
+    },
+    "com.amazonaws.transcribe#ChannelDefinitions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#ChannelDefinition"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ChannelId": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ClinicalNoteGenerationSettings": {
+      "type": "structure",
+      "members": {
+        "NoteTemplate": {
+          "target": "com.amazonaws.transcribe#MedicalScribeNoteTemplate",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify one of the following templates to use for the clinical note summary. The default is <code>HISTORY_AND_PHYSICAL</code>.</p>\n         <ul>\n            <li>\n               <p>HISTORY_AND_PHYSICAL: Provides summaries for key sections of the clinical documentation. Examples of sections include Chief Complaint, History of Present Illness, Review of Systems, Past Medical History, Assessment, and Plan.\n                </p>\n            </li>\n            <li>\n               <p>GIRPP: Provides summaries based on the patients progress toward goals. Examples of sections include Goal, Intervention,\n                    Response, Progress, and Plan.</p>\n            </li>\n            <li>\n               <p>BIRP: Focuses on the patient's behavioral patterns and responses. Examples of sections include Behavior, Intervention, Response, and Plan.</p>\n            </li>\n            <li>\n               <p>SIRP: Emphasizes the situational context of therapy. Examples of sections include Situation, Intervention, Response, and Plan.</p>\n            </li>\n            <li>\n               <p>DAP: Provides a simplified format for clinical documentation. Examples of sections include Data, Assessment, and Plan.</p>\n            </li>\n            <li>\n               <p>BEHAVIORAL_SOAP: Behavioral health focused documentation format. Examples of sections include Subjective, Objective, Assessment, and Plan.</p>\n            </li>\n            <li>\n               <p>PHYSICAL_SOAP: Physical health focused documentation format. Examples of sections include Subjective, Objective, Assessment, and Plan.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output configuration for clinical note generation.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#ConflictException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.transcribe#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A resource already exists with this name. Resource names must be unique within an\n                Amazon Web Services account.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.transcribe#ContentRedaction": {
+      "type": "structure",
+      "members": {
+        "RedactionType": {
+          "target": "com.amazonaws.transcribe#RedactionType",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the category of information you want to redact; <code>PII</code> (personally\n            identifiable information) is the only valid value. You can use <code>PiiEntityTypes</code> to \n            choose which types of PII you want to redact. If you do not include <code>PiiEntityTypes</code> in \n            your request, all PII is redacted.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RedactionOutput": {
+          "target": "com.amazonaws.transcribe#RedactionOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify if you want only a redacted transcript, or if you want a redacted and an\n            unredacted transcript.</p>\n         <p>When you choose <code>redacted</code>\n            Amazon Transcribe creates only a redacted transcript.</p>\n         <p>When you choose <code>redacted_and_unredacted</code>\n            Amazon Transcribe creates a redacted and an unredacted transcript (as two separate\n            files).</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "PiiEntityTypes": {
+          "target": "com.amazonaws.transcribe#PiiEntityTypes",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify which types of personally identifiable information (PII) you want to redact in\n            your transcript. You can include as many types as you'd like, or you can select\n            <code>ALL</code>. If you do not include <code>PiiEntityTypes</code> in your request, all PII is \n            redacted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Makes it possible to redact or flag specified personally identifiable information (PII) in \n            your transcript. If you use <code>ContentRedaction</code>, you must also include the \n            sub-parameters: <code>RedactionOutput</code> and <code>RedactionType</code>. You can \n            optionally include <code>PiiEntityTypes</code> to choose which types of PII you want to \n            redact.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#CreateCallAnalyticsCategory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#CreateCallAnalyticsCategoryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#CreateCallAnalyticsCategoryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new Call Analytics category.</p>\n         <p>All categories are automatically applied to your Call Analytics transcriptions. Note that in\n            order to apply categories to your transcriptions, you must create them before submitting your\n            transcription request, as categories cannot be applied retroactively.</p>\n         <p>When creating a new category, you can use the <code>InputType</code> parameter to \n            label the category as a <code>POST_CALL</code> or a <code>REAL_TIME</code> category. \n            <code>POST_CALL</code> categories can only be applied to post-call transcriptions and \n            <code>REAL_TIME</code> categories can only be applied to real-time transcriptions. If you \n            do not include <code>InputType</code>, your category is created as a \n            <code>POST_CALL</code> category by default.</p>\n         <p>Call Analytics categories are composed of rules. For each category, you must create\n            between 1 and 20 rules. Rules can include these parameters: , , , and .</p>\n         <p>To update an existing category, see .</p>\n         <p>To learn more about Call Analytics categories, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html\">Creating categories for post-call\n            transcriptions</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-stream.html\">Creating categories for\n                real-time transcriptions</a>.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/callanalyticscategories/{CategoryName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CreateCallAnalyticsCategoryRequest": {
+      "type": "structure",
+      "members": {
+        "CategoryName": {
+          "target": "com.amazonaws.transcribe#CategoryName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your Call Analytics category. It's helpful to use a\n            detailed naming system that will make sense to you in the future. For example, it's\n            better to use <code>sentiment-positive-last30seconds</code> for a category over a\n            generic name like <code>test-category</code>.</p>\n         <p>Category names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Rules": {
+          "target": "com.amazonaws.transcribe#RuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>Rules define a Call Analytics category. When creating a new category, you must create \n            between 1 and 20 rules for that category. For each rule, you specify a filter you want \n            applied to the attributes of a call. For example, you can choose a sentiment filter that \n            detects if a customer's sentiment was positive during the last 30 seconds of the call.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new\n            call analytics category at the time you start this new job.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n            resources</a>.</p>"
+          }
+        },
+        "InputType": {
+          "target": "com.amazonaws.transcribe#InputType",
+          "traits": {
+            "smithy.api#documentation": "<p>Choose whether you want to create a real-time or a post-call category for your Call \n            Analytics transcription.</p>\n         <p>Specifying <code>POST_CALL</code> assigns your category to post-call transcriptions; \n            categories with this input type cannot be applied to streaming (real-time) \n            transcriptions.</p>\n         <p>Specifying <code>REAL_TIME</code> assigns your category to streaming transcriptions; \n            categories with this input type cannot be applied to post-call transcriptions.</p>\n         <p>If you do not include <code>InputType</code>, your category is created as a post-call \n            category by default.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateCallAnalyticsCategoryResponse": {
+      "type": "structure",
+      "members": {
+        "CategoryProperties": {
+          "target": "com.amazonaws.transcribe#CategoryProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides you with the properties of your new category, including its associated\n            rules.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateLanguageModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#CreateLanguageModelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#CreateLanguageModelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new custom language model.</p>\n         <p>When creating a new custom language model, you must specify:</p>\n         <ul>\n            <li>\n               <p>If you want a Wideband (audio sample rates over 16,000 Hz) or Narrowband\n                    (audio sample rates under 16,000 Hz) base model</p>\n            </li>\n            <li>\n               <p>The location of your training and tuning files (this must be an Amazon S3 URI)</p>\n            </li>\n            <li>\n               <p>The language of your model</p>\n            </li>\n            <li>\n               <p>A unique name for your model</p>\n            </li>\n         </ul>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/languagemodels/{ModelName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CreateLanguageModelRequest": {
+      "type": "structure",
+      "members": {
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#CLMLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of your model. Each custom language\n            model must contain terms in only one language, and the language you select for your\n            custom language model must match the language of your training and tuning data.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table. Note that US English (<code>en-US</code>) is the \n            only language supported with Amazon Transcribe Medical.</p>\n         <p>A custom language model can only be used to transcribe files in the same language as\n            the model. For example, if you create a custom language model using US English\n                (<code>en-US</code>), you can only apply this model to files that contain English\n            audio.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "BaseModelName": {
+          "target": "com.amazonaws.transcribe#BaseModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Transcribe standard language model, or base model, used to create your\n            custom language model. Amazon Transcribe offers two options for base models: Wideband\n            and Narrowband.</p>\n         <p>If the audio you want to transcribe has a sample rate of 16,000 Hz or greater, choose\n                <code>WideBand</code>. To transcribe audio with a sample rate less than 16,000 Hz,\n            choose <code>NarrowBand</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your custom language model.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new custom language model with\n            the same name as an existing custom language model, you get a\n                <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.transcribe#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the Amazon S3 location of the training data you want to use to create\n            a new custom language model, and permissions to access this location.</p>\n         <p>When using <code>InputDataConfig</code>, you must include these sub-parameters:\n                <code>S3Uri</code>, which is the Amazon S3 location of your training data,\n            and <code>DataAccessRoleArn</code>, which is the Amazon Resource Name (ARN) of the role\n            that has permission to access your specified Amazon S3 location. You can\n            optionally include <code>TuningDataS3Uri</code>, which is the Amazon S3 location\n            of your tuning data. If you specify different Amazon S3 locations for training\n            and tuning data, the ARN you use must have permissions to access both locations.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new custom\n            language model at the time you create this new model.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateLanguageModelResponse": {
+      "type": "structure",
+      "members": {
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#CLMLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom language model.</p>"
+          }
+        },
+        "BaseModelName": {
+          "target": "com.amazonaws.transcribe#BaseModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Transcribe standard language model, or base model, you specified when\n            creating your custom language model.</p>"
+          }
+        },
+        "ModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of your custom language model.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.transcribe#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists your data access role ARN (Amazon Resource Name) and the Amazon S3\n            locations you provided for your training (<code>S3Uri</code>) and tuning\n                (<code>TuningDataS3Uri</code>) data.</p>"
+          }
+        },
+        "ModelStatus": {
+          "target": "com.amazonaws.transcribe#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of your custom language model. When the status displays as\n                <code>COMPLETED</code>, your model is ready to use.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateMedicalVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#CreateMedicalVocabularyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#CreateMedicalVocabularyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new custom medical vocabulary.</p>\n         <p>Before creating a new custom medical vocabulary, you must first upload a text file\n            that contains your vocabulary table into an Amazon S3 bucket.\n            Note that this differs from , where you can\n            include a list of terms within your request using the <code>Phrases</code> flag;\n                <code>CreateMedicalVocabulary</code> does not support the <code>Phrases</code>\n            flag and only accepts vocabularies in table format.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary request\n            fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom Vocabularies</a> to get the character set for your\n            language.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/custom-vocabulary.html\">Custom\n            vocabularies</a>.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/medicalvocabularies/{VocabularyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CreateMedicalVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your new custom medical vocabulary.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new custom medical vocabulary\n            with the same name as an existing custom medical vocabulary, you get a\n                <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of the entries in your custom\n            vocabulary. US English (<code>en-US</code>) is the only language supported with Amazon Transcribe Medical.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VocabularyFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location (URI) of the text file that contains your custom\n            medical vocabulary. The URI must be in the same Amazon Web Services Region as the\n            resource you're calling.</p>\n         <p>Here's an example URI path:\n            <code>s3://DOC-EXAMPLE-BUCKET/my-vocab-file.txt</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new custom\n            medical vocabulary at the time you create this new custom vocabulary.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateMedicalVocabularyResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name you chose for your custom medical vocabulary.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom medical vocabulary. US English\n                (<code>en-US</code>) is the only language supported with Amazon Transcribe\n            Medical.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom medical vocabulary. If the state is\n                <code>READY</code>, you can use the custom vocabulary in a\n                <code>StartMedicalTranscriptionJob</code> request.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time you created your custom medical vocabulary.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>VocabularyState</code> is <code>FAILED</code>, <code>FailureReason</code>\n            contains information about why the medical transcription job request failed. See also:\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#CreateVocabularyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#CreateVocabularyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new custom vocabulary.</p>\n         <p>When creating a new custom vocabulary, you can either upload a text file that contains\n            your new entries, phrases, and terms into an Amazon S3 bucket and include the\n            URI in your request. Or you can include a list of terms directly in your request using\n            the <code>Phrases</code> flag.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary request\n            fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom Vocabularies</a> to get the character set for your\n            language.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/custom-vocabulary.html\">Custom\n            vocabularies</a>.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CreateVocabularyFilter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#CreateVocabularyFilterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#CreateVocabularyFilterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new custom vocabulary filter.</p>\n         <p>You can use custom vocabulary filters to mask, delete, or flag specific words from\n            your transcript. Custom vocabulary filters are commonly used to mask profanity in\n            transcripts.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary filter\n            request fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom\n                Vocabularies</a> to get the character set for your language.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/vocabulary-filtering.html\">Vocabulary\n            filtering</a>.</p>",
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/vocabularyFilters/{VocabularyFilterName}",
+          "code": 201
+        }
+      }
+    },
+    "com.amazonaws.transcribe#CreateVocabularyFilterRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your new custom vocabulary filter.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new custom vocabulary filter with\n            the same name as an existing custom vocabulary filter, you get a\n                <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of the entries in your vocabulary\n            filter. Each custom vocabulary filter must contain terms in only one language.</p>\n         <p>A custom vocabulary filter can only be used to transcribe files in the same language\n            as the filter. For example, if you create a custom vocabulary filter using US English\n                (<code>en-US</code>), you can only apply this filter to files that contain English\n            audio.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Words": {
+          "target": "com.amazonaws.transcribe#Words",
+          "traits": {
+            "smithy.api#documentation": "<p>Use this parameter if you want to create your custom vocabulary filter by including\n            all desired terms, as comma-separated values, within your request. The other option for\n            creating your vocabulary filter is to save your entries in a text file and upload them\n            to an Amazon S3 bucket, then specify the location of your file using the\n                <code>VocabularyFilterFileUri</code> parameter.</p>\n         <p>Note that if you include <code>Words</code> in your request, you cannot use\n                <code>VocabularyFilterFileUri</code>; you must choose one or the other.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary filter\n            request fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom\n                Vocabularies</a> to get the character set for your language.</p>"
+          }
+        },
+        "VocabularyFilterFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the text file that contains your custom vocabulary\n            filter terms. The URI must be located in the same Amazon Web Services Region as the\n            resource you're calling.</p>\n         <p>Here's an example URI path:\n                <code>s3://DOC-EXAMPLE-BUCKET/my-vocab-filter-file.txt</code>\n         </p>\n         <p>Note that if you include <code>VocabularyFilterFileUri</code> in your request, you\n            cannot use <code>Words</code>; you must choose one or the other.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new custom\n            vocabulary filter at the time you create this new vocabulary filter.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files (in this case, your custom\n            vocabulary filter). If the role that you specify doesn\u2019t have the appropriate permissions to access\n            the specified Amazon S3 location, your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateVocabularyFilterResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name you chose for your custom vocabulary filter.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom vocabulary filter.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time you created your custom vocabulary filter.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your new custom vocabulary.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new custom vocabulary with the\n            same name as an existing custom vocabulary, you get a <code>ConflictException</code>\n            error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of the entries in your custom\n            vocabulary. Each custom vocabulary must contain terms in only one language.</p>\n         <p>A custom vocabulary can only be used to transcribe files in the same language as the\n            custom vocabulary. For example, if you create a custom vocabulary using US English\n                (<code>en-US</code>), you can only apply this custom vocabulary to files that\n            contain English audio.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Phrases": {
+          "target": "com.amazonaws.transcribe#Phrases",
+          "traits": {
+            "smithy.api#documentation": "<p>Use this parameter if you want to create your custom vocabulary by including all\n            desired terms, as comma-separated values, within your request. The other option for\n            creating your custom vocabulary is to save your entries in a text file and upload them\n            to an Amazon S3 bucket, then specify the location of your file using the\n                <code>VocabularyFileUri</code> parameter.</p>\n         <p>Note that if you include <code>Phrases</code> in your request, you cannot use\n                <code>VocabularyFileUri</code>; you must choose one or the other.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary filter\n            request fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom\n                Vocabularies</a> to get the character set for your language.</p>"
+          }
+        },
+        "VocabularyFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the text file that contains your custom vocabulary.\n            The URI must be located in the same Amazon Web Services Region as the resource you're\n            calling.</p>\n         <p>Here's an example URI path:\n            <code>s3://DOC-EXAMPLE-BUCKET/my-vocab-file.txt</code>\n         </p>\n         <p>Note that if you include <code>VocabularyFileUri</code> in your request, you cannot\n            use the <code>Phrases</code> flag; you must choose one or the other.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new custom\n            vocabulary at the time you create this new custom vocabulary.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files (in this case, your custom\n            vocabulary). If the role that you specify doesn\u2019t have the appropriate permissions to access\n            the specified Amazon S3 location, your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#CreateVocabularyResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name you chose for your custom vocabulary.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom vocabulary.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom vocabulary. If the state is <code>READY</code>,\n            you can use the custom vocabulary in a <code>StartTranscriptionJob</code>\n            request.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time you created your custom vocabulary.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>VocabularyState</code> is <code>FAILED</code>, <code>FailureReason</code>\n            contains information about why the custom vocabulary request failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common\n                Errors</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#DataAccessRoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:(aws|aws-cn|aws-us-gov|aws-iso-{0,1}[a-z]{0,1}):iam::[0-9]{0,63}:role/[A-Za-z0-9:_/+=,@.-]{0,1024}$"
+      }
+    },
+    "com.amazonaws.transcribe#DateTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.transcribe#DeleteCallAnalyticsCategory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteCallAnalyticsCategoryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#DeleteCallAnalyticsCategoryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Call Analytics category. To use this operation, specify the name of the\n            category you want to delete using <code>CategoryName</code>. Category names are case\n            sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/callanalyticscategories/{CategoryName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteCallAnalyticsCategoryRequest": {
+      "type": "structure",
+      "members": {
+        "CategoryName": {
+          "target": "com.amazonaws.transcribe#CategoryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics category you want to delete. Category names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteCallAnalyticsCategoryResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteCallAnalyticsJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteCallAnalyticsJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#DeleteCallAnalyticsJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Call Analytics job. To use this operation, specify the name of the job you\n            want to delete using <code>CallAnalyticsJobName</code>. Job names are case\n            sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/callanalyticsjobs/{CallAnalyticsJobName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteCallAnalyticsJobRequest": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJobName": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics job you want to delete. Job names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteCallAnalyticsJobResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteLanguageModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteLanguageModelRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a custom language model. To use this operation, specify the name of the\n            language model you want to delete using <code>ModelName</code>. custom language model\n            names are case sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/languagemodels/{ModelName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteLanguageModelRequest": {
+      "type": "structure",
+      "members": {
+        "ModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom language model you want to delete. Model names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteMedicalScribeJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteMedicalScribeJobRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a Medical Scribe job. To use this operation, specify the name of the\n            job you want to delete using <code>MedicalScribeJobName</code>. Job names are\n            case sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/medicalscribejobs/{MedicalScribeJobName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteMedicalScribeJobRequest": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Medical Scribe job you want to delete. Job names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteMedicalTranscriptionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteMedicalTranscriptionJobRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a medical transcription job. To use this operation, specify the name of the\n            job you want to delete using <code>MedicalTranscriptionJobName</code>. Job names are\n            case sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/medicaltranscriptionjobs/{MedicalTranscriptionJobName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteMedicalTranscriptionJobRequest": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the medical transcription job you want to delete. Job names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteMedicalVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteMedicalVocabularyRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a custom medical vocabulary. To use this operation, specify the name of the\n            custom vocabulary you want to delete using <code>VocabularyName</code>. Custom\n            vocabulary names are case sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/medicalvocabularies/{VocabularyName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteMedicalVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom medical vocabulary you want to delete. Custom medical\n            vocabulary names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteTranscriptionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteTranscriptionJobRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a transcription job. To use this operation, specify the name of the job you\n            want to delete using <code>TranscriptionJobName</code>. Job names are case\n            sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/transcriptionjobs/{TranscriptionJobName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteTranscriptionJobRequest": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the transcription job you want to delete. Job names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteVocabularyRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a custom vocabulary. To use this operation, specify the name of the custom\n            vocabulary you want to delete using <code>VocabularyName</code>. Custom vocabulary names\n            are case sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteVocabularyFilter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DeleteVocabularyFilterRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a custom vocabulary filter. To use this operation, specify the name of the\n            custom vocabulary filter you want to delete using <code>VocabularyFilterName</code>.\n            Custom vocabulary filter names are case sensitive.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/vocabularyFilters/{VocabularyFilterName}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DeleteVocabularyFilterRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want to delete. Custom vocabulary filter\n            names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DeleteVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to delete. Custom vocabulary names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DescribeLanguageModel": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#DescribeLanguageModelRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#DescribeLanguageModelResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified custom language model.</p>\n         <p>This operation also shows if the base language model that you used to create your\n            custom language model has been updated. If Amazon Transcribe has updated the base\n            model, you can create a new custom language model using the updated base model.</p>\n         <p>If you tried to create a new custom language model and the request wasn't successful,\n            you can use <code>DescribeLanguageModel</code> to help identify the reason for this\n            failure.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/languagemodels/{ModelName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "LanguageModelCompleted": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "LanguageModel.ModelStatus",
+                    "expected": "COMPLETED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "LanguageModel.ModelStatus",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 120
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#DescribeLanguageModelRequest": {
+      "type": "structure",
+      "members": {
+        "ModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom language model you want information about. Model names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#DescribeLanguageModelResponse": {
+      "type": "structure",
+      "members": {
+        "LanguageModel": {
+          "target": "com.amazonaws.transcribe#LanguageModel",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the specified custom language model.</p>\n         <p>This parameter also shows if the base language model you used to create your custom\n            language model has been updated. If Amazon Transcribe has updated the base model, you\n            can create a new custom language model using the updated base model.</p>\n         <p>If you tried to create a new custom language model and the request wasn't successful,\n            you can use this <code>DescribeLanguageModel</code> to help identify the reason for this\n            failure.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#DurationInSeconds": {
+      "type": "float"
+    },
+    "com.amazonaws.transcribe#FailureReason": {
+      "type": "string"
+    },
+    "com.amazonaws.transcribe#GetCallAnalyticsCategory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetCallAnalyticsCategoryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetCallAnalyticsCategoryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified Call Analytics category.</p>\n         <p>To get a list of your Call Analytics categories, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/callanalyticscategories/{CategoryName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetCallAnalyticsCategoryRequest": {
+      "type": "structure",
+      "members": {
+        "CategoryName": {
+          "target": "com.amazonaws.transcribe#CategoryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics category you want information about. Category names are\n            case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetCallAnalyticsCategoryResponse": {
+      "type": "structure",
+      "members": {
+        "CategoryProperties": {
+          "target": "com.amazonaws.transcribe#CategoryProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides you with the properties of the Call Analytics category you specified in your\n                <code>GetCallAnalyticsCategory</code> request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetCallAnalyticsJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetCallAnalyticsJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetCallAnalyticsJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified Call Analytics job.</p>\n         <p>To view the job's status, refer to <code>CallAnalyticsJobStatus</code>. If the status\n            is <code>COMPLETED</code>, the job is finished. You can find your completed transcript\n            at the URI specified in <code>TranscriptFileUri</code>. If the status is\n                <code>FAILED</code>, <code>FailureReason</code> provides details on why your\n            transcription job failed.</p>\n         <p>If you enabled personally identifiable information (PII) redaction, the redacted\n            transcript appears at the location specified in\n            <code>RedactedTranscriptFileUri</code>.</p>\n         <p>If you chose to redact the audio in your media file, you can find your redacted media\n            file at the location specified in <code>RedactedMediaFileUri</code>.</p>\n         <p>To get a list of your Call Analytics jobs, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/callanalyticsjobs/{CallAnalyticsJobName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "CallAnalyticsJobCompleted": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "CallAnalyticsJob.CallAnalyticsJobStatus",
+                    "expected": "COMPLETED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "CallAnalyticsJob.CallAnalyticsJobStatus",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 10
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetCallAnalyticsJobRequest": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJobName": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics job you want information about. Job names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetCallAnalyticsJobResponse": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJob": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the specified Call Analytics job, including job\n            status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalScribeJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetMedicalScribeJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetMedicalScribeJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified Medical Scribe job.</p>\n         <p>To view the status of the specified medical transcription job, check the\n                <code>MedicalScribeJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished. You can find the results at the location specified in\n                <code>MedicalScribeOutput</code>. \n                If the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why your Medical Scribe job\n            failed.</p>\n         <p>To get a list of your Medical Scribe jobs, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/medicalscribejobs/{MedicalScribeJobName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "MedicalScribeJobCompleted": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "MedicalScribeJob.MedicalScribeJobStatus",
+                    "expected": "COMPLETED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "MedicalScribeJob.MedicalScribeJobStatus",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 10
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalScribeJobRequest": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Medical Scribe job you want information about. Job names are\n            case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalScribeJobResponse": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJob": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the specified Medical Scribe job, including \n            job status and, if applicable, failure reason</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalTranscriptionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetMedicalTranscriptionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetMedicalTranscriptionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified medical transcription job.</p>\n         <p>To view the status of the specified medical transcription job, check the\n                <code>TranscriptionJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished. You can find the results at the location specified in\n                <code>TranscriptFileUri</code>. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your transcription job\n            failed.</p>\n         <p>To get a list of your medical transcription jobs, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/medicaltranscriptionjobs/{MedicalTranscriptionJobName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "MedicalTranscriptionJobCompleted": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "MedicalTranscriptionJob.TranscriptionJobStatus",
+                    "expected": "COMPLETED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "MedicalTranscriptionJob.TranscriptionJobStatus",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 10
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalTranscriptionJobRequest": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the medical transcription job you want information about. Job names are\n            case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalTranscriptionJobResponse": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJob": {
+          "target": "com.amazonaws.transcribe#MedicalTranscriptionJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the specified medical transcription job, including\n            job status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetMedicalVocabularyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetMedicalVocabularyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified custom medical vocabulary.</p>\n         <p>To view the status of the specified custom medical vocabulary, check the\n                <code>VocabularyState</code> field. If the status is <code>READY</code>, your custom\n            vocabulary is available to use. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your vocabulary failed.</p>\n         <p>To get a list of your custom medical vocabularies, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/medicalvocabularies/{VocabularyName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "MedicalVocabularyReady": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "VocabularyState",
+                    "expected": "READY",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "VocabularyState",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 10
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom medical vocabulary you want information about. Custom medical\n            vocabulary names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetMedicalVocabularyResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom medical vocabulary you requested information about.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom medical vocabulary. US English\n                (<code>en-US</code>) is the only language supported with Amazon Transcribe\n            Medical.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom medical vocabulary. If the state is\n                <code>READY</code>, you can use the custom vocabulary in a\n                <code>StartMedicalTranscriptionJob</code> request.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom medical vocabulary was last modified.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>VocabularyState</code> is <code>FAILED</code>, <code>FailureReason</code>\n            contains information about why the custom medical vocabulary request failed. See also:\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        },
+        "DownloadUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location where the specified custom medical vocabulary is stored; use this URI\n            to view or download the custom vocabulary.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetTranscriptionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetTranscriptionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetTranscriptionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified transcription job.</p>\n         <p>To view the status of the specified transcription job, check the\n                <code>TranscriptionJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished. You can find the results at the location specified in\n                <code>TranscriptFileUri</code>. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your transcription job\n            failed.</p>\n         <p>If you enabled content redaction, the redacted transcript can be found at the location\n            specified in <code>RedactedTranscriptFileUri</code>.</p>\n         <p>To get a list of your transcription jobs, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/transcriptionjobs/{TranscriptionJobName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "TranscriptionJobCompleted": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "TranscriptionJob.TranscriptionJobStatus",
+                    "expected": "COMPLETED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "TranscriptionJob.TranscriptionJobStatus",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 10
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetTranscriptionJobRequest": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the transcription job you want information about. Job names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetTranscriptionJobResponse": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJob": {
+          "target": "com.amazonaws.transcribe#TranscriptionJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the specified transcription job, including job\n            status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetVocabularyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetVocabularyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified custom vocabulary.</p>\n         <p>To view the status of the specified custom vocabulary, check the\n                <code>VocabularyState</code> field. If the status is <code>READY</code>, your custom\n            vocabulary is available to use. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your custom vocabulary\n            failed.</p>\n         <p>To get a list of your custom vocabularies, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "VocabularyReady": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "VocabularyState",
+                    "expected": "READY",
+                    "comparator": "stringEquals"
+                  }
+                }
+              },
+              {
+                "state": "failure",
+                "matcher": {
+                  "output": {
+                    "path": "VocabularyState",
+                    "expected": "FAILED",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 10
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetVocabularyFilter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#GetVocabularyFilterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#GetVocabularyFilterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about the specified custom vocabulary filter.</p>\n         <p>To get a list of your custom vocabulary filters, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/vocabularyFilters/{VocabularyFilterName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#GetVocabularyFilterRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want information about. Custom vocabulary\n            filter names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetVocabularyFilterResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you requested information about.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom vocabulary filter.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom vocabulary filter was last modified.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "DownloadUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location where the custom vocabulary filter is stored; use this\n            URI to view or download the custom vocabulary filter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want information about. Custom vocabulary names\n            are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#GetVocabularyResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you requested information about.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom vocabulary.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom vocabulary. If the state is <code>READY</code>,\n            you can use the custom vocabulary in a <code>StartTranscriptionJob</code>\n            request.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom vocabulary was last modified.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>VocabularyState</code> is <code>FAILED</code>, <code>FailureReason</code>\n            contains information about why the custom vocabulary request failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common\n                Errors</a>.</p>"
+          }
+        },
+        "DownloadUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location where the custom vocabulary is stored; use this URI to view or\n            download the custom vocabulary.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#IdentifiedLanguageScore": {
+      "type": "float"
+    },
+    "com.amazonaws.transcribe#InputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location (URI) of the text files you want to use to train your\n            custom language model.</p>\n         <p>Here's an example URI path:\n                <code>s3://DOC-EXAMPLE-BUCKET/my-model-training-data/</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TuningDataS3Uri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location (URI) of the text files you want to use to tune your\n            custom language model.</p>\n         <p>Here's an example URI path:\n            <code>s3://DOC-EXAMPLE-BUCKET/my-model-tuning-data/</code>\n         </p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files. If the role that you\n            specify doesn\u2019t have the appropriate permissions to access the specified Amazon S3\n            location, your request fails.</p>\n         <p>IAM role ARNs have the format\n                <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n                <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n                ARNs</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the Amazon S3 location of the training data you want to use to create\n            a new custom language model, and permissions to access this location.</p>\n         <p>When using <code>InputDataConfig</code>, you must include these sub-parameters:\n                <code>S3Uri</code> and <code>DataAccessRoleArn</code>. You can optionally include\n                <code>TuningDataS3Uri</code>.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#InputType": {
+      "type": "enum",
+      "members": {
+        "REAL_TIME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "REAL_TIME"
+          }
+        },
+        "POST_CALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POST_CALL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#InternalFailureException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.transcribe#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There was an internal error. Check the error message, correct the issue, and try your\n            request again.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.transcribe#InterruptionFilter": {
+      "type": "structure",
+      "members": {
+        "Threshold": {
+          "target": "com.amazonaws.transcribe#TimestampMilliseconds",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the duration of the interruptions in milliseconds. For example, you can flag\n            speech that contains more than 10,000 milliseconds of interruptions.</p>"
+          }
+        },
+        "ParticipantRole": {
+          "target": "com.amazonaws.transcribe#ParticipantRole",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the interrupter that you want to flag. Omitting this parameter is equivalent\n            to specifying both participants.</p>"
+          }
+        },
+        "AbsoluteTimeRange": {
+          "target": "com.amazonaws.transcribe#AbsoluteTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in milliseconds) in your audio, during\n            which you want to search for an interruption. See  for more detail.</p>"
+          }
+        },
+        "RelativeTimeRange": {
+          "target": "com.amazonaws.transcribe#RelativeTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in percentage) in your media file, during\n            which you want to search for an interruption. See  for more detail.</p>"
+          }
+        },
+        "Negate": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Set to <code>TRUE</code> to flag speech that does not contain interruptions. Set to\n                <code>FALSE</code> to flag speech that contains interruptions.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Flag the presence or absence of interruptions in your Call Analytics transcription\n            output.</p>\n         <p>Rules using <code>InterruptionFilter</code> are designed to match:</p>\n         <ul>\n            <li>\n               <p>Instances where an agent interrupts a customer</p>\n            </li>\n            <li>\n               <p>Instances where a customer interrupts an agent</p>\n            </li>\n            <li>\n               <p>Either participant interrupting the other</p>\n            </li>\n            <li>\n               <p>A lack of interruptions</p>\n            </li>\n         </ul>\n         <p>See <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html#tca-rules-batch\">Rule criteria for post-call \n            categories</a> for usage examples.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#JobExecutionSettings": {
+      "type": "structure",
+      "members": {
+        "AllowDeferredExecution": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to enable job queuing when your concurrent request limit is\n            exceeded. When <code>AllowDeferredExecution</code> is set to <code>true</code>,\n            transcription job requests are placed in a queue until the number of jobs falls below\n            the concurrent request limit. If <code>AllowDeferredExecution</code> is set to\n                <code>false</code> and the number of transcription job requests exceed the\n            concurrent request limit, you get a <code>LimitExceededException</code> error.</p>\n         <p>If you include <code>AllowDeferredExecution</code> in your request, you must also\n            include <code>DataAccessRoleArn</code>.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files. If the role that you\n            specify doesn\u2019t have the appropriate permissions to access the specified Amazon S3 \n            location, your request fails.</p>\n         <p>IAM role ARNs have the format\n                <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n                <code>arn:aws:iam::111122223333:role/Admin</code>. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n                ARNs</a>.</p>\n         <p>Note that if you include <code>DataAccessRoleArn</code> in your request, you must also\n            include <code>AllowDeferredExecution</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Makes it possible to control how your transcription job is processed. Currently, the\n            only <code>JobExecutionSettings</code> modification you can choose is enabling job\n            queueing using the <code>AllowDeferredExecution</code> sub-parameter.</p>\n         <p>If you include <code>JobExecutionSettings</code> in your request, you must also\n            include the sub-parameters: <code>AllowDeferredExecution</code> and\n                <code>DataAccessRoleArn</code>.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#KMSEncryptionContextMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.transcribe#NonEmptyString"
+      },
+      "value": {
+        "target": "com.amazonaws.transcribe#NonEmptyString"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.transcribe#KMSKeyId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^[A-Za-z0-9][A-Za-z0-9:_/+=,@.-]{0,2048}$"
+      }
+    },
+    "com.amazonaws.transcribe#LanguageCode": {
+      "type": "enum",
+      "members": {
+        "AF_ZA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "af-ZA"
+          }
+        },
+        "AR_AE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ar-AE"
+          }
+        },
+        "AR_SA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ar-SA"
+          }
+        },
+        "AM_ET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "am-ET"
+          }
+        },
+        "CY_GB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "cy-GB"
+          }
+        },
+        "DA_DK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "da-DK"
+          }
+        },
+        "DE_CH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "de-CH"
+          }
+        },
+        "DE_DE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "de-DE"
+          }
+        },
+        "EN_AB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-AB"
+          }
+        },
+        "EN_AU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-AU"
+          }
+        },
+        "EN_GB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-GB"
+          }
+        },
+        "EN_IE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-IE"
+          }
+        },
+        "EN_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-IN"
+          }
+        },
+        "EN_US": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-US"
+          }
+        },
+        "EN_WL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-WL"
+          }
+        },
+        "ES_ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es-ES"
+          }
+        },
+        "ES_MX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es-MX"
+          }
+        },
+        "ES_US": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es-US"
+          }
+        },
+        "FA_AF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fa-AF"
+          }
+        },
+        "FA_IR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fa-IR"
+          }
+        },
+        "FR_CA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fr-CA"
+          }
+        },
+        "FR_FR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fr-FR"
+          }
+        },
+        "GA_IE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ga-IE"
+          }
+        },
+        "GD_GB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "gd-GB"
+          }
+        },
+        "HE_IL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "he-IL"
+          }
+        },
+        "HI_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "hi-IN"
+          }
+        },
+        "HT_HT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ht-HT"
+          }
+        },
+        "ID_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "id-ID"
+          }
+        },
+        "IT_IT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "it-IT"
+          }
+        },
+        "JA_JP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ja-JP"
+          }
+        },
+        "JV_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "jv-ID"
+          }
+        },
+        "KM_KH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "km-KH"
+          }
+        },
+        "KO_KR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ko-KR"
+          }
+        },
+        "MY_MM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "my-MM"
+          }
+        },
+        "MS_MY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ms-MY"
+          }
+        },
+        "NL_NL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "nl-NL"
+          }
+        },
+        "PT_BR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pt-BR"
+          }
+        },
+        "PT_PT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pt-PT"
+          }
+        },
+        "RU_RU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ru-RU"
+          }
+        },
+        "TA_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ta-IN"
+          }
+        },
+        "TE_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "te-IN"
+          }
+        },
+        "TR_TR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "tr-TR"
+          }
+        },
+        "ZH_CN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh-CN"
+          }
+        },
+        "ZH_TW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh-TW"
+          }
+        },
+        "TH_TH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "th-TH"
+          }
+        },
+        "EN_ZA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-ZA"
+          }
+        },
+        "EN_NZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-NZ"
+          }
+        },
+        "VI_VN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "vi-VN"
+          }
+        },
+        "SV_SE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sv-SE"
+          }
+        },
+        "AB_GE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ab-GE"
+          }
+        },
+        "AST_ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ast-ES"
+          }
+        },
+        "AZ_AZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "az-AZ"
+          }
+        },
+        "BA_RU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ba-RU"
+          }
+        },
+        "BE_BY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "be-BY"
+          }
+        },
+        "BG_BG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "bg-BG"
+          }
+        },
+        "BN_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "bn-IN"
+          }
+        },
+        "BS_BA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "bs-BA"
+          }
+        },
+        "CA_ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ca-ES"
+          }
+        },
+        "CKB_IQ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ckb-IQ"
+          }
+        },
+        "CKB_IR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ckb-IR"
+          }
+        },
+        "CS_CZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "cs-CZ"
+          }
+        },
+        "CY_WL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "cy-WL"
+          }
+        },
+        "EL_GR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "el-GR"
+          }
+        },
+        "ET_EE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "et-EE"
+          }
+        },
+        "ET_ET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "et-ET"
+          }
+        },
+        "EU_ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "eu-ES"
+          }
+        },
+        "FI_FI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fi-FI"
+          }
+        },
+        "GL_ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "gl-ES"
+          }
+        },
+        "GU_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "gu-IN"
+          }
+        },
+        "HA_NG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ha-NG"
+          }
+        },
+        "HR_HR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "hr-HR"
+          }
+        },
+        "HU_HU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "hu-HU"
+          }
+        },
+        "HY_AM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "hy-AM"
+          }
+        },
+        "IS_IS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "is-IS"
+          }
+        },
+        "KA_GE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ka-GE"
+          }
+        },
+        "KAB_DZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "kab-DZ"
+          }
+        },
+        "KK_KZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "kk-KZ"
+          }
+        },
+        "KN_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "kn-IN"
+          }
+        },
+        "KY_KG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ky-KG"
+          }
+        },
+        "LG_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "lg-IN"
+          }
+        },
+        "LT_LT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "lt-LT"
+          }
+        },
+        "LV_LV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "lv-LV"
+          }
+        },
+        "MHR_RU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mhr-RU"
+          }
+        },
+        "MI_NZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mi-NZ"
+          }
+        },
+        "MK_MK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mk-MK"
+          }
+        },
+        "ML_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ml-IN"
+          }
+        },
+        "MN_MN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mn-MN"
+          }
+        },
+        "MR_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mr-IN"
+          }
+        },
+        "MT_MT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mt-MT"
+          }
+        },
+        "NO_NO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "no-NO"
+          }
+        },
+        "NE_NP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ne-NP"
+          }
+        },
+        "OR_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "or-IN"
+          }
+        },
+        "PA_IN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pa-IN"
+          }
+        },
+        "PL_PL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pl-PL"
+          }
+        },
+        "PS_AF": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ps-AF"
+          }
+        },
+        "RO_RO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ro-RO"
+          }
+        },
+        "RW_RW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "rw-RW"
+          }
+        },
+        "SI_LK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "si-LK"
+          }
+        },
+        "SK_SK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sk-SK"
+          }
+        },
+        "SL_SI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sl-SI"
+          }
+        },
+        "SO_SO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "so-SO"
+          }
+        },
+        "SQ_AL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sq-AL"
+          }
+        },
+        "SR_RS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sr-RS"
+          }
+        },
+        "SU_ID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "su-ID"
+          }
+        },
+        "SW_BI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sw-BI"
+          }
+        },
+        "SW_KE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sw-KE"
+          }
+        },
+        "SW_RW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sw-RW"
+          }
+        },
+        "SW_TZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sw-TZ"
+          }
+        },
+        "SW_UG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "sw-UG"
+          }
+        },
+        "TL_PH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "tl-PH"
+          }
+        },
+        "TT_RU": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "tt-RU"
+          }
+        },
+        "UG_CN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ug-CN"
+          }
+        },
+        "UK_UA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "uk-UA"
+          }
+        },
+        "UZ_UZ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "uz-UZ"
+          }
+        },
+        "WO_SN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "wo-SN"
+          }
+        },
+        "ZH_HK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh-HK"
+          }
+        },
+        "ZU_ZA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zu-ZA"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#LanguageCodeItem": {
+      "type": "structure",
+      "members": {
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the language code for each language identified in your media.</p>"
+          }
+        },
+        "DurationInSeconds": {
+          "target": "com.amazonaws.transcribe#DurationInSeconds",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the total time, in seconds, each identified language is spoken in your\n            media.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information on the speech contained in a discreet utterance when\n            multi-language identification is enabled in your request. This utterance represents a\n            block of speech consisting of one language, preceded or followed by a block of speech in\n            a different language.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#LanguageCodeList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#LanguageCodeItem"
+      }
+    },
+    "com.amazonaws.transcribe#LanguageIdSettings": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to use when processing your transcription\n            job. Custom vocabulary names are case sensitive.</p>\n         <p>The language of the specified custom vocabulary must match the language code that you\n            specify in your transcription request. If the languages do not match, the custom\n            vocabulary isn't applied. There are no errors or warnings associated with a language\n            mismatch.</p>"
+          }
+        },
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want to use when processing your\n            transcription job. Custom vocabulary filter names are case sensitive.</p>\n         <p>The language of the specified custom vocabulary filter must match the language code\n            that you specify in your transcription request. If the languages do not match, the custom\n            vocabulary filter isn't applied. There are no errors or warnings associated with a\n            language mismatch.</p>\n         <p>Note that if you include <code>VocabularyFilterName</code> in your request, you must\n            also include <code>VocabularyFilterMethod</code>.</p>"
+          }
+        },
+        "LanguageModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom language model you want to use when processing your\n            transcription job. Note that custom language model names are case sensitive.</p>\n         <p>The language of the specified custom language model must match the language code that\n            you specify in your transcription request. If the languages do not match, the custom\n            language model isn't applied. There are no errors or warnings associated with a language\n            mismatch.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>If using automatic language identification in your request and you want to apply a\n            custom language model, a custom vocabulary, or a custom vocabulary filter, include\n                <code>LanguageIdSettings</code> with the relevant sub-parameters\n                (<code>VocabularyName</code>, <code>LanguageModelName</code>, and\n                <code>VocabularyFilterName</code>). Note that multi-language identification\n                (<code>IdentifyMultipleLanguages</code>) doesn't support custom language\n            models.</p>\n         <p>\n            <code>LanguageIdSettings</code> supports two to five language codes. Each language\n            code you include can have an associated custom language model, custom vocabulary, and\n            custom vocabulary filter. The language codes that you specify must match the languages\n            of the associated custom language models, custom vocabularies, and custom vocabulary\n            filters.</p>\n         <p>It's  recommended that you include <code>LanguageOptions</code> when using\n                <code>LanguageIdSettings</code> to ensure that the correct language dialect is\n            identified. For example, if you specify a custom vocabulary that is in\n                <code>en-US</code> but Amazon Transcribe determines that the language spoken in\n            your media is <code>en-AU</code>, your custom vocabulary <i>is not</i>\n            applied to your transcription. If you include <code>LanguageOptions</code> and include\n                <code>en-US</code> as the only English language dialect, your custom vocabulary\n                <i>is</i> applied to your transcription.</p>\n         <p>If you want to include a custom language model with your request but <b>do not</b> want to use automatic language identification, use\n            instead the <code></code> parameter with the\n                <code>LanguageModelName</code> sub-parameter. If you want to include a custom\n            vocabulary or a custom vocabulary filter (or both) with your request but <b>do not</b> want to use automatic language identification, use\n            instead the <code></code> parameter with the\n                <code>VocabularyName</code> or <code>VocabularyFilterName</code> (or both)\n            sub-parameter.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#LanguageIdSettingsMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.transcribe#LanguageCode"
+      },
+      "value": {
+        "target": "com.amazonaws.transcribe#LanguageIdSettings"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.transcribe#LanguageModel": {
+      "type": "structure",
+      "members": {
+        "ModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your custom language model.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account.</p>"
+          }
+        },
+        "CreateTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom language model was created.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom language model was last modified.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#CLMLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your custom language model. Each custom language\n            model must contain terms in only one language, and the language you select for your\n            custom language model must match the language of your training and tuning data.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table. Note that US English (<code>en-US</code>) is\n            the only language supported with Amazon Transcribe Medical.</p>"
+          }
+        },
+        "BaseModelName": {
+          "target": "com.amazonaws.transcribe#BaseModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Transcribe standard language model, or base model, used to create your\n            custom language model.</p>"
+          }
+        },
+        "ModelStatus": {
+          "target": "com.amazonaws.transcribe#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the specified custom language model. When the status displays as\n                <code>COMPLETED</code> the model is ready for use.</p>"
+          }
+        },
+        "UpgradeAvailability": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Shows if a more current base model is available for use with the specified custom\n            language model.</p>\n         <p>If <code>false</code>, your custom language model is using the most up-to-date base\n            model.</p>\n         <p>If <code>true</code>, there is a newer base model available than the one your language\n            model is using.</p>\n         <p>Note that to update a base model, you must recreate the custom language model using\n            the new base model. Base model upgrades for existing custom language models are not\n            supported.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>ModelStatus</code> is <code>FAILED</code>, <code>FailureReason</code>\n            contains information about why the custom language model request failed. See also:\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.transcribe#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the input files used to train and tune your custom\n            language model, in addition to the data access role ARN (Amazon Resource Name) that has\n            permissions to access these data.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a custom language model, including:</p>\n         <ul>\n            <li>\n               <p>The base model name</p>\n            </li>\n            <li>\n               <p>When the model was created</p>\n            </li>\n            <li>\n               <p>The location of the files used to train the model</p>\n            </li>\n            <li>\n               <p>When the model was last modified</p>\n            </li>\n            <li>\n               <p>The name you chose for the model</p>\n            </li>\n            <li>\n               <p>The model's language</p>\n            </li>\n            <li>\n               <p>The model's  processing state</p>\n            </li>\n            <li>\n               <p>Any available upgrades for the base model</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.transcribe#LanguageOptions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#LanguageCode"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.transcribe#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You've either sent too many requests or your input file is too long. Wait before\n            retrying your request, or use a smaller file and try your request again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.transcribe#ListCallAnalyticsCategories": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListCallAnalyticsCategoriesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListCallAnalyticsCategoriesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of Call Analytics categories, including all rules that make up each\n            category.</p>\n         <p>To get detailed information about a specific Call Analytics category, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/callanalyticscategories",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListCallAnalyticsCategoriesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListCallAnalyticsCategories</code> request returns more results than can\n            be displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of Call Analytics categories to return in each page of results. If\n            there are fewer results than the value that you specify, only the actual results are\n            returned. If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListCallAnalyticsCategoriesResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "Categories": {
+          "target": "com.amazonaws.transcribe#CategoryPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about your Call Analytics categories, including all the\n            rules associated with each category.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListCallAnalyticsJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListCallAnalyticsJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListCallAnalyticsJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of Call Analytics jobs that match the specified criteria. If no\n            criteria are specified, all Call Analytics jobs are returned.</p>\n         <p>To get detailed information about a specific Call Analytics job, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/callanalyticsjobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListCallAnalyticsJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only Call Analytics jobs with the specified status. Jobs are ordered by\n            creation date, with the newest job first. If you do not include <code>Status</code>, all\n            Call Analytics jobs are returned.</p>",
+            "smithy.api#httpQuery": "Status"
+          }
+        },
+        "JobNameContains": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the Call Analytics jobs that contain the specified string. The search is\n            not case sensitive.</p>",
+            "smithy.api#httpQuery": "JobNameContains"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListCallAnalyticsJobs</code> request returns more results than can be\n            displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of Call Analytics jobs to return in each page of results. If there\n            are fewer results than the value that you specify, only the actual results are returned.\n            If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListCallAnalyticsJobsResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all Call Analytics jobs that have the status specified in your request. Jobs are\n            ordered by creation date, with the newest job first.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "CallAnalyticsJobSummaries": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a summary of information about each result.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListLanguageModels": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListLanguageModelsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListLanguageModelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of custom language models that match the specified criteria. If no\n            criteria are specified, all custom language models are returned.</p>\n         <p>To get detailed information about a specific custom language model, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/languagemodels",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListLanguageModelsRequest": {
+      "type": "structure",
+      "members": {
+        "StatusEquals": {
+          "target": "com.amazonaws.transcribe#ModelStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only custom language models with the specified status. Language models are\n            ordered by creation date, with the newest model first. If you do not include\n                <code>StatusEquals</code>, all custom language models are returned.</p>",
+            "smithy.api#httpQuery": "         StatusEquals"
+          }
+        },
+        "NameContains": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the custom language models that contain the specified string. The search\n            is not case sensitive.</p>",
+            "smithy.api#httpQuery": "NameContains"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListLanguageModels</code> request returns more results than can be\n            displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of custom language models to return in each page of results. If\n            there are fewer results than the value that you specify, only the actual results are\n            returned. If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListLanguageModelsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "Models": {
+          "target": "com.amazonaws.transcribe#Models",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the custom language models that match the criteria\n            specified in your request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalScribeJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListMedicalScribeJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListMedicalScribeJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of Medical Scribe jobs that match the specified criteria. If no\n            criteria are specified, all Medical Scribe jobs are returned.</p>\n         <p>To get detailed information about a specific Medical Scribe job, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/medicalscribejobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalScribeJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only Medical Scribe jobs with the specified status. Jobs are ordered by\n            creation date, with the newest job first. If you do not include <code>Status</code>, all\n            Medical Scribe jobs are returned.</p>",
+            "smithy.api#httpQuery": "Status"
+          }
+        },
+        "JobNameContains": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the Medical Scribe jobs that contain the specified string. The\n            search is not case sensitive.</p>",
+            "smithy.api#httpQuery": "JobNameContains"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListMedicalScribeJobs</code> request returns more results than\n            can be displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of Medical Scribe jobs to return in each page of results. If\n            there are fewer results than the value that you specify, only the actual results are\n            returned. If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalScribeJobsResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all Medical Scribe jobs that have the status specified in your request.\n            Jobs are ordered by creation date, with the newest job first.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "MedicalScribeJobSummaries": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJobSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a summary of information about each result.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalTranscriptionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListMedicalTranscriptionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListMedicalTranscriptionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of medical transcription jobs that match the specified criteria. If no\n            criteria are specified, all medical transcription jobs are returned.</p>\n         <p>To get detailed information about a specific medical transcription job, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/medicaltranscriptionjobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalTranscriptionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only medical transcription jobs with the specified status. Jobs are ordered by\n            creation date, with the newest job first. If you do not include <code>Status</code>, all\n            medical transcription jobs are returned.</p>",
+            "smithy.api#httpQuery": "Status"
+          }
+        },
+        "JobNameContains": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the medical transcription jobs that contain the specified string. The\n            search is not case sensitive.</p>",
+            "smithy.api#httpQuery": "JobNameContains"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListMedicalTranscriptionJobs</code> request returns more results than\n            can be displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of medical transcription jobs to return in each page of results. If\n            there are fewer results than the value that you specify, only the actual results are\n            returned. If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalTranscriptionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all medical transcription jobs that have the status specified in your request.\n            Jobs are ordered by creation date, with the newest job first.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "MedicalTranscriptionJobSummaries": {
+          "target": "com.amazonaws.transcribe#MedicalTranscriptionJobSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a summary of information about each result.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalVocabularies": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListMedicalVocabulariesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListMedicalVocabulariesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of custom medical vocabularies that match the specified criteria. If\n            no criteria are specified, all custom medical vocabularies are returned.</p>\n         <p>To get detailed information about a specific custom medical vocabulary, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/medicalvocabularies",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalVocabulariesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListMedicalVocabularies</code> request returns more results than can be\n            displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of custom medical vocabularies to return in each page of results.\n            If there are fewer results than the value that you specify, only the actual results are\n            returned. If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "StateEquals": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only custom medical vocabularies with the specified state. Custom vocabularies\n            are ordered by creation date, with the newest vocabulary first. If you do not include\n                <code>StateEquals</code>, all custom medical vocabularies are returned.</p>",
+            "smithy.api#httpQuery": "StateEquals"
+          }
+        },
+        "NameContains": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the custom medical vocabularies that contain the specified string. The\n            search is not case sensitive.</p>",
+            "smithy.api#httpQuery": "NameContains"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListMedicalVocabulariesResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all custom medical vocabularies that have the status specified in your request.\n            Custom vocabularies are ordered by creation date, with the newest vocabulary\n            first.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "Vocabularies": {
+          "target": "com.amazonaws.transcribe#Vocabularies",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the custom medical vocabularies that match the criteria\n            specified in your request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all tags associated with the specified transcription job, vocabulary, model, or\n            resource.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/tags/{ResourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.transcribe#TranscribeArn",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns a list of all tags associated with the specified Amazon Resource Name (ARN).\n            ARNs have the format\n                <code>arn:partition:service:region:account-id:resource-type/resource-id</code>.</p>\n         <p>For example,\n                <code>arn:aws:transcribe:us-west-2:111122223333:transcription-job/transcription-job-name</code>.</p>\n         <p>Valid values for <code>resource-type</code> are: <code>transcription-job</code>,\n                <code>medical-transcription-job</code>, <code>vocabulary</code>,\n                <code>medical-vocabulary</code>, <code>vocabulary-filter</code>, and\n                <code>language-model</code>.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.transcribe#TranscribeArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) specified in your request.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all tags associated with the given transcription job, vocabulary, model, or\n            resource.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListTranscriptionJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListTranscriptionJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListTranscriptionJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of transcription jobs that match the specified criteria. If no\n            criteria are specified, all transcription jobs are returned.</p>\n         <p>To get detailed information about a specific transcription job, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/transcriptionjobs",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListTranscriptionJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only transcription jobs with the specified status. Jobs are ordered by\n            creation date, with the newest job first. If you do not include <code>Status</code>, all\n            transcription jobs are returned.</p>",
+            "smithy.api#httpQuery": "Status"
+          }
+        },
+        "JobNameContains": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the transcription jobs that contain the specified string. The search is\n            not case sensitive.</p>",
+            "smithy.api#httpQuery": "JobNameContains"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListTranscriptionJobs</code> request returns more results than can be\n            displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of transcription jobs to return in each page of results. If there\n            are fewer results than the value that you specify, only the actual results are returned.\n            If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListTranscriptionJobsResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all transcription jobs that have the status specified in your request. Jobs are\n            ordered by creation date, with the newest job first.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "TranscriptionJobSummaries": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobSummaries",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides a summary of information about each result.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListVocabularies": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListVocabulariesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListVocabulariesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of custom vocabularies that match the specified criteria. If no\n            criteria are specified, all custom vocabularies are returned.</p>\n         <p>To get detailed information about a specific custom vocabulary, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/vocabularies",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListVocabulariesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListVocabularies</code> request returns more results than can be\n            displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of custom vocabularies to return in each page of results. If there\n            are fewer results than the value that you specify, only the actual results are returned.\n            If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "StateEquals": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only custom vocabularies with the specified state. Vocabularies are ordered by\n            creation date, with the newest vocabulary first. If you do not include\n                <code>StateEquals</code>, all custom medical vocabularies are returned.</p>",
+            "smithy.api#httpQuery": "StateEquals"
+          }
+        },
+        "NameContains": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the custom vocabularies that contain the specified string. The search is\n            not case sensitive.</p>",
+            "smithy.api#httpQuery": "NameContains"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListVocabulariesResponse": {
+      "type": "structure",
+      "members": {
+        "Status": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>Lists all custom vocabularies that have the status specified in your request.\n            Vocabularies are ordered by creation date, with the newest vocabulary first.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "Vocabularies": {
+          "target": "com.amazonaws.transcribe#Vocabularies",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the custom vocabularies that match the criteria specified\n            in your request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListVocabularyFilters": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#ListVocabularyFiltersRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#ListVocabularyFiltersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of custom vocabulary filters that match the specified criteria. If no\n            criteria are specified, all custom vocabularies are returned.</p>\n         <p>To get detailed information about a specific custom vocabulary filter, use the  operation.</p>",
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/vocabularyFilters",
+          "code": 200
+        },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ListVocabularyFiltersRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If your <code>ListVocabularyFilters</code> request returns more results than can be\n            displayed, <code>NextToken</code> is displayed in the response with an associated\n            string. To get the next page of results, copy this string and repeat your request,\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>",
+            "smithy.api#httpQuery": "NextToken"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.transcribe#MaxResults",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of custom vocabulary filters to return in each page of results. If\n            there are fewer results than the value that you specify, only the actual results are\n            returned. If you do not specify a value, a default of 5 is used.</p>",
+            "smithy.api#httpQuery": "MaxResults"
+          }
+        },
+        "NameContains": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>Returns only the custom vocabulary filters that contain the specified string. The\n            search is not case sensitive.</p>",
+            "smithy.api#httpQuery": "NameContains"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#ListVocabularyFiltersResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.transcribe#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>NextToken</code> is present in your response, it indicates that not all\n            results are displayed. To view the next set of results, copy the string associated with\n            the <code>NextToken</code> parameter in your results output, then run your request again\n            including <code>NextToken</code> with the value of the copied string. Repeat as needed\n            to view all your results.</p>"
+          }
+        },
+        "VocabularyFilters": {
+          "target": "com.amazonaws.transcribe#VocabularyFilters",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the custom vocabulary filters that match the criteria\n            specified in your request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#MaxAlternatives": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 2,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MaxResults": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MaxSpeakers": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 2,
+          "max": 30
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Media": {
+      "type": "structure",
+      "members": {
+        "MediaFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the media file you want to transcribe. For\n            example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>s3://DOC-EXAMPLE-BUCKET/my-media-file.flac</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>s3://DOC-EXAMPLE-BUCKET/media-files/my-media-file.flac</code>\n               </p>\n            </li>\n         </ul>\n         <p>Note that the Amazon S3 bucket that contains your input media must be located\n            in the same Amazon Web Services Region where you're making your transcription\n            request.</p>"
+          }
+        },
+        "RedactedMediaFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the media file you want to redact. For\n            example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>s3://DOC-EXAMPLE-BUCKET/my-media-file.flac</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>s3://DOC-EXAMPLE-BUCKET/media-files/my-media-file.flac</code>\n               </p>\n            </li>\n         </ul>\n         <p>Note that the Amazon S3 bucket that contains your input media must be located\n            in the same Amazon Web Services Region where you're making your transcription\n            request.</p>\n         <important>\n            <p>\n               <code>RedactedMediaFileUri</code> produces a redacted audio file in addition to a \n                redacted transcript. It is only supported for Call Analytics\n                (<code>StartCallAnalyticsJob</code>) transcription requests.</p>\n         </important>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the Amazon S3 location of the media file you want to use in your\n            request.</p>\n         <p>For information on supported media formats, refer to the <code>MediaFormat</code> \n            parameter or the <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/how-input.html#how-input-audio\">Media formats</a> section \n            in the Amazon S3 Developer Guide.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MediaFormat": {
+      "type": "enum",
+      "members": {
+        "MP3": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mp3"
+          }
+        },
+        "MP4": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mp4"
+          }
+        },
+        "WAV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "wav"
+          }
+        },
+        "FLAC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "flac"
+          }
+        },
+        "OGG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ogg"
+          }
+        },
+        "AMR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "amr"
+          }
+        },
+        "WEBM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "webm"
+          }
+        },
+        "M4A": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "m4a"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MediaSampleRateHertz": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 8000,
+          "max": 48000
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalContentIdentificationType": {
+      "type": "enum",
+      "members": {
+        "PHI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PHI"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalMediaSampleRateHertz": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 16000,
+          "max": 48000
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeChannelDefinition": {
+      "type": "structure",
+      "members": {
+        "ChannelId": {
+          "target": "com.amazonaws.transcribe#MedicalScribeChannelId",
+          "traits": {
+            "smithy.api#default": 0,
+            "smithy.api#documentation": "<p>Specify the audio channel you want to define.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ParticipantRole": {
+          "target": "com.amazonaws.transcribe#MedicalScribeParticipantRole",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the participant that you want to flag. \n      The options are <code>CLINICIAN</code> and <code>PATIENT</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Indicates which speaker is on which channel. The options are \n      <code>CLINICIAN</code> and <code>PATIENT</code>\n         </p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeChannelDefinitions": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#MedicalScribeChannelDefinition"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 2
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeChannelId": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0,
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeContext": {
+      "type": "structure",
+      "members": {
+        "PatientContext": {
+          "target": "com.amazonaws.transcribe#MedicalScribePatientContext",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains patient-specific information.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The <code>MedicalScribeContext</code> object that contains contextual information used to generate\n            customized clinical notes.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeJob": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Medical Scribe job. Job names are case sensitive and must be\n            unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "MedicalScribeJobStatus": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the specified Medical Scribe job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>MedicalScribeOutput</code> If\n            the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why\n            your Medical Scribe job failed.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#MedicalScribeLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your Medical Scribe job. US English\n                (<code>en-US</code>) is the only supported language for Medical Scribe jobs. </p>"
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media"
+        },
+        "MedicalScribeOutput": {
+          "target": "com.amazonaws.transcribe#MedicalScribeOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>The location of the output of your Medical Scribe job. \n      <code>ClinicalDocumentUri</code> holds the Amazon S3 URI for the Clinical Document \n      and <code>TranscriptFileUri</code> holds the Amazon S3 URI for the Transcript.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time your Medical Scribe job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a Medical Scribe job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Medical Scribe job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a Medical Scribe job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Medical Scribe job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a Medical Scribe job\n            that finished processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>MedicalScribeJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the transcription job\n            failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#MedicalScribeSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to control how your Medical Scribe job is processed using a\n            <code>MedicalScribeSettings</code> object. Specify <code>ChannelIdentification</code> if \n            <code>ChannelDefinitions</code> are set. Enabled <code>ShowSpeakerLabels</code> if <code>ChannelIdentification</code> \n            and <code>ChannelDefinitions</code> are not set. One and only one of <code>ChannelIdentification</code> and <code>ShowSpeakerLabels</code>\n            must be set. If <code>ShowSpeakerLabels</code> is set, <code>MaxSpeakerLabels</code> must also be set. Use <code>Settings</code>\n            to specify a vocabulary or vocabulary filter or both using <code>VocabularyName</code>, <code>VocabularyFilterName</code>. \n            <code>VocabularyFilterMethod</code> must be specified if <code>VocabularyFilterName</code> is set.\n        </p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files, \n            write to the output bucket, and use your KMS key if supplied.  \n             If the role that you specify doesn\u2019t have the appropriate permissions your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>"
+          }
+        },
+        "ChannelDefinitions": {
+          "target": "com.amazonaws.transcribe#MedicalScribeChannelDefinitions",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify which speaker is on which channel. For example, if the clinician\n            is the first participant to speak, you would set <code>ChannelId</code> of the first <code>ChannelDefinition</code> \n            in the list to <code>0</code> (to indicate the first channel) and <code>ParticipantRole</code> to\n            <code>CLINICIAN</code> (to indicate that it's the clinician speaking).\n            Then you would set the <code>ChannelId</code> of the second <code>ChannelDefinition</code> in the list to\n            <code>1</code> (to indicate the second channel) and <code>ParticipantRole</code> to\n            <code>PATIENT</code> (to indicate that it's the patient speaking).\n        </p>"
+          }
+        },
+        "MedicalScribeContextProvided": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the <code>MedicalScribeContext</code> object was provided when the Medical Scribe job was started.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to the Medical Scribe job.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a Medical Scribe job.</p>\n         <p>To view the status of the specified Medical Scribe job, check the\n                <code>MedicalScribeJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished and you can find the results at the locations specified in\n                <code>MedicalScribeOutput</code>. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your Medical Scribe job\n            failed.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeJobStatus": {
+      "type": "enum",
+      "members": {
+        "QUEUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUEUED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeJobSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#MedicalScribeJobSummary"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeJobSummary": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Medical Scribe job. Job names are case sensitive and must be\n            unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Medical Scribe job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a Medical Scribe job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time your Medical Scribe job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a Medical Scribe job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified Medical Scribe job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a Medical Scribe job\n            that finished processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#MedicalScribeLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your Medical Scribe job. US English\n                (<code>en-US</code>) is the only supported language for Medical Scribe jobs. </p>"
+          }
+        },
+        "MedicalScribeJobStatus": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the specified Medical Scribe job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>MedicalScribeOutput</code> If\n            the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why\n            your Medical Scribe job failed.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>MedicalScribeJobStatus</code> is <code>FAILED</code>,\n            <code>FailureReason</code> contains information about why the transcription job\n            failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a specific Medical Scribe job.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeLanguageCode": {
+      "type": "enum",
+      "members": {
+        "EN_US": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en-US"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeNoteTemplate": {
+      "type": "enum",
+      "members": {
+        "HISTORY_AND_PHYSICAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HISTORY_AND_PHYSICAL"
+          }
+        },
+        "GIRPP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GIRPP"
+          }
+        },
+        "BIRP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BIRP"
+          }
+        },
+        "SIRP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SIRP"
+          }
+        },
+        "DAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DAP"
+          }
+        },
+        "BEHAVIORAL_SOAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BEHAVIORAL_SOAP"
+          }
+        },
+        "PHYSICAL_SOAP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PHYSICAL_SOAP"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeOutput": {
+      "type": "structure",
+      "members": {
+        "TranscriptFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Holds the Amazon S3 URI for the Transcript.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClinicalDocumentUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>Holds the Amazon S3 URI for the Clinical Document.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The location of the output of your Medical Scribe job. \n      <code>ClinicalDocumentUri</code> holds the Amazon S3 URI for the Clinical Document \n      and <code>TranscriptFileUri</code> holds the Amazon S3 URI for the Transcript.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeParticipantRole": {
+      "type": "enum",
+      "members": {
+        "PATIENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PATIENT"
+          }
+        },
+        "CLINICIAN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CLINICIAN"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribePatientContext": {
+      "type": "structure",
+      "members": {
+        "Pronouns": {
+          "target": "com.amazonaws.transcribe#Pronouns",
+          "traits": {
+            "smithy.api#documentation": "<p>The patient's preferred pronouns that the user wants to provide as a context for clinical note generation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains patient-specific information used to customize the clinical note generation.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalScribeSettings": {
+      "type": "structure",
+      "members": {
+        "ShowSpeakerLabels": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables speaker partitioning (diarization) in your Medical Scribe output. Speaker\n            partitioning labels the speech from individual speakers in your media file.</p>\n         <p>If you enable <code>ShowSpeakerLabels</code> in your request, you must also include\n                <code>MaxSpeakerLabels</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/diarization.html\">Partitioning speakers\n                (diarization)</a>.</p>"
+          }
+        },
+        "MaxSpeakerLabels": {
+          "target": "com.amazonaws.transcribe#MaxSpeakers",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the maximum number of speakers you want to partition in your media.</p>\n         <p>Note that if your media contains more speakers than the specified number, multiple\n            speakers are treated as a single speaker.</p>\n         <p>If you specify the <code>MaxSpeakerLabels</code> field, you must set the\n                <code>ShowSpeakerLabels</code> field to true.</p>"
+          }
+        },
+        "ChannelIdentification": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables channel identification in multi-channel audio.</p>\n         <p>Channel identification transcribes the audio on each channel independently, then\n            appends the output for each channel into one transcript.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/channel-id.html\">Transcribing multi-channel\n            audio</a>.</p>"
+          }
+        },
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to include in your Medical Scribe\n            request. Custom vocabulary names are case sensitive.</p>"
+          }
+        },
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want to include in your Medical Scribe\n            request. Custom vocabulary filter names are case sensitive.</p>\n         <p>Note that if you include <code>VocabularyFilterName</code> in your request, you must\n            also include <code>VocabularyFilterMethod</code>.</p>"
+          }
+        },
+        "VocabularyFilterMethod": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterMethod",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify how you want your custom vocabulary filter applied to your transcript.</p>\n         <p>To replace words with <code>***</code>, choose <code>mask</code>.</p>\n         <p>To delete words, choose <code>remove</code>.</p>\n         <p>To flag words without changing them, choose <code>tag</code>.</p>"
+          }
+        },
+        "ClinicalNoteGenerationSettings": {
+          "target": "com.amazonaws.transcribe#ClinicalNoteGenerationSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify settings for the clinical note generation.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Makes it possible to control how your Medical Scribe job is processed using a\n            <code>MedicalScribeSettings</code> object. Specify <code>ChannelIdentification</code> if \n            <code>ChannelDefinitions</code> are set. Enabled <code>ShowSpeakerLabels</code> if <code>ChannelIdentification</code> \n            and <code>ChannelDefinitions</code> are not set. One and only one of <code>ChannelIdentification</code> and <code>ShowSpeakerLabels</code>\n            must be set. If <code>ShowSpeakerLabels</code> is set, <code>MaxSpeakerLabels</code> must also be set. Use <code>Settings</code>\n            to specify a vocabulary or vocabulary filter or both using <code>VocabularyName</code>, <code>VocabularyFilterName</code>. \n            <code>VocabularyFilterMethod</code> must be specified if <code>VocabularyFilterName</code> is set.\n        </p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalTranscript": {
+      "type": "structure",
+      "members": {
+        "TranscriptFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of your transcript. You can use this URI to access or\n            download your transcript.</p>\n         <p>Note that this is the Amazon S3 location you specified in your request using the \n            <code>OutputBucketName</code> parameter.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides you with the Amazon S3 URI you can use to access your\n            transcript.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalTranscriptionJob": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the medical transcription job. Job names are case sensitive and must be\n            unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "TranscriptionJobStatus": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the specified medical transcription job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>TranscriptFileUri</code>. If the status is\n                <code>FAILED</code>, <code>FailureReason</code> provides details on why your\n            transcription job failed.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your medical transcription job. US English\n                (<code>en-US</code>) is the only supported language for medical\n            transcriptions.</p>"
+          }
+        },
+        "MediaSampleRateHertz": {
+          "target": "com.amazonaws.transcribe#MedicalMediaSampleRateHertz",
+          "traits": {
+            "smithy.api#documentation": "<p>The sample rate, in hertz, of the audio track in your input media file.</p>"
+          }
+        },
+        "MediaFormat": {
+          "target": "com.amazonaws.transcribe#MediaFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of the input media file.</p>"
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media"
+        },
+        "Transcript": {
+          "target": "com.amazonaws.transcribe#MedicalTranscript",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides you with the Amazon S3 URI you can use to access your\n            transcript.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified medical transcription job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified medical transcription job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified medical transcription job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:33:13.922000-07:00</code> represents a transcription job\n            that started processing at 12:33 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>TranscriptionJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the transcription job\n            request failed.</p>\n         <p>The <code>FailureReason</code> field contains one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Unsupported media format</code>.</p>\n               <p>The media format specified in <code>MediaFormat</code> isn't valid. Refer to\n                    refer to the <code>MediaFormat</code> parameter for a list of supported\n                    formats.</p>\n            </li>\n            <li>\n               <p>\n                  <code>The media format provided does not match the detected media\n                        format</code>.</p>\n               <p>The media format specified in <code>MediaFormat</code> doesn't match the\n                    format of the input file. Check the media format of your media file and correct\n                    the specified value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid sample rate for audio file</code>.</p>\n               <p>The sample rate specified in <code>MediaSampleRateHertz</code> isn't valid.\n                    The sample rate must be between 16,000 and 48,000 hertz.</p>\n            </li>\n            <li>\n               <p>\n                  <code>The sample rate provided does not match the detected sample\n                    rate</code>.</p>\n               <p>The sample rate specified in <code>MediaSampleRateHertz</code> doesn't match\n                    the sample rate detected in your input media file. Check the sample rate of your\n                    media file and correct the specified value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid file size: file size too large</code>.</p>\n               <p>The size of your media file is larger than what Amazon Transcribe can\n                    process. For more information, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html#limits-amazon-transcribe\">Service \n                        quotas</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid number of channels: number of channels too large</code>.</p>\n               <p>Your audio contains more channels than Amazon Transcribe is able to process.\n                    For more information, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html#limits-amazon-transcribe\">Service \n                        quotas</a>.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#MedicalTranscriptionSetting",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information on any additional settings that were included in your request.\n            Additional settings include channel identification, alternative transcriptions, speaker\n            partitioning, custom vocabularies, and custom vocabulary filters.</p>"
+          }
+        },
+        "ContentIdentificationType": {
+          "target": "com.amazonaws.transcribe#MedicalContentIdentificationType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether content identification was enabled for your transcription\n            request.</p>"
+          }
+        },
+        "Specialty": {
+          "target": "com.amazonaws.transcribe#Specialty",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the medical specialty represented in your media.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.transcribe#Type",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the input media is a dictation or a conversation, as specified in\n            the <code>StartMedicalTranscriptionJob</code> request.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags, each in the form of a key:value pair, assigned to the specified medical\n            transcription job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a medical transcription job.</p>\n         <p>To view the status of the specified medical transcription job, check the\n                <code>TranscriptionJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished and you can find the results at the location specified in\n                <code>TranscriptFileUri</code>. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your transcription job\n            failed.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalTranscriptionJobSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#MedicalTranscriptionJobSummary"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalTranscriptionJobSummary": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the medical transcription job. Job names are case sensitive and must be\n            unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified medical transcription job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time your medical transcription job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified medical transcription job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:33:13.922000-07:00</code> represents a transcription job\n            that started processing at 12:33 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your medical transcription. US English\n                (<code>en-US</code>) is the only supported language for medical\n            transcriptions.</p>"
+          }
+        },
+        "TranscriptionJobStatus": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of your medical transcription job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>TranscriptFileUri</code>. If the status is\n                <code>FAILED</code>, <code>FailureReason</code> provides details on why your\n            transcription job failed.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>TranscriptionJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the transcription job\n            failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        },
+        "OutputLocationType": {
+          "target": "com.amazonaws.transcribe#OutputLocationType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates where the specified medical transcription output is stored.</p>\n         <p>If the value is <code>CUSTOMER_BUCKET</code>, the location is the Amazon S3\n            bucket you specified using the <code>OutputBucketName</code> parameter in your  request. If you also included\n                <code>OutputKey</code> in your request, your output is located in the path you\n            specified in your request.</p>\n         <p>If the value is <code>SERVICE_BUCKET</code>, the location is a service-managed Amazon S3 bucket. To access a transcript stored in a service-managed bucket, use the\n            URI shown in the <code>TranscriptFileUri</code> field.</p>"
+          }
+        },
+        "Specialty": {
+          "target": "com.amazonaws.transcribe#Specialty",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the medical specialty represented in your media.</p>"
+          }
+        },
+        "ContentIdentificationType": {
+          "target": "com.amazonaws.transcribe#MedicalContentIdentificationType",
+          "traits": {
+            "smithy.api#documentation": "<p>Labels all personal health information (PHI) identified in your transcript. For more\n            information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/phi-id.html\">Identifying personal health information (PHI) in a transcription</a>.</p>"
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.transcribe#Type",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the input media is a dictation or a conversation, as specified in\n            the <code>StartMedicalTranscriptionJob</code> request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a specific medical transcription job.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#MedicalTranscriptionSetting": {
+      "type": "structure",
+      "members": {
+        "ShowSpeakerLabels": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables speaker partitioning (diarization) in your transcription output. Speaker\n            partitioning labels the speech from individual speakers in your media file.</p>\n         <p>If you enable <code>ShowSpeakerLabels</code> in your request, you must also include\n                <code>MaxSpeakerLabels</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/diarization.html\">Partitioning speakers\n                (diarization)</a>.</p>"
+          }
+        },
+        "MaxSpeakerLabels": {
+          "target": "com.amazonaws.transcribe#MaxSpeakers",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the maximum number of speakers you want to partition in your media.</p>\n         <p>Note that if your media contains more speakers than the specified number, multiple\n            speakers are treated as a single speaker.</p>\n         <p>If you specify the <code>MaxSpeakerLabels</code> field, you must set the\n                <code>ShowSpeakerLabels</code> field to true.</p>"
+          }
+        },
+        "ChannelIdentification": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables channel identification in multi-channel audio.</p>\n         <p>Channel identification transcribes the audio on each channel independently, then\n            appends the output for each channel into one transcript.</p>\n         <p>If you have multi-channel audio and do not enable channel identification, your audio\n            is transcribed in a continuous manner and your transcript does not separate the speech\n            by channel.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/channel-id.html\">Transcribing multi-channel\n            audio</a>.</p>"
+          }
+        },
+        "ShowAlternatives": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>To include alternative transcriptions within your transcription output, include\n                <code>ShowAlternatives</code> in your transcription request.</p>\n         <p>If you include <code>ShowAlternatives</code>, you must also include\n                <code>MaxAlternatives</code>, which is the maximum number of alternative\n            transcriptions you want Amazon Transcribe Medical to generate.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/how-alternatives.html\">Alternative\n            transcriptions</a>.</p>"
+          }
+        },
+        "MaxAlternatives": {
+          "target": "com.amazonaws.transcribe#MaxAlternatives",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicate the maximum number of alternative transcriptions you want Amazon Transcribe\n            Medical to include in your transcript.</p>\n         <p>If you select a number greater than the number of alternative transcriptions generated\n            by Amazon Transcribe Medical, only the actual number of alternative transcriptions are\n            included.</p>\n         <p>If you include <code>MaxAlternatives</code> in your request, you must also include\n                <code>ShowAlternatives</code> with a value of <code>true</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/how-alternatives.html\">Alternative\n            transcriptions</a>.</p>"
+          }
+        },
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to use when processing your medical\n            transcription job. Custom vocabulary names are case sensitive.</p>\n         <p>The language of the specified custom vocabulary must match the language code that you\n            specify in your transcription request. If the languages do not match, the custom\n            vocabulary isn't applied. There are no errors or warnings associated with a language\n            mismatch. US English (<code>en-US</code>) is the only valid language for Amazon Transcribe Medical.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Allows additional optional settings in your  request, including channel\n            identification, alternative transcriptions, and speaker partitioning. You can use that to\n            apply custom vocabularies to your medical transcription job.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#ModelName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#ModelSettings": {
+      "type": "structure",
+      "members": {
+        "LanguageModelName": {
+          "target": "com.amazonaws.transcribe#ModelName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom language model you want to use when processing your\n            transcription job. Note that custom language model names are case sensitive.</p>\n         <p>The language of the specified custom language model must match the language code that\n            you specify in your transcription request. If the languages do not match, the custom\n            language model isn't applied. There are no errors or warnings associated with a language\n            mismatch.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides the name of the custom language model that was included in the specified\n            transcription job.</p>\n         <p>Only use <code>ModelSettings</code> with the <code>LanguageModelName</code>\n            sub-parameter if you're <b>not</b> using automatic language\n            identification (<code></code>). If using\n                <code>LanguageIdSettings</code> in your request, this parameter contains a\n                <code>LanguageModelName</code> sub-parameter.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#ModelStatus": {
+      "type": "enum",
+      "members": {
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Models": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#LanguageModel"
+      }
+    },
+    "com.amazonaws.transcribe#NextToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 8192
+        },
+        "smithy.api#pattern": "^.+$"
+      }
+    },
+    "com.amazonaws.transcribe#NonEmptyString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2000
+        },
+        "smithy.api#pattern": "\\S"
+      }
+    },
+    "com.amazonaws.transcribe#NonTalkTimeFilter": {
+      "type": "structure",
+      "members": {
+        "Threshold": {
+          "target": "com.amazonaws.transcribe#TimestampMilliseconds",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the duration, in milliseconds, of the period of silence that you want to flag.\n            For example, you can flag a silent period that lasts 30,000 milliseconds.</p>"
+          }
+        },
+        "AbsoluteTimeRange": {
+          "target": "com.amazonaws.transcribe#AbsoluteTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in milliseconds) in your audio, during\n            which you want to search for a period of silence. See  for more detail.</p>"
+          }
+        },
+        "RelativeTimeRange": {
+          "target": "com.amazonaws.transcribe#RelativeTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in percentage) in your media file, during\n            which you want to search for a period of silence. See  for more detail.</p>"
+          }
+        },
+        "Negate": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Set to <code>TRUE</code> to flag periods of speech. Set to <code>FALSE</code> to flag\n            periods of silence</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Flag the presence or absence of periods of silence in your Call Analytics\n            transcription output.</p>\n         <p>Rules using <code>NonTalkTimeFilter</code> are designed to match:</p>\n         <ul>\n            <li>\n               <p>The presence of silence at specified periods throughout the call</p>\n            </li>\n            <li>\n               <p>The presence of speech at specified periods throughout the call</p>\n            </li>\n         </ul>\n         <p>See <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html#tca-rules-batch\">Rule criteria for post-call \n            categories</a> for usage examples.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#NotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.transcribe#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>We can't find the requested resource. Check that the specified name is correct and try\n            your request again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.transcribe#OutputBucketName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+      }
+    },
+    "com.amazonaws.transcribe#OutputKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-_.!*'()/]{1,1024}$"
+      }
+    },
+    "com.amazonaws.transcribe#OutputLocationType": {
+      "type": "enum",
+      "members": {
+        "CUSTOMER_BUCKET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOMER_BUCKET"
+          }
+        },
+        "SERVICE_BUCKET": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SERVICE_BUCKET"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ParticipantRole": {
+      "type": "enum",
+      "members": {
+        "AGENT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AGENT"
+          }
+        },
+        "CUSTOMER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CUSTOMER"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Percentage": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Phrase": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^.+$"
+      }
+    },
+    "com.amazonaws.transcribe#Phrases": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#Phrase"
+      }
+    },
+    "com.amazonaws.transcribe#PiiEntityType": {
+      "type": "enum",
+      "members": {
+        "BANK_ACCOUNT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BANK_ACCOUNT_NUMBER"
+          }
+        },
+        "BANK_ROUTING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BANK_ROUTING"
+          }
+        },
+        "CREDIT_DEBIT_NUMBER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREDIT_DEBIT_NUMBER"
+          }
+        },
+        "CREDIT_DEBIT_CVV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREDIT_DEBIT_CVV"
+          }
+        },
+        "CREDIT_DEBIT_EXPIRY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREDIT_DEBIT_EXPIRY"
+          }
+        },
+        "PIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PIN"
+          }
+        },
+        "EMAIL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EMAIL"
+          }
+        },
+        "ADDRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADDRESS"
+          }
+        },
+        "NAME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NAME"
+          }
+        },
+        "PHONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PHONE"
+          }
+        },
+        "SSN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSN"
+          }
+        },
+        "ALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#PiiEntityTypes": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#PiiEntityType"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 11
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Pronouns": {
+      "type": "enum",
+      "members": {
+        "HE_HIM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HE_HIM"
+          }
+        },
+        "SHE_HER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SHE_HER"
+          }
+        },
+        "THEY_THEM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "THEY_THEM"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.transcribe#RedactionOutput": {
+      "type": "enum",
+      "members": {
+        "REDACTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "redacted"
+          }
+        },
+        "REDACTED_AND_UNREDACTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "redacted_and_unredacted"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#RedactionType": {
+      "type": "enum",
+      "members": {
+        "PII": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PII"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#RelativeTimeRange": {
+      "type": "structure",
+      "members": {
+        "StartPercentage": {
+          "target": "com.amazonaws.transcribe#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in percentage, when Amazon Transcribe starts searching for the specified\n            criteria in your media file. If you include <code>StartPercentage</code> in your\n            request, you must also include <code>EndPercentage</code>.</p>"
+          }
+        },
+        "EndPercentage": {
+          "target": "com.amazonaws.transcribe#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in percentage, when Amazon Transcribe stops searching for the specified\n            criteria in your media file. If you include <code>EndPercentage</code> in your request,\n            you must also include <code>StartPercentage</code>.</p>"
+          }
+        },
+        "First": {
+          "target": "com.amazonaws.transcribe#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in percentage, from the start of your media file until the specified value. \n            Amazon Transcribe searches for your specified criteria in this time segment.</p>"
+          }
+        },
+        "Last": {
+          "target": "com.amazonaws.transcribe#Percentage",
+          "traits": {
+            "smithy.api#documentation": "<p>The time, in percentage, from the specified value until the end of your media file.\n            Amazon Transcribe searches for your specified criteria in this time segment.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A time range, in percentage, between two points in your media file.</p>\n         <p>You can use <code>StartPercentage</code> and <code>EndPercentage</code> to search a\n            custom segment. For example, setting <code>StartPercentage</code> to 10 and\n                <code>EndPercentage</code> to 50 only searches for your specified criteria in the\n            audio contained between the 10 percent mark and the 50 percent mark of your media\n            file.</p>\n         <p>You can use also <code>First</code> to search from the start of the media file until\n            the time that you specify. Or use <code>Last</code> to search from the time that you\n            specify until the end of the media file. For example, setting <code>First</code> to 10\n            only searches for your specified criteria in the audio contained in the first 10 percent\n            of the media file.</p>\n         <p>If you prefer to use milliseconds instead of percentage, see .</p>"
+      }
+    },
+    "com.amazonaws.transcribe#Rule": {
+      "type": "union",
+      "members": {
+        "NonTalkTimeFilter": {
+          "target": "com.amazonaws.transcribe#NonTalkTimeFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Flag the presence or absence of periods of silence in your Call Analytics\n            transcription output. Refer to  for more\n            detail.</p>"
+          }
+        },
+        "InterruptionFilter": {
+          "target": "com.amazonaws.transcribe#InterruptionFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Flag the presence or absence of interruptions in your Call Analytics transcription\n            output. Refer to  for more detail.</p>"
+          }
+        },
+        "TranscriptFilter": {
+          "target": "com.amazonaws.transcribe#TranscriptFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Flag the presence or absence of specific words or phrases in your Call Analytics\n            transcription output. Refer to  for more\n            detail.</p>"
+          }
+        },
+        "SentimentFilter": {
+          "target": "com.amazonaws.transcribe#SentimentFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>Flag the presence or absence of specific sentiments in your Call Analytics\n            transcription output. Refer to  for more\n            detail.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A rule is a set of criteria that you can specify to flag an attribute in your Call\n            Analytics output. Rules define a Call Analytics category.</p>\n         <p>Rules can include these parameters: , , , and .</p>\n         <p>To learn more about Call Analytics rules and categories, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html\">Creating categories for post-call\n            transcriptions</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-stream.html\">Creating categories for\n                real-time transcriptions</a>.</p>\n         <p>To learn more about Call Analytics, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/call-analytics.html\">Analyzing call center audio with Call\n                Analytics</a>.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#RuleList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#Rule"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.transcribe#SentimentFilter": {
+      "type": "structure",
+      "members": {
+        "Sentiments": {
+          "target": "com.amazonaws.transcribe#SentimentValueList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the sentiments that you want to flag.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AbsoluteTimeRange": {
+          "target": "com.amazonaws.transcribe#AbsoluteTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in milliseconds) in your audio, during\n            which you want to search for the specified sentiments. See  for more detail.</p>"
+          }
+        },
+        "RelativeTimeRange": {
+          "target": "com.amazonaws.transcribe#RelativeTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in percentage) in your media file, during\n            which you want to search for the specified sentiments. See  for more detail.</p>"
+          }
+        },
+        "ParticipantRole": {
+          "target": "com.amazonaws.transcribe#ParticipantRole",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the participant that you want to flag. Omitting this parameter is equivalent\n            to specifying both participants.</p>"
+          }
+        },
+        "Negate": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Set to <code>TRUE</code> to flag the sentiments that you didn't include in your\n            request. Set to <code>FALSE</code> to flag the sentiments that you specified in your\n            request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Flag the presence or absence of specific sentiments detected in your Call Analytics\n            transcription output.</p>\n         <p>Rules using <code>SentimentFilter</code> are designed to match:</p>\n         <ul>\n            <li>\n               <p>The presence or absence of a positive sentiment felt by the customer, agent,\n                    or both at specified points in the call</p>\n            </li>\n            <li>\n               <p>The presence or absence of a negative sentiment felt by the customer, agent,\n                    or both at specified points in the call</p>\n            </li>\n            <li>\n               <p>The presence or absence of a neutral sentiment felt by the customer, agent, or\n                    both at specified points in the call</p>\n            </li>\n            <li>\n               <p>The presence or absence of a mixed sentiment felt by the customer, the agent,\n                    or both at specified points in the call</p>\n            </li>\n         </ul>\n         <p>See <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html#tca-rules-batch\">Rule criteria for post-call \n            categories</a> for usage examples.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#SentimentValue": {
+      "type": "enum",
+      "members": {
+        "POSITIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "POSITIVE"
+          }
+        },
+        "NEGATIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEGATIVE"
+          }
+        },
+        "NEUTRAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NEUTRAL"
+          }
+        },
+        "MIXED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MIXED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#SentimentValueList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#SentimentValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Settings": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to use in your transcription job request.\n            This name is case sensitive, cannot contain spaces, and must be unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "ShowSpeakerLabels": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables speaker partitioning (diarization) in your transcription output. Speaker\n            partitioning labels the speech from individual speakers in your media file.</p>\n         <p>If you enable <code>ShowSpeakerLabels</code> in your request, you must also include\n                <code>MaxSpeakerLabels</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/diarization.html\">Partitioning speakers\n                (diarization)</a>.</p>"
+          }
+        },
+        "MaxSpeakerLabels": {
+          "target": "com.amazonaws.transcribe#MaxSpeakers",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the maximum number of speakers you want to partition in your media.</p>\n         <p>Note that if your media contains more speakers than the specified number, multiple\n            speakers are treated as a single speaker.</p>\n         <p>If you specify the <code>MaxSpeakerLabels</code> field, you must set the\n                <code>ShowSpeakerLabels</code> field to true.</p>"
+          }
+        },
+        "ChannelIdentification": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables channel identification in multi-channel audio.</p>\n         <p>Channel identification transcribes the audio on each channel independently, then\n            appends the output for each channel into one transcript.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/channel-id.html\">Transcribing multi-channel\n            audio</a>.</p>"
+          }
+        },
+        "ShowAlternatives": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>To include alternative transcriptions within your transcription output, include\n                <code>ShowAlternatives</code> in your transcription request.</p>\n         <p>If you have multi-channel audio and do not enable channel identification, your audio\n            is transcribed in a continuous manner and your transcript does not separate the speech\n            by channel.</p>\n         <p>If you include <code>ShowAlternatives</code>, you must also include\n                <code>MaxAlternatives</code>, which is the maximum number of alternative\n            transcriptions you want Amazon Transcribe to generate.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/how-alternatives.html\">Alternative\n            transcriptions</a>.</p>"
+          }
+        },
+        "MaxAlternatives": {
+          "target": "com.amazonaws.transcribe#MaxAlternatives",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicate the maximum number of alternative transcriptions you want Amazon Transcribe\n            to include in your transcript.</p>\n         <p>If you select a number greater than the number of alternative transcriptions generated\n            by Amazon Transcribe, only the actual number of alternative transcriptions are\n            included.</p>\n         <p>If you include <code>MaxAlternatives</code> in your request, you must also include\n                <code>ShowAlternatives</code> with a value of <code>true</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/how-alternatives.html\">Alternative\n            transcriptions</a>.</p>"
+          }
+        },
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want to use in your transcription job\n            request. This name is case sensitive, cannot contain spaces, and must be unique within\n            an Amazon Web Services account.</p>\n         <p>Note that if you include <code>VocabularyFilterName</code> in your request, you must\n            also include <code>VocabularyFilterMethod</code>.</p>"
+          }
+        },
+        "VocabularyFilterMethod": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterMethod",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify how you want your custom vocabulary filter applied to your transcript.</p>\n         <p>To replace words with <code>***</code>, choose <code>mask</code>.</p>\n         <p>To delete words, choose <code>remove</code>.</p>\n         <p>To flag words without changing them, choose <code>tag</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Allows additional optional settings in your  \n            request, including channel identification, alternative transcriptions, and speaker\n            partitioning. You can use that to apply custom vocabularies to your transcription\n            job.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#Specialty": {
+      "type": "enum",
+      "members": {
+        "PRIMARYCARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PRIMARYCARE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#StartCallAnalyticsJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#StartCallAnalyticsJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#StartCallAnalyticsJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Transcribes the audio from a customer service call and applies any additional Request\n            Parameters you choose to include in your request.</p>\n         <p>In addition to many standard transcription features, Call Analytics provides you with\n            call characteristics, call summarization, speaker sentiment, and optional redaction of\n            your text transcript and your audio file. You can also apply custom categories to flag\n            specified conditions. To learn more about these features and insights, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/call-analytics.html\">Analyzing call\n                center audio with Call Analytics</a>.</p>\n         <p>If you want to apply categories to your Call Analytics job, you must create them\n            before submitting your job request. Categories cannot be retroactively applied to a job.\n            To create a new category, use the \n            operation. To learn more about Call Analytics categories, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html\">Creating categories for post-call \n                transcriptions</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-stream.html\">Creating categories for \n                    real-time transcriptions</a>.</p>\n         <p>To make a <code>StartCallAnalyticsJob</code> request, you must first upload your media\n            file into an Amazon S3 bucket; you can then specify the Amazon S3\n            location of the file using the <code>Media</code> parameter.</p>\n         <p>Job queuing is available for Call Analytics jobs. If you pass a <code>DataAccessRoleArn</code> \n            in your request and you exceed your Concurrent Job Limit, your job will automatically be \n            added to a queue to be processed once your concurrent job count is below the limit.</p>\n         <p>You must include the following parameters in your <code>StartCallAnalyticsJob</code>\n            request:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>region</code>: The Amazon Web Services Region where you are making your\n                    request. For a list of Amazon Web Services Regions supported with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html\">Amazon Transcribe endpoints and\n                        quotas</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CallAnalyticsJobName</code>: A custom name that you create for your\n                    transcription job that's unique within your Amazon Web Services account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Media</code> (<code>MediaFileUri</code> or\n                        <code>RedactedMediaFileUri</code>): The Amazon S3 location of your\n                    media file.</p>\n            </li>\n         </ul>\n         <note>\n            <p>With Call Analytics, you can redact the audio contained in your media file by\n                including <code>RedactedMediaFileUri</code>, instead of <code>MediaFileUri</code>,\n                to specify the location of your input audio. If you choose to redact your audio, you\n                can find your redacted media at the location specified in the\n                    <code>RedactedMediaFileUri</code> field of your response.</p>\n         </note>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/callanalyticsjobs/{CallAnalyticsJobName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#StartCallAnalyticsJobRequest": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJobName": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your Call Analytics job.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new job with the same name as an\n            existing job, you get a <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the Amazon S3 location of the media file you want to use in your\n            Call Analytics request.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputLocation": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location where you want your Call Analytics transcription output\n            stored. You can use any of the following formats to specify the output location:</p>\n         <ol>\n            <li>\n               <p>s3://DOC-EXAMPLE-BUCKET</p>\n            </li>\n            <li>\n               <p>s3://DOC-EXAMPLE-BUCKET/my-output-folder/</p>\n            </li>\n            <li>\n               <p>s3://DOC-EXAMPLE-BUCKET/my-output-folder/my-call-analytics-job.json</p>\n            </li>\n         </ol>\n         <p>Unless you specify a file name (option 3), the name of your output file has a default\n            value that matches the name you specified for your transcription job using the\n                <code>CallAnalyticsJobName</code> parameter.</p>\n         <p>You can specify a KMS key to encrypt your output using the\n                <code>OutputEncryptionKMSKeyId</code> parameter. If you do not specify a KMS key, Amazon Transcribe uses the default Amazon S3 key for\n            server-side encryption.</p>\n         <p>If you do not specify <code>OutputLocation</code>, your transcript is placed in a\n            service-managed Amazon S3 bucket and you are provided with a URI to access your\n            transcript.</p>"
+          }
+        },
+        "OutputEncryptionKMSKeyId": {
+          "target": "com.amazonaws.transcribe#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a KMS key that you want to use to\n            encrypt your Call Analytics output.</p>\n         <p>KMS key ARNs have the format <code>arn:partition:kms:region:account:key/key-id</code>. For example:\n    \t<code>arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>.\n            For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">\n                KMS key ARNs</a>.</p>\n         <p>If you do not specify an encryption key, your output is encrypted with the default\n            Amazon S3 key (SSE-S3).</p>\n         <p>Note that the role making the  request and the role specified in \n\t\tthe <code>DataAccessRoleArn</code> request parameter (if present) must have permission to use the \n\t\tspecified KMS key.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files. If the role that you\n            specify doesn\u2019t have the appropriate permissions to access the specified Amazon S3 location, your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJobSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify additional optional settings in your  request, including content redaction; allows you to apply custom language models,\n            vocabulary filters, and custom vocabularies to your Call Analytics job.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new\n            call analytics job at the time you start this new job.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n            resources</a>.</p>"
+          }
+        },
+        "ChannelDefinitions": {
+          "target": "com.amazonaws.transcribe#ChannelDefinitions",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify which speaker is on which channel. For example, if your\n            agent is the first participant to speak, you would set <code>ChannelId</code> to\n                <code>0</code> (to indicate the first channel) and <code>ParticipantRole</code> to\n                <code>AGENT</code> (to indicate that it's the agent speaking).</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartCallAnalyticsJobResponse": {
+      "type": "structure",
+      "members": {
+        "CallAnalyticsJob": {
+          "target": "com.amazonaws.transcribe#CallAnalyticsJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the current Call Analytics job, including job\n            status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartMedicalScribeJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#StartMedicalScribeJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#StartMedicalScribeJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Transcribes patient-clinician conversations and generates clinical notes. </p>\n         <p>Amazon Web Services HealthScribe automatically provides rich conversation transcripts, identifies speaker roles, \n            classifies dialogues, extracts medical terms, and generates preliminary clinical notes.\n            To learn more about these features, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/health-scribe.html\">Amazon Web Services HealthScribe</a>.</p>\n         <p>To make a <code>StartMedicalScribeJob</code> request, you must first upload\n            your media file into an Amazon S3 bucket; you can then specify the Amazon S3 location\n            of the file using the <code>Media</code> parameter.</p>\n         <p>You must include the following parameters in your\n                <code>StartMedicalTranscriptionJob</code> request:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DataAccessRoleArn</code>: The ARN of an IAM role with the these minimum permissions: read permission on input file Amazon S3 bucket specified in <code>Media</code>,\n                write permission on the Amazon S3 bucket specified in <code>OutputBucketName</code>, and full permissions on the KMS key specified in <code>OutputEncryptionKMSKeyId</code> (if set).\n                The role should also allow <code>transcribe.amazonaws.com</code> to assume it.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>Media</code> (<code>MediaFileUri</code>): The Amazon S3 location\n                    of your media file.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MedicalScribeJobName</code>: A custom name you create for your\n                    MedicalScribe job that is unique within your Amazon Web Services account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OutputBucketName</code>: The Amazon S3 bucket where you want\n                    your output files stored.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Settings</code>: A <code>MedicalScribeSettings</code> object\n                that must set exactly one of <code>ShowSpeakerLabels</code> or <code>ChannelIdentification</code> to true.\n                If <code>ShowSpeakerLabels</code> is true, <code>MaxSpeakerLabels</code> must also be set.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>ChannelDefinitions</code>: A <code>MedicalScribeChannelDefinitions</code> array should be set if and only if the <code>ChannelIdentification</code>\n                value of <code>Settings</code> is set to true. \n                </p>\n            </li>\n         </ul>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/medicalscribejobs/{MedicalScribeJobName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#StartMedicalScribeJobRequest": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your Medical Scribe job.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new job with the same name as an\n            existing job, you get a <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "OutputBucketName": {
+          "target": "com.amazonaws.transcribe#OutputBucketName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where you want your Medical Scribe\n            output stored. Do not include the <code>S3://</code> prefix of the specified\n            bucket.</p>\n         <p>Note that the role specified in the <code>DataAccessRoleArn</code> request parameter \n            must have permission to use the specified location. You\n            can change Amazon S3 permissions using the <a href=\"https://console.aws.amazon.com/s3\">Amazon Web Services Management Console</a>. See also <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/security_iam_id-based-policy-examples.html#auth-role-iam-user\">Permissions Required for IAM User Roles</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputEncryptionKMSKeyId": {
+          "target": "com.amazonaws.transcribe#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a KMS key that you want to use to\n            encrypt your Medical Scribe output.</p>\n         <p>KMS key ARNs have the format <code>arn:partition:kms:region:account:key/key-id</code>. For example:\n\t\t<code>arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>.\n            \tFor more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">\n                KMS key ARNs</a>.</p>\n         <p>If you do not specify an encryption key, your output is encrypted with the default\n                Amazon S3 key (SSE-S3).</p>\n         <p>Note that the role making the  request and the role specified in \n\t\tthe <code>DataAccessRoleArn</code> request parameter (if present) \n\t\tmust have permission to use the specified KMS key.</p>"
+          }
+        },
+        "KMSEncryptionContext": {
+          "target": "com.amazonaws.transcribe#KMSEncryptionContextMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of plain text, non-secret key:value pairs, known as encryption context pairs,\n            that provide an added layer of security for your data. For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/key-management.html#kms-context\">KMS encryption context</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/symmetric-asymmetric.html\">Asymmetric keys in KMS</a>.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files, \n            write to the output bucket, and use your KMS key if supplied.  \n             If the role that you specify doesn\u2019t have the appropriate permissions your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#MedicalScribeSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to control how your Medical Scribe job is processed using a\n            <code>MedicalScribeSettings</code> object. Specify <code>ChannelIdentification</code> if \n            <code>ChannelDefinitions</code> are set. Enabled <code>ShowSpeakerLabels</code> if <code>ChannelIdentification</code> \n            and <code>ChannelDefinitions</code> are not set. One and only one of <code>ChannelIdentification</code> and <code>ShowSpeakerLabels</code>\n            must be set. If <code>ShowSpeakerLabels</code> is set, <code>MaxSpeakerLabels</code> must also be set. Use <code>Settings</code>\n            to specify a vocabulary or vocabulary filter or both using <code>VocabularyName</code>, <code>VocabularyFilterName</code>. \n            <code>VocabularyFilterMethod</code> must be specified if <code>VocabularyFilterName</code> is set.\n        </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ChannelDefinitions": {
+          "target": "com.amazonaws.transcribe#MedicalScribeChannelDefinitions",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify which speaker is on which channel. For example, if the clinician\n             is the first participant to speak, you would set <code>ChannelId</code> of the first <code>ChannelDefinition</code> \n             in the list to <code>0</code> (to indicate the first channel) and <code>ParticipantRole</code> to\n                <code>CLINICIAN</code> (to indicate that it's the clinician speaking).\n                Then you would set the <code>ChannelId</code> of the second <code>ChannelDefinition</code> in the list to\n                <code>1</code> (to indicate the second channel) and <code>ParticipantRole</code> to\n                <code>PATIENT</code> (to indicate that it's the patient speaking).\n                </p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to the Medical Scribe job.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        },
+        "MedicalScribeContext": {
+          "target": "com.amazonaws.transcribe#MedicalScribeContext",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>MedicalScribeContext</code> object that contains contextual information which is used during\n            clinical note generation to add relevant context to the note.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartMedicalScribeJobResponse": {
+      "type": "structure",
+      "members": {
+        "MedicalScribeJob": {
+          "target": "com.amazonaws.transcribe#MedicalScribeJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the current Medical Scribe job, including\n            job status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartMedicalTranscriptionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#StartMedicalTranscriptionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#StartMedicalTranscriptionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Transcribes the audio from a medical dictation or conversation and applies any\n            additional Request Parameters you choose to include in your request.</p>\n         <p>In addition to many standard transcription features, Amazon Transcribe Medical\n            provides you with a robust medical vocabulary and, optionally, content identification,\n            which adds flags to personal health information (PHI). To learn more about these\n            features, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/how-it-works-med.html\">How Amazon Transcribe Medical\n                works</a>.</p>\n         <p>To make a <code>StartMedicalTranscriptionJob</code> request, you must first upload\n            your media file into an Amazon S3 bucket; you can then specify the Amazon S3 location\n            of the file using the <code>Media</code> parameter.</p>\n         <p>You must include the following parameters in your\n                <code>StartMedicalTranscriptionJob</code> request:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>region</code>: The Amazon Web Services Region where you are making your\n                    request. For a list of Amazon Web Services Regions supported with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html\">Amazon Transcribe endpoints and\n                        quotas</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>MedicalTranscriptionJobName</code>: A custom name you create for your\n                    transcription job that is unique within your Amazon Web Services account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Media</code> (<code>MediaFileUri</code>): The Amazon S3 location\n                    of your media file.</p>\n            </li>\n            <li>\n               <p>\n                  <code>LanguageCode</code>: This must be <code>en-US</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OutputBucketName</code>: The Amazon S3 bucket where you want\n                    your transcript stored. If you want your output stored in a sub-folder of this\n                    bucket, you must also include <code>OutputKey</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Specialty</code>: This must be <code>PRIMARYCARE</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Type</code>: Choose whether your audio is a conversation or a\n                    dictation.</p>\n            </li>\n         </ul>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/medicaltranscriptionjobs/{MedicalTranscriptionJobName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#StartMedicalTranscriptionJobRequest": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your medical transcription job. The name that you\n            specify is also used as the default name of your transcription output file. If you want\n            to specify a different name for your transcription output, use the\n                <code>OutputKey</code> parameter.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new job with the same name as an\n            existing job, you get a <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language spoken in the input media file. US\n            English (<code>en-US</code>) is the only valid value for medical transcription jobs. Any\n            other value you enter for language code results in a <code>BadRequestException</code>\n            error.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MediaSampleRateHertz": {
+          "target": "com.amazonaws.transcribe#MedicalMediaSampleRateHertz",
+          "traits": {
+            "smithy.api#documentation": "<p>The sample rate, in hertz, of the audio track in your input media file.</p>\n         <p>If you do not specify the media sample rate, Amazon Transcribe Medical determines it\n            for you. If you specify the sample rate, it must match the rate detected by Amazon Transcribe Medical; if there's a mismatch between the value that you specify and the\n            value detected, your job fails. Therefore, in most cases, it's advised to omit\n                <code>MediaSampleRateHertz</code> and let Amazon Transcribe Medical determine the\n            sample rate.</p>"
+          }
+        },
+        "MediaFormat": {
+          "target": "com.amazonaws.transcribe#MediaFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the format of your input media file.</p>"
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "OutputBucketName": {
+          "target": "com.amazonaws.transcribe#OutputBucketName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where you want your medical transcription\n            output stored. Do not include the <code>S3://</code> prefix of the specified\n            bucket.</p>\n         <p>If you want your output to go to a sub-folder of this bucket, specify it using the\n                <code>OutputKey</code> parameter; <code>OutputBucketName</code> only accepts the\n            name of a bucket.</p>\n         <p>For example, if you want your output stored in <code>S3://DOC-EXAMPLE-BUCKET</code>,\n            set <code>OutputBucketName</code> to <code>DOC-EXAMPLE-BUCKET</code>. However, if you\n            want your output stored in <code>S3://DOC-EXAMPLE-BUCKET/test-files/</code>, set\n                <code>OutputBucketName</code> to <code>DOC-EXAMPLE-BUCKET</code> and\n                <code>OutputKey</code> to <code>test-files/</code>.</p>\n         <p>Note that Amazon Transcribe must have permission to use the specified location. You\n            can change Amazon S3 permissions using the <a href=\"https://console.aws.amazon.com/s3\">Amazon Web Services Management Console</a>. See also <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/security_iam_id-based-policy-examples.html#auth-role-iam-user\">Permissions Required for IAM User Roles</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputKey": {
+          "target": "com.amazonaws.transcribe#OutputKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Use in combination with <code>OutputBucketName</code> to specify the output location\n            of your transcript and, optionally, a unique name for your output file. The default name\n            for your transcription output is the same as the name you specified for your medical\n            transcription job (<code>MedicalTranscriptionJobName</code>).</p>\n         <p>Here are some examples of how you can use <code>OutputKey</code>:</p>\n         <ul>\n            <li>\n               <p>If you specify 'DOC-EXAMPLE-BUCKET' as the <code>OutputBucketName</code> and\n                    'my-transcript.json' as the <code>OutputKey</code>, your transcription output\n                    path is <code>s3://DOC-EXAMPLE-BUCKET/my-transcript.json</code>.</p>\n            </li>\n            <li>\n               <p>If you specify 'my-first-transcription' as the\n                        <code>MedicalTranscriptionJobName</code>, 'DOC-EXAMPLE-BUCKET' as the\n                        <code>OutputBucketName</code>, and 'my-transcript' as the\n                        <code>OutputKey</code>, your transcription output path is\n                        <code>s3://DOC-EXAMPLE-BUCKET/my-transcript/my-first-transcription.json</code>.</p>\n            </li>\n            <li>\n               <p>If you specify 'DOC-EXAMPLE-BUCKET' as the <code>OutputBucketName</code> and\n                    'test-files/my-transcript.json' as the <code>OutputKey</code>, your\n                    transcription output path is\n                        <code>s3://DOC-EXAMPLE-BUCKET/test-files/my-transcript.json</code>.</p>\n            </li>\n            <li>\n               <p>If you specify 'my-first-transcription' as the\n                        <code>MedicalTranscriptionJobName</code>, 'DOC-EXAMPLE-BUCKET' as the\n                        <code>OutputBucketName</code>, and 'test-files/my-transcript' as the\n                        <code>OutputKey</code>, your transcription output path is\n                        <code>s3://DOC-EXAMPLE-BUCKET/test-files/my-transcript/my-first-transcription.json</code>.</p>\n            </li>\n         </ul>\n         <p>If you specify the name of an Amazon S3 bucket sub-folder that doesn't exist,\n            one is created for you.</p>"
+          }
+        },
+        "OutputEncryptionKMSKeyId": {
+          "target": "com.amazonaws.transcribe#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a KMS key that you want to use to\n            encrypt your medical transcription output.</p>\n         <p>KMS key ARNs have the format <code>arn:partition:kms:region:account:key/key-id</code>. For example:\n    \t<code>arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>.\n            For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">\n                KMS key ARNs</a>.</p>\n         <p>If you do not specify an encryption key, your output is encrypted with the default\n            Amazon S3 key (SSE-S3).</p>\n         <p>Note that the role making the  request and the role specified \n    \t\tin the <code>DataAccessRoleArn</code> request parameter (if present) must have permission to use the \n\t\tspecified KMS key.</p>"
+          }
+        },
+        "KMSEncryptionContext": {
+          "target": "com.amazonaws.transcribe#KMSEncryptionContextMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of plain text, non-secret key:value pairs, known as encryption context pairs,\n            that provide an added layer of security for your data. For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/key-management.html#kms-context\">KMS encryption context</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/symmetric-asymmetric.html\">Asymmetric keys in KMS</a>.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#MedicalTranscriptionSetting",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify additional optional settings in your  request, including channel\n            identification, alternative transcriptions, and speaker partitioning. You can use that to\n            apply custom vocabularies to your transcription job.</p>"
+          }
+        },
+        "ContentIdentificationType": {
+          "target": "com.amazonaws.transcribe#MedicalContentIdentificationType",
+          "traits": {
+            "smithy.api#documentation": "<p>Labels all personal health information (PHI) identified in your transcript. For more\n            information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/phi-id.html\">Identifying personal health information (PHI) in a transcription</a>.</p>"
+          }
+        },
+        "Specialty": {
+          "target": "com.amazonaws.transcribe#Specialty",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the predominant medical specialty represented in your media. For batch\n            transcriptions, <code>PRIMARYCARE</code> is the only valid value. If you require\n            additional specialties, refer to .</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Type": {
+          "target": "com.amazonaws.transcribe#Type",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify whether your input media contains only one person (<code>DICTATION</code>) or\n            contains a conversation between two people (<code>CONVERSATION</code>).</p>\n         <p>For example, <code>DICTATION</code> could be used for a medical professional wanting\n            to transcribe voice memos; <code>CONVERSATION</code> could be used for transcribing the\n            doctor-patient dialogue during the patient's office visit.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new medical\n            transcription job at the time you start this new job.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartMedicalTranscriptionJobResponse": {
+      "type": "structure",
+      "members": {
+        "MedicalTranscriptionJob": {
+          "target": "com.amazonaws.transcribe#MedicalTranscriptionJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the current medical transcription job, including\n            job status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartTranscriptionJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#StartTranscriptionJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#StartTranscriptionJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Transcribes the audio from a media file and applies any additional Request Parameters\n            you choose to include in your request.</p>\n         <p>To make a <code>StartTranscriptionJob</code> request, you must first upload your media\n            file into an Amazon S3 bucket; you can then specify the Amazon S3\n            location of the file using the <code>Media</code> parameter.</p>\n         <p>You must include the following parameters in your <code>StartTranscriptionJob</code>\n            request:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>region</code>: The Amazon Web Services Region where you are making your\n                    request. For a list of Amazon Web Services Regions supported with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html\">Amazon Transcribe endpoints and\n                        quotas</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TranscriptionJobName</code>: A custom name you create for your\n                    transcription job that is unique within your Amazon Web Services account.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Media</code> (<code>MediaFileUri</code>): The Amazon S3 location\n                    of your media file.</p>\n            </li>\n            <li>\n               <p>One of <code>LanguageCode</code>, <code>IdentifyLanguage</code>, or\n                        <code>IdentifyMultipleLanguages</code>: If you know the language of your\n                    media file, specify it using the <code>LanguageCode</code> parameter; you can\n                    find all valid language codes in the <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported\n                        languages</a> table. If you do not know the languages spoken in your\n                    media, use either <code>IdentifyLanguage</code> or\n                        <code>IdentifyMultipleLanguages</code> and let Amazon Transcribe identify\n                    the languages for you.</p>\n            </li>\n         </ul>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/transcriptionjobs/{TranscriptionJobName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#StartTranscriptionJobRequest": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your transcription job. The name that you specify is\n            also used as the default name of your transcription output file. If you want to specify\n            a different name for your transcription output, use the <code>OutputKey</code>\n            parameter.</p>\n         <p>This name is case sensitive, cannot contain spaces, and must be unique within an\n                Amazon Web Services account. If you try to create a new job with the same name as an\n            existing job, you get a <code>ConflictException</code> error.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language spoken in the input media file.</p>\n         <p>If you're unsure of the language spoken in your media file, consider using\n                <code>IdentifyLanguage</code> or <code>IdentifyMultipleLanguages</code> to enable\n            automatic language identification.</p>\n         <p>Note that you must include one of <code>LanguageCode</code>,\n                <code>IdentifyLanguage</code>, or <code>IdentifyMultipleLanguages</code> in your\n            request. If you include more than one of these parameters, your transcription job\n            fails.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table.</p>\n         <note>\n            <p>To transcribe speech in Modern Standard Arabic (<code>ar-SA</code>) in Amazon Web Services GovCloud (US) (US-West, us-gov-west-1), Amazon Web Services GovCloud (US) (US-East, us-gov-east-1), Canada (Calgary, ca-west-1) and Africa (Cape Town, af-south-1), your media\n                file must be encoded at a sample rate of 16,000 Hz or higher.</p>\n         </note>"
+          }
+        },
+        "MediaSampleRateHertz": {
+          "target": "com.amazonaws.transcribe#MediaSampleRateHertz",
+          "traits": {
+            "smithy.api#documentation": "<p>The sample rate, in hertz, of the audio track in your input media file.</p>\n         <p>If you do not specify the media sample rate, Amazon Transcribe determines it for you.\n            If you specify the sample rate, it must match the rate detected by Amazon Transcribe.\n            If there's a mismatch between the value that you specify and the value detected, your\n            job fails. In most cases, you can omit <code>MediaSampleRateHertz</code> and let Amazon Transcribe determine the sample rate.</p>"
+          }
+        },
+        "MediaFormat": {
+          "target": "com.amazonaws.transcribe#MediaFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the format of your input media file.</p>"
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the Amazon S3 location of the media file you want to use in your\n            request.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputBucketName": {
+          "target": "com.amazonaws.transcribe#OutputBucketName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Amazon S3 bucket where you want your transcription output\n            stored. Do not include the <code>S3://</code> prefix of the specified bucket.</p>\n         <p>If you want your output to go to a sub-folder of this bucket, specify it using the\n                <code>OutputKey</code> parameter; <code>OutputBucketName</code> only accepts the\n            name of a bucket.</p>\n         <p>For example, if you want your output stored in <code>S3://DOC-EXAMPLE-BUCKET</code>,\n            set <code>OutputBucketName</code> to <code>DOC-EXAMPLE-BUCKET</code>. However, if you\n            want your output stored in <code>S3://DOC-EXAMPLE-BUCKET/test-files/</code>, set\n                <code>OutputBucketName</code> to <code>DOC-EXAMPLE-BUCKET</code> and\n                <code>OutputKey</code> to <code>test-files/</code>.</p>\n         <p>Note that Amazon Transcribe must have permission to use the specified location. You\n            can change Amazon S3 permissions using the <a href=\"https://console.aws.amazon.com/s3\">Amazon Web Services Management Console</a>. See also <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/security_iam_id-based-policy-examples.html#auth-role-iam-user\">Permissions Required for IAM User Roles</a>.</p>\n         <p>If you do not specify <code>OutputBucketName</code>, your transcript is placed in a\n            service-managed Amazon S3 bucket and you are provided with a URI to access your\n            transcript.</p>"
+          }
+        },
+        "OutputKey": {
+          "target": "com.amazonaws.transcribe#OutputKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Use in combination with <code>OutputBucketName</code> to specify the output location\n            of your transcript and, optionally, a unique name for your output file. The default name\n            for your transcription output is the same as the name you specified for your\n            transcription job (<code>TranscriptionJobName</code>).</p>\n         <p>Here are some examples of how you can use <code>OutputKey</code>:</p>\n         <ul>\n            <li>\n               <p>If you specify 'DOC-EXAMPLE-BUCKET' as the <code>OutputBucketName</code> and\n                    'my-transcript.json' as the <code>OutputKey</code>, your transcription output\n                    path is <code>s3://DOC-EXAMPLE-BUCKET/my-transcript.json</code>.</p>\n            </li>\n            <li>\n               <p>If you specify 'my-first-transcription' as the\n                        <code>TranscriptionJobName</code>, 'DOC-EXAMPLE-BUCKET' as the\n                        <code>OutputBucketName</code>, and 'my-transcript' as the\n                        <code>OutputKey</code>, your transcription output path is\n                        <code>s3://DOC-EXAMPLE-BUCKET/my-transcript/my-first-transcription.json</code>.</p>\n            </li>\n            <li>\n               <p>If you specify 'DOC-EXAMPLE-BUCKET' as the <code>OutputBucketName</code> and\n                    'test-files/my-transcript.json' as the <code>OutputKey</code>, your\n                    transcription output path is\n                        <code>s3://DOC-EXAMPLE-BUCKET/test-files/my-transcript.json</code>.</p>\n            </li>\n            <li>\n               <p>If you specify 'my-first-transcription' as the\n                        <code>TranscriptionJobName</code>, 'DOC-EXAMPLE-BUCKET' as the\n                        <code>OutputBucketName</code>, and 'test-files/my-transcript' as the\n                        <code>OutputKey</code>, your transcription output path is\n                        <code>s3://DOC-EXAMPLE-BUCKET/test-files/my-transcript/my-first-transcription.json</code>.</p>\n            </li>\n         </ul>\n         <p>If you specify the name of an Amazon S3 bucket sub-folder that doesn't exist,\n            one is created for you.</p>"
+          }
+        },
+        "OutputEncryptionKMSKeyId": {
+          "target": "com.amazonaws.transcribe#KMSKeyId",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a KMS key that you want to use to\n            encrypt your transcription output.</p>\n         <p>KMS key ARNs have the format <code>arn:partition:kms:region:account:key/key-id</code>. For example:\n    \t<code>arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>.\n            For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">\n                KMS key ARNs</a>.</p>\n         <p>If you do not specify an encryption key, your output is encrypted with the default\n            Amazon S3 key (SSE-S3).</p>\n         <p>Note that the role making the  request and the role specified in the \n\t\t<code>DataAccessRoleArn</code> request parameter (if present) must have permission to use the specified \n\t\tKMS key.</p>"
+          }
+        },
+        "KMSEncryptionContext": {
+          "target": "com.amazonaws.transcribe#KMSEncryptionContextMap",
+          "traits": {
+            "smithy.api#documentation": "<p>A map of plain text, non-secret key:value pairs, known as encryption context pairs,\n            that provide an added layer of security for your data. For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/key-management.html#kms-context\">KMS encryption context</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/symmetric-asymmetric.html\">Asymmetric keys in KMS</a>.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#Settings",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify additional optional settings in your  \n            request, including channel identification, alternative transcriptions, speaker\n            partitioning. You can use that to apply custom vocabularies and vocabulary filters.</p>\n         <p>If you want to include a custom vocabulary or a custom vocabulary filter (or both)\n            with your request but <b>do not</b> want to use automatic\n            language identification, use <code>Settings</code> with the <code>VocabularyName</code>\n            or <code>VocabularyFilterName</code> (or both) sub-parameter.</p>\n         <p>If you're using automatic language identification with your request and want to\n            include a custom language model, a custom vocabulary, or a custom vocabulary filter, use\n            instead the <code></code> parameter with the\n                <code>LanguageModelName</code>, <code>VocabularyName</code> or\n                <code>VocabularyFilterName</code> sub-parameters.</p>"
+          }
+        },
+        "ModelSettings": {
+          "target": "com.amazonaws.transcribe#ModelSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the custom language model you want to include with your transcription job. If\n            you include <code>ModelSettings</code> in your request, you must include the\n                <code>LanguageModelName</code> sub-parameter.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/custom-language-models.html\">Custom language\n                models</a>.</p>"
+          }
+        },
+        "JobExecutionSettings": {
+          "target": "com.amazonaws.transcribe#JobExecutionSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to control how your transcription job is processed. Currently, the\n            only <code>JobExecutionSettings</code> modification you can choose is enabling job\n            queueing using the <code>AllowDeferredExecution</code> sub-parameter.</p>\n         <p>If you include <code>JobExecutionSettings</code> in your request, you must also\n            include the sub-parameters: <code>AllowDeferredExecution</code> and\n                <code>DataAccessRoleArn</code>.</p>"
+          }
+        },
+        "ContentRedaction": {
+          "target": "com.amazonaws.transcribe#ContentRedaction",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to redact or flag specified personally identifiable information (PII) in \n            your transcript. If you use <code>ContentRedaction</code>, you must also include the \n            sub-parameters: <code>RedactionOutput</code> and <code>RedactionType</code>. You can \n            optionally include <code>PiiEntityTypes</code> to choose which types of PII you want to redact.\n            If you do not include <code>PiiEntityTypes</code> in your request, all PII is redacted.</p>"
+          }
+        },
+        "IdentifyLanguage": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables automatic language identification in your transcription job request. Use this\n            parameter if your media file contains only one language. If your media contains multiple\n            languages, use <code>IdentifyMultipleLanguages</code> instead.</p>\n         <p>If you include <code>IdentifyLanguage</code>, you can optionally include a list of\n            language codes, using <code>LanguageOptions</code>, that you think may be present in\n            your media file. Including <code>LanguageOptions</code> restricts\n                <code>IdentifyLanguage</code> to only the language options that you specify, which\n            can improve transcription accuracy.</p>\n         <p>If you want to apply a custom language model, a custom vocabulary, or a custom\n            vocabulary filter to your automatic language identification request, include\n                <code>LanguageIdSettings</code> with the relevant sub-parameters\n                (<code>VocabularyName</code>, <code>LanguageModelName</code>, and\n                <code>VocabularyFilterName</code>). If you include <code>LanguageIdSettings</code>,\n            also include <code>LanguageOptions</code>.</p>\n         <p>Note that you must include one of <code>LanguageCode</code>,\n                <code>IdentifyLanguage</code>, or <code>IdentifyMultipleLanguages</code> in your\n            request. If you include more than one of these parameters, your transcription job\n            fails.</p>"
+          }
+        },
+        "IdentifyMultipleLanguages": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables automatic multi-language identification in your transcription job request. Use\n            this parameter if your media file contains more than one language. If your media\n            contains only one language, use <code>IdentifyLanguage</code> instead.</p>\n         <p>If you include <code>IdentifyMultipleLanguages</code>, you can optionally include a\n            list of language codes, using <code>LanguageOptions</code>, that you think may be\n            present in your media file. Including <code>LanguageOptions</code> restricts\n                <code>IdentifyLanguage</code> to only the language options that you specify, which\n            can improve transcription accuracy.</p>\n         <p>If you want to apply a custom vocabulary or a custom vocabulary filter to your\n            automatic language identification request, include <code>LanguageIdSettings</code> with\n            the relevant sub-parameters (<code>VocabularyName</code> and\n                <code>VocabularyFilterName</code>). If you include <code>LanguageIdSettings</code>,\n            also include <code>LanguageOptions</code>.</p>\n         <p>Note that you must include one of <code>LanguageCode</code>,\n                <code>IdentifyLanguage</code>, or <code>IdentifyMultipleLanguages</code> in your\n            request. If you include more than one of these parameters, your transcription job\n            fails.</p>"
+          }
+        },
+        "LanguageOptions": {
+          "target": "com.amazonaws.transcribe#LanguageOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>You can specify two or more language codes that represent the languages you think may\n            be present in your media. Including more than five is not recommended. If you're unsure\n            what languages are present, do not include this parameter.</p>\n         <p>If you include <code>LanguageOptions</code> in your request, you must also include\n                <code>IdentifyLanguage</code>.</p>\n         <p>For more information, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported\n            languages</a>.</p>\n         <p>To transcribe speech in Modern Standard Arabic (<code>ar-SA</code>)in Amazon Web Services GovCloud (US) (US-West, us-gov-west-1), Amazon Web Services GovCloud (US) (US-East, us-gov-east-1), in Canada (Calgary) ca-west-1 and Africa (Cape Town) af-south-1, your media file\n            must be encoded at a sample rate of 16,000 Hz or higher.</p>"
+          }
+        },
+        "Subtitles": {
+          "target": "com.amazonaws.transcribe#Subtitles",
+          "traits": {
+            "smithy.api#documentation": "<p>Produces subtitle files for your input media. You can specify WebVTT (*.vtt) and\n            SubRip (*.srt) formats.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to a new\n            transcription job at the time you start this new job.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>"
+          }
+        },
+        "LanguageIdSettings": {
+          "target": "com.amazonaws.transcribe#LanguageIdSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>If using automatic language identification in your request and you want to apply a\n            custom language model, a custom vocabulary, or a custom vocabulary filter, include\n                <code>LanguageIdSettings</code> with the relevant sub-parameters\n                (<code>VocabularyName</code>, <code>LanguageModelName</code>, and\n                <code>VocabularyFilterName</code>). Note that multi-language identification\n                (<code>IdentifyMultipleLanguages</code>) doesn't support custom language\n            models.</p>\n         <p>\n            <code>LanguageIdSettings</code> supports two to five language codes. Each language\n            code you include can have an associated custom language model, custom vocabulary, and\n            custom vocabulary filter. The language codes that you specify must match the languages\n            of the associated custom language models, custom vocabularies, and custom vocabulary\n            filters.</p>\n         <p>It's recommended that you include <code>LanguageOptions</code> when using\n                <code>LanguageIdSettings</code> to ensure that the correct language dialect is\n            identified. For example, if you specify a custom vocabulary that is in\n                <code>en-US</code> but Amazon Transcribe determines that the language spoken in\n            your media is <code>en-AU</code>, your custom vocabulary <i>is not</i>\n            applied to your transcription. If you include <code>LanguageOptions</code> and include\n                <code>en-US</code> as the only English language dialect, your custom vocabulary\n                <i>is</i> applied to your transcription.</p>\n         <p>If you want to include a custom language model with your request but <b>do not</b> want to use automatic language identification, use\n            instead the <code></code> parameter with the\n                <code>LanguageModelName</code> sub-parameter. If you want to include a custom\n            vocabulary or a custom vocabulary filter (or both) with your request but <b>do not</b> want to use automatic language identification, use\n            instead the <code></code> parameter with the\n                <code>VocabularyName</code> or <code>VocabularyFilterName</code> (or both)\n            sub-parameter.</p>"
+          }
+        },
+        "ToxicityDetection": {
+          "target": "com.amazonaws.transcribe#ToxicityDetection",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables toxic speech detection in your transcript. If you include \n            <code>ToxicityDetection</code> in your request, you must also include\n            <code>ToxicityCategories</code>.</p>\n         <p>For information on the types of toxic speech Amazon Transcribe can detect, see \n            <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/toxic-language.html\">Detecting toxic\n                speech</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#StartTranscriptionJobResponse": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJob": {
+          "target": "com.amazonaws.transcribe#TranscriptionJob",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides detailed information about the current transcription job, including job\n            status and, if applicable, failure reason.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#String": {
+      "type": "string"
+    },
+    "com.amazonaws.transcribe#StringTargetList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#NonEmptyString"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#SubtitleFileUris": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#Uri"
+      }
+    },
+    "com.amazonaws.transcribe#SubtitleFormat": {
+      "type": "enum",
+      "members": {
+        "VTT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "vtt"
+          }
+        },
+        "SRT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "srt"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#SubtitleFormats": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#SubtitleFormat"
+      }
+    },
+    "com.amazonaws.transcribe#SubtitleOutputStartIndex": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Subtitles": {
+      "type": "structure",
+      "members": {
+        "Formats": {
+          "target": "com.amazonaws.transcribe#SubtitleFormats",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the output format for your subtitle file; if you select both WebVTT\n                (<code>vtt</code>) and SubRip (<code>srt</code>) formats, two output files are\n            generated.</p>"
+          }
+        },
+        "OutputStartIndex": {
+          "target": "com.amazonaws.transcribe#SubtitleOutputStartIndex",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the starting value that is assigned to the first subtitle segment.</p>\n         <p>The default start index for Amazon Transcribe is <code>0</code>, which differs from\n            the more widely used standard of <code>1</code>. If you're uncertain which value to use,\n            we recommend choosing <code>1</code>, as this may improve compatibility with other\n            services.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Generate subtitles for your media file with your transcription request.</p>\n         <p>You can choose a start index of 0 or 1, and you can specify either WebVTT or SubRip\n            (or both) as your output format.</p>\n         <p>Note that your subtitle files are placed in the same location as your transcription\n            output.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#SubtitlesOutput": {
+      "type": "structure",
+      "members": {
+        "Formats": {
+          "target": "com.amazonaws.transcribe#SubtitleFormats",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the format of your subtitle files. If your request included both WebVTT\n                (<code>vtt</code>) and SubRip (<code>srt</code>) formats, both formats are\n            shown.</p>"
+          }
+        },
+        "SubtitleFileUris": {
+          "target": "com.amazonaws.transcribe#SubtitleFileUris",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of your transcript. You can use this URI to access or\n            download your subtitle file. Your subtitle file is stored in the same location as your\n            transcript. If you specified both WebVTT and SubRip subtitle formats, two URIs are\n            provided.</p>\n         <p>If you included <code>OutputBucketName</code> in your transcription job request, this\n            is the URI of that bucket. If you also included <code>OutputKey</code> in your request,\n            your output is located in the path you specified in your request.</p>\n         <p>If you didn't include <code>OutputBucketName</code> in your transcription job request,\n            your subtitle file is stored in a service-managed bucket, and\n                <code>TranscriptFileUri</code> provides you with a temporary URI you can use for\n            secure access to your subtitle file.</p>\n         <note>\n            <p>Temporary URIs for service-managed Amazon S3 buckets are only valid for 15\n                minutes. If you get an <code>AccesDenied</code> error, you can get a new temporary\n                URI by running a <code>GetTranscriptionJob</code> or\n                    <code>ListTranscriptionJob</code> request.</p>\n         </note>"
+          }
+        },
+        "OutputStartIndex": {
+          "target": "com.amazonaws.transcribe#SubtitleOutputStartIndex",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the start index value for your subtitle files. If you did not specify a value\n            in your request, the default value of <code>0</code> is used.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about your subtitle file, including format, start index, and\n                Amazon S3 location.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#Summarization": {
+      "type": "structure",
+      "members": {
+        "GenerateAbstractiveSummary": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Enables Generative call summarization in your Call Analytics request</p>\n         <p>Generative call summarization provides a summary of the transcript including important\n\t    components discussed in the conversation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-enable-summarization.html\">Enabling generative call \n\t        summarization</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains <code>GenerateAbstractiveSummary</code>, which is a required parameter if you\n\t    want to enable Generative call summarization in your Call Analytics request.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.transcribe#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The first part of a key:value pair that forms a tag associated with a given resource.\n            For example, in the tag <code>Department:Sales</code>, the key is 'Department'.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.transcribe#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The second part of a key:value pair that forms a tag associated with a given resource.\n            For example, in the tag <code>Department:Sales</code>, the value is 'Sales'.</p>\n         <p>Note that you can set the value of a tag to an empty string, but you can't set the\n            value of a tag to null. Omitting the tag value is the same as using an empty\n            string.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Adds metadata, in the form of a key:value pair, to the specified resource.</p>\n         <p>For example, you could add the tag <code>Department:Sales</code> to a resource to\n            indicate that it pertains to your organization's sales department. You can also use tags\n            for tag-based access control.</p>\n         <p>To learn more about tagging, see <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging resources</a>.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to the specified\n            resource.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/tags/{ResourceArn}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.transcribe#TranscribeArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the resource you want to tag. ARNs have the format\n                <code>arn:partition:service:region:account-id:resource-type/resource-id</code>.</p>\n         <p>For example,\n                <code>arn:aws:transcribe:us-west-2:111122223333:transcription-job/transcription-job-name</code>.</p>\n         <p>Valid values for <code>resource-type</code> are: <code>transcription-job</code>,\n                <code>medical-transcription-job</code>, <code>vocabulary</code>,\n                <code>medical-vocabulary</code>, <code>vocabulary-filter</code>, and\n                <code>language-model</code>.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Adds one or more custom tags, each in the form of a key:value pair, to the specified\n            resource.</p>\n         <p>To learn more about using tags with Amazon Transcribe, refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tagging.html\">Tagging\n                resources</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TimestampMilliseconds": {
+      "type": "long",
+      "traits": {
+        "smithy.api#range": {
+          "min": 0,
+          "max": 14400000
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ToxicityCategories": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#ToxicityCategory"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ToxicityCategory": {
+      "type": "enum",
+      "members": {
+        "ALL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ALL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ToxicityDetection": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#ToxicityDetectionSettings"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    },
+    "com.amazonaws.transcribe#ToxicityDetectionSettings": {
+      "type": "structure",
+      "members": {
+        "ToxicityCategories": {
+          "target": "com.amazonaws.transcribe#ToxicityCategories",
+          "traits": {
+            "smithy.api#documentation": "<p> If you include <code>ToxicityDetection</code> in your transcription request, you \n            must also include <code>ToxicityCategories</code>. The only accepted value for this \n            parameter is <code>ALL</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains <code>ToxicityCategories</code>, which is a required parameter if you \n            want to enable toxicity detection (<code>ToxicityDetection</code>) in your transcription \n            request.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#Transcribe": {
+      "type": "service",
+      "version": "2017-10-26",
+      "operations": [
+        {
+          "target": "com.amazonaws.transcribe#CreateCallAnalyticsCategory"
+        },
+        {
+          "target": "com.amazonaws.transcribe#CreateLanguageModel"
+        },
+        {
+          "target": "com.amazonaws.transcribe#CreateMedicalVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#CreateVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#CreateVocabularyFilter"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteCallAnalyticsCategory"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteCallAnalyticsJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteLanguageModel"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteMedicalScribeJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteMedicalTranscriptionJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteMedicalVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteTranscriptionJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DeleteVocabularyFilter"
+        },
+        {
+          "target": "com.amazonaws.transcribe#DescribeLanguageModel"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetCallAnalyticsCategory"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetCallAnalyticsJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetMedicalScribeJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetMedicalTranscriptionJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetMedicalVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetTranscriptionJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#GetVocabularyFilter"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListCallAnalyticsCategories"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListCallAnalyticsJobs"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListLanguageModels"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListMedicalScribeJobs"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListMedicalTranscriptionJobs"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListMedicalVocabularies"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListTranscriptionJobs"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListVocabularies"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ListVocabularyFilters"
+        },
+        {
+          "target": "com.amazonaws.transcribe#StartCallAnalyticsJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#StartMedicalScribeJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#StartMedicalTranscriptionJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#StartTranscriptionJob"
+        },
+        {
+          "target": "com.amazonaws.transcribe#TagResource"
+        },
+        {
+          "target": "com.amazonaws.transcribe#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.transcribe#UpdateCallAnalyticsCategory"
+        },
+        {
+          "target": "com.amazonaws.transcribe#UpdateMedicalVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#UpdateVocabulary"
+        },
+        {
+          "target": "com.amazonaws.transcribe#UpdateVocabularyFilter"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Transcribe",
+          "arnNamespace": "transcribe",
+          "cloudFormationName": "Transcribe",
+          "cloudTrailEventSource": "transcribe.amazonaws.com",
+          "endpointPrefix": "transcribe"
+        },
+        "aws.auth#sigv4": {
+          "name": "transcribe"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<p>Amazon Transcribe offers three main types of batch transcription: <b>Standard</b>, <b>Medical</b>, and\n                <b>Call Analytics</b>.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Standard transcriptions</b> are the most common\n                    option. Refer to  for details.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Medical transcriptions</b> are tailored to\n                    medical professionals and incorporate medical terms. A common use case for this\n                    service is transcribing doctor-patient dialogue into after-visit notes. Refer to\n                         for details.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Call Analytics transcriptions</b> are designed\n                    for use with call center audio on two different channels; if you're looking for\n                    insight into customer service calls, use this option. Refer to  for details.</p>\n            </li>\n         </ul>",
+        "smithy.api#title": "Amazon Transcribe Service",
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "ref": "Region"
+                },
+                "cn-north-1"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "ref": "Region"
+                },
+                "cn-northwest-1"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws-us-gov"
+              ]
+            },
+            {
+              "fn": "stringEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "name"
+                  ]
+                },
+                "aws"
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://transcribe-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://fips.transcribe.{Region}.amazonaws.com",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://transcribe-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://transcribe.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://cn.transcribe.cn-north-1.amazonaws.com.cn",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://cn.transcribe.cn-northwest-1.amazonaws.com.cn",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://transcribe.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 17,
+          "nodes": "/////wAAAAH/////AAAAAAAAABAAAAADAAAAAQAAAAQF9eEOAAAAAgAAAAUF9eEOAAAAAwAAAAoAAAAGAAAABQAAAAkAAAAHAAAABwX14QsAAAAIAAAACAX14QwF9eENAAAABgX14QkF9eEKAAAABAAAAAwAAAALAAAABQX14QUF9eEIAAAABQAAAA8AAAANAAAACQX14QYAAAAOAAAACgX14QYF9eEHAAAABgX14QQF9eEFAAAAAwX14QEAAAARAAAABQX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://transcribe-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://fips.transcribe.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "stringEquals",
+                                  "argv": [
+                                    {
+                                      "fn": "getAttr",
+                                      "argv": [
+                                        {
+                                          "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                      ]
+                                    },
+                                    "aws-us-gov"
+                                  ]
+                                }
+                              ],
+                              "endpoint": {
+                                "url": "https://fips.transcribe.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://transcribe-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://transcribe.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "ref": "Region"
+                            },
+                            "cn-north-1"
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://cn.transcribe.cn-north-1.amazonaws.com.cn",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "ref": "Region"
+                            },
+                            "cn-northwest-1"
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://cn.transcribe.cn-northwest-1.amazonaws.com.cn",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://transcribe.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.af-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "af-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ap-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.me-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "me-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.sa-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "sa-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://cn.transcribe.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://cn.transcribe.cn-northwest-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-northwest-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://fips.transcribe.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://transcribe.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TranscribeArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1011
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#Transcript": {
+      "type": "structure",
+      "members": {
+        "TranscriptFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of your transcript. You can use this URI to access or\n            download your transcript.</p>\n         <p>If you included <code>OutputBucketName</code> in your transcription job request, this\n            is the URI of that bucket. If you also included <code>OutputKey</code> in your request,\n            your output is located in the path you specified in your request.</p>\n         <p>If you didn't include <code>OutputBucketName</code> in your transcription job request,\n            your transcript is stored in a service-managed bucket, and\n                <code>TranscriptFileUri</code> provides you with a temporary URI you can use for\n            secure access to your transcript.</p>\n         <note>\n            <p>Temporary URIs for service-managed Amazon S3 buckets are only valid for 15\n                minutes. If you get an <code>AccesDenied</code> error, you can get a new temporary\n                URI by running a <code>GetTranscriptionJob</code> or\n                    <code>ListTranscriptionJob</code> request.</p>\n         </note>"
+          }
+        },
+        "RedactedTranscriptFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of your redacted transcript. You can use this URI to\n            access or download your transcript.</p>\n         <p>If you included <code>OutputBucketName</code> in your transcription job request, this\n            is the URI of that bucket. If you also included <code>OutputKey</code> in your request,\n            your output is located in the path you specified in your request.</p>\n         <p>If you didn't include <code>OutputBucketName</code> in your transcription job request,\n            your transcript is stored in a service-managed bucket, and\n                <code>RedactedTranscriptFileUri</code> provides you with a temporary URI you can use\n            for secure access to your transcript.</p>\n         <note>\n            <p>Temporary URIs for service-managed Amazon S3 buckets are only valid for 15\n                minutes. If you get an <code>AccesDenied</code> error, you can get a new temporary\n                URI by running a <code>GetTranscriptionJob</code> or\n                    <code>ListTranscriptionJob</code> request.</p>\n         </note>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides you with the Amazon S3 URI you can use to access your\n            transcript.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptFilter": {
+      "type": "structure",
+      "members": {
+        "TranscriptFilterType": {
+          "target": "com.amazonaws.transcribe#TranscriptFilterType",
+          "traits": {
+            "smithy.api#documentation": "<p>Flag the presence or absence of an exact match to the phrases that you specify. For\n            example, if you specify the phrase \"speak to a manager\" as your <code>Targets</code>\n            value, only that exact phrase is flagged.</p>\n         <p>Note that semantic matching is not supported. For example, if your customer says\n            \"speak to <i>the</i> manager\", instead of \"speak to <i>a</i>\n            manager\", your content is not flagged.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AbsoluteTimeRange": {
+          "target": "com.amazonaws.transcribe#AbsoluteTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in milliseconds) in your audio, during\n            which you want to search for the specified key words or phrases. See  for more detail.</p>"
+          }
+        },
+        "RelativeTimeRange": {
+          "target": "com.amazonaws.transcribe#RelativeTimeRange",
+          "traits": {
+            "smithy.api#documentation": "<p>Makes it possible to specify a time range (in percentage) in your media file, during\n            which you want to search for the specified key words or phrases. See  for more detail.</p>"
+          }
+        },
+        "ParticipantRole": {
+          "target": "com.amazonaws.transcribe#ParticipantRole",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the participant that you want to flag. Omitting this parameter is equivalent\n            to specifying both participants.</p>"
+          }
+        },
+        "Negate": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Set to <code>TRUE</code> to flag the absence of the phrase that you specified in your\n            request. Set to <code>FALSE</code> to flag the presence of the phrase that you specified\n            in your request.</p>"
+          }
+        },
+        "Targets": {
+          "target": "com.amazonaws.transcribe#StringTargetList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specify the phrases that you want to flag.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Flag the presence or absence of specific words or phrases detected in your Call\n            Analytics transcription output.</p>\n         <p>Rules using <code>TranscriptFilter</code> are designed to match:</p>\n         <ul>\n            <li>\n               <p>Custom words or phrases spoken by the agent, the customer, or both</p>\n            </li>\n            <li>\n               <p>Custom words or phrases <b>not</b> spoken by the\n                    agent, the customer, or either</p>\n            </li>\n            <li>\n               <p>Custom words or phrases that occur at a specific time frame</p>\n            </li>\n         </ul>\n         <p>See <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-batch.html#tca-rules-batch\">Rule criteria for post-call \n            categories</a> and <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/tca-categories-stream.html#tca-rules-stream\">Rule criteria for \n                streaming categories</a> for usage examples.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptFilterType": {
+      "type": "enum",
+      "members": {
+        "EXACT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "EXACT"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptionJob": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the transcription job. Job names are case sensitive and must be unique\n            within an Amazon Web Services account.</p>"
+          }
+        },
+        "TranscriptionJobStatus": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of the specified transcription job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>TranscriptFileUri</code> (or\n                <code>RedactedTranscriptFileUri</code>, if you requested transcript redaction). If\n            the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why\n            your transcription job failed.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your transcription job. This parameter is used with\n            single-language identification. For multi-language identification requests, refer to the\n            plural version of this parameter, <code>LanguageCodes</code>.</p>"
+          }
+        },
+        "MediaSampleRateHertz": {
+          "target": "com.amazonaws.transcribe#MediaSampleRateHertz",
+          "traits": {
+            "smithy.api#documentation": "<p>The sample rate, in hertz, of the audio track in your input media file.</p>"
+          }
+        },
+        "MediaFormat": {
+          "target": "com.amazonaws.transcribe#MediaFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of the input media file.</p>"
+          }
+        },
+        "Media": {
+          "target": "com.amazonaws.transcribe#Media",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the Amazon S3 location of the media file you used in your\n            request.</p>"
+          }
+        },
+        "Transcript": {
+          "target": "com.amazonaws.transcribe#Transcript",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides you with the Amazon S3 URI you can use to access your\n            transcript.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified transcription job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified transcription job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified transcription job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:33:13.922000-07:00</code> represents a transcription job\n            that started processing at 12:33 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>TranscriptionJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the transcription job\n            request failed.</p>\n         <p>The <code>FailureReason</code> field contains one of the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Unsupported media format</code>.</p>\n               <p>The media format specified in <code>MediaFormat</code> isn't valid. Refer to\n                    refer to the <code>MediaFormat</code> parameter for a list of supported\n                    formats.</p>\n            </li>\n            <li>\n               <p>\n                  <code>The media format provided does not match the detected media\n                        format</code>.</p>\n               <p>The media format specified in <code>MediaFormat</code> doesn't match the\n                    format of the input file. Check the media format of your media file and correct\n                    the specified value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid sample rate for audio file</code>.</p>\n               <p>The sample rate specified in <code>MediaSampleRateHertz</code> isn't valid.\n                    The sample rate must be between 8,000 and 48,000 hertz.</p>\n            </li>\n            <li>\n               <p>\n                  <code>The sample rate provided does not match the detected sample\n                    rate</code>.</p>\n               <p>The sample rate specified in <code>MediaSampleRateHertz</code> doesn't match\n                    the sample rate detected in your input media file. Check the sample rate of your\n                    media file and correct the specified value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid file size: file size too large</code>.</p>\n               <p>The size of your media file is larger than what Amazon Transcribe can\n                    process. For more information, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html#limits-amazon-transcribe\">Service \n                        quotas</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Invalid number of channels: number of channels too large</code>.</p>\n               <p>Your audio contains more channels than Amazon Transcribe is able to process.\n                    For more information, refer to <a href=\"https://docs.aws.amazon.com/general/latest/gr/transcribe.html#limits-amazon-transcribe\">Service \n                        quotas</a>.</p>\n            </li>\n         </ul>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.transcribe#Settings",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information on any additional settings that were included in your request.\n            Additional settings include channel identification, alternative transcriptions, speaker\n            partitioning, custom vocabularies, and custom vocabulary filters.</p>"
+          }
+        },
+        "ModelSettings": {
+          "target": "com.amazonaws.transcribe#ModelSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information on the custom language model you included in your request.</p>"
+          }
+        },
+        "JobExecutionSettings": {
+          "target": "com.amazonaws.transcribe#JobExecutionSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about how your transcription job was processed. This parameter\n            shows if your request was queued and what data access role was used.</p>"
+          }
+        },
+        "ContentRedaction": {
+          "target": "com.amazonaws.transcribe#ContentRedaction",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether redaction was enabled in your transcript.</p>"
+          }
+        },
+        "IdentifyLanguage": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether automatic language identification was enabled (<code>TRUE</code>)\n            for the specified transcription job.</p>"
+          }
+        },
+        "IdentifyMultipleLanguages": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether automatic multi-language identification was enabled\n                (<code>TRUE</code>) for the specified transcription job.</p>"
+          }
+        },
+        "LanguageOptions": {
+          "target": "com.amazonaws.transcribe#LanguageOptions",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the language codes you specified in your request.</p>"
+          }
+        },
+        "IdentifiedLanguageScore": {
+          "target": "com.amazonaws.transcribe#IdentifiedLanguageScore",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score associated with the language identified in your media\n            file.</p>\n         <p>Confidence scores are values between 0 and 1; a larger value indicates a higher\n            probability that the identified language correctly matches the language spoken in your\n            media.</p>"
+          }
+        },
+        "LanguageCodes": {
+          "target": "com.amazonaws.transcribe#LanguageCodeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The language codes used to create your transcription job. This parameter is used with\n            multi-language identification. For single-language identification requests, refer to the\n            singular version of this parameter, <code>LanguageCode</code>.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.transcribe#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The tags, each in the form of a key:value pair, assigned to the specified\n            transcription job.</p>"
+          }
+        },
+        "Subtitles": {
+          "target": "com.amazonaws.transcribe#SubtitlesOutput",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether subtitles were generated with your transcription.</p>"
+          }
+        },
+        "LanguageIdSettings": {
+          "target": "com.amazonaws.transcribe#LanguageIdSettingsMap",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the name and language of all custom language models, custom vocabularies, and\n            custom vocabulary filters that you included in your request.</p>"
+          }
+        },
+        "ToxicityDetection": {
+          "target": "com.amazonaws.transcribe#ToxicityDetection",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides information about the toxicity detection settings applied to your transcription.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a transcription job.</p>\n         <p>To view the status of the specified transcription job, check the\n                <code>TranscriptionJobStatus</code> field. If the status is <code>COMPLETED</code>,\n            the job is finished and you can find the results at the location specified in\n                <code>TranscriptFileUri</code>. If the status is <code>FAILED</code>,\n                <code>FailureReason</code> provides details on why your transcription job\n            failed.</p>\n         <p>If you enabled content redaction, the redacted transcript can be found at the location\n            specified in <code>RedactedTranscriptFileUri</code>.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptionJobName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptionJobStatus": {
+      "type": "enum",
+      "members": {
+        "QUEUED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "QUEUED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptionJobSummaries": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#TranscriptionJobSummary"
+      }
+    },
+    "com.amazonaws.transcribe#TranscriptionJobSummary": {
+      "type": "structure",
+      "members": {
+        "TranscriptionJobName": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the transcription job. Job names are case sensitive and must be unique\n            within an Amazon Web Services account.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified transcription job request was made.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "StartTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time your transcription job began processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.789000-07:00</code> represents a transcription job\n            that started processing at 12:32 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "CompletionTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified transcription job finished processing.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:33:13.922000-07:00</code> represents a transcription job\n            that started processing at 12:33 PM UTC-7 on May 4, 2022.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your transcription.</p>"
+          }
+        },
+        "TranscriptionJobStatus": {
+          "target": "com.amazonaws.transcribe#TranscriptionJobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides the status of your transcription job.</p>\n         <p>If the status is <code>COMPLETED</code>, the job is finished and you can find the\n            results at the location specified in <code>TranscriptFileUri</code> (or\n                <code>RedactedTranscriptFileUri</code>, if you requested transcript redaction). If\n            the status is <code>FAILED</code>, <code>FailureReason</code> provides details on why\n            your transcription job failed.</p>"
+          }
+        },
+        "FailureReason": {
+          "target": "com.amazonaws.transcribe#FailureReason",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>TranscriptionJobStatus</code> is <code>FAILED</code>,\n                <code>FailureReason</code> contains information about why the transcription job\n            failed. See also: <a href=\"https://docs.aws.amazon.com/transcribe/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p>"
+          }
+        },
+        "OutputLocationType": {
+          "target": "com.amazonaws.transcribe#OutputLocationType",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates where the specified transcription output is stored.</p>\n         <p>If the value is <code>CUSTOMER_BUCKET</code>, the location is the Amazon S3\n            bucket you specified using the <code>OutputBucketName</code> parameter in your  request. If you also included\n                <code>OutputKey</code> in your request, your output is located in the path you\n            specified in your request.</p>\n         <p>If the value is <code>SERVICE_BUCKET</code>, the location is a service-managed Amazon S3 bucket. To access a transcript stored in a service-managed bucket, use the\n            URI shown in the <code>TranscriptFileUri</code> or\n                <code>RedactedTranscriptFileUri</code> field.</p>"
+          }
+        },
+        "ContentRedaction": {
+          "target": "com.amazonaws.transcribe#ContentRedaction",
+          "traits": {
+            "smithy.api#documentation": "<p>The content redaction settings of the transcription job.</p>"
+          }
+        },
+        "ModelSettings": {
+          "target": "com.amazonaws.transcribe#ModelSettings"
+        },
+        "IdentifyLanguage": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether automatic language identification was enabled (<code>TRUE</code>)\n            for the specified transcription job.</p>"
+          }
+        },
+        "IdentifyMultipleLanguages": {
+          "target": "com.amazonaws.transcribe#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether automatic multi-language identification was enabled\n                (<code>TRUE</code>) for the specified transcription job.</p>"
+          }
+        },
+        "IdentifiedLanguageScore": {
+          "target": "com.amazonaws.transcribe#IdentifiedLanguageScore",
+          "traits": {
+            "smithy.api#documentation": "<p>The confidence score associated with the language identified in your media\n            file.</p>\n         <p>Confidence scores are values between 0 and 1; a larger value indicates a higher\n            probability that the identified language correctly matches the language spoken in your\n            media.</p>"
+          }
+        },
+        "LanguageCodes": {
+          "target": "com.amazonaws.transcribe#LanguageCodeList",
+          "traits": {
+            "smithy.api#documentation": "<p>The language codes used to create your transcription job. This parameter is used with\n            multi-language identification. For single-language identification, the singular version\n            of this parameter, <code>LanguageCode</code>, is present.</p>"
+          }
+        },
+        "ToxicityDetection": {
+          "target": "com.amazonaws.transcribe#ToxicityDetection",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether toxicity detection was enabled for the specified transcription \n            job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides detailed information about a specific transcription job.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#Type": {
+      "type": "enum",
+      "members": {
+        "CONVERSATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CONVERSATION"
+          }
+        },
+        "DICTATION": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DICTATION"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes the specified tags from the specified Amazon Transcribe resource.</p>\n         <p>If you include <code>UntagResource</code> in your request, you must also include\n                <code>ResourceArn</code> and <code>TagKeys</code>.</p>",
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/tags/{ResourceArn}",
+          "code": 204
+        }
+      }
+    },
+    "com.amazonaws.transcribe#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.transcribe#TranscribeArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to remove\n            tags from. ARNs have the format\n                <code>arn:partition:service:region:account-id:resource-type/resource-id</code>.</p>\n         <p>For example,\n                <code>arn:aws:transcribe:us-west-2:111122223333:transcription-job/transcription-job-name</code>.</p>\n         <p>Valid values for <code>resource-type</code> are: <code>transcription-job</code>,\n                <code>medical-transcription-job</code>, <code>vocabulary</code>,\n                <code>medical-vocabulary</code>, <code>vocabulary-filter</code>, and\n                <code>language-model</code>.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.transcribe#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>Removes the specified tag keys from the specified Amazon Transcribe resource.</p>",
+            "smithy.api#httpQuery": "tagKeys",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateCallAnalyticsCategory": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#UpdateCallAnalyticsCategoryRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#UpdateCallAnalyticsCategoryResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates the specified Call Analytics category with new rules. Note that the\n                <code>UpdateCallAnalyticsCategory</code> operation overwrites all existing rules\n            contained in the specified category. You cannot append additional rules onto an existing\n            category.</p>\n         <p>To create a new category, see .</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/callanalyticscategories/{CategoryName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#UpdateCallAnalyticsCategoryRequest": {
+      "type": "structure",
+      "members": {
+        "CategoryName": {
+          "target": "com.amazonaws.transcribe#CategoryName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the Call Analytics category you want to update. Category names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Rules": {
+          "target": "com.amazonaws.transcribe#RuleList",
+          "traits": {
+            "smithy.api#documentation": "<p>The rules used for the updated Call Analytics category. The rules you provide in this\n            field replace the ones that are currently being used in the specified category.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputType": {
+          "target": "com.amazonaws.transcribe#InputType",
+          "traits": {
+            "smithy.api#documentation": "<p>Choose whether you want to update a real-time or a post-call category. The \n            input type you specify must match the input type specified when the category was created. For\n            example, if you created a category with the <code>POST_CALL</code> input type, you must\n            use <code>POST_CALL</code> as the input type when updating this category.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateCallAnalyticsCategoryResponse": {
+      "type": "structure",
+      "members": {
+        "CategoryProperties": {
+          "target": "com.amazonaws.transcribe#CategoryProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>Provides you with the properties of the Call Analytics category you specified in your\n                <code>UpdateCallAnalyticsCategory</code> request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateMedicalVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#UpdateMedicalVocabularyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#UpdateMedicalVocabularyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an existing custom medical vocabulary with new values. This operation\n            overwrites all existing information with your new values; you cannot append new terms\n            onto an existing custom vocabulary.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/medicalvocabularies/{VocabularyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#UpdateMedicalVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom medical vocabulary you want to update. Custom medical\n            vocabulary names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of the entries in the custom vocabulary\n            you want to update. US English (<code>en-US</code>) is the only language supported with\n                Amazon Transcribe Medical.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "VocabularyFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the text file that contains your custom medical\n            vocabulary. The URI must be located in the same Amazon Web Services Region as the\n            resource you're calling.</p>\n         <p>Here's an example URI path:\n            <code>s3://DOC-EXAMPLE-BUCKET/my-vocab-file.txt</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateMedicalVocabularyResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the updated custom medical vocabulary.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom medical vocabulary. US English\n                (<code>en-US</code>) is the only language supported with Amazon Transcribe\n            Medical.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom medical vocabulary was last updated.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom medical vocabulary. If the state is\n                <code>READY</code>, you can use the custom vocabulary in a\n                <code>StartMedicalTranscriptionJob</code> request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateVocabulary": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#UpdateVocabularyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#UpdateVocabularyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an existing custom vocabulary with new values. This operation overwrites all\n            existing information with your new values; you cannot append new terms onto an existing\n            custom vocabulary.</p>",
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "/vocabularies/{VocabularyName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#UpdateVocabularyFilter": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.transcribe#UpdateVocabularyFilterRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.transcribe#UpdateVocabularyFilterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.transcribe#BadRequestException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#InternalFailureException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.transcribe#NotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates an existing custom vocabulary filter with a new list of words. The new list\n            you provide overwrites all previous entries; you cannot append new terms onto an\n            existing custom vocabulary filter.</p>",
+        "smithy.api#http": {
+          "method": "PUT",
+          "uri": "/vocabularyFilters/{VocabularyFilterName}",
+          "code": 200
+        }
+      }
+    },
+    "com.amazonaws.transcribe#UpdateVocabularyFilterRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary filter you want to update. Custom vocabulary filter\n            names are case sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Words": {
+          "target": "com.amazonaws.transcribe#Words",
+          "traits": {
+            "smithy.api#documentation": "<p>Use this parameter if you want to update your custom vocabulary filter by including\n            all desired terms, as comma-separated values, within your request. The other option for\n            updating your vocabulary filter is to save your entries in a text file and upload them\n            to an Amazon S3 bucket, then specify the location of your file using the\n                <code>VocabularyFilterFileUri</code> parameter.</p>\n         <p>Note that if you include <code>Words</code> in your request, you cannot use\n                <code>VocabularyFilterFileUri</code>; you must choose one or the other.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary filter\n            request fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom\n                Vocabularies</a> to get the character set for your language.</p>"
+          }
+        },
+        "VocabularyFilterFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the text file that contains your custom vocabulary\n            filter terms. The URI must be located in the same Amazon Web Services Region as the\n            resource you're calling.</p>\n         <p>Here's an example URI path:\n                <code>s3://DOC-EXAMPLE-BUCKET/my-vocab-filter-file.txt</code>\n         </p>\n         <p>Note that if you include <code>VocabularyFilterFileUri</code> in your request, you\n            cannot use <code>Words</code>; you must choose one or the other.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files (in this case, your custom\n            vocabulary filter). If the role that you specify doesn\u2019t have the appropriate permissions to access\n            the specified Amazon S3 location, your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateVocabularyFilterResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the updated custom vocabulary filter.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom vocabulary filter.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom vocabulary filter was last updated.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateVocabularyRequest": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom vocabulary you want to update. Custom vocabulary names are case\n            sensitive.</p>",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of the entries in the custom vocabulary\n            you want to update. Each custom vocabulary must contain terms in only one\n            language.</p>\n         <p>A custom vocabulary can only be used to transcribe files in the same language as the\n            custom vocabulary. For example, if you create a custom vocabulary using US English\n                (<code>en-US</code>), you can only apply this custom vocabulary to files that\n            contain English audio.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Phrases": {
+          "target": "com.amazonaws.transcribe#Phrases",
+          "traits": {
+            "smithy.api#documentation": "<p>Use this parameter if you want to update your custom vocabulary by including all\n            desired terms, as comma-separated values, within your request. The other option for\n            updating your custom vocabulary is to save your entries in a text file and upload them\n            to an Amazon S3 bucket, then specify the location of your file using the\n                <code>VocabularyFileUri</code> parameter.</p>\n         <p>Note that if you include <code>Phrases</code> in your request, you cannot use\n                <code>VocabularyFileUri</code>; you must choose one or the other.</p>\n         <p>Each language has a character set that contains all allowed characters for that\n            specific language. If you use unsupported characters, your custom vocabulary filter\n            request fails. Refer to <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/charsets.html\">Character Sets for Custom\n                Vocabularies</a> to get the character set for your language.</p>"
+          }
+        },
+        "VocabularyFileUri": {
+          "target": "com.amazonaws.transcribe#Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the text file that contains your custom vocabulary.\n            The URI must be located in the same Amazon Web Services Region as the resource you're\n            calling.</p>\n         <p>Here's an example URI path:\n            <code>s3://DOC-EXAMPLE-BUCKET/my-vocab-file.txt</code>\n         </p>\n         <p>Note that if you include <code>VocabularyFileUri</code> in your request, you cannot\n            use the <code>Phrases</code> flag; you must choose one or the other.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.transcribe#DataAccessRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an IAM role that has permissions to\n            access the Amazon S3 bucket that contains your input files (in this case, your custom\n            vocabulary). If the role that you specify doesn\u2019t have the appropriate permissions to access\n            the specified Amazon S3 location, your request fails.</p>\n         <p>IAM role ARNs have the format\n            <code>arn:partition:iam::account:role/role-name-with-path</code>. For example:\n            <code>arn:aws:iam::111122223333:role/Admin</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM\n            ARNs</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.transcribe#UpdateVocabularyResponse": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the updated custom vocabulary.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code you selected for your custom vocabulary.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom vocabulary was last updated.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom vocabulary. If the state is <code>READY</code>,\n            you can use the custom vocabulary in a <code>StartTranscriptionJob</code>\n            request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.transcribe#Uri": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2000
+        },
+        "smithy.api#pattern": "^(s3://|http(s*)://).+$"
+      }
+    },
+    "com.amazonaws.transcribe#Vocabularies": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#VocabularyInfo"
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyFilterInfo": {
+      "type": "structure",
+      "members": {
+        "VocabularyFilterName": {
+          "target": "com.amazonaws.transcribe#VocabularyFilterName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your custom vocabulary filter. This name is case\n            sensitive, cannot contain spaces, and must be unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code that represents the language of the entries in your vocabulary\n            filter. Each custom vocabulary filter must contain terms in only one language.</p>\n         <p>A custom vocabulary filter can only be used to transcribe files in the same language\n            as the filter. For example, if you create a custom vocabulary filter using US English\n                (<code>en-US</code>), you can only apply this filter to files that contain English\n            audio.</p>\n         <p>For a list of supported languages and their associated language codes, refer to the\n                <a href=\"https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html\">Supported languages</a> table.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom vocabulary filter was last modified.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a custom vocabulary filter, including the language of the\n            filter, when it was last modified, and its name.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyFilterMethod": {
+      "type": "enum",
+      "members": {
+        "REMOVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "remove"
+          }
+        },
+        "MASK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "mask"
+          }
+        },
+        "TAG": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "tag"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyFilterName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyFilters": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#VocabularyFilterInfo"
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyInfo": {
+      "type": "structure",
+      "members": {
+        "VocabularyName": {
+          "target": "com.amazonaws.transcribe#VocabularyName",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique name, chosen by you, for your custom vocabulary. This name is case sensitive,\n            cannot contain spaces, and must be unique within an Amazon Web Services account.</p>"
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.transcribe#LanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code used to create your custom vocabulary. Each custom vocabulary must\n            contain terms in only one language.</p>\n         <p>A custom vocabulary can only be used to transcribe files in the same language as the\n            custom vocabulary. For example, if you create a custom vocabulary using US English\n                (<code>en-US</code>), you can only apply this custom vocabulary to files that\n            contain English audio.</p>"
+          }
+        },
+        "LastModifiedTime": {
+          "target": "com.amazonaws.transcribe#DateTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the specified custom vocabulary was last modified.</p>\n         <p>Timestamps are in the format <code>YYYY-MM-DD'T'HH:MM:SS.SSSSSS-UTC</code>. For\n            example, <code>2022-05-04T12:32:58.761000-07:00</code> represents 12:32 PM UTC-7 on May\n            4, 2022.</p>"
+          }
+        },
+        "VocabularyState": {
+          "target": "com.amazonaws.transcribe#VocabularyState",
+          "traits": {
+            "smithy.api#documentation": "<p>The processing state of your custom vocabulary. If the state is <code>READY</code>,\n            you can use the custom vocabulary in a <code>StartTranscriptionJob</code>\n            request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a custom vocabulary, including the language of the custom\n            vocabulary, when it was last modified, its name, and the processing state.</p>"
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 200
+        },
+        "smithy.api#pattern": "^[0-9a-zA-Z._-]+$"
+      }
+    },
+    "com.amazonaws.transcribe#VocabularyState": {
+      "type": "enum",
+      "members": {
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PENDING"
+          }
+        },
+        "READY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "READY"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Word": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.transcribe#Words": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.transcribe#Word"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    }
+  }
+}

--- a/crates/fakecloud-transcribe/src/validate.rs
+++ b/crates/fakecloud-transcribe/src/validate.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 /// The vendored Transcribe Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/transcribe.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 #[derive(Debug, Default)]
 struct MemberConstraint {

--- a/crates/fakecloud-translate/model.json
+++ b/crates/fakecloud-translate/model.json
@@ -1,0 +1,4090 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.translate#AWSShineFrontendService_20170701": {
+      "type": "service",
+      "version": "2017-07-01",
+      "operations": [
+        {
+          "target": "com.amazonaws.translate#CreateParallelData"
+        },
+        {
+          "target": "com.amazonaws.translate#DeleteParallelData"
+        },
+        {
+          "target": "com.amazonaws.translate#DeleteTerminology"
+        },
+        {
+          "target": "com.amazonaws.translate#DescribeTextTranslationJob"
+        },
+        {
+          "target": "com.amazonaws.translate#GetParallelData"
+        },
+        {
+          "target": "com.amazonaws.translate#GetTerminology"
+        },
+        {
+          "target": "com.amazonaws.translate#ImportTerminology"
+        },
+        {
+          "target": "com.amazonaws.translate#ListLanguages"
+        },
+        {
+          "target": "com.amazonaws.translate#ListParallelData"
+        },
+        {
+          "target": "com.amazonaws.translate#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.translate#ListTerminologies"
+        },
+        {
+          "target": "com.amazonaws.translate#ListTextTranslationJobs"
+        },
+        {
+          "target": "com.amazonaws.translate#StartTextTranslationJob"
+        },
+        {
+          "target": "com.amazonaws.translate#StopTextTranslationJob"
+        },
+        {
+          "target": "com.amazonaws.translate#TagResource"
+        },
+        {
+          "target": "com.amazonaws.translate#TranslateDocument"
+        },
+        {
+          "target": "com.amazonaws.translate#TranslateText"
+        },
+        {
+          "target": "com.amazonaws.translate#UntagResource"
+        },
+        {
+          "target": "com.amazonaws.translate#UpdateParallelData"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "Translate",
+          "arnNamespace": "translate",
+          "cloudFormationName": "Translate",
+          "cloudTrailEventSource": "translate.amazonaws.com",
+          "endpointPrefix": "translate"
+        },
+        "aws.auth#sigv4": {
+          "name": "translate"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<p>Provides translation of the input content from the source language to the target language.</p>",
+        "smithy.api#title": "Amazon Translate",
+        "smithy.rules#endpointBdd": {
+          "version": "1.1",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Endpoint"
+                }
+              ]
+            },
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ]
+            },
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsDualStack"
+                  ]
+                },
+                true
+              ]
+            },
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartitionResult"
+                    },
+                    "supportsFIPS"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "results": [
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": {
+                  "ref": "Endpoint"
+                },
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://translate-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://translate-fips.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "FIPS is enabled but this partition does not support FIPS",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://translate.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "DualStack is enabled but this partition does not support DualStack",
+              "type": "error"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://translate.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ],
+          "root": 2,
+          "nodeCount": 13,
+          "nodes": "/////wAAAAH/////AAAAAAAAAAwAAAADAAAAAQAAAAQF9eELAAAAAgAAAAUF9eELAAAAAwAAAAgAAAAGAAAABAAAAAcF9eEKAAAABQX14QgF9eEJAAAABAAAAAoAAAAJAAAABgX14QYF9eEHAAAABQAAAAsF9eEFAAAABgX14QQF9eEFAAAAAwX14QEAAAANAAAABAX14QIF9eED"
+        },
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "Region": {
+              "builtIn": "AWS::Region",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request.",
+              "type": "string"
+            },
+            "UseDualStack": {
+              "builtIn": "AWS::UseDualStack",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+              "type": "boolean"
+            },
+            "UseFIPS": {
+              "builtIn": "AWS::UseFIPS",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+              "type": "boolean"
+            },
+            "Endpoint": {
+              "builtIn": "SDK::Endpoint",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request",
+              "type": "string"
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Endpoint"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseFIPS"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "ref": "UseDualStack"
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": {
+                      "ref": "Endpoint"
+                    },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "Region"
+                    }
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "aws.partition",
+                      "argv": [
+                        {
+                          "ref": "Region"
+                        }
+                      ],
+                      "assign": "PartitionResult"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        },
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://translate-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseFIPS"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsFIPS"
+                                  ]
+                                },
+                                true
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://translate-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "FIPS is enabled but this partition does not support FIPS",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [
+                        {
+                          "fn": "booleanEquals",
+                          "argv": [
+                            {
+                              "ref": "UseDualStack"
+                            },
+                            true
+                          ]
+                        }
+                      ],
+                      "rules": [
+                        {
+                          "conditions": [
+                            {
+                              "fn": "booleanEquals",
+                              "argv": [
+                                true,
+                                {
+                                  "fn": "getAttr",
+                                  "argv": [
+                                    {
+                                      "ref": "PartitionResult"
+                                    },
+                                    "supportsDualStack"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": "https://translate.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "DualStack is enabled but this partition does not support DualStack",
+                          "type": "error"
+                        }
+                      ],
+                      "type": "tree"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://translate.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        },
+        "smithy.rules#endpointTests": {
+          "testCases": [
+            {
+              "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ap-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ap-northeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ap-northeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-northeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ap-south-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-south-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ap-southeast-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ap-southeast-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ap-southeast-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.ca-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "ca-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.eu-central-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-central-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.eu-north-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.eu-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.eu-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.eu-west-3.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "eu-west-3",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-east-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-west-2.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-west-2",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.cn-north-1.api.amazonwebservices.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.cn-north-1.amazonaws.com.cn"
+                }
+              },
+              "params": {
+                "Region": "cn-north-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-gov-west-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-west-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-gov-east-1.api.aws"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true
+              }
+            },
+            {
+              "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-gov-east-1.amazonaws.com"
+                }
+              },
+              "params": {
+                "Region": "us-gov-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-iso-east-1.c2s.ic.gov"
+                }
+              },
+              "params": {
+                "Region": "us-iso-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate-fips.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://translate.us-isob-east-1.sc2s.sgov.gov"
+                }
+              },
+              "params": {
+                "Region": "us-isob-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+              "expect": {
+                "endpoint": {
+                  "url": "https://example.com"
+                }
+              },
+              "params": {
+                "UseFIPS": false,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+              "expect": {
+                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": true,
+                "UseDualStack": false,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+              "expect": {
+                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+              },
+              "params": {
+                "Region": "us-east-1",
+                "UseFIPS": false,
+                "UseDualStack": true,
+                "Endpoint": "https://example.com"
+              }
+            },
+            {
+              "documentation": "Missing region",
+              "expect": {
+                "error": "Invalid Configuration: Missing Region"
+              }
+            }
+          ],
+          "version": "1.0"
+        }
+      }
+    },
+    "com.amazonaws.translate#AppliedTerminology": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom terminology applied to the input text by Amazon Translate for the translated\n      text response.</p>"
+          }
+        },
+        "Terms": {
+          "target": "com.amazonaws.translate#TermList",
+          "traits": {
+            "smithy.api#documentation": "<p>The specific terms of the custom terminology applied to the input text by Amazon Translate for the\n      translated text response. A maximum of 250 terms will be returned, and the specific terms\n      applied will be the first 250 terms in the source text. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom terminology applied to the input text by Amazon Translate for the translated text\n      response. This is optional in the response and will only be present if you specified\n      terminology input in the request. Currently, only one terminology can be applied per\n      TranslateText request.</p>"
+      }
+    },
+    "com.amazonaws.translate#AppliedTerminologyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#AppliedTerminology"
+      }
+    },
+    "com.amazonaws.translate#BoundedLengthString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10000
+        },
+        "smithy.api#pattern": "^[\\P{M}\\p{M}]{1,10000}$"
+      }
+    },
+    "com.amazonaws.translate#Brevity": {
+      "type": "enum",
+      "members": {
+        "ON": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ON"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#ClientTokenString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "^[a-zA-Z0-9-]+$"
+      }
+    },
+    "com.amazonaws.translate#ConcurrentModificationException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Another modification is being made. That modification must complete before you can make\n      your change.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.translate#ConflictException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There was a conflict processing the request. Try your request again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409
+      }
+    },
+    "com.amazonaws.translate#ContentType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[-\\w.]+\\/[-\\w.+]+$"
+      }
+    },
+    "com.amazonaws.translate#CreateParallelData": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#CreateParallelDataRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#CreateParallelDataResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.translate#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.translate#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a parallel data resource in Amazon Translate by importing an input file from\n      Amazon S3. Parallel data files contain examples that show how you want segments of text to be\n      translated. By adding parallel data, you can influence the style, tone, and word choice in\n      your translation output.</p>"
+      }
+    },
+    "com.amazonaws.translate#CreateParallelDataRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>A custom name for the parallel data resource in Amazon Translate. You must assign a name\n      that is unique in the account and region.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.translate#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A custom description for the parallel data resource in Amazon Translate.</p>"
+          }
+        },
+        "ParallelDataConfig": {
+          "target": "com.amazonaws.translate#ParallelDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and S3 location of the parallel data input file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EncryptionKey": {
+          "target": "com.amazonaws.translate#EncryptionKey"
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.translate#ClientTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. This token is automatically generated when you use\n      Amazon Translate through an AWS SDK.</p>",
+            "smithy.api#idempotencyToken": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.translate#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to be associated with this resource. A tag is a key-value pair that\n      adds metadata to a resource. Each tag key for the resource must be unique.\n      For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/tagging.html\">\n        Tagging your resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#CreateParallelDataResponse": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name that you assigned to the parallel data resource.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.translate#ParallelDataStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the parallel data resource. When the resource is ready for you to use, the\n      status is <code>ACTIVE</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#DeleteParallelData": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#DeleteParallelDataRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#DeleteParallelDataResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes a parallel data resource in Amazon Translate.</p>"
+      }
+    },
+    "com.amazonaws.translate#DeleteParallelDataRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parallel data resource that is being deleted.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#DeleteParallelDataResponse": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parallel data resource that is being deleted.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.translate#ParallelDataStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the parallel data deletion.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#DeleteTerminology": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#DeleteTerminologyRequest"
+      },
+      "output": {
+        "target": "smithy.api#Unit"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>A synchronous action that deletes a custom terminology.</p>"
+      }
+    },
+    "com.amazonaws.translate#DeleteTerminologyRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom terminology being deleted. </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#DescribeTextTranslationJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#DescribeTextTranslationJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#DescribeTextTranslationJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets the properties associated with an asynchronous batch translation job including name,\n      ID, status, source and target languages, input/output S3 buckets, and so on.</p>"
+      }
+    },
+    "com.amazonaws.translate#DescribeTextTranslationJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.translate#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier that Amazon Translate generated for the job. The <a>StartTextTranslationJob</a> operation returns this identifier in its\n      response.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#DescribeTextTranslationJobResponse": {
+      "type": "structure",
+      "members": {
+        "TextTranslationJobProperties": {
+          "target": "com.amazonaws.translate#TextTranslationJobProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>An object that contains the properties associated with an asynchronous batch translation\n      job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#Description": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        },
+        "smithy.api#pattern": "^[\\P{M}\\p{M}]{0,256}$"
+      }
+    },
+    "com.amazonaws.translate#DetectedLanguageLowConfidenceException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        },
+        "DetectedLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the auto-detected language from Amazon Comprehend.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The confidence that Amazon Comprehend accurately detected the source language is low. If a\n      low confidence level is acceptable for your application, you can use the language in the\n      exception to call Amazon Translate again. For more information, see the <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectDominantLanguage.html\">DetectDominantLanguage</a> operation in the <i>Amazon Comprehend Developer\n        Guide</i>. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#Directionality": {
+      "type": "enum",
+      "members": {
+        "UNI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNI"
+          }
+        },
+        "MULTI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MULTI"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#DisplayLanguageCode": {
+      "type": "enum",
+      "members": {
+        "DE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "de"
+          }
+        },
+        "EN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "en"
+          }
+        },
+        "ES": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "es"
+          }
+        },
+        "FR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "fr"
+          }
+        },
+        "IT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "it"
+          }
+        },
+        "JA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ja"
+          }
+        },
+        "KO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ko"
+          }
+        },
+        "PT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pt"
+          }
+        },
+        "ZH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh"
+          }
+        },
+        "ZH_TW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zh-TW"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#Document": {
+      "type": "structure",
+      "members": {
+        "Content": {
+          "target": "com.amazonaws.translate#DocumentContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The <code>Content</code>field type is Binary large object (blob).\n      This object contains the document content converted into base64-encoded binary data.   \n      If you use one of the AWS SDKs, the SDK performs the\n      Base64-encoding on this field before sending the request.   \n    </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.translate#ContentType",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the format of the document. You can specify one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>text/html</code> - The input data consists of HTML content. \n        Amazon Translate translates only the text in the HTML element.</p>\n            </li>\n            <li>\n               <p>\n                  <code>text/plain</code> - The input data consists of unformatted text. \n        Amazon Translate translates every character in the content. </p>\n            </li>\n            <li>\n               <p>\n                  <code>application/vnd.openxmlformats-officedocument.wordprocessingml.document</code> - The \n          input data consists of a Word document (.docx).</p>\n            </li>\n         </ul>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The content and content type of a document.</p>"
+      }
+    },
+    "com.amazonaws.translate#DocumentContent": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 102400
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.translate#EncryptionKey": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.translate#EncryptionKeyType",
+          "traits": {
+            "smithy.api#documentation": "<p>The type of encryption key used by Amazon Translate to encrypt this object.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.translate#EncryptionKeyID",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the encryption key being used to encrypt this object.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The encryption key used to encrypt this object.</p>"
+      }
+    },
+    "com.amazonaws.translate#EncryptionKeyID": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 400
+        },
+        "smithy.api#pattern": "^(arn:aws((-us-gov)|(-iso)|(-iso-b)|(-cn))?:kms:)?([a-z]{2}-[a-z]+(-[a-z]+)?-\\d:)?(\\d{12}:)?(((key/)?[a-zA-Z0-9-_]+)|(alias/[a-zA-Z0-9:/_-]+))$"
+      }
+    },
+    "com.amazonaws.translate#EncryptionKeyType": {
+      "type": "enum",
+      "members": {
+        "KMS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "KMS"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#Formality": {
+      "type": "enum",
+      "members": {
+        "FORMAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FORMAL"
+          }
+        },
+        "INFORMAL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "INFORMAL"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#GetParallelData": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#GetParallelDataRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#GetParallelDataResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a parallel data resource.</p>"
+      }
+    },
+    "com.amazonaws.translate#GetParallelDataRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parallel data resource that is being retrieved.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#GetParallelDataResponse": {
+      "type": "structure",
+      "members": {
+        "ParallelDataProperties": {
+          "target": "com.amazonaws.translate#ParallelDataProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of the parallel data resource that is being retrieved.</p>"
+          }
+        },
+        "DataLocation": {
+          "target": "com.amazonaws.translate#ParallelDataDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the most recent parallel data input file that was successfully\n      imported into Amazon Translate. The location is returned as a presigned URL that has a\n      30-minute expiration.</p>\n    \n         <important>\n            <p>Amazon Translate doesn't scan all input files for the risk of CSV injection\n        attacks. </p>\n            <p>CSV injection occurs when a .csv or .tsv file is altered so that a record contains\n        malicious code. The record begins with a special character, such as =, +, -, or @. When the\n        file is opened in a spreadsheet program, the program might interpret the record as a formula\n        and run the code within it.</p>\n            <p>Before you download an input file from Amazon S3, ensure that you recognize the file and trust its creator.</p>\n         </important>"
+          }
+        },
+        "AuxiliaryDataLocation": {
+          "target": "com.amazonaws.translate#ParallelDataDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of a file that provides any errors or warnings that were produced\n      by your input file. This file was created when Amazon Translate attempted to create a parallel\n      data resource. The location is returned as a presigned URL to that has a 30-minute\n      expiration.</p>"
+          }
+        },
+        "LatestUpdateAttemptAuxiliaryDataLocation": {
+          "target": "com.amazonaws.translate#ParallelDataDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of a file that provides any errors or warnings that were produced\n      by your input file. This file was created when Amazon Translate attempted to update a parallel\n      data resource. The location is returned as a presigned URL to that has a 30-minute\n      expiration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#GetTerminology": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#GetTerminologyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#GetTerminologyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Retrieves a custom terminology.</p>"
+      }
+    },
+    "com.amazonaws.translate#GetTerminologyRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom terminology being retrieved.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TerminologyDataFormat": {
+          "target": "com.amazonaws.translate#TerminologyDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The data format of the custom terminology being retrieved.</p>\n         <p>If you don't specify this parameter, Amazon Translate returns a file with the same format\n      as the file that was imported to create the terminology. </p>\n         <p>If you specify this parameter when you retrieve a multi-directional terminology resource,\n      you must specify the same format as the input file that was imported to create it. Otherwise,\n      Amazon Translate throws an error.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#GetTerminologyResponse": {
+      "type": "structure",
+      "members": {
+        "TerminologyProperties": {
+          "target": "com.amazonaws.translate#TerminologyProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of the custom terminology being retrieved.</p>"
+          }
+        },
+        "TerminologyDataLocation": {
+          "target": "com.amazonaws.translate#TerminologyDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the most recent custom terminology input file that was\n      successfully imported into Amazon Translate. The location is returned as a presigned URL that\n      has a 30-minute expiration.</p>\n    \n         <important>\n            <p>Amazon Translate doesn't scan all input files for the risk of CSV injection\n        attacks. </p>\n            <p>CSV injection occurs when a .csv or .tsv file is altered so that a record contains\n        malicious code. The record begins with a special character, such as =, +, -, or @. When the\n        file is opened in a spreadsheet program, the program might interpret the record as a formula\n        and run the code within it.</p>\n            <p>Before you download an input file from Amazon S3, ensure that you recognize the file and trust its creator.</p>\n         </important>"
+          }
+        },
+        "AuxiliaryDataLocation": {
+          "target": "com.amazonaws.translate#TerminologyDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of a file that provides any errors or warnings that were produced\n      by your input file. This file was created when Amazon Translate attempted to create a\n      terminology resource. The location is returned as a presigned URL to that has a 30-minute\n      expiration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#IamRoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 20,
+          "max": 2048
+        },
+        "smithy.api#pattern": "^arn:aws(-[^:]+)?:iam::[0-9]{12}:role/.+$"
+      }
+    },
+    "com.amazonaws.translate#ImportTerminology": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#ImportTerminologyRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#ImportTerminologyResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates a custom terminology, depending on whether one already exists for the\n      given terminology name. Importing a terminology with the same name as an existing one will\n      merge the terminologies based on the chosen merge strategy. The only supported merge strategy\n      is OVERWRITE, where the imported terminology overwrites the existing terminology of the same\n      name.</p>\n         <p>If you import a terminology that overwrites an existing one, the new terminology takes up\n      to 10 minutes to fully propagate. After that, translations have access to the new\n      terminology.</p>"
+      }
+    },
+    "com.amazonaws.translate#ImportTerminologyRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom terminology being imported.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "MergeStrategy": {
+          "target": "com.amazonaws.translate#MergeStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The merge strategy of the custom terminology being imported. Currently, only the OVERWRITE\n      merge strategy is supported. In this case, the imported terminology will overwrite an existing\n      terminology of the same name.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.translate#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the custom terminology being imported.</p>"
+          }
+        },
+        "TerminologyData": {
+          "target": "com.amazonaws.translate#TerminologyData",
+          "traits": {
+            "smithy.api#documentation": "<p>The terminology data for the custom terminology being imported.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EncryptionKey": {
+          "target": "com.amazonaws.translate#EncryptionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The encryption key for the custom terminology being imported.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.translate#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to be associated with this resource. A tag is a key-value pair that\n      adds metadata to a resource. Each tag key for the resource must be unique.\n      For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/tagging.html\">\n        Tagging your resources</a>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#ImportTerminologyResponse": {
+      "type": "structure",
+      "members": {
+        "TerminologyProperties": {
+          "target": "com.amazonaws.translate#TerminologyProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of the custom terminology being imported.</p>"
+          }
+        },
+        "AuxiliaryDataLocation": {
+          "target": "com.amazonaws.translate#TerminologyDataLocation",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of a file that provides any errors or warnings that were produced\n      by your input file. This file was created when Amazon Translate attempted to create a\n      terminology resource. The location is returned as a presigned URL to that has a 30 minute\n      expiration.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#InputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.translate#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the AWS S3 folder that contains the input files. Amazon Translate translates all the\n      files in the folder and all its sub-folders. The folder must be in the same Region as the API endpoint you are\n      calling.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ContentType": {
+          "target": "com.amazonaws.translate#ContentType",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the format of the data that you submit to Amazon Translate as input. You can\n      specify one of the following multipurpose internet mail extension (MIME) types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>text/html</code>: The input data consists of one or more HTML files. Amazon\n          Translate translates only the text that resides in the <code>html</code> element in each\n          file.</p>\n            </li>\n            <li>\n               <p>\n                  <code>text/plain</code>: The input data consists of one or more unformatted text\n          files. Amazon Translate translates every character in this type of input.</p>\n            </li>\n            <li>\n               <p>\n                  <code>application/vnd.openxmlformats-officedocument.wordprocessingml.document</code>:\n          The input data consists of one or more Word documents (.docx).</p>\n            </li>\n            <li>\n               <p>\n                  <code>application/vnd.openxmlformats-officedocument.presentationml.presentation</code>:\n          The input data consists of one or more PowerPoint Presentation files (.pptx).</p>\n            </li>\n            <li>\n               <p>\n                  <code>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</code>: The\n          input data consists of one or more Excel Workbook files (.xlsx).</p>\n            </li>\n            <li>\n               <p>\n                  <code>application/x-xliff+xml</code>: The input data consists of one or more XML\n          Localization Interchange File Format (XLIFF) files (.xlf). Amazon Translate supports only\n          XLIFF version 1.2.</p>\n            </li>\n         </ul>\n         <important>\n            <p>If you structure your input data as HTML, ensure that you set this parameter to\n          <code>text/html</code>. By doing so, you cut costs by limiting the translation to the\n        contents of the <code>html</code> element in each file. Otherwise, if you set this parameter\n        to <code>text/plain</code>, your costs will cover the translation of every character.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The input configuration properties for requesting a batch translation job.</p>"
+      }
+    },
+    "com.amazonaws.translate#Integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.translate#InternalServerException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An internal server error occurred. Retry your request.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 500
+      }
+    },
+    "com.amazonaws.translate#InvalidFilterException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The filter specified for the operation is not valid. Specify a different filter.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#InvalidParameterValueException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The value of the parameter is not valid. Review the value of the parameter you are using\n      to correct it, and then retry your operation.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#InvalidRequestException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The request that you made is not valid. Check your request to determine why it's not\n      valid and then retry the request. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#JobDetails": {
+      "type": "structure",
+      "members": {
+        "TranslatedDocumentsCount": {
+          "target": "com.amazonaws.translate#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents successfully processed during a translation job.</p>"
+          }
+        },
+        "DocumentsWithErrorsCount": {
+          "target": "com.amazonaws.translate#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents that could not be processed during a translation job.</p>"
+          }
+        },
+        "InputDocumentsCount": {
+          "target": "com.amazonaws.translate#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents used as input in a translation job.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The number of documents successfully and unsuccessfully processed during a translation\n      job.</p>"
+      }
+    },
+    "com.amazonaws.translate#JobId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 32
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+      }
+    },
+    "com.amazonaws.translate#JobName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+      }
+    },
+    "com.amazonaws.translate#JobStatus": {
+      "type": "enum",
+      "members": {
+        "SUBMITTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SUBMITTED"
+          }
+        },
+        "IN_PROGRESS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IN_PROGRESS"
+          }
+        },
+        "COMPLETED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED"
+          }
+        },
+        "COMPLETED_WITH_ERROR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETED_WITH_ERROR"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        },
+        "STOP_REQUESTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOP_REQUESTED"
+          }
+        },
+        "STOPPED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "STOPPED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#Language": {
+      "type": "structure",
+      "members": {
+        "LanguageName": {
+          "target": "com.amazonaws.translate#LocalizedNameString",
+          "traits": {
+            "smithy.api#documentation": "<p>Language name of the supported language.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>Language code for the supported language.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A supported language.</p>"
+      }
+    },
+    "com.amazonaws.translate#LanguageCodeString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 2,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.translate#LanguageCodeStringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#LanguageCodeString"
+      }
+    },
+    "com.amazonaws.translate#LanguagesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#Language"
+      }
+    },
+    "com.amazonaws.translate#LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified limit has been exceeded. Review your request and retry it with a quantity\n      below the stated limit.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#ListLanguages": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#ListLanguagesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#ListLanguagesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.translate#UnsupportedDisplayLanguageCodeException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of languages (RFC-5646 codes and names) that Amazon Translate supports.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.translate#ListLanguagesRequest": {
+      "type": "structure",
+      "members": {
+        "DisplayLanguageCode": {
+          "target": "com.amazonaws.translate#DisplayLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language to use to display the language names in the response.\n      The language code is <code>en</code> by default. </p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Include the NextToken value to fetch the next group of supported languages. </p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.translate#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each response.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#ListLanguagesResponse": {
+      "type": "structure",
+      "members": {
+        "Languages": {
+          "target": "com.amazonaws.translate#LanguagesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of supported languages.</p>"
+          }
+        },
+        "DisplayLanguageCode": {
+          "target": "com.amazonaws.translate#DisplayLanguageCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code passed in with the request.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p> If the response does not include all remaining results, use the NextToken\n      in the next request to fetch the next group of supported languages.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#ListParallelData": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#ListParallelDataRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#ListParallelDataResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of your parallel data resources in Amazon Translate.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.translate#ListParallelDataRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A string that specifies the next page of results to return in a paginated response.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.translate#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of parallel data resources returned for each request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#ListParallelDataResponse": {
+      "type": "structure",
+      "members": {
+        "ParallelDataPropertiesList": {
+          "target": "com.amazonaws.translate#ParallelDataPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties of the parallel data resources returned by this request.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The string to use in a subsequent request to get the next page of results in a paginated\n      response. This value is null if there are no additional pages.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all tags associated with a given Amazon Translate resource.\n      For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/tagging.html\">\n        Tagging your resources</a>.</p>"
+      }
+    },
+    "com.amazonaws.translate#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.translate#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the given Amazon Translate resource you are querying.\n    </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.translate#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags associated with the Amazon Translate resource being queried. A tag is a key-value\n      pair that adds as a metadata to a resource used by Amazon Translate. For example, a tag with\n      \"Sales\" as the key might be added to a resource to indicate its use by the sales department.\n    </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#ListTerminologies": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#ListTerminologiesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#ListTerminologiesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Provides a list of custom terminologies associated with your account.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.translate#ListTerminologiesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>If the result of the request to ListTerminologies was truncated, include the NextToken to\n      fetch the next group of custom terminologies. </p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.translate#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of custom terminologies returned per list request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#ListTerminologiesResponse": {
+      "type": "structure",
+      "members": {
+        "TerminologyPropertiesList": {
+          "target": "com.amazonaws.translate#TerminologyPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>The properties list of the custom terminologies returned on the list request.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p> If the response to the ListTerminologies was truncated, the NextToken fetches the next\n      group of custom terminologies.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#ListTextTranslationJobs": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#ListTextTranslationJobsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#ListTextTranslationJobsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidFilterException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Gets a list of the batch translation jobs that you have submitted.</p>",
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "pageSize": "MaxResults"
+        }
+      }
+    },
+    "com.amazonaws.translate#ListTextTranslationJobsRequest": {
+      "type": "structure",
+      "members": {
+        "Filter": {
+          "target": "com.amazonaws.translate#TextTranslationJobFilter",
+          "traits": {
+            "smithy.api#documentation": "<p>The parameters that specify which batch translation jobs to retrieve. Filters include job\n      name, job status, and submission time. You can only set one filter at a time.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token to request the next page of results.</p>"
+          }
+        },
+        "MaxResults": {
+          "target": "com.amazonaws.translate#MaxResultsInteger",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return in each page. The default value is 100.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#ListTextTranslationJobsResponse": {
+      "type": "structure",
+      "members": {
+        "TextTranslationJobPropertiesList": {
+          "target": "com.amazonaws.translate#TextTranslationJobPropertiesList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the properties of each job that is returned.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.translate#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token to use to retrieve the next page of results. This value is <code>null</code>\n      when there are no more results to return.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#LocalizedNameString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.translate#Long": {
+      "type": "long"
+    },
+    "com.amazonaws.translate#MaxResultsInteger": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#range": {
+          "min": 1,
+          "max": 500
+        }
+      }
+    },
+    "com.amazonaws.translate#MergeStrategy": {
+      "type": "enum",
+      "members": {
+        "OVERWRITE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OVERWRITE"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#NextToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 8192
+        },
+        "smithy.api#pattern": "^\\p{ASCII}{0,8192}$"
+      }
+    },
+    "com.amazonaws.translate#OutputDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.translate#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the S3 folder that contains a translation job's output file. The folder must\n      be in the same Region as the API endpoint that you are calling.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EncryptionKey": {
+          "target": "com.amazonaws.translate#EncryptionKey"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The output configuration properties for a batch translation job.</p>"
+      }
+    },
+    "com.amazonaws.translate#ParallelDataArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.translate#ParallelDataConfig": {
+      "type": "structure",
+      "members": {
+        "S3Uri": {
+          "target": "com.amazonaws.translate#S3Uri",
+          "traits": {
+            "smithy.api#documentation": "<p>The URI of the Amazon S3 folder that contains the parallel data input file. The folder\n      must be in the same Region as the API endpoint you are calling.</p>"
+          }
+        },
+        "Format": {
+          "target": "com.amazonaws.translate#ParallelDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of the parallel data input file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Specifies the format and S3 location of the parallel data input file.</p>"
+      }
+    },
+    "com.amazonaws.translate#ParallelDataDataLocation": {
+      "type": "structure",
+      "members": {
+        "RepositoryType": {
+          "target": "com.amazonaws.translate#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Describes the repository that contains the parallel data input file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Location": {
+          "target": "com.amazonaws.translate#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the parallel data input file. The location is returned as a\n      presigned URL to that has a 30-minute expiration.</p>\n    \n         <important>\n            <p>Amazon Translate doesn't scan all input files for the risk of CSV injection\n        attacks. </p>\n            <p>CSV injection occurs when a .csv or .tsv file is altered so that a record contains\n        malicious code. The record begins with a special character, such as =, +, -, or @. When the\n        file is opened in a spreadsheet program, the program might interpret the record as a formula\n        and run the code within it.</p>\n            <p>Before you download an input file from Amazon S3, ensure that you recognize the file and trust its creator.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The location of the most recent parallel data input file that was successfully imported\n      into Amazon Translate.</p>"
+      }
+    },
+    "com.amazonaws.translate#ParallelDataFormat": {
+      "type": "enum",
+      "members": {
+        "TSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TSV"
+          }
+        },
+        "CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CSV"
+          }
+        },
+        "TMX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TMX"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#ParallelDataProperties": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom name assigned to the parallel data resource.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.translate#ParallelDataArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the parallel data resource.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.translate#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>The description assigned to the parallel data resource.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.translate#ParallelDataStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the parallel data resource. When the parallel data is ready for you to use,\n      the status is <code>ACTIVE</code>.</p>"
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The source language of the translations in the parallel data file.</p>"
+          }
+        },
+        "TargetLanguageCodes": {
+          "target": "com.amazonaws.translate#LanguageCodeStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The language codes for the target languages available in the parallel data file. All\n      possible target languages are returned as an array.</p>"
+          }
+        },
+        "ParallelDataConfig": {
+          "target": "com.amazonaws.translate#ParallelDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and S3 location of the parallel data input file.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.translate#UnboundedLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information from Amazon Translate about the parallel data resource. </p>"
+          }
+        },
+        "ImportedDataSize": {
+          "target": "com.amazonaws.translate#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of UTF-8 characters that Amazon Translate imported from the parallel data input\n      file. This number includes only the characters in your translation examples. It does not\n      include characters that are used to format your file. For example, if you provided a\n      Translation Memory Exchange (.tmx) file, this number does not include the tags.</p>"
+          }
+        },
+        "ImportedRecordCount": {
+          "target": "com.amazonaws.translate#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of records successfully imported from the parallel data input file.</p>"
+          }
+        },
+        "FailedRecordCount": {
+          "target": "com.amazonaws.translate#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of records unsuccessfully imported from the parallel data input file.</p>"
+          }
+        },
+        "SkippedRecordCount": {
+          "target": "com.amazonaws.translate#Long",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of items in the input file that Amazon Translate skipped when you created or\n      updated the parallel data resource. For example, Amazon Translate skips empty records, empty\n      target texts, and empty lines.</p>"
+          }
+        },
+        "EncryptionKey": {
+          "target": "com.amazonaws.translate#EncryptionKey"
+        },
+        "CreatedAt": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the parallel data resource was created.</p>"
+          }
+        },
+        "LastUpdatedAt": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the parallel data resource was last updated.</p>"
+          }
+        },
+        "LatestUpdateAttemptStatus": {
+          "target": "com.amazonaws.translate#ParallelDataStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the most recent update attempt for the parallel data resource.</p>"
+          }
+        },
+        "LatestUpdateAttemptAt": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the most recent update was attempted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties of a parallel data resource.</p>"
+      }
+    },
+    "com.amazonaws.translate#ParallelDataPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#ParallelDataProperties"
+      }
+    },
+    "com.amazonaws.translate#ParallelDataStatus": {
+      "type": "enum",
+      "members": {
+        "CREATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CREATING"
+          }
+        },
+        "UPDATING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UPDATING"
+          }
+        },
+        "ACTIVE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ACTIVE"
+          }
+        },
+        "DELETING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETING"
+          }
+        },
+        "FAILED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "FAILED"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#Profanity": {
+      "type": "enum",
+      "members": {
+        "MASK": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MASK"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#ResourceArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.translate#ResourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "^([A-Za-z0-9-]_?)+$"
+      }
+    },
+    "com.amazonaws.translate#ResourceNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#ResourceName"
+      }
+    },
+    "com.amazonaws.translate#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resource you are looking for has not been found. Review the resource you're looking\n      for and see if a different resource will accomplish your needs before retrying the revised\n      request.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404
+      }
+    },
+    "com.amazonaws.translate#S3Uri": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 1024
+        },
+        "smithy.api#pattern": "^s3://[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9](/.*)?$"
+      }
+    },
+    "com.amazonaws.translate#ServiceUnavailableException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The Amazon Translate service is temporarily unavailable. Wait a bit and then retry your\n      request.</p>",
+        "smithy.api#error": "server",
+        "smithy.api#httpError": 503
+      }
+    },
+    "com.amazonaws.translate#StartTextTranslationJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#StartTextTranslationJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#StartTextTranslationJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.translate#UnsupportedLanguagePairException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Starts an asynchronous batch translation job. Use batch translation jobs to\n      translate large volumes of text across multiple documents at once.\n      For batch translation, you can input documents with different source languages (specify <code>auto</code>\n      as the source language). You can specify one\n      or more target languages. Batch translation translates each input document into each of the target languages.\n      For more information, see\n      <a href=\"https://docs.aws.amazon.com/translate/latest/dg/async.html\">Asynchronous batch processing</a>.</p>\n\n         <p>Batch translation jobs can be described with the <a>DescribeTextTranslationJob</a> operation, listed with the <a>ListTextTranslationJobs</a> operation, and stopped with the <a>StopTextTranslationJob</a> operation.</p>"
+      }
+    },
+    "com.amazonaws.translate#StartTextTranslationJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.translate#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the batch translation job to be performed.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.translate#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and location of the input documents for the translation job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.translate#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the S3 folder to which your job output will be saved.\n      </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.translate#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an AWS Identity Access and Management (IAM) role\n      that grants Amazon Translate read access to your input data. For more information, see\n      <a href=\"https://docs.aws.amazon.com/translate/latest/dg/identity-and-access-management.html\">Identity and access management </a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the input language. Specify the language if all input documents share the same language.\n      If you don't know the language of the source files, or your input documents contains different source\n      languages, select <code>auto</code>. Amazon Translate auto detects the source language for each input document.\n      For a list of supported language codes, see\n      <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetLanguageCodes": {
+          "target": "com.amazonaws.translate#TargetLanguageCodeStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The target languages of the translation job. Enter up to 10 language codes.\n      Each input file is translated into each target language.</p>\n         <p>Each language code is 2 or 5 characters long. For a list of language codes, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TerminologyNames": {
+          "target": "com.amazonaws.translate#ResourceNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a custom terminology resource to add to the translation job. This resource\n      lists examples source terms and the desired translation for each term.</p>\n         <p>This parameter accepts only one custom terminology resource.</p>\n         <p>If you specify multiple target languages for the\n      job, translate uses the designated terminology for each\n      requested target language that has an entry for the source term\n      in the terminology file.</p>\n         <p>For a list of available custom terminology resources, use the <a>ListTerminologies</a> operation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/how-custom-terminology.html\">Custom terminology</a>.</p>"
+          }
+        },
+        "ParallelDataNames": {
+          "target": "com.amazonaws.translate#ResourceNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a parallel data resource to add to the translation job. This resource consists\n      of examples that show how you want segments of text to be translated.\n      If you specify multiple target languages for\n      the job, the parallel data file must include translations for\n      all the target languages.</p>\n         <p>When you add parallel\n      data to a translation job, you create an <i>Active Custom Translation</i> job. </p>\n         <p>This parameter accepts only one parallel data resource.</p>\n         <note>\n            <p>Active Custom Translation jobs are priced at a higher rate than other jobs that don't\n        use parallel data. For more information, see <a href=\"http://aws.amazon.com/translate/pricing/\">Amazon Translate pricing</a>.</p>\n         </note>\n         <p>For a list of available parallel data resources, use the <a>ListParallelData</a> operation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-parallel-data.html\">\n    Customizing your translations with parallel data</a>.</p>"
+          }
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.translate#ClientTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. This token is generated for you when using the Amazon Translate\n      SDK.</p>",
+            "smithy.api#idempotencyToken": {},
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.translate#TranslationSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings to configure your translation output. You can configure the following options:</p>\n         <ul>\n            <li>\n               <p>Brevity: not supported.</p>\n            </li>\n            <li>\n               <p>Formality: sets the formality level of the output text.</p>\n            </li>\n            <li>\n               <p>Profanity: masks profane words and phrases in your translation output.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#StartTextTranslationJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.translate#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The identifier generated for the job. To get the status of a job, use this ID with the\n        <a>DescribeTextTranslationJob</a> operation.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.translate#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the job. Possible values include:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SUBMITTED</code> - The job has been received and is queued for\n          processing.</p>\n            </li>\n            <li>\n               <p>\n                  <code>IN_PROGRESS</code> - Amazon Translate is processing the job.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLETED</code> - The job was successfully completed and the output is\n          available.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COMPLETED_WITH_ERROR</code> - The job was completed with errors. The errors can\n          be analyzed in the job's output.</p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> - The job did not complete. To get details, use the <a>DescribeTextTranslationJob</a> operation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOP_REQUESTED</code> - The user who started the job has requested that it be\n          stopped.</p>\n            </li>\n            <li>\n               <p>\n                  <code>STOPPED</code> - The job has been stopped.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#StopTextTranslationJob": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#StopTextTranslationJobRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#StopTextTranslationJobResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Stops an asynchronous batch translation job that is in progress.</p>\n         <p>If the job's state is <code>IN_PROGRESS</code>, the job will be marked for termination and\n      put into the <code>STOP_REQUESTED</code> state. If the job completes before it can be stopped,\n      it is put into the <code>COMPLETED</code> state. Otherwise, the job is put into the\n        <code>STOPPED</code> state.</p>\n         <p>Asynchronous batch translation jobs are started with the <a>StartTextTranslationJob</a> operation. You can use the <a>DescribeTextTranslationJob</a> or <a>ListTextTranslationJobs</a>\n      operations to get a batch translation job's <code>JobId</code>.</p>"
+      }
+    },
+    "com.amazonaws.translate#StopTextTranslationJobRequest": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.translate#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The job ID of the job to be stopped.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#StopTextTranslationJobResponse": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.translate#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The job ID of the stopped batch translation job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.translate#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the designated job. Upon successful completion, the job's status will be\n        <code>STOPPED</code>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#String": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10000
+        },
+        "smithy.api#pattern": "^[\\P{M}\\p{M}]{0,10000}$"
+      }
+    },
+    "com.amazonaws.translate#Tag": {
+      "type": "structure",
+      "members": {
+        "Key": {
+          "target": "com.amazonaws.translate#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The initial part of a key-value pair that forms a tag associated with a given resource.\n    </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.translate#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p> The second part of a key-value pair that forms a tag associated with a given resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair that adds as a metadata to a resource used by Amazon Translate. </p>"
+      }
+    },
+    "com.amazonaws.translate#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.translate#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#TagKey"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.translate#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#Tag"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 200
+        }
+      }
+    },
+    "com.amazonaws.translate#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyTagsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Associates a specific tag with a resource. A tag is a key-value pair\n      that adds as a metadata to a resource.\n      For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/tagging.html\">\n        Tagging your resources</a>.</p>"
+      }
+    },
+    "com.amazonaws.translate#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.translate#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the given Amazon Translate resource to which you want\n      to associate the tags. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.translate#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags being associated with a specific Amazon Translate resource. There can be a maximum\n      of 50 tags (both existing and pending) associated with a specific resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#TagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.translate#TargetLanguageCodeStringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#LanguageCodeString"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.translate#Term": {
+      "type": "structure",
+      "members": {
+        "SourceText": {
+          "target": "com.amazonaws.translate#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The source text of the term being translated by the custom terminology.</p>"
+          }
+        },
+        "TargetText": {
+          "target": "com.amazonaws.translate#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The target text of the term being translated by the custom terminology.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The term being translated by the custom terminology.</p>"
+      }
+    },
+    "com.amazonaws.translate#TermList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#Term"
+      }
+    },
+    "com.amazonaws.translate#TerminologyArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.translate#TerminologyData": {
+      "type": "structure",
+      "members": {
+        "File": {
+          "target": "com.amazonaws.translate#TerminologyFile",
+          "traits": {
+            "smithy.api#documentation": "<p>The file containing the custom terminology data. Your version of the AWS SDK performs a\n      Base64-encoding on this field before sending a request to the AWS service. Users of the SDK\n      should not perform Base64-encoding themselves.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Format": {
+          "target": "com.amazonaws.translate#TerminologyDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The data format of the custom terminology.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Directionality": {
+          "target": "com.amazonaws.translate#Directionality",
+          "traits": {
+            "smithy.api#documentation": "<p>The directionality of your terminology resource indicates whether it has one source\n      language (uni-directional) or multiple (multi-directional).</p>\n         <dl>\n            <dt>UNI</dt>\n            <dd>\n               <p>The terminology resource has one source language (for example, the first column in a\n            CSV file), and all of its other languages are target languages. </p>\n            </dd>\n            <dt>MULTI</dt>\n            <dd>\n               <p>Any language in the terminology resource can be the source language or a target\n            language. A single multi-directional terminology resource can be used for jobs that\n            translate different language pairs. For example, if the terminology contains English and\n            Spanish terms, it can be used for jobs that translate English to Spanish and Spanish to\n            English.</p>\n            </dd>\n         </dl>\n         <p>When you create a custom terminology resource without specifying the directionality, it\n      behaves as uni-directional terminology, although this parameter will have a null value.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The data associated with the custom terminology. For information about the custom terminology file, see\n      <a href=\"https://docs.aws.amazon.com/translate/latest/dg/creating-custom-terminology.html\">\n      Creating a Custom Terminology</a>.</p>"
+      }
+    },
+    "com.amazonaws.translate#TerminologyDataFormat": {
+      "type": "enum",
+      "members": {
+        "CSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CSV"
+          }
+        },
+        "TMX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TMX"
+          }
+        },
+        "TSV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TSV"
+          }
+        }
+      }
+    },
+    "com.amazonaws.translate#TerminologyDataLocation": {
+      "type": "structure",
+      "members": {
+        "RepositoryType": {
+          "target": "com.amazonaws.translate#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The repository type for the custom terminology data.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Location": {
+          "target": "com.amazonaws.translate#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon S3 location of the most recent custom terminology input file that was\n      successfully imported into Amazon Translate. The location is returned as a presigned URL that\n      has a 30-minute expiration .</p>\n    \n         <important>\n            <p>Amazon Translate doesn't scan all input files for the risk of CSV injection\n        attacks. </p>\n            <p>CSV injection occurs when a .csv or .tsv file is altered so that a record contains\n        malicious code. The record begins with a special character, such as =, +, -, or @. When the\n        file is opened in a spreadsheet program, the program might interpret the record as a formula\n        and run the code within it.</p>\n            <p>Before you download an input file from Amazon S3, ensure that you recognize the file and trust its creator.</p>\n         </important>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The location of the custom terminology data.</p>"
+      }
+    },
+    "com.amazonaws.translate#TerminologyFile": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10485760
+        },
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.translate#TerminologyProperties": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the custom terminology.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.translate#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the custom terminology properties.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.translate#TerminologyArn",
+          "traits": {
+            "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the custom terminology. </p>"
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the source text of the translation request for which the custom\n      terminology is being used.</p>"
+          }
+        },
+        "TargetLanguageCodes": {
+          "target": "com.amazonaws.translate#LanguageCodeStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The language codes for the target languages available with the custom terminology\n      resource. All possible target languages are returned in array.</p>"
+          }
+        },
+        "EncryptionKey": {
+          "target": "com.amazonaws.translate#EncryptionKey",
+          "traits": {
+            "smithy.api#documentation": "<p>The encryption key for the custom terminology.</p>"
+          }
+        },
+        "SizeBytes": {
+          "target": "com.amazonaws.translate#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size of the file used when importing a custom terminology.</p>"
+          }
+        },
+        "TermCount": {
+          "target": "com.amazonaws.translate#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of terms included in the custom terminology.</p>"
+          }
+        },
+        "CreatedAt": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the custom terminology was created, based on the timestamp.</p>"
+          }
+        },
+        "LastUpdatedAt": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the custom terminology was last update, based on the timestamp.</p>"
+          }
+        },
+        "Directionality": {
+          "target": "com.amazonaws.translate#Directionality",
+          "traits": {
+            "smithy.api#documentation": "<p>The directionality of your terminology resource indicates whether it has one source\n      language (uni-directional) or multiple (multi-directional). </p>\n         <dl>\n            <dt>UNI</dt>\n            <dd>\n               <p>The terminology resource has one source language (the first column in a CSV file),\n            and all of its other languages are target languages.</p>\n            </dd>\n            <dt>MULTI</dt>\n            <dd>\n               <p>Any language in the terminology resource can be the source language.</p>\n            </dd>\n         </dl>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.translate#UnboundedLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>Additional information from Amazon Translate about the terminology resource.</p>"
+          }
+        },
+        "SkippedTermCount": {
+          "target": "com.amazonaws.translate#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of terms in the input file that Amazon Translate skipped when you created or\n      updated the terminology resource.</p>"
+          }
+        },
+        "Format": {
+          "target": "com.amazonaws.translate#TerminologyDataFormat",
+          "traits": {
+            "smithy.api#documentation": "<p>The format of the custom terminology input file.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The properties of the custom terminology.</p>"
+      }
+    },
+    "com.amazonaws.translate#TerminologyPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#TerminologyProperties"
+      }
+    },
+    "com.amazonaws.translate#TextSizeLimitExceededException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> The size of the text you submitted exceeds the size limit. Reduce the size of the text or\n      use a smaller document and then retry your request. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#TextTranslationJobFilter": {
+      "type": "structure",
+      "members": {
+        "JobName": {
+          "target": "com.amazonaws.translate#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs by name.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.translate#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based by job status.</p>"
+          }
+        },
+        "SubmittedBeforeTime": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing and\n      returns only the jobs submitted before the specified time. Jobs are returned in ascending\n      order, oldest to newest.</p>"
+          }
+        },
+        "SubmittedAfterTime": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>Filters the list of jobs based on the time that the job was submitted for processing and\n      returns only the jobs submitted after the specified time. Jobs are returned in descending\n      order, newest to oldest.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information for filtering a list of translation jobs. For more information, see\n        <a>ListTextTranslationJobs</a>.</p>"
+      }
+    },
+    "com.amazonaws.translate#TextTranslationJobProperties": {
+      "type": "structure",
+      "members": {
+        "JobId": {
+          "target": "com.amazonaws.translate#JobId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the translation job.</p>"
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.translate#JobName",
+          "traits": {
+            "smithy.api#documentation": "<p>The user-defined name of the translation job.</p>"
+          }
+        },
+        "JobStatus": {
+          "target": "com.amazonaws.translate#JobStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the translation job.</p>"
+          }
+        },
+        "JobDetails": {
+          "target": "com.amazonaws.translate#JobDetails",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of documents successfully and unsuccessfully processed during the translation\n      job.</p>"
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the language of the source text. The language must be a language\n      supported by Amazon Translate.</p>"
+          }
+        },
+        "TargetLanguageCodes": {
+          "target": "com.amazonaws.translate#TargetLanguageCodeStringList",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the language of the target text. The language must be a language\n      supported by Amazon Translate.</p>"
+          }
+        },
+        "TerminologyNames": {
+          "target": "com.amazonaws.translate#ResourceNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the names of the terminologies applied to a translation job. Only one\n      terminology can be applied per <a>StartTextTranslationJob</a> request at this\n      time.</p>"
+          }
+        },
+        "ParallelDataNames": {
+          "target": "com.amazonaws.translate#ResourceNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>A list containing the names of the parallel data resources applied to the translation\n      job.</p>"
+          }
+        },
+        "Message": {
+          "target": "com.amazonaws.translate#UnboundedLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>An explanation of any errors that may have occurred during the translation job.</p>"
+          }
+        },
+        "SubmittedTime": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the translation job was submitted.</p>"
+          }
+        },
+        "EndTime": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time at which the translation job ended.</p>"
+          }
+        },
+        "InputDataConfig": {
+          "target": "com.amazonaws.translate#InputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The input configuration properties that were specified when the job was requested.</p>"
+          }
+        },
+        "OutputDataConfig": {
+          "target": "com.amazonaws.translate#OutputDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>The output configuration properties that were specified when the job was requested.</p>"
+          }
+        },
+        "DataAccessRoleArn": {
+          "target": "com.amazonaws.translate#IamRoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of an AWS Identity Access and Management (IAM) role\n      that granted Amazon Translate read access to the job's input data.</p>"
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.translate#TranslationSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings that modify the translation output.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Provides information about a translation job.</p>"
+      }
+    },
+    "com.amazonaws.translate#TextTranslationJobPropertiesList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.translate#TextTranslationJobProperties"
+      }
+    },
+    "com.amazonaws.translate#Timestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.translate#TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p> You have made too many requests within a short period of time. Wait for a short time and\n      then try your request again.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 429
+      }
+    },
+    "com.amazonaws.translate#TooManyTagsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.translate#String"
+        },
+        "ResourceArn": {
+          "target": "com.amazonaws.translate#ResourceArn"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You have added too many tags to this resource. The maximum is 50 tags.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#TranslateDocument": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#TranslateDocumentRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#TranslateDocumentResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.translate#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.translate#UnsupportedLanguagePairException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Translates the input document from the source language to the target language.    \n      This synchronous operation supports text, HTML, or Word documents as the input document.\n      \n      <code>TranslateDocument</code> supports translations from English to any supported language, \n      and from any supported language to English. Therefore, specify either the source language code\n      or the target language code as \u201cen\u201d (English). \n    </p>\n         <p> If you set the <code>Formality</code> parameter, the request will fail if the target language does \n       not support formality. For a list of target languages that support formality, see\n       <a href=\"https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-formality.html\">Setting formality</a>.\n    </p>"
+      }
+    },
+    "com.amazonaws.translate#TranslateDocumentRequest": {
+      "type": "structure",
+      "members": {
+        "Document": {
+          "target": "com.amazonaws.translate#Document",
+          "traits": {
+            "smithy.api#documentation": "<p>The content and content type for the document to be translated. The document size must not exceed 100 KB.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TerminologyNames": {
+          "target": "com.amazonaws.translate#ResourceNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a terminology list file to add to the translation job. This file\n      provides source terms and the desired translation for each term. \n      A terminology list can contain a maximum of 256 terms.\n      You can use one custom terminology resource in your translation request.</p>\n         <p>Use the <a>ListTerminologies</a> operation\n       to get the available terminology lists.</p>\n         <p>For more information about custom terminology lists, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/how-custom-terminology.html\">Custom terminology</a>.</p>"
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the source text. For a list of supported language codes, see\n      <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>\n         <p>To have Amazon Translate determine the source language of your text, you can specify\n      <code>auto</code> in the <code>SourceLanguageCode</code> field. If you specify\n      <code>auto</code>, Amazon Translate will call <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/comprehend-general.html\">Amazon\n        Comprehend</a> to determine the source language.</p>\n         <note>\n            <p>If you specify <code>auto</code>, you must send the <code>TranslateDocument</code> request in a region that supports\n      Amazon Comprehend. Otherwise, the request returns an error indicating that autodetect is not supported. </p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code requested for the translated document.  \n      For a list of supported language codes, see\n      <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.translate#TranslationSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings to configure your translation output. You can configure the following options:</p>\n         <ul>\n            <li>\n               <p>Brevity: not supported.</p>\n            </li>\n            <li>\n               <p>Formality: sets the formality level of the output text.</p>\n            </li>\n            <li>\n               <p>Profanity: masks profane words and phrases in your translation output.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#TranslateDocumentResponse": {
+      "type": "structure",
+      "members": {
+        "TranslatedDocument": {
+          "target": "com.amazonaws.translate#TranslatedDocument",
+          "traits": {
+            "smithy.api#documentation": "<p>The document containing the translated content. The document format matches the source document format.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the source document.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code of the translated document. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AppliedTerminologies": {
+          "target": "com.amazonaws.translate#AppliedTerminologyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of the custom terminologies applied to the input text by Amazon Translate to produce the\n      translated text document.</p>"
+          }
+        },
+        "AppliedSettings": {
+          "target": "com.amazonaws.translate#TranslationSettings"
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#TranslateText": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#TranslateTextRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#TranslateTextResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#DetectedLanguageLowConfidenceException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#ServiceUnavailableException"
+        },
+        {
+          "target": "com.amazonaws.translate#TextSizeLimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        },
+        {
+          "target": "com.amazonaws.translate#UnsupportedLanguagePairException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Translates input text from the source language to the target language. For a list of\n      available languages and language codes, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>"
+      }
+    },
+    "com.amazonaws.translate#TranslateTextRequest": {
+      "type": "structure",
+      "members": {
+        "Text": {
+          "target": "com.amazonaws.translate#BoundedLengthString",
+          "traits": {
+            "smithy.api#documentation": "<p>The text to translate. The text string can be a maximum of 10,000 bytes long. Depending on\n      your character set, this may be fewer than 10,000 characters.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TerminologyNames": {
+          "target": "com.amazonaws.translate#ResourceNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of a terminology list file to add to the translation job. This file\n      provides source terms and the desired translation for each term. \n      A terminology list can contain a maximum of 256 terms.\n      You can use one custom terminology resource in your translation request.</p>\n         <p>Use the <a>ListTerminologies</a> operation\n      to get the available terminology lists.</p>\n         <p>For more information about custom terminology lists, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/how-custom-terminology.html\">Custom terminology</a>.</p>"
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the source text. For a list of language codes, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>\n         <p>To have Amazon Translate determine the source language of your text, you can specify\n        <code>auto</code> in the <code>SourceLanguageCode</code> field. If you specify\n        <code>auto</code>, Amazon Translate will call <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/comprehend-general.html\">Amazon\n        Comprehend</a> to determine the source language.</p>\n         <note>\n            <p>If you specify <code>auto</code>, you must send the <code>TranslateText</code> request in a region that supports\n          Amazon Comprehend. Otherwise, the request returns an error indicating that autodetect is not supported. </p>\n         </note>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code requested for the language of the target text.\n      For a list of language codes, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Settings": {
+          "target": "com.amazonaws.translate#TranslationSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings to configure your translation output. You can configure the following options:</p>\n         <ul>\n            <li>\n               <p>Brevity: reduces the length of the translated output for most translations.</p>\n            </li>\n            <li>\n               <p>Formality: sets the formality level of the output text.</p>\n            </li>\n            <li>\n               <p>Profanity: masks profane words and phrases in your translation output.</p>\n            </li>\n         </ul>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#TranslateTextResponse": {
+      "type": "structure",
+      "members": {
+        "TranslatedText": {
+          "target": "com.amazonaws.translate#TranslatedTextString",
+          "traits": {
+            "smithy.api#documentation": "<p>The translated text.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the source text.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TargetLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the target text. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "AppliedTerminologies": {
+          "target": "com.amazonaws.translate#AppliedTerminologyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of the custom terminologies applied to the input text by Amazon Translate for the\n      translated text response.</p>"
+          }
+        },
+        "AppliedSettings": {
+          "target": "com.amazonaws.translate#TranslationSettings",
+          "traits": {
+            "smithy.api#documentation": "<p>Optional settings that modify the translation output.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#TranslatedDocument": {
+      "type": "structure",
+      "members": {
+        "Content": {
+          "target": "com.amazonaws.translate#TranslatedDocumentContent",
+          "traits": {
+            "smithy.api#documentation": "<p>The document containing the translated content.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The translated content.</p>"
+      }
+    },
+    "com.amazonaws.translate#TranslatedDocumentContent": {
+      "type": "blob",
+      "traits": {
+        "smithy.api#sensitive": {}
+      }
+    },
+    "com.amazonaws.translate#TranslatedTextString": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 20000
+        },
+        "smithy.api#pattern": "^[\\P{M}\\p{M}]{0,20000}$"
+      }
+    },
+    "com.amazonaws.translate#TranslationSettings": {
+      "type": "structure",
+      "members": {
+        "Formality": {
+          "target": "com.amazonaws.translate#Formality",
+          "traits": {
+            "smithy.api#documentation": "<p>You can specify the desired level of formality for translations\n        to supported target languages. The formality\n      setting controls the level of formal language usage (also known as <a href=\"https://en.wikipedia.org/wiki/Register_(sociolinguistics)\">register</a>) in the\n      translation output.  You can set the value to informal or formal. If you don't specify a value for\n      formality, or if the target language doesn't support formality, the translation will\n      ignore the formality setting.</p>\n         <p> If you specify multiple target languages for the job, translate ignores\n      the formality setting for any unsupported target language.</p>\n         <p>For a list of target languages that support formality, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-formality.html#customizing-translations-formality-languages\">Supported languages</a>\n      in the Amazon Translate Developer Guide.</p>"
+          }
+        },
+        "Profanity": {
+          "target": "com.amazonaws.translate#Profanity",
+          "traits": {
+            "smithy.api#documentation": "<p>You can enable the profanity setting if you want to mask profane words and\n      phrases in your translation output.</p>\n         <p>To mask profane words and phrases, Amazon Translate replaces them with the grawlix string\n      \u201c?$#@$\u201c. This 5-character sequence is used for each profane word or phrase, regardless of the\n      length or number of words.</p>\n         <p>Amazon Translate doesn't detect profanity in all of its supported languages. For languages\n      that don't support profanity detection, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-profanity.html#customizing-translations-profanity-languages\">Unsupported languages</a> in the Amazon Translate Developer Guide.</p>\n         <p>If you specify multiple target languages for the job, all the\n      target languages must support profanity masking. If any of the\n      target languages don't support profanity masking, the\n      translation job won't mask profanity for any target\n      language.</p>"
+          }
+        },
+        "Brevity": {
+          "target": "com.amazonaws.translate#Brevity",
+          "traits": {
+            "smithy.api#documentation": "<p>When you turn on brevity, Amazon Translate reduces the length of the translation output for most translations (when\n      compared with the same translation with brevity turned off). By default, brevity is turned\n      off.</p>\n         <p>If you turn on brevity for a translation request with an unsupported language pair, the\n      translation proceeds with the brevity setting turned off.</p>\n         <p>For the language pairs that brevity supports, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-brevity\">Using brevity</a> in the\n      Amazon Translate Developer Guide.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Settings to configure your translation output. You can configure the following options:</p>\n         <ul>\n            <li>\n               <p>Brevity: reduces the length of the translation output for most translations. Available for\n            <code>TranslateText</code> only.</p>\n            </li>\n            <li>\n               <p>Formality: sets the formality level of the translation output.</p>\n            </li>\n            <li>\n               <p>Profanity: masks profane words and phrases in the translation output.</p>\n            </li>\n         </ul>"
+      }
+    },
+    "com.amazonaws.translate#UnboundedLengthString": {
+      "type": "string"
+    },
+    "com.amazonaws.translate#UnsupportedDisplayLanguageCodeException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        },
+        "DisplayLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>Language code passed in with the request.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Requested display language code is not supported.</p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#UnsupportedLanguagePairException": {
+      "type": "structure",
+      "members": {
+        "Message": {
+          "target": "com.amazonaws.translate#String"
+        },
+        "SourceLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the input text. </p>"
+          }
+        },
+        "TargetLanguageCode": {
+          "target": "com.amazonaws.translate#LanguageCodeString",
+          "traits": {
+            "smithy.api#documentation": "<p>The language code for the language of the translated text. </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Amazon Translate does not support translation from the language of the source text into the requested\n      target language. For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/what-is-languages.html\">Supported languages</a>. </p>",
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400
+      }
+    },
+    "com.amazonaws.translate#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes a specific tag associated with an Amazon Translate resource.\n      For more information, see <a href=\"https://docs.aws.amazon.com/translate/latest/dg/tagging.html\">\n        Tagging your resources</a>.</p>"
+      }
+    },
+    "com.amazonaws.translate#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceArn": {
+          "target": "com.amazonaws.translate#ResourceArn",
+          "traits": {
+            "smithy.api#documentation": "<p> The Amazon Resource Name (ARN) of the given Amazon Translate resource from which you\n      want to remove the tags. </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.translate#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The initial part of a key-value pair that forms a tag being removed from a given resource.\n        Keys must be unique and cannot be duplicated for a particular resource.\n    </p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#UntagResourceResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.amazonaws.translate#UpdateParallelData": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.translate#UpdateParallelDataRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.translate#UpdateParallelDataResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.translate#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.translate#ConflictException"
+        },
+        {
+          "target": "com.amazonaws.translate#InternalServerException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidParameterValueException"
+        },
+        {
+          "target": "com.amazonaws.translate#InvalidRequestException"
+        },
+        {
+          "target": "com.amazonaws.translate#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.translate#ResourceNotFoundException"
+        },
+        {
+          "target": "com.amazonaws.translate#TooManyRequestsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Updates a previously created parallel data resource by importing a new input file from\n      Amazon S3.</p>"
+      }
+    },
+    "com.amazonaws.translate#UpdateParallelDataRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parallel data resource being updated.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.translate#Description",
+          "traits": {
+            "smithy.api#documentation": "<p>A custom description for the parallel data resource in Amazon Translate.</p>"
+          }
+        },
+        "ParallelDataConfig": {
+          "target": "com.amazonaws.translate#ParallelDataConfig",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the format and S3 location of the parallel data input file.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "ClientToken": {
+          "target": "com.amazonaws.translate#ClientTokenString",
+          "traits": {
+            "smithy.api#documentation": "<p>A unique identifier for the request. This token is automatically generated when you use\n      Amazon Translate through an AWS SDK.</p>",
+            "smithy.api#idempotencyToken": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.amazonaws.translate#UpdateParallelDataResponse": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.translate#ResourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the parallel data resource being updated.</p>"
+          }
+        },
+        "Status": {
+          "target": "com.amazonaws.translate#ParallelDataStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the parallel data resource that you are attempting to update. Your update\n      request is accepted only if this status is either <code>ACTIVE</code> or\n      <code>FAILED</code>.</p>"
+          }
+        },
+        "LatestUpdateAttemptStatus": {
+          "target": "com.amazonaws.translate#ParallelDataStatus",
+          "traits": {
+            "smithy.api#documentation": "<p>The status of the parallel data update attempt. When the updated parallel data resource is\n      ready for you to use, the status is <code>ACTIVE</code>.</p>"
+          }
+        },
+        "LatestUpdateAttemptAt": {
+          "target": "com.amazonaws.translate#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The time that the most recent update was attempted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {}
+      }
+    }
+  }
+}

--- a/crates/fakecloud-translate/src/validate.rs
+++ b/crates/fakecloud-translate/src/validate.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 
 /// The vendored Translate Smithy model (byte-for-byte from aws/api-models-aws),
 /// embedded so validation needs no runtime file access.
-const MODEL_JSON: &str = include_str!("../../../aws-models/translate.json");
+const MODEL_JSON: &str = include_str!("../model.json");
 
 #[derive(Debug, Default)]
 struct MemberConstraint {

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.41.0")
+    testImplementation("dev.fakecloud:fakecloud:0.41.1")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.41.0</version>
+    <version>0.41.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -391,7 +391,7 @@ import dev.fakecloud.Types.BedrockResponseRule;
 import java.util.List;
 
 FakeCloud fc = new FakeCloud();
-String modelId = "anthropic.claude-3-haiku-20.41.07-v1:0";
+String modelId = "anthropic.claude-3-haiku-20.41.17-v1:0";
 
 // beforeEach
 fc.reset();

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.41.0"
+version = "0.41.1"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.41.0"
+version = "0.41.1"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

**v0.41.0 shipped broken model crates to crates.io.** Ten crates embedded their Smithy model via `include_str!("../../../aws-models/<svc>.json")` — a path that escapes the crate directory. `cargo package` only bundles files under the crate root, so the published tarballs omitted the JSON and **fail to compile from crates.io** (`couldn't read .../aws-models/config.json: No such file`), which breaks `cargo install fakecloud`. The local publish used `--no-verify` so it slipped through; the CI `Publish Crates` verify step caught it.

### Fix
- Vendor a per-crate copy `crates/fakecloud-<svc>/model.json` and point `include_str!` at `../model.json` (inside the crate → packaged in the tarball).
- Affected: `config, comprehend, emr, shield, textract, translate, support, swf, timestream, transcribe`.
- Verified every one with `cargo publish --dry-run` (compiles from the packaged tarball).
- **Regression guard**: `crates/fakecloud-server/tests/no_escaping_include_str.rs` fails if any `include_str!`/`include_bytes!` climbs above its crate root. Confirmed it flags the pre-fix pattern and passes post-fix.
- Bumps workspace to **v0.41.1** so the corrected crates can republish (0.41.0 is immutable).

### Post-merge
Tag `v0.41.1` to publish the fixed crates; yank the broken `0.41.0` of the ten crates. `fakecloud` bin's pins are `^0.41.0`, so once the fixed deps publish at 0.41.1, installs resolve them.

## Test plan
- `cargo publish --dry-run -p fakecloud-<svc>` for all 10 → compiles from tarball.
- `cargo test -p fakecloud --test no_escaping_include_str` → passes (0 offenders).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors Smithy `model.json` into each affected crate so crates.io tarballs include them and compile. Bumps the workspace and SDKs to v0.41.1 to republish fixed crates.

- **Bug Fixes**
  - Vendored `model.json` into each crate and switched `include_str!` to `../model.json`.
  - Affected crates: `fakecloud-config`, `fakecloud-comprehend`, `fakecloud-emr`, `fakecloud-shield`, `fakecloud-textract`, `fakecloud-translate`, `fakecloud-support`, `fakecloud-swf`, `fakecloud-timestream`, `fakecloud-transcribe`.
  - Added `crates/fakecloud-server/tests/no_escaping_include_str.rs` to block `include_*` paths escaping the crate root; formatted per `rustfmt`.
  - Verified all affected crates with `cargo publish --dry-run`.
  - Updated versions to `0.41.1` across the Rust workspace and SDKs (Java, Python, TypeScript).

- **Migration**
  - Tag and publish `v0.41.1`, then yank the broken `0.41.0` of the 10 crates.
  - `cargo install fakecloud` will resolve the fixed `0.41.1` once published.

<sup>Written for commit 4e89ec9575749c2278ee539795133b427376a37c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

