### PR TITLE
fix(neptune,docdb,apigateway,eks,ssm): apply modify/update fields dropped by handlers (bug-hunt)

### DIFF
--- a/crates/fakecloud-apigateway/src/helpers.rs
+++ b/crates/fakecloud-apigateway/src/helpers.rs
@@ -295,6 +295,74 @@ pub(crate) fn methods_for_resource(
     out
 }
 
+/// Recompute every resource's full `path` from its parent chain. Paths are
+/// stored (not derived on read) and drive both `resource_to_json` and the
+/// data-plane router, so any `pathPart` rename or reparent must refresh them
+/// for the resource itself AND all of its descendants.
+pub(crate) fn recompute_resource_paths(resources: &mut BTreeMap<String, Resource>) {
+    let snapshot: BTreeMap<String, (Option<String>, Option<String>)> = resources
+        .iter()
+        .map(|(id, r)| (id.clone(), (r.parent_id.clone(), r.path_part.clone())))
+        .collect();
+    for (id, r) in resources.iter_mut() {
+        r.path = compute_resource_path(id, &snapshot);
+    }
+}
+
+fn compute_resource_path(
+    id: &str,
+    snapshot: &BTreeMap<String, (Option<String>, Option<String>)>,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut cur = Some(id.to_string());
+    let max_depth = snapshot.len() + 1;
+    let mut steps = 0;
+    while let Some(cid) = cur {
+        steps += 1;
+        if steps > max_depth {
+            break; // cycle guard
+        }
+        match snapshot.get(&cid) {
+            Some((parent, part)) => {
+                if let Some(p) = part {
+                    parts.push(p.clone());
+                }
+                cur = parent.clone();
+            }
+            None => break,
+        }
+    }
+    parts.reverse();
+    if parts.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", parts.join("/"))
+    }
+}
+
+/// True if `candidate` is `target` itself or a descendant of `target`.
+/// Reparenting `target` under such a node would create a cycle.
+pub(crate) fn is_self_or_descendant(
+    resources: &BTreeMap<String, Resource>,
+    target: &str,
+    candidate: &str,
+) -> bool {
+    let mut cur = Some(candidate.to_string());
+    let max_depth = resources.len() + 1;
+    let mut steps = 0;
+    while let Some(cid) = cur {
+        if cid == target {
+            return true;
+        }
+        steps += 1;
+        if steps > max_depth {
+            break;
+        }
+        cur = resources.get(&cid).and_then(|r| r.parent_id.clone());
+    }
+    false
+}
+
 pub(crate) fn tags_from(body: &Value) -> BTreeMap<String, String> {
     body.get("tags")
         .and_then(Value::as_object)
@@ -322,10 +390,27 @@ pub(crate) fn apply_patch_operations(req: &AwsRequest, mut on: impl FnMut(&str, 
 pub(crate) fn apply_rest_api_patch(api: &mut RestApi, op: &str, path: &str, value: &Value) {
     let is_binary_media_path =
         path == "/binaryMediaTypes" || path.starts_with("/binaryMediaTypes/");
-    if op != "replace" && op != "add" && !(op == "remove" && is_binary_media_path) {
+    let is_endpoint_path =
+        path == "/endpointConfiguration" || path.starts_with("/endpointConfiguration/");
+    let remove_ok = is_binary_media_path || is_endpoint_path || path == "/minimumCompressionSize";
+    if op != "replace" && op != "add" && !(op == "remove" && remove_ok) {
+        return;
+    }
+    if is_endpoint_path {
+        apply_endpoint_config_patch(api, op, path, value);
         return;
     }
     match path {
+        "/minimumCompressionSize" => {
+            if op == "remove" {
+                api.minimum_compression_size = None;
+            } else if let Some(n) = value
+                .as_i64()
+                .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+            {
+                api.minimum_compression_size = Some(n);
+            }
+        }
         "/name" => {
             if let Some(s) = value.as_str() {
                 api.name = s.to_string();
@@ -363,6 +448,75 @@ pub(crate) fn apply_rest_api_patch(api: &mut RestApi, op: &str, path: &str, valu
                     }
                 } else if op == "remove" {
                     api.binary_media_types.retain(|m| m != &mt);
+                }
+            }
+        }
+    }
+}
+
+/// Apply a patch op to a REST API's `endpointConfiguration`. Supports the whole
+/// object (`/endpointConfiguration`) and the `types` / `vpcEndpointIds` arrays
+/// (indexed: `/endpointConfiguration/types/0`, or the whole array).
+fn apply_endpoint_config_patch(api: &mut RestApi, op: &str, path: &str, value: &Value) {
+    // Ensure the stored value is an object we can mutate.
+    if !api.endpoint_configuration.is_object() {
+        api.endpoint_configuration = json!({});
+    }
+    if path == "/endpointConfiguration" {
+        if op == "remove" {
+            api.endpoint_configuration = json!({});
+        } else if value.is_object() {
+            api.endpoint_configuration = value.clone();
+        }
+        return;
+    }
+    let Some(rest) = path.strip_prefix("/endpointConfiguration/") else {
+        return;
+    };
+    let obj = api
+        .endpoint_configuration
+        .as_object_mut()
+        .expect("endpoint_configuration coerced to object above");
+    // rest is e.g. "types", "types/0", "vpcEndpointIds", "vpcEndpointIds/1".
+    let (field, index) = match rest.split_once('/') {
+        Some((f, i)) => (f, i.parse::<usize>().ok()),
+        None => (rest, None),
+    };
+    match index {
+        None => {
+            // Whole array replace/remove.
+            if op == "remove" {
+                obj.remove(field);
+            } else {
+                obj.insert(field.to_string(), value.clone());
+            }
+        }
+        Some(idx) => {
+            let arr = obj
+                .entry(field.to_string())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            if let Some(items) = arr.as_array_mut() {
+                match op {
+                    "remove" => {
+                        if idx < items.len() {
+                            items.remove(idx);
+                        }
+                    }
+                    "add" => {
+                        if idx >= items.len() {
+                            items.push(value.clone());
+                        } else {
+                            items.insert(idx, value.clone());
+                        }
+                    }
+                    _ => {
+                        // replace
+                        if idx < items.len() {
+                            items[idx] = value.clone();
+                        } else {
+                            items.push(value.clone());
+                        }
+                    }
                 }
             }
         }

--- a/crates/fakecloud-apigateway/src/service_rest_api_resources.rs
+++ b/crates/fakecloud-apigateway/src/service_rest_api_resources.rs
@@ -523,23 +523,82 @@ impl ApiGatewayService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let api_id = params.get("restApiId").cloned().unwrap_or_default();
         let id = params.get("resourceId").cloned().unwrap_or_default();
+        // Collect the mutations up front so we can borrow the whole resource map
+        // afterwards (renames/moves require recomputing descendant paths).
+        let mut new_path_part: Option<String> = None;
+        let mut new_parent_id: Option<String> = None;
+        apply_patch_operations(req, |op, path, value| match (op, path) {
+            ("replace", "/pathPart") => {
+                if let Some(s) = value.as_str() {
+                    new_path_part = Some(s.to_string());
+                }
+            }
+            // `move` carries the new parent in `value` (JSON pointer form),
+            // `replace` carries it directly. Accept both.
+            ("move", "/parentId") | ("replace", "/parentId") => {
+                if let Some(s) = value.as_str() {
+                    new_parent_id = Some(s.trim_start_matches('/').to_string());
+                }
+            }
+            _ => {}
+        });
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request_account(req));
         let resources = state
             .resources
             .get_mut(&api_id)
             .ok_or_else(|| not_found(format!("RestApi {api_id} not found")))?;
-        let resource = resources
-            .get_mut(&id)
-            .ok_or_else(|| not_found(format!("Resource {id} not found")))?;
-        apply_patch_operations(req, |op, path, value| {
-            if path == "/pathPart" && op == "replace" {
-                if let Some(s) = value.as_str() {
-                    resource.path_part = Some(s.to_string());
-                }
+        if !resources.contains_key(&id) {
+            return Err(not_found(format!("Resource {id} not found")));
+        }
+        // Validate a requested reparent target before mutating anything.
+        if let Some(pid) = &new_parent_id {
+            if !resources.contains_key(pid) {
+                return Err(not_found(format!("Resource {pid} not found")));
             }
-        });
-        ok(resource_to_json(resource, BTreeMap::new()))
+            if is_self_or_descendant(resources, &id, pid) {
+                return Err(bad_request(
+                    "Invalid parentId: cannot move a resource under itself or its descendant",
+                ));
+            }
+        }
+        // Snapshot the pre-mutation identity so a colliding change can roll back.
+        let (prev_path_part, prev_parent_id) = {
+            let r = resources.get(&id).expect("presence checked above");
+            (r.path_part.clone(), r.parent_id.clone())
+        };
+        {
+            let resource = resources.get_mut(&id).expect("presence checked above");
+            if let Some(pp) = new_path_part {
+                resource.path_part = Some(pp);
+            }
+            if let Some(pid) = new_parent_id {
+                resource.parent_id = Some(pid);
+            }
+        }
+        // Refresh stored paths for the whole tree (target + descendants).
+        recompute_resource_paths(resources);
+        // Reject a rename/reparent that collides with a sibling path (matches
+        // CreateResource, which rejects duplicates). On collision, roll back.
+        let new_path = resources[&id].path.clone();
+        if resources
+            .iter()
+            .any(|(rid, r)| rid != &id && r.path == new_path)
+        {
+            // Revert this resource's identity to the pre-mutation snapshot,
+            // then refresh paths so no partial change is persisted.
+            if let Some(r) = resources.get_mut(&id) {
+                r.path_part = prev_path_part;
+                r.parent_id = prev_parent_id;
+            }
+            recompute_resource_paths(resources);
+            return Err(conflict(format!(
+                "Another resource with the same parent already has this name: {new_path}"
+            )));
+        }
+        let resource = resources.get(&id).expect("presence checked above").clone();
+        let methods = methods_for_resource(state, &api_id, &id);
+        ok(resource_to_json(&resource, methods))
     }
 
     // ── Methods ──
@@ -773,5 +832,209 @@ impl ApiGatewayService {
             }
         });
         ok(v.clone())
+    }
+}
+
+#[cfg(test)]
+mod resource_patch_tests {
+    use super::*;
+    use fakecloud_core::service::ResponseBody;
+    use std::collections::HashMap;
+
+    fn svc() -> ApiGatewayService {
+        let state =
+            std::sync::Arc::new(
+                parking_lot::RwLock::new(fakecloud_core::multi_account::MultiAccountState::<
+                    crate::state::ApiGatewayState,
+                >::new("123456789012", "us-east-1", "")),
+            );
+        ApiGatewayService::new(state)
+    }
+
+    fn req_body(body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "apigateway".into(),
+            action: "x".into(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body_json(resp: &AwsResponse) -> Value {
+        match &resp.body {
+            ResponseBody::Bytes(b) => serde_json::from_slice(b).unwrap(),
+            _ => panic!("expected bytes body"),
+        }
+    }
+
+    fn params(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn update_rest_api_applies_compression_and_endpoint_config() {
+        let s = svc();
+        let created = body_json(
+            &s.create_rest_api(&req_body(json!({
+                "name": "api",
+                "endpointConfiguration": { "types": ["EDGE"] }
+            })))
+            .unwrap(),
+        );
+        let api_id = created["id"].as_str().unwrap().to_string();
+        let p = params(&[("restApiId", &api_id)]);
+
+        let updated = body_json(
+            &s.update_rest_api(
+                &req_body(json!({ "patchOperations": [
+                    { "op": "replace", "path": "/minimumCompressionSize", "value": "1024" },
+                    { "op": "replace", "path": "/endpointConfiguration/types/0", "value": "REGIONAL" },
+                ]})),
+                &p,
+            )
+            .unwrap(),
+        );
+        assert_eq!(updated["minimumCompressionSize"], json!(1024));
+        assert_eq!(
+            updated["endpointConfiguration"]["types"][0],
+            json!("REGIONAL")
+        );
+
+        // Persisted via GetRestApi.
+        let got = body_json(&s.get_rest_api(&req_body(json!({})), &p).unwrap());
+        assert_eq!(got["minimumCompressionSize"], json!(1024));
+        assert_eq!(got["endpointConfiguration"]["types"][0], json!("REGIONAL"));
+    }
+
+    #[test]
+    fn update_resource_rename_and_reparent_recompute_paths() {
+        let s = svc();
+        let api = body_json(
+            &s.create_rest_api(&req_body(json!({ "name": "api" })))
+                .unwrap(),
+        );
+        let api_id = api["id"].as_str().unwrap().to_string();
+        let root_id = api["rootResourceId"].as_str().unwrap().to_string();
+
+        // /pets
+        let pets = body_json(
+            &s.create_resource(
+                &req_body(json!({ "pathPart": "pets" })),
+                &params(&[("restApiId", &api_id), ("parentId", &root_id)]),
+            )
+            .unwrap(),
+        );
+        let pets_id = pets["id"].as_str().unwrap().to_string();
+        assert_eq!(pets["path"], json!("/pets"));
+
+        // /pets/list
+        let list = body_json(
+            &s.create_resource(
+                &req_body(json!({ "pathPart": "list" })),
+                &params(&[("restApiId", &api_id), ("parentId", &pets_id)]),
+            )
+            .unwrap(),
+        );
+        let list_id = list["id"].as_str().unwrap().to_string();
+        assert_eq!(list["path"], json!("/pets/list"));
+
+        // Rename /pets -> /animals; descendant must follow.
+        let renamed = body_json(
+            &s.update_resource(
+                &req_body(json!({ "patchOperations": [
+                    { "op": "replace", "path": "/pathPart", "value": "animals" }
+                ]})),
+                &params(&[("restApiId", &api_id), ("resourceId", &pets_id)]),
+            )
+            .unwrap(),
+        );
+        assert_eq!(renamed["path"], json!("/animals"));
+        let got_list = body_json(
+            &s.get_resource(
+                &req_body(json!({})),
+                &params(&[("restApiId", &api_id), ("resourceId", &list_id)]),
+            )
+            .unwrap(),
+        );
+        assert_eq!(got_list["path"], json!("/animals/list"));
+
+        // Reparent /animals under a new /store resource.
+        let store = body_json(
+            &s.create_resource(
+                &req_body(json!({ "pathPart": "store" })),
+                &params(&[("restApiId", &api_id), ("parentId", &root_id)]),
+            )
+            .unwrap(),
+        );
+        let store_id = store["id"].as_str().unwrap().to_string();
+        let moved = body_json(
+            &s.update_resource(
+                &req_body(json!({ "patchOperations": [
+                    { "op": "replace", "path": "/parentId", "value": store_id }
+                ]})),
+                &params(&[("restApiId", &api_id), ("resourceId", &pets_id)]),
+            )
+            .unwrap(),
+        );
+        assert_eq!(moved["path"], json!("/store/animals"));
+        let got_list = body_json(
+            &s.get_resource(
+                &req_body(json!({})),
+                &params(&[("restApiId", &api_id), ("resourceId", &list_id)]),
+            )
+            .unwrap(),
+        );
+        assert_eq!(got_list["path"], json!("/store/animals/list"));
+
+        // Cycle guard: cannot move /store under its own descendant.
+        let err = s.update_resource(
+            &req_body(json!({ "patchOperations": [
+                { "op": "replace", "path": "/parentId", "value": list_id }
+            ]})),
+            &params(&[("restApiId", &api_id), ("resourceId", &store_id)]),
+        );
+        assert!(err.is_err());
+
+        // Collision guard: create /store/other, then renaming it to "animals"
+        // (colliding with the existing /store/animals) must fail and roll back.
+        let other = body_json(
+            &s.create_resource(
+                &req_body(json!({ "pathPart": "other" })),
+                &params(&[("restApiId", &api_id), ("parentId", &store_id)]),
+            )
+            .unwrap(),
+        );
+        let other_id = other["id"].as_str().unwrap().to_string();
+        let collision = s.update_resource(
+            &req_body(json!({ "patchOperations": [
+                { "op": "replace", "path": "/pathPart", "value": "animals" }
+            ]})),
+            &params(&[("restApiId", &api_id), ("resourceId", &other_id)]),
+        );
+        assert!(collision.is_err());
+        // Rolled back: /store/other still resolves to its original path.
+        let got_other = body_json(
+            &s.get_resource(
+                &req_body(json!({})),
+                &params(&[("restApiId", &api_id), ("resourceId", &other_id)]),
+            )
+            .unwrap(),
+        );
+        assert_eq!(got_other["path"], json!("/store/other"));
     }
 }

--- a/crates/fakecloud-docdb/src/service.rs
+++ b/crates/fakecloud-docdb/src/service.rs
@@ -498,6 +498,35 @@ impl DocDbService {
         if let Some(v) = optional_query_param(req, "DBClusterParameterGroupName") {
             cluster.db_cluster_parameter_group = v;
         }
+        let new_vpc_sgs = collect_list(
+            req,
+            "VpcSecurityGroupIds",
+            &["VpcSecurityGroupId", "member"],
+        );
+        if !new_vpc_sgs.is_empty() {
+            cluster.vpc_security_group_ids = new_vpc_sgs;
+        }
+        // CloudwatchLogsExportConfiguration: enable/disable individual log types.
+        let enable_logs = collect_list(
+            req,
+            "CloudwatchLogsExportConfiguration.EnableLogTypes",
+            &["member", "LogType"],
+        );
+        let disable_logs = collect_list(
+            req,
+            "CloudwatchLogsExportConfiguration.DisableLogTypes",
+            &["member", "LogType"],
+        );
+        if !enable_logs.is_empty() || !disable_logs.is_empty() {
+            cluster
+                .enabled_cloudwatch_logs_exports
+                .retain(|l| !disable_logs.contains(l));
+            for log in enable_logs {
+                if !cluster.enabled_cloudwatch_logs_exports.contains(&log) {
+                    cluster.enabled_cloudwatch_logs_exports.push(log);
+                }
+            }
+        }
         // NewDBClusterIdentifier: rename.
         let renamed = optional_query_param(req, "NewDBClusterIdentifier");
         let mut cluster = cluster.clone();

--- a/crates/fakecloud-docdb/src/tests.rs
+++ b/crates/fakecloud-docdb/src/tests.rs
@@ -459,3 +459,52 @@ async fn supported_actions_cover_full_surface() {
     let svc = service();
     assert_eq!(svc.supported_actions().len(), 55);
 }
+
+#[tokio::test]
+async fn modify_cluster_applies_vpc_sgs_and_log_exports() {
+    let svc = service();
+    call(
+        &svc,
+        "CreateDBCluster",
+        &[
+            ("DBClusterIdentifier", "mc"),
+            ("Engine", "docdb"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-initial"),
+            ("EnableCloudwatchLogsExports.member.1", "audit"),
+        ],
+    )
+    .await;
+
+    let resp = call(
+        &svc,
+        "ModifyDBCluster",
+        &[
+            ("DBClusterIdentifier", "mc"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-new-a"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.2", "sg-new-b"),
+            (
+                "CloudwatchLogsExportConfiguration.EnableLogTypes.member.1",
+                "profiler",
+            ),
+            (
+                "CloudwatchLogsExportConfiguration.DisableLogTypes.member.1",
+                "audit",
+            ),
+        ],
+    )
+    .await;
+    let xml = body(&resp);
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-a</VpcSecurityGroupId>"));
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-b</VpcSecurityGroupId>"));
+    assert!(!xml.contains("sg-initial"));
+    assert!(xml.contains("profiler"));
+    assert!(!xml.contains("audit"));
+
+    let resp = call(&svc, "DescribeDBClusters", &[("DBClusterIdentifier", "mc")]).await;
+    let xml = body(&resp);
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-a</VpcSecurityGroupId>"));
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-b</VpcSecurityGroupId>"));
+    assert!(!xml.contains("sg-initial"));
+    assert!(xml.contains("profiler"));
+    assert!(!xml.contains("audit"));
+}

--- a/crates/fakecloud-eks/src/eks_helpers.rs
+++ b/crates/fakecloud-eks/src/eks_helpers.rs
@@ -600,6 +600,15 @@ pub(crate) fn build_scaling_config(req: Option<&Value>) -> Value {
     json!({ "minSize": min, "maxSize": max, "desiredSize": desired })
 }
 
+/// Identity of a Kubernetes taint for add/update/remove matching: taints are
+/// keyed by `key` + `effect` (value can change on an update-in-place).
+pub(crate) fn taint_identity(t: &Value) -> (Option<&str>, Option<&str>) {
+    (
+        t.get("key").and_then(|v| v.as_str()),
+        t.get("effect").and_then(|v| v.as_str()),
+    )
+}
+
 /// Build a `NodegroupUpdateConfig`, defaulting `maxUnavailable` to 1.
 pub(crate) fn build_nodegroup_update_config(req: Option<&Value>) -> Value {
     if let Some(pct) = req

--- a/crates/fakecloud-eks/src/service.rs
+++ b/crates/fakecloud-eks/src/service.rs
@@ -569,7 +569,10 @@ impl EksService {
             tags,
             updates: Default::default(),
             connector_config: None,
-            encryption_config: None,
+            encryption_config: body
+                .get("encryptionConfig")
+                .filter(|v| v.is_array())
+                .cloned(),
             access_config: build_access_config(body.get("accessConfig")),
             upgrade_policy: build_upgrade_policy(body.get("upgradePolicy")),
             compute_config: body.get("computeConfig").cloned(),
@@ -1203,15 +1206,47 @@ impl EksService {
             params.push(("ScalingConfig".to_string(), scaling.to_string()));
         }
         if let Some(labels) = body.get("labels") {
-            if let Some(add) = labels.get("addOrUpdateLabels").and_then(|v| v.as_object()) {
-                let map = ng.labels.as_object_mut();
-                if let Some(map) = map {
+            if !ng.labels.is_object() {
+                ng.labels = json!({});
+            }
+            if let Some(map) = ng.labels.as_object_mut() {
+                if let Some(add) = labels.get("addOrUpdateLabels").and_then(|v| v.as_object()) {
                     for (k, v) in add {
                         map.insert(k.clone(), v.clone());
                     }
                 }
+                if let Some(remove) = labels.get("removeLabels").and_then(|v| v.as_array()) {
+                    for k in remove.iter().filter_map(|v| v.as_str()) {
+                        map.remove(k);
+                    }
+                }
             }
             params.push(("LabelsToAdd".to_string(), labels.to_string()));
+        }
+        if let Some(taints) = body.get("taints") {
+            if !ng.taints.is_array() {
+                ng.taints = json!([]);
+            }
+            if let Some(arr) = ng.taints.as_array_mut() {
+                // Remove first so an add+remove of the same key in one call keeps the add.
+                if let Some(remove) = taints.get("removeTaints").and_then(|v| v.as_array()) {
+                    for rt in remove {
+                        let id = taint_identity(rt);
+                        arr.retain(|t| taint_identity(t) != id);
+                    }
+                }
+                if let Some(add) = taints.get("addOrUpdateTaints").and_then(|v| v.as_array()) {
+                    for nt in add {
+                        let id = taint_identity(nt);
+                        if let Some(existing) = arr.iter_mut().find(|t| taint_identity(t) == id) {
+                            *existing = nt.clone();
+                        } else {
+                            arr.push(nt.clone());
+                        }
+                    }
+                }
+            }
+            params.push(("Taints".to_string(), taints.to_string()));
         }
         if let Some(update_config) = body.get("updateConfig") {
             ng.update_config = build_nodegroup_update_config(Some(update_config));

--- a/crates/fakecloud-eks/src/service_tests.rs
+++ b/crates/fakecloud-eks/src/service_tests.rs
@@ -2270,3 +2270,126 @@ async fn subscription_accepts_valid_duration() {
     assert_eq!(v["subscription"]["term"]["duration"], 36);
     assert_eq!(v["subscription"]["status"], "ACTIVE");
 }
+
+#[tokio::test]
+async fn update_nodegroup_config_applies_taints_and_removes_labels() {
+    let svc = EksService::new(make_state());
+    svc.handle(make_request(Method::POST, "/clusters", &create_body("ngc")))
+        .await
+        .unwrap();
+    svc.handle(make_request(
+        Method::POST,
+        "/clusters/ngc/node-groups",
+        &json!({
+            "nodegroupName": "ng1",
+            "nodeRole": "arn:aws:iam::111122223333:role/eks-node",
+            "subnets": ["subnet-1"],
+            "labels": { "team": "core", "tier": "gold" },
+            "taints": [ { "key": "dedicated", "value": "gpu", "effect": "NO_SCHEDULE" } ]
+        })
+        .to_string(),
+    ))
+    .await
+    .unwrap();
+
+    // Update: add/update a taint, remove a taint that doesn't exist yet is a
+    // no-op; also add a label and remove one.
+    svc.handle(make_request(
+        Method::POST,
+        "/clusters/ngc/node-groups/ng1/update-config",
+        &json!({
+            "labels": {
+                "addOrUpdateLabels": { "env": "prod" },
+                "removeLabels": ["tier"]
+            },
+            "taints": {
+                "addOrUpdateTaints": [
+                    { "key": "dedicated", "value": "tpu", "effect": "NO_SCHEDULE" },
+                    { "key": "spot", "value": "true", "effect": "PREFER_NO_SCHEDULE" }
+                ],
+                "removeTaints": []
+            }
+        })
+        .to_string(),
+    ))
+    .await
+    .unwrap();
+
+    let resp = svc
+        .handle(make_request(
+            Method::GET,
+            "/clusters/ngc/node-groups/ng1",
+            "",
+        ))
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    // Labels: env added, tier removed, team + core unchanged.
+    assert_eq!(v["nodegroup"]["labels"]["env"], "prod");
+    assert_eq!(v["nodegroup"]["labels"]["team"], "core");
+    assert!(v["nodegroup"]["labels"].get("tier").is_none());
+    // Taints: dedicated updated in place to tpu, spot added.
+    let taints = v["nodegroup"]["taints"].as_array().unwrap();
+    assert_eq!(taints.len(), 2);
+    let dedicated = taints
+        .iter()
+        .find(|t| t["key"] == "dedicated")
+        .expect("dedicated taint");
+    assert_eq!(dedicated["value"], "tpu");
+    assert!(taints.iter().any(|t| t["key"] == "spot"));
+
+    // Now remove the dedicated taint.
+    svc.handle(make_request(
+        Method::POST,
+        "/clusters/ngc/node-groups/ng1/update-config",
+        &json!({
+            "taints": { "removeTaints": [ { "key": "dedicated", "effect": "NO_SCHEDULE" } ] }
+        })
+        .to_string(),
+    ))
+    .await
+    .unwrap();
+    let resp = svc
+        .handle(make_request(
+            Method::GET,
+            "/clusters/ngc/node-groups/ng1",
+            "",
+        ))
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let taints = v["nodegroup"]["taints"].as_array().unwrap();
+    assert_eq!(taints.len(), 1);
+    assert_eq!(taints[0]["key"], "spot");
+}
+
+#[tokio::test]
+async fn create_cluster_stores_encryption_config() {
+    let svc = EksService::new(make_state());
+    let body = json!({
+        "name": "enc",
+        "roleArn": "arn:aws:iam::111122223333:role/eks-cluster",
+        "resourcesVpcConfig": { "subnetIds": ["subnet-1"] },
+        "encryptionConfig": [
+            {
+                "resources": ["secrets"],
+                "provider": { "keyArn": "arn:aws:kms:us-east-1:111122223333:key/abc" }
+            }
+        ]
+    })
+    .to_string();
+    svc.handle(make_request(Method::POST, "/clusters", &body))
+        .await
+        .unwrap();
+    let resp = svc
+        .handle(make_request(Method::GET, "/clusters/enc", ""))
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let ec = &v["cluster"]["encryptionConfig"][0];
+    assert_eq!(ec["resources"][0], "secrets");
+    assert_eq!(
+        ec["provider"]["keyArn"],
+        "arn:aws:kms:us-east-1:111122223333:key/abc"
+    );
+}

--- a/crates/fakecloud-neptune/src/service.rs
+++ b/crates/fakecloud-neptune/src/service.rs
@@ -552,6 +552,35 @@ impl NeptuneService {
         if let Some(v) = optional_query_param(req, "DBClusterParameterGroupName") {
             cluster.db_cluster_parameter_group = v;
         }
+        let new_vpc_sgs = collect_list(
+            req,
+            "VpcSecurityGroupIds",
+            &["VpcSecurityGroupId", "member"],
+        );
+        if !new_vpc_sgs.is_empty() {
+            cluster.vpc_security_group_ids = new_vpc_sgs;
+        }
+        // CloudwatchLogsExportConfiguration: enable/disable individual log types.
+        let enable_logs = collect_list(
+            req,
+            "CloudwatchLogsExportConfiguration.EnableLogTypes",
+            &["member", "LogType"],
+        );
+        let disable_logs = collect_list(
+            req,
+            "CloudwatchLogsExportConfiguration.DisableLogTypes",
+            &["member", "LogType"],
+        );
+        if !enable_logs.is_empty() || !disable_logs.is_empty() {
+            cluster
+                .enabled_cloudwatch_logs_exports
+                .retain(|l| !disable_logs.contains(l));
+            for log in enable_logs {
+                if !cluster.enabled_cloudwatch_logs_exports.contains(&log) {
+                    cluster.enabled_cloudwatch_logs_exports.push(log);
+                }
+            }
+        }
         // NewDBClusterIdentifier: rename.
         let renamed = optional_query_param(req, "NewDBClusterIdentifier");
         let mut cluster = cluster.clone();

--- a/crates/fakecloud-neptune/src/tests.rs
+++ b/crates/fakecloud-neptune/src/tests.rs
@@ -651,3 +651,54 @@ async fn supported_actions_cover_full_surface() {
     let svc = service();
     assert_eq!(svc.supported_actions().len(), 70);
 }
+
+#[tokio::test]
+async fn modify_cluster_applies_vpc_sgs_and_log_exports() {
+    let svc = service();
+    call(
+        &svc,
+        "CreateDBCluster",
+        &[
+            ("DBClusterIdentifier", "mc"),
+            ("Engine", "neptune"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-initial"),
+            ("EnableCloudwatchLogsExports.member.1", "audit"),
+        ],
+    )
+    .await;
+
+    // Modify: swap the SGs and enable an extra log type while disabling audit.
+    let resp = call(
+        &svc,
+        "ModifyDBCluster",
+        &[
+            ("DBClusterIdentifier", "mc"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-new-a"),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.2", "sg-new-b"),
+            (
+                "CloudwatchLogsExportConfiguration.EnableLogTypes.member.1",
+                "slowquery",
+            ),
+            (
+                "CloudwatchLogsExportConfiguration.DisableLogTypes.member.1",
+                "audit",
+            ),
+        ],
+    )
+    .await;
+    let xml = body(&resp);
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-a</VpcSecurityGroupId>"));
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-b</VpcSecurityGroupId>"));
+    assert!(!xml.contains("sg-initial"));
+    assert!(xml.contains("slowquery"));
+    assert!(!xml.contains("audit"));
+
+    // Persisted: Describe reflects the modified values.
+    let resp = call(&svc, "DescribeDBClusters", &[("DBClusterIdentifier", "mc")]).await;
+    let xml = body(&resp);
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-a</VpcSecurityGroupId>"));
+    assert!(xml.contains("<VpcSecurityGroupId>sg-new-b</VpcSecurityGroupId>"));
+    assert!(!xml.contains("sg-initial"));
+    assert!(xml.contains("slowquery"));
+    assert!(!xml.contains("audit"));
+}

--- a/crates/fakecloud-ssm/src/service/maintenance.rs
+++ b/crates/fakecloud-ssm/src/service/maintenance.rs
@@ -11,6 +11,23 @@ use crate::state::{MaintenanceWindow, MaintenanceWindowTarget, MaintenanceWindow
 
 use super::{aws_400, missing, missing_with_code, SsmService};
 
+/// Append the optional invocation/logging fields of a maintenance-window task
+/// to a response object, so Get/Describe faithfully echo what Register stored.
+fn append_task_invocation_fields(resp: &mut Value, task: &MaintenanceWindowTask) {
+    if let Some(ref tip) = task.task_invocation_parameters {
+        resp["TaskInvocationParameters"] = tip.clone();
+    }
+    if let Some(ref tp) = task.task_parameters {
+        resp["TaskParameters"] = tp.clone();
+    }
+    if let Some(ref li) = task.logging_info {
+        resp["LoggingInfo"] = li.clone();
+    }
+    if let Some(ref cb) = task.cutoff_behavior {
+        resp["CutoffBehavior"] = json!(cb);
+    }
+}
+
 /// All fields of a `CreateMaintenanceWindow` request, parsed and validated.
 struct CreateMaintenanceWindowInput {
     name: String,
@@ -520,6 +537,13 @@ impl SsmService {
         let service_role_arn = body["ServiceRoleArn"].as_str().map(|s| s.to_string());
         let name = body["Name"].as_str().map(|s| s.to_string());
         let description = body["Description"].as_str().map(|s| s.to_string());
+        let task_invocation_parameters = body
+            .get("TaskInvocationParameters")
+            .filter(|v| !v.is_null())
+            .cloned();
+        let task_parameters = body.get("TaskParameters").filter(|v| !v.is_null()).cloned();
+        let logging_info = body.get("LoggingInfo").filter(|v| !v.is_null()).cloned();
+        let cutoff_behavior = body["CutoffBehavior"].as_str().map(|s| s.to_string());
 
         let task_id = format!(
             "{}-{}",
@@ -546,6 +570,10 @@ impl SsmService {
             service_role_arn,
             name,
             description,
+            task_invocation_parameters,
+            task_parameters,
+            logging_info,
+            cutoff_behavior,
         };
         mw.tasks.push(task);
 
@@ -623,6 +651,7 @@ impl SsmService {
                 if let Some(ref desc) = t.description {
                     v["Description"] = json!(desc);
                 }
+                append_task_invocation_fields(&mut v, t);
                 v
             })
             .collect();
@@ -751,6 +780,21 @@ impl SsmService {
         if let Some(role) = body["ServiceRoleArn"].as_str() {
             task.service_role_arn = Some(role.to_string());
         }
+        if body.get("TaskInvocationParameters").is_some() {
+            task.task_invocation_parameters = body
+                .get("TaskInvocationParameters")
+                .filter(|v| !v.is_null())
+                .cloned();
+        }
+        if body.get("TaskParameters").is_some() {
+            task.task_parameters = body.get("TaskParameters").filter(|v| !v.is_null()).cloned();
+        }
+        if body.get("LoggingInfo").is_some() {
+            task.logging_info = body.get("LoggingInfo").filter(|v| !v.is_null()).cloned();
+        }
+        if let Some(cb) = body["CutoffBehavior"].as_str() {
+            task.cutoff_behavior = Some(cb.to_string());
+        }
 
         let mut resp = json!({
             "WindowId": window_id,
@@ -775,6 +819,7 @@ impl SsmService {
         if let Some(ref sra) = task.service_role_arn {
             resp["ServiceRoleArn"] = json!(sra);
         }
+        append_task_invocation_fields(&mut resp, task);
 
         Ok(AwsResponse::ok_json(resp))
     }
@@ -834,6 +879,7 @@ impl SsmService {
         if let Some(ref sra) = task.service_role_arn {
             resp["ServiceRoleArn"] = json!(sra);
         }
+        append_task_invocation_fields(&mut resp, task);
 
         Ok(AwsResponse::ok_json(resp))
     }

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -5070,3 +5070,131 @@ fn put_parameter_duplicate_without_overwrite_reports_already_exists_first() {
     };
     assert_eq!(err.code(), "ParameterAlreadyExists");
 }
+
+#[test]
+fn maintenance_window_task_persists_invocation_params() {
+    let svc = make_service();
+    // Create window.
+    let req = make_request(
+        "CreateMaintenanceWindow",
+        json!({
+            "Name": "inv-mw",
+            "Schedule": "cron(0 2 ? * SUN *)",
+            "Duration": 3,
+            "Cutoff": 1,
+            "AllowUnassociatedTargets": true,
+        }),
+    );
+    let body: Value = serde_json::from_slice(
+        svc.create_maintenance_window(&req)
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .unwrap();
+    let window_id = body["WindowId"].as_str().unwrap().to_string();
+
+    // Register a task carrying invocation params, logging, and cutoff behavior.
+    let invocation = json!({
+        "RunCommand": {
+            "DocumentVersion": "$LATEST",
+            "Parameters": { "commands": ["echo hi"] },
+            "TimeoutSeconds": 600
+        }
+    });
+    let logging = json!({ "S3BucketName": "logs", "S3KeyPrefix": "mw/" });
+    let req = make_request(
+        "RegisterTaskWithMaintenanceWindow",
+        json!({
+            "WindowId": window_id,
+            "TaskArn": "AWS-RunShellScript",
+            "TaskType": "RUN_COMMAND",
+            "Targets": [{"Key": "InstanceIds", "Values": ["i-001"]}],
+            "TaskInvocationParameters": invocation,
+            "LoggingInfo": logging,
+            "CutoffBehavior": "CONTINUE_TASK",
+        }),
+    );
+    let body: Value = serde_json::from_slice(
+        svc.register_task_with_maintenance_window(&req)
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .unwrap();
+    let task_id = body["WindowTaskId"].as_str().unwrap().to_string();
+
+    // Get returns the stored fields.
+    let req = make_request(
+        "GetMaintenanceWindowTask",
+        json!({ "WindowId": window_id, "WindowTaskId": task_id }),
+    );
+    let body: Value = serde_json::from_slice(
+        svc.get_maintenance_window_task(&req)
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .unwrap();
+    assert_eq!(body["TaskInvocationParameters"], invocation);
+    assert_eq!(body["LoggingInfo"], logging);
+    assert_eq!(body["CutoffBehavior"], "CONTINUE_TASK");
+
+    // Describe returns them too.
+    let req = make_request(
+        "DescribeMaintenanceWindowTasks",
+        json!({ "WindowId": window_id }),
+    );
+    let body: Value = serde_json::from_slice(
+        svc.describe_maintenance_window_tasks(&req)
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .unwrap();
+    let task = &body["Tasks"][0];
+    assert_eq!(task["TaskInvocationParameters"], invocation);
+    assert_eq!(task["CutoffBehavior"], "CONTINUE_TASK");
+
+    // Update can modify them.
+    let new_cutoff = "CANCEL_TASK";
+    let req = make_request(
+        "UpdateMaintenanceWindowTask",
+        json!({
+            "WindowId": window_id,
+            "WindowTaskId": task_id,
+            "CutoffBehavior": new_cutoff,
+            "TaskInvocationParameters": { "RunCommand": { "TimeoutSeconds": 120 } },
+        }),
+    );
+    let body: Value = serde_json::from_slice(
+        svc.update_maintenance_window_task(&req)
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .unwrap();
+    assert_eq!(body["CutoffBehavior"], new_cutoff);
+    assert_eq!(
+        body["TaskInvocationParameters"]["RunCommand"]["TimeoutSeconds"],
+        120
+    );
+
+    // And the change persists.
+    let req = make_request(
+        "GetMaintenanceWindowTask",
+        json!({ "WindowId": window_id, "WindowTaskId": task_id }),
+    );
+    let body: Value = serde_json::from_slice(
+        svc.get_maintenance_window_task(&req)
+            .unwrap()
+            .body
+            .expect_bytes(),
+    )
+    .unwrap();
+    assert_eq!(body["CutoffBehavior"], new_cutoff);
+    assert_eq!(
+        body["TaskInvocationParameters"]["RunCommand"]["TimeoutSeconds"],
+        120
+    );
+}

--- a/crates/fakecloud-ssm/src/state.rs
+++ b/crates/fakecloud-ssm/src/state.rs
@@ -165,6 +165,10 @@ pub struct MaintenanceWindowTask {
     pub service_role_arn: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
+    pub task_invocation_parameters: Option<serde_json::Value>,
+    pub task_parameters: Option<serde_json::Value>,
+    pub logging_info: Option<serde_json::Value>,
+    pub cutoff_behavior: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary

Bug-hunt cluster: Create + Describe fully support a field, but the matching Modify/Update handler had no branch for it, so the value was accepted (200) then silently dropped, producing a perpetual Terraform plan diff. Each fix adds the missing branch so Modify actually applies and persists the field.

1. **Neptune `ModifyDBCluster`** — now applies `VpcSecurityGroupIds` and `CloudwatchLogsExportConfiguration` (Enable/DisableLogTypes) to the cluster; previously only Create stored them and Describe emitted them.
2. **DocDB `ModifyDBCluster`** — same two fields (`VpcSecurityGroupIds`, `CloudwatchLogsExportConfiguration`).
3. **apigateway `UpdateRestApi`** — added patch arms for `/minimumCompressionSize` (replace/remove) and `/endpointConfiguration` (whole object and indexed sub-fields, e.g. `/endpointConfiguration/types/0`, `/endpointConfiguration/vpcEndpointIds`). Both were accepted on CreateRestApi and emitted by `rest_api_to_json` but had no update path.
4. **apigateway `UpdateResource`** — `path` is stored (not derived) and drives `resource_to_json` and the data-plane router. A `/pathPart` replace previously updated `path_part` but never recomputed the stored `path`, and `op=move`/`replace` on `/parentId` was ignored entirely. Now: renames and reparents recompute the full `path` for the resource **and all descendants** from the parent chain, with a cycle guard (cannot move a resource under itself or a descendant -> BadRequest) and a sibling-path collision guard that rolls back and returns Conflict (matching CreateResource's duplicate rejection).
5. **EKS `UpdateNodegroupConfig`** — added a `taints` branch (`addOrUpdateTaints` update-in-place by key+effect / `removeTaints`) and now honors `removeLabels` (previously only `addOrUpdateLabels` was applied). Also **`CreateCluster`** now reads and stores `encryptionConfig` (was hardcoded `None` though it's a modeled input and the read path emits it) mirroring the AssociateEncryptionConfig path.
6. **SSM `RegisterTaskWithMaintenanceWindow`** — the `MaintenanceWindowTask` state struct gained `TaskInvocationParameters`, `TaskParameters`, `LoggingInfo`, and `CutoffBehavior` fields. Register now stores them, Get/DescribeMaintenanceWindowTasks emit them, and UpdateMaintenanceWindowTask can modify them (all were previously dropped on register and unreachable thereafter).

No new public API surface / operations, no SDK changes. No per-service reference doc under `website/content/docs/**` documents these fields as "supported on modify", so no doc changes are needed.

## Test plan

Added modify/update-then-describe round-trip tests asserting the new values are reflected and persist:
- Neptune / DocDB: `ModifyDBCluster(VpcSecurityGroupIds=[...], CloudwatchLogsExportConfiguration{Enable,Disable})` -> `DescribeDBClusters` shows swapped SGs and adjusted log-export list.
- apigateway: `UpdateRestApi` compression + endpointConfiguration -> `GetRestApi`; `UpdateResource` rename recomputes descendant paths, reparent recomputes subtree, cycle + collision guards.
- EKS: `UpdateNodegroupConfig` taints (add/update/remove) + removeLabels -> `DescribeNodegroup`; `CreateCluster` encryptionConfig -> `DescribeCluster`.
- SSM: register-with-invocation-params/logging/cutoff -> `GetMaintenanceWindowTask` + `DescribeMaintenanceWindowTasks` return them; `UpdateMaintenanceWindowTask` modifies and persists them.

- `cargo test -p fakecloud-neptune -p fakecloud-docdb -p fakecloud-apigateway -p fakecloud-eks -p fakecloud-ssm` — all pass.
- `cargo build -p fakecloud --tests` — passes (SSM struct-field ctor sweep; only Register constructs `MaintenanceWindowTask`).
- `cargo clippy --all-targets -- -D warnings` on all five crates — clean.
- `cargo fmt` — clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix modify/update handlers to persist previously dropped fields across Neptune, DocDB, API Gateway, EKS, and SSM, eliminating silent no-ops and perpetual plan diffs. No public API changes.

- **Bug Fixes**
  - Neptune `ModifyDBCluster`: apply `VpcSecurityGroupIds` and `CloudwatchLogsExportConfiguration` (Enable/DisableLogTypes).
  - DocDB `ModifyDBCluster`: same as Neptune (`VpcSecurityGroupIds`, `CloudwatchLogsExportConfiguration`).
  - API Gateway `UpdateRestApi`: support `/minimumCompressionSize` and `/endpointConfiguration` (whole object and indexed arrays like `/types/0`, `/vpcEndpointIds/1`).
  - API Gateway `UpdateResource`: on `/pathPart` rename or `/parentId` move, recompute stored `path` for the resource and all descendants; reject cycles (BadRequest) and sibling path collisions (Conflict) with rollback.
  - EKS `UpdateNodegroupConfig`: support `taints` add/update/remove and honor `removeLabels`; `CreateCluster` now persists `encryptionConfig`.
  - SSM `RegisterTaskWithMaintenanceWindow`/`UpdateMaintenanceWindowTask`: store and emit `TaskInvocationParameters`, `TaskParameters`, `LoggingInfo`, and `CutoffBehavior` in Get/Describe.

<sup>Written for commit 5185e6ee8831cb713d0b3db40d104f56b2244608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

