### PR TITLE
fix(kms): reject hostile CiphertextBlob length fields to prevent Decrypt panic (bug-hunt)

### DIFF
--- a/crates/fakecloud-kms/src/blob.rs
+++ b/crates/fakecloud-kms/src/blob.rs
@@ -136,6 +136,20 @@ pub fn decode_with_context(
 
     let key_len = u64::from_be_bytes(blob[cursor..cursor + 8].try_into().ok()?) as usize;
     cursor += 8;
+    // `key_len` is fully attacker-controlled (it comes straight from the
+    // base64 `CiphertextBlob` a client hands to `Decrypt`/`ReEncrypt`).
+    // Reject any length that alone exceeds the bytes still remaining
+    // BEFORE it enters an addition: the release profile has no
+    // `overflow-checks`, so a hostile `key_len` near `usize::MAX` would
+    // otherwise wrap the `cursor + key_len + ...` sum to a tiny value,
+    // pass the guard, and panic on the slice below. Bounding it first
+    // makes every downstream index self-evidently in range.
+    let remaining = blob.len().saturating_sub(cursor);
+    if key_len > remaining {
+        return None;
+    }
+    // Trailer after the key-id: IV (12) + ct_len (4) + tag (16). This
+    // sum cannot wrap now that `key_len <= remaining <= blob.len()`.
     if cursor + key_len + 12 + 4 + 16 > blob.len() {
         return None;
     }
@@ -149,10 +163,16 @@ pub fn decode_with_context(
 
     let ct_len = u32::from_be_bytes(blob[cursor..cursor + 4].try_into().ok()?) as usize;
     cursor += 4;
-    if cursor + ct_len + 16 != blob.len() {
+    // On 64-bit `usize` this sum can't wrap (`cursor` is small and
+    // `ct_len <= u32::MAX`), but use `checked_add` so the bound is
+    // provably panic-free regardless of `usize` width, then require an
+    // exact fit: the ciphertext-plus-tag must consume the rest of the
+    // blob with nothing left over.
+    let body_end = cursor.checked_add(ct_len)?.checked_add(16)?;
+    if body_end != blob.len() {
         return None;
     }
-    let ct_with_tag = &blob[cursor..cursor + ct_len + 16];
+    let ct_with_tag = &blob[cursor..body_end];
 
     let cipher = cipher_for(master_key_bytes)?;
     let mut aad = Vec::with_capacity(key_id.len() + extra_aad.len());
@@ -266,6 +286,45 @@ mod tests {
         assert!(decode_with_context(&mk, &blob, b"{\"app\":\"staging\"}").is_none());
         // Missing EC at decrypt time — same outcome.
         assert!(decode_with_context(&mk, &blob, b"").is_none());
+    }
+
+    #[test]
+    fn decode_rejects_hostile_max_key_len_without_panicking() {
+        // Regression: a `CiphertextBlob` whose key-id length field is
+        // `u64::MAX` must be rejected as `None`, never panic. Before the
+        // fix the `cursor + key_len + ...` guard wrapped `usize` (release
+        // builds have no overflow-checks), passed, then the key-id slice
+        // panicked with "slice index starts at 12 but ends at 11".
+        let mk = fixed_master();
+        let mut hostile = Vec::new();
+        hostile.extend_from_slice(&VERSION_HEADER); // 4
+        hostile.extend_from_slice(&[0xFF; 8]); // key_len = u64::MAX
+        hostile.extend_from_slice(&[0u8; 32]); // padding to clear min-length gate
+        assert_eq!(hostile.len(), 44);
+        assert!(decode_with_context(&mk, &hostile, b"").is_none());
+    }
+
+    #[test]
+    fn decode_rejects_large_key_len_without_panicking() {
+        // A large-but-not-max `key_len` that still overruns the blob (and
+        // whose `+ 12 + 4 + 16` would overrun) must also cleanly reject.
+        let mk = fixed_master();
+        let mut hostile = Vec::new();
+        hostile.extend_from_slice(&VERSION_HEADER);
+        hostile.extend_from_slice(&0x0000_0000_1000_0000u64.to_be_bytes());
+        hostile.extend_from_slice(&[0u8; 32]);
+        assert!(decode_with_context(&mk, &hostile, b"").is_none());
+    }
+
+    #[test]
+    fn decode_with_context_round_trips_key_id_and_plaintext() {
+        // Happy path stays intact after the bounds hardening.
+        let mk = fixed_master();
+        let aad = b"ctx-bytes";
+        let blob = encode_with_context(&mk, "alias/rt-key", b"payload", aad);
+        let decoded = decode_with_context(&mk, &blob, aad).expect("well-formed blob must decode");
+        assert_eq!(decoded.key_id, "alias/rt-key");
+        assert_eq!(decoded.plaintext, b"payload");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a CONFIRMED CRITICAL request-path DoS panic reachable through `kms:Decrypt` / `kms:ReEncrypt` with no KMS key required.

`crates/fakecloud-kms/src/blob.rs::decode_with_context` read an attacker-controlled 8-byte `key_len` straight from the base64 `CiphertextBlob` a client supplies, then used it in the guard `cursor + key_len + 12 + 4 + 16 > blob.len()`. The release profile has no `overflow-checks`, so a hostile `key_len` near `usize::MAX` (e.g. `0xFFFF_FFFF_FFFF_FFFF`) wraps the sum to a tiny value, the guard passes, and the next line `&blob[cursor..cursor + key_len]` computes a wrapped, inverted slice range and panics ("slice index starts at 12 but ends at 11"). The request task dies and the client sees a dropped connection. The panic happens before any key lookup, so no KMS key needs to exist.

The fix bounds `key_len` against the bytes actually remaining (`key_len > blob.len().saturating_sub(cursor)`) BEFORE it enters any addition, so the downstream sum and slice are self-evidently in range. The `ct_len` (u32) trailer guard is switched to a `checked_add` chain for symmetric, provably panic-free bounds regardless of `usize` width. This mirrors the robustness of the sibling decoder in `api.rs` (which uses a `u16` length + a non-wrapping guard); `api.rs` is unchanged.

Behavior is identical for all well-formed blobs (happy-path round-trip still decodes). Only hostile/malformed blobs change from panic to a clean `None`, which the caller already surfaces as `InvalidCiphertextException`.

### Surface sync
Internal decode-robustness fix only. No new API surface, no field, no operation, no response-shape change, so no SDK / docs / website / metadata updates are needed.

## Test plan

Added three unit tests in `blob.rs` and ran `cargo test -p fakecloud-kms` (208 passed):

1. `decode_rejects_hostile_max_key_len_without_panicking` - blob = `VERSION_HEADER` + 8x`0xFF` (key_len = u64::MAX) + 32 bytes padding (44 bytes, clears the min-length gate) returns `None` without panicking.
2. `decode_rejects_large_key_len_without_panicking` - large-but-not-max `key_len` (`0x1000_0000`) that would also overrun returns `None`.
3. `decode_with_context_round_trips_key_id_and_plaintext` - well-formed `encode_with_context` -> `decode_with_context` still returns the correct key_id and plaintext.

Also: `cargo clippy -p fakecloud-kms --all-targets -- -D warnings` clean, `cargo fmt` clean, `/code-review` (medium) clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a request-path panic in `kms:Decrypt`/`kms:ReEncrypt` by rejecting hostile `CiphertextBlob` length fields. Malformed blobs now fail cleanly instead of crashing; no API or behavior changes for valid blobs.

- **Bug Fixes**
  - Hardened `decode_with_context` to bound `key_len` against remaining bytes before any addition.
  - Switched trailer checks to `checked_add` for `ct_len` to avoid overflow and require an exact fit.
  - Added tests for hostile max/large `key_len` and a round-trip happy path.
  - Invalid blobs now return `None`, surfaced as `InvalidCiphertextException` by the caller.

<sup>Written for commit 34b42b8de0af989b85db656b40d17afb0991eb4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

