### PR TITLE
fix(iot,iotwireless,stepfunctions): apply write fields the read path projects + populate MapRun (bug-hunt)

### DIFF
--- a/crates/fakecloud-iot/src/service/engine.rs
+++ b/crates/fakecloud-iot/src/service/engine.rs
@@ -79,7 +79,50 @@ fn build_record(
             _ => {}
         }
     }
+    apply_attribute_payload(&mut record);
     Value::Object(record)
+}
+
+/// Unwrap a Thing `attributePayload` (`{attributes, merge}`) into the top-level
+/// `attributes` map that the read path (`DescribeThing` / `ListThings`)
+/// projects. Without this the payload is stored verbatim under a key no read
+/// consumes, so attributes set at create/update time silently vanish.
+///
+/// When `merge` is true the payload attributes overlay the record's existing
+/// `attributes`; otherwise they replace it wholesale. In both modes an
+/// empty-string value removes that attribute, matching AWS IoT semantics. A
+/// record without an `attributePayload` is left untouched.
+fn apply_attribute_payload(record: &mut Map<String, Value>) {
+    let Some(payload) = record.remove("attributePayload") else {
+        return;
+    };
+    let merge = payload
+        .get("merge")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let incoming = payload
+        .get("attributes")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut attributes = if merge {
+        record
+            .get("attributes")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default()
+    } else {
+        Map::new()
+    };
+    for (k, v) in incoming {
+        if v.as_str() == Some("") {
+            attributes.remove(&k);
+        } else {
+            attributes.insert(k, v);
+        }
+    }
+    record.insert("attributes".to_string(), Value::Object(attributes));
 }
 
 pub(super) fn create(
@@ -130,6 +173,10 @@ pub(super) fn update(
         for (k, v) in body {
             obj.insert(k.clone(), v.clone());
         }
+        // Fold any `attributePayload` (honouring its `merge` flag against the
+        // existing attributes) into the top-level `attributes` map before it is
+        // stored, so the update is visible to DescribeThing / ListThings.
+        apply_attribute_payload(obj);
         obj.insert("lastModifiedDate".to_string(), now_epoch());
     }
     let out = build_output(meta, &record);

--- a/crates/fakecloud-iot/src/service/tests.rs
+++ b/crates/fakecloud-iot/src/service/tests.rs
@@ -1264,6 +1264,77 @@ fn put_verification_state_round_trips_through_list_violation_events() {
     assert_eq!(events[0]["verificationState"], "FALSE_POSITIVE");
 }
 
+// ---------- Thing attributePayload round-trip (bug-hunt read-shape) ----------
+
+#[test]
+fn create_thing_attribute_payload_surfaces_in_describe_and_list() {
+    let s = svc();
+    run(
+        &s,
+        "POST",
+        "/things/sensor-1",
+        &[],
+        json!({"attributePayload": {"attributes": {"color": "red", "zone": "a"}}}),
+    )
+    .unwrap();
+
+    // DescribeThing must project the attributes at the top level, not swallow
+    // them inside the stored `attributePayload`.
+    let described = body_of(&run(&s, "GET", "/things/sensor-1", &[], Value::Null).unwrap());
+    assert_eq!(described["attributes"]["color"], "red");
+    assert_eq!(described["attributes"]["zone"], "a");
+    assert!(described.get("attributePayload").is_none());
+
+    // ListThings projects the same attributes onto each element.
+    let listed = body_of(&run(&s, "GET", "/things", &[], Value::Null).unwrap());
+    let things = listed["things"].as_array().unwrap();
+    let sensor = things
+        .iter()
+        .find(|t| t["thingName"] == "sensor-1")
+        .unwrap();
+    assert_eq!(sensor["attributes"]["color"], "red");
+}
+
+#[test]
+fn update_thing_attribute_payload_merge_semantics() {
+    let s = svc();
+    run(
+        &s,
+        "POST",
+        "/things/sensor-2",
+        &[],
+        json!({"attributePayload": {"attributes": {"color": "red", "zone": "a"}}}),
+    )
+    .unwrap();
+
+    // merge=true overlays onto the existing attributes: `zone` survives, `color`
+    // is updated, and an empty-string value removes the attribute.
+    run(
+        &s,
+        "PATCH",
+        "/things/sensor-2",
+        &[],
+        json!({"attributePayload": {"merge": true, "attributes": {"color": "blue", "zone": ""}}}),
+    )
+    .unwrap();
+    let described = body_of(&run(&s, "GET", "/things/sensor-2", &[], Value::Null).unwrap());
+    assert_eq!(described["attributes"]["color"], "blue");
+    assert!(described["attributes"].get("zone").is_none());
+
+    // merge=false (default) replaces the whole attribute set.
+    run(
+        &s,
+        "PATCH",
+        "/things/sensor-2",
+        &[],
+        json!({"attributePayload": {"attributes": {"shape": "round"}}}),
+    )
+    .unwrap();
+    let described = body_of(&run(&s, "GET", "/things/sensor-2", &[], Value::Null).unwrap());
+    assert_eq!(described["attributes"]["shape"], "round");
+    assert!(described["attributes"].get("color").is_none());
+}
+
 // ---------- every operation routes to a handler ----------
 
 #[test]

--- a/crates/fakecloud-iotwireless/src/service/engine.rs
+++ b/crates/fakecloud-iotwireless/src/service/engine.rs
@@ -153,6 +153,11 @@ pub(super) fn update(
     for (k, v) in body {
         record.insert(k.clone(), v.clone());
     }
+    // Reshape update-only members into the shape the matching Get projects:
+    // add/remove delta lists into their base membership lists, and top-level
+    // gateway filters into the nested `LoRaWAN` sub-object. Without this the
+    // deltas / filters are stored under keys no read consumes and vanish.
+    apply_update_shape(meta, &mut record);
     record
         .entry("Arn".to_string())
         .or_insert_with(|| Value::String(mint_arn(ctx, &rtype, &key)));
@@ -163,6 +168,88 @@ pub(super) fn update(
     let out = build_output(meta, &Value::Object(record.clone()));
     data.put_resource(&rtype, &key, Value::Object(record));
     ok_json(out)
+}
+
+/// Reshape update-only request members into the shape the family's Get reads.
+///
+/// * `UpdateNetworkAnalyzerConfiguration` carries `*ToAdd`/`*ToRemove` delta
+///   lists; `GetNetworkAnalyzerConfiguration` projects the resolved
+///   `WirelessDevices`/`WirelessGateways`/`MulticastGroups` membership lists.
+/// * `UpdateWirelessGateway` carries top-level `JoinEuiFilters`/`NetIdFilters`/
+///   `MaxEirp`; `GetWirelessGateway` surfaces them nested inside `LoRaWAN`.
+fn apply_update_shape(meta: &OpMeta, record: &mut Map<String, Value>) {
+    match meta.op {
+        "UpdateNetworkAnalyzerConfiguration" => {
+            apply_list_delta(
+                record,
+                "WirelessDevices",
+                "WirelessDevicesToAdd",
+                "WirelessDevicesToRemove",
+            );
+            apply_list_delta(
+                record,
+                "WirelessGateways",
+                "WirelessGatewaysToAdd",
+                "WirelessGatewaysToRemove",
+            );
+            apply_list_delta(
+                record,
+                "MulticastGroups",
+                "MulticastGroupsToAdd",
+                "MulticastGroupsToRemove",
+            );
+        }
+        "UpdateWirelessGateway" => {
+            nest_into_lorawan(record, &["JoinEuiFilters", "NetIdFilters", "MaxEirp"]);
+        }
+        _ => {}
+    }
+}
+
+/// Apply add/remove deltas to a base membership list, consuming the delta keys.
+/// Adds append members not already present; removes drop listed members.
+fn apply_list_delta(record: &mut Map<String, Value>, base: &str, add: &str, remove: &str) {
+    let adds = record.remove(add);
+    let removes = record.remove(remove);
+    if adds.is_none() && removes.is_none() {
+        return;
+    }
+    let mut list: Vec<Value> = record
+        .get(base)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(Value::Array(a)) = adds {
+        for item in a {
+            if !list.contains(&item) {
+                list.push(item);
+            }
+        }
+    }
+    if let Some(Value::Array(r)) = removes {
+        list.retain(|x| !r.contains(x));
+    }
+    record.insert(base.to_string(), Value::Array(list));
+}
+
+/// Move the named top-level members into the record's `LoRaWAN` sub-object,
+/// merging with any existing nested members. Consumes the top-level keys.
+fn nest_into_lorawan(record: &mut Map<String, Value>, keys: &[&str]) {
+    let mut lorawan = record
+        .get("LoRaWAN")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut changed = false;
+    for k in keys {
+        if let Some(v) = record.remove(*k) {
+            lorawan.insert((*k).to_string(), v);
+            changed = true;
+        }
+    }
+    if changed {
+        record.insert("LoRaWAN".to_string(), Value::Object(lorawan));
+    }
 }
 
 pub(super) fn delete(

--- a/crates/fakecloud-iotwireless/src/service/special.rs
+++ b/crates/fakecloud-iotwireless/src/service/special.rs
@@ -14,8 +14,8 @@ use fakecloud_core::service::{AwsResponse, AwsServiceError};
 use crate::generated::OpMeta;
 
 use super::{
-    build_output, mint_arn, mint_uuid, now_epoch, ok_json, query_get, resource_type, storage_key,
-    Ctx, IotWirelessService,
+    build_element, build_output, mint_arn, mint_uuid, now_epoch, ok_json, query_get, resource_type,
+    storage_key, Ctx, IotWirelessService,
 };
 
 type Handled = Result<Option<(AwsResponse, bool)>, AwsServiceError>;
@@ -209,6 +209,12 @@ pub(super) fn dispatch(
         "ListMulticastGroupsByFuotaTask" => {
             Ok(Some(list_multicast_groups_by_fuota_task(svc, ctx, labels)))
         }
+
+        // ---- filtered wireless-device listing (finding 3) ----
+        // The generic engine list ignores the modelled query filters, so the
+        // membership Associate*WithMulticastGroup / WithFuotaTask persist is
+        // never observable. Serve the list here so the filters apply.
+        "ListWirelessDevices" => Ok(Some(list_wireless_devices(svc, meta, ctx, query))),
 
         // ---- multicast-group LoRaWAN session lifecycle ----
         // Start persists the requested LoRaWAN session under `multicast-sessions`
@@ -974,6 +980,108 @@ fn disassociate_partner_account(
             .map(|m| m.remove(id));
     }
     (ok_json(Value::Object(Map::new())), true)
+}
+
+// ---------- filtered wireless-device listing (finding 3) ----------
+
+/// A `LoRaWAN` sub-field of a wireless-device record, when present.
+fn lorawan_field<'a>(rec: &'a Value, field: &str) -> Option<&'a str> {
+    rec.get("LoRaWAN")
+        .and_then(|l| l.get(field))
+        .and_then(Value::as_str)
+}
+
+/// `ListWirelessDevices` with the modelled query filters applied. The generic
+/// engine ignores them, which hides the membership edges that
+/// `AssociateWirelessDeviceWithMulticastGroup` / `WithFuotaTask` persist and
+/// drops the `destinationName` / `deviceProfileId` / `serviceProfileId` /
+/// `wirelessDeviceType` selectors. Filtering here makes the associations (and
+/// the other filters) observable through a read.
+fn list_wireless_devices(
+    svc: &IotWirelessService,
+    meta: &OpMeta,
+    ctx: &Ctx,
+    query: &[(String, String)],
+) -> (AwsResponse, bool) {
+    let g = svc.state.read();
+    let data = g.get(&ctx.account);
+
+    // Association filters resolve through the membership relations persisted by
+    // the associate ops; an absent group/task yields an empty member set.
+    let multicast_members = query_get(query, "multicastGroupId").map(|id| {
+        data.map(|d| d.list_relation(&format!("multicast-devices:{id}")))
+            .unwrap_or_default()
+    });
+    let fuota_members = query_get(query, "fuotaTaskId").map(|id| {
+        data.map(|d| d.list_relation(&format!("fuota-devices:{id}")))
+            .unwrap_or_default()
+    });
+    let destination = query_get(query, "destinationName");
+    let device_type = query_get(query, "wirelessDeviceType");
+    let device_profile = query_get(query, "deviceProfileId");
+    let service_profile = query_get(query, "serviceProfileId");
+
+    let entries = data
+        .map(|d| d.list_resource_entries("wireless-devices"))
+        .unwrap_or_default();
+
+    let filtered: Vec<Value> = entries
+        .into_iter()
+        .filter(|(id, rec)| {
+            if let Some(members) = &multicast_members {
+                if !members.iter().any(|m| m == id) {
+                    return false;
+                }
+            }
+            if let Some(members) = &fuota_members {
+                if !members.iter().any(|m| m == id) {
+                    return false;
+                }
+            }
+            if let Some(dn) = destination {
+                if rec.get("DestinationName").and_then(Value::as_str) != Some(dn) {
+                    return false;
+                }
+            }
+            if let Some(t) = device_type {
+                if rec.get("Type").and_then(Value::as_str) != Some(t) {
+                    return false;
+                }
+            }
+            if let Some(dp) = device_profile {
+                if lorawan_field(rec, "DeviceProfileId") != Some(dp) {
+                    return false;
+                }
+            }
+            if let Some(sp) = service_profile {
+                if lorawan_field(rec, "ServiceProfileId") != Some(sp) {
+                    return false;
+                }
+            }
+            true
+        })
+        .map(|(_, rec)| build_element(meta, &rec))
+        .collect();
+
+    let page_size = query_get(query, "maxResults")
+        .or_else(|| query_get(query, "MaxResults"))
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(250);
+    let start = query_get(query, "nextToken")
+        .or_else(|| query_get(query, "NextToken"))
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    let end = (start + page_size).min(filtered.len());
+    let page = filtered.get(start..end).unwrap_or(&[]).to_vec();
+    let has_next = end < filtered.len();
+
+    let mut out = Map::new();
+    out.insert("WirelessDeviceList".to_string(), Value::Array(page));
+    if has_next {
+        out.insert("NextToken".to_string(), Value::String(end.to_string()));
+    }
+    (ok_json(Value::Object(out)), false)
 }
 
 // ---------- multicast-group LoRaWAN session ----------

--- a/crates/fakecloud-iotwireless/src/service/tests.rs
+++ b/crates/fakecloud-iotwireless/src/service/tests.rs
@@ -1222,3 +1222,228 @@ fn required_body_omission_is_rejected_for_every_op() {
         failures.join("\n")
     );
 }
+
+// ---------- read-shape round-trips (bug-hunt) ----------
+
+fn create_device(s: &IotWirelessService, dest: &str) -> String {
+    let d = body_of(
+        &run(
+            s,
+            "POST",
+            "/wireless-devices",
+            &[],
+            json!({"Type": "Sidewalk", "DestinationName": dest}),
+        )
+        .unwrap(),
+    );
+    d["Id"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn associate_device_with_multicast_group_filters_list_wireless_devices() {
+    let s = svc();
+    let group = body_of(
+        &run(
+            &s,
+            "POST",
+            "/multicast-groups",
+            &[],
+            json!({"Name": "g1", "LoRaWAN": {"RfRegion": "US915", "DlClass": "ClassC"}}),
+        )
+        .unwrap(),
+    );
+    let group_id = group["Id"].as_str().unwrap().to_string();
+    let dev_in = create_device(&s, "d");
+    let _dev_out = create_device(&s, "d");
+
+    // Associate one device with the group.
+    run(
+        &s,
+        "PUT",
+        &format!("/multicast-groups/{group_id}/wireless-device"),
+        &[],
+        json!({"WirelessDeviceId": dev_in}),
+    )
+    .unwrap();
+
+    // Filtered list returns ONLY the associated device.
+    let listed = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-devices?multicastGroupId={group_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    let devs = listed["WirelessDeviceList"].as_array().unwrap();
+    assert_eq!(devs.len(), 1);
+    assert_eq!(devs[0]["Id"], dev_in);
+
+    // Unfiltered list still returns both.
+    let all = body_of(&run(&s, "GET", "/wireless-devices", &[], Value::Null).unwrap());
+    assert_eq!(all["WirelessDeviceList"].as_array().unwrap().len(), 2);
+
+    // Disassociate removes membership: filtered list is now empty.
+    run(
+        &s,
+        "DELETE",
+        &format!("/multicast-groups/{group_id}/wireless-devices/{dev_in}"),
+        &[],
+        Value::Null,
+    )
+    .unwrap();
+    let after = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-devices?multicastGroupId={group_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    assert!(after["WirelessDeviceList"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn associate_device_with_fuota_task_filters_list_wireless_devices() {
+    let s = svc();
+    let task = body_of(
+        &run(
+            &s,
+            "POST",
+            "/fuota-tasks",
+            &[],
+            json!({
+                "Name": "t1",
+                "FirmwareUpdateImage": "img",
+                "FirmwareUpdateRole": "role"
+            }),
+        )
+        .unwrap(),
+    );
+    let task_id = task["Id"].as_str().unwrap().to_string();
+    let dev = create_device(&s, "d");
+
+    run(
+        &s,
+        "PUT",
+        &format!("/fuota-tasks/{task_id}/wireless-device"),
+        &[],
+        json!({"WirelessDeviceId": dev}),
+    )
+    .unwrap();
+
+    let listed = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-devices?fuotaTaskId={task_id}"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    let devs = listed["WirelessDeviceList"].as_array().unwrap();
+    assert_eq!(devs.len(), 1);
+    assert_eq!(devs[0]["Id"], dev);
+}
+
+#[test]
+fn update_network_analyzer_configuration_applies_membership_deltas() {
+    let s = svc();
+    run(
+        &s,
+        "POST",
+        "/network-analyzer-configurations",
+        &[],
+        json!({"Name": "nac1", "WirelessDevices": ["d1"], "WirelessGateways": ["g1"]}),
+    )
+    .unwrap();
+
+    run(
+        &s,
+        "PATCH",
+        "/network-analyzer-configurations/nac1",
+        &[],
+        json!({
+            "WirelessDevicesToAdd": ["d2"],
+            "WirelessDevicesToRemove": ["d1"],
+            "WirelessGatewaysToAdd": ["g2"],
+            "MulticastGroupsToAdd": ["mc1"]
+        }),
+    )
+    .unwrap();
+
+    let got = body_of(
+        &run(
+            &s,
+            "GET",
+            "/network-analyzer-configurations/nac1",
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    let devices: Vec<&str> = got["WirelessDevices"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(devices, vec!["d2"]);
+    let gateways: Vec<&str> = got["WirelessGateways"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(gateways, vec!["g1", "g2"]);
+    assert_eq!(got["MulticastGroups"].as_array().unwrap().len(), 1);
+    // Delta keys must not leak into the read.
+    assert!(got.get("WirelessDevicesToAdd").is_none());
+}
+
+#[test]
+fn update_wireless_gateway_nests_filters_into_lorawan() {
+    let s = svc();
+    let gw = body_of(
+        &run(
+            &s,
+            "POST",
+            "/wireless-gateways",
+            &[],
+            json!({"LoRaWAN": {"GatewayEui": "0000000000000000", "RfRegion": "US915"}}),
+        )
+        .unwrap(),
+    );
+    let id = gw["Id"].as_str().unwrap().to_string();
+
+    run(
+        &s,
+        "PATCH",
+        &format!("/wireless-gateways/{id}"),
+        &[],
+        json!({"JoinEuiFilters": [["0000", "ffff"]], "NetIdFilters": ["000000"], "MaxEirp": 15}),
+    )
+    .unwrap();
+
+    let got = body_of(
+        &run(
+            &s,
+            "GET",
+            &format!("/wireless-gateways/{id}?identifierType=WirelessGatewayId"),
+            &[],
+            Value::Null,
+        )
+        .unwrap(),
+    );
+    // Filters surface nested inside LoRaWAN, not at the top level.
+    assert_eq!(got["LoRaWAN"]["NetIdFilters"][0], "000000");
+    assert_eq!(got["LoRaWAN"]["MaxEirp"], 15);
+    assert_eq!(got["LoRaWAN"]["GatewayEui"], "0000000000000000");
+    assert!(got.get("JoinEuiFilters").is_none());
+    assert!(got.get("MaxEirp").is_none());
+}

--- a/crates/fakecloud-stepfunctions/src/interpreter.rs
+++ b/crates/fakecloud-stepfunctions/src/interpreter.rs
@@ -13,7 +13,7 @@ use crate::choice::evaluate_choice;
 use crate::error_handling::{find_catcher, should_retry};
 use crate::io_processing::{apply_input_path, apply_output_path, apply_result_path};
 use crate::service::SharedServiceRegistry;
-use crate::state::{ExecutionStatus, HistoryEvent, SharedStepFunctionsState};
+use crate::state::{ExecutionStatus, HistoryEvent, MapRun, SharedStepFunctionsState};
 
 /// Execute a state machine definition with the given input.
 /// Updates the execution record in shared state as it progresses.
@@ -764,8 +764,36 @@ async fn execute_map_state(
     let tolerated_failure_percentage = state_def["ToleratedFailurePercentage"]
         .as_f64()
         .unwrap_or(0.0);
+    let tolerated_failure_count = state_def["ToleratedFailureCount"].as_i64().unwrap_or(0);
     let total_items = batched_items.len() as f64;
     let mut failure_count = 0usize;
+
+    // A distributed Map (`ItemProcessor.ProcessorConfig.Mode == "DISTRIBUTED"`)
+    // materialises a MapRun record that `ListMapRuns` / `DescribeMapRun`
+    // surface. Inline Map states do not create one, matching AWS.
+    let is_distributed = iterator_def
+        .get("ProcessorConfig")
+        .and_then(|c| c.get("Mode"))
+        .and_then(Value::as_str)
+        == Some("DISTRIBUTED");
+    let map_run_arn = if is_distributed {
+        map_run_arn_for(execution_arn).inspect(|arn| {
+            start_map_run(
+                shared_state,
+                arn,
+                execution_arn,
+                // The configured MaxConcurrency (0 == unlimited), as AWS reports
+                // it, not the internal `effective_concurrency` (which defaults
+                // an unset value to 40).
+                max_concurrency as usize,
+                tolerated_failure_percentage,
+                tolerated_failure_count,
+                batched_items.len(),
+            );
+        })
+    } else {
+        None
+    };
 
     let semaphore = Arc::new(tokio::sync::Semaphore::new(effective_concurrency));
 
@@ -841,10 +869,33 @@ async fn execute_map_state(
                 failure_count += 1;
                 let failure_percentage = (failure_count as f64 / total_items) * 100.0;
                 if failure_percentage > tolerated_failure_percentage {
+                    if let Some(arn) = &map_run_arn {
+                        finish_map_run(
+                            shared_state,
+                            arn,
+                            execution_arn,
+                            results.len() as i64,
+                            failure_count as i64,
+                            "FAILED",
+                        );
+                    }
                     return Err((error, cause));
                 }
             }
         }
+    }
+
+    // Every iteration is accounted for and the tolerated-failure threshold was
+    // not exceeded: the map run succeeded.
+    if let Some(arn) = &map_run_arn {
+        finish_map_run(
+            shared_state,
+            arn,
+            execution_arn,
+            results.len() as i64,
+            failure_count as i64,
+            "SUCCEEDED",
+        );
     }
 
     // Sort by index to maintain order
@@ -878,6 +929,69 @@ async fn execute_map_state(
     };
 
     Ok(output)
+}
+
+/// Build a MapRun ARN for a distributed Map running inside `execution_arn`.
+/// `arn:aws:states:R:A:execution:SM:Exec` -> `arn:aws:states:R:A:mapRun:SM/Exec:<label>`.
+fn map_run_arn_for(execution_arn: &str) -> Option<String> {
+    let (prefix, tail) = execution_arn.split_once(":execution:")?;
+    // `tail` is `StateMachineName:ExecutionName`; the MapRun ARN joins them with
+    // a slash and appends a unique label.
+    let sm_exec = tail.replacen(':', "/", 1);
+    let label = uuid::Uuid::new_v4().simple().to_string();
+    Some(format!("{prefix}:mapRun:{sm_exec}:{label}"))
+}
+
+/// Persist a fresh RUNNING MapRun record for a distributed Map.
+fn start_map_run(
+    shared_state: &SharedStepFunctionsState,
+    map_run_arn: &str,
+    execution_arn: &str,
+    max_concurrency: usize,
+    tolerated_failure_percentage: f64,
+    tolerated_failure_count: i64,
+    total: usize,
+) {
+    let account = account_id_from_arn(execution_arn).to_string();
+    let mut accounts = shared_state.write();
+    let s = accounts.get_or_create(&account);
+    s.map_runs.insert(
+        map_run_arn.to_string(),
+        MapRun {
+            map_run_arn: map_run_arn.to_string(),
+            execution_arn: execution_arn.to_string(),
+            max_concurrency: max_concurrency as i32,
+            tolerated_failure_percentage,
+            tolerated_failure_count,
+            status: "RUNNING".to_string(),
+            start_date: Utc::now(),
+            stop_date: None,
+            total_count: total as i64,
+            succeeded_count: 0,
+            failed_count: 0,
+        },
+    );
+}
+
+/// Transition a MapRun to a terminal status, recording the final iteration
+/// tallies. No-op if the record was reaped (e.g. a state reset mid-run).
+fn finish_map_run(
+    shared_state: &SharedStepFunctionsState,
+    map_run_arn: &str,
+    execution_arn: &str,
+    succeeded: i64,
+    failed: i64,
+    status: &str,
+) {
+    let account = account_id_from_arn(execution_arn).to_string();
+    let mut accounts = shared_state.write();
+    let s = accounts.get_or_create(&account);
+    if let Some(mr) = s.map_runs.get_mut(map_run_arn) {
+        mr.status = status.to_string();
+        mr.succeeded_count = succeeded;
+        mr.failed_count = failed;
+        mr.stop_date = Some(Utc::now());
+    }
 }
 
 /// Read items from S3 for distributed Map mode ItemReader.

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -367,6 +367,28 @@ fn state_machine_alias_to_json(alias: &crate::state::StateMachineAlias) -> Value
 }
 
 fn map_run_to_json(mr: &crate::state::MapRun) -> Value {
+    // Iterations still in flight while the map run is RUNNING; zero once it has
+    // reached a terminal status.
+    let accounted = mr.succeeded_count + mr.failed_count;
+    let running = if mr.status == "RUNNING" {
+        (mr.total_count - accounted).max(0)
+    } else {
+        0
+    };
+    // AWS reports parallel `itemCounts` and `executionCounts` maps; with one
+    // child execution per item they carry identical tallies here.
+    let counts = json!({
+        "pending": 0,
+        "running": running,
+        "succeeded": mr.succeeded_count,
+        "failed": mr.failed_count,
+        "timedOut": 0,
+        "aborted": 0,
+        "results": mr.succeeded_count,
+        "total": mr.total_count,
+        "failuresNotRedrivable": 0,
+        "pendingRedrive": 0,
+    });
     json!({
         "mapRunArn": mr.map_run_arn,
         "executionArn": mr.execution_arn,
@@ -376,6 +398,8 @@ fn map_run_to_json(mr: &crate::state::MapRun) -> Value {
         "status": mr.status,
         "startDate": mr.start_date.timestamp(),
         "stopDate": mr.stop_date.map(|d| d.timestamp()),
+        "itemCounts": counts,
+        "executionCounts": counts,
     })
 }
 
@@ -2128,6 +2152,115 @@ mod tests {
         assert!(running.stop_date.is_some());
         assert_eq!(running.error.as_deref(), Some("Fakecloud.Restart"));
         assert_eq!(s.executions["done"].status, ExecutionStatus::Succeeded);
+    }
+
+    // ── Distributed Map -> MapRun population (bug-hunt read-shape) ──
+
+    #[tokio::test]
+    async fn distributed_map_populates_map_run() {
+        let state = make_state();
+        let svc = StepFunctionsService::new(state.clone());
+        let execution_arn =
+            "arn:aws:states:us-east-1:123456789012:execution:dist-sm:exec-1".to_string();
+
+        let def = json!({
+            "StartAt": "M",
+            "States": {
+                "M": {
+                    "Type": "Map",
+                    "ItemsPath": "$.items",
+                    "ItemProcessor": {
+                        "ProcessorConfig": { "Mode": "DISTRIBUTED", "ExecutionType": "STANDARD" },
+                        "StartAt": "Item",
+                        "States": { "Item": { "Type": "Pass", "End": true } }
+                    },
+                    "End": true
+                }
+            }
+        });
+
+        interpreter::execute_state_machine(
+            state.clone(),
+            execution_arn.clone(),
+            def.to_string(),
+            Some(r#"{"items":[1,2,3]}"#.to_string()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        // ListMapRuns(executionArn) surfaces the newly created MapRun.
+        let req = make_request(
+            "ListMapRuns",
+            &json!({ "executionArn": execution_arn }).to_string(),
+        );
+        let listed = body_json(&svc.list_map_runs(&req).unwrap());
+        let runs = listed["mapRuns"].as_array().unwrap();
+        assert_eq!(
+            runs.len(),
+            1,
+            "distributed map must create exactly one MapRun"
+        );
+        let map_run_arn = runs[0]["mapRunArn"].as_str().unwrap().to_string();
+        assert!(map_run_arn.contains(":mapRun:"));
+        assert_eq!(runs[0]["executionArn"], execution_arn);
+
+        // DescribeMapRun(mapRunArn) returns the record with real counts.
+        let req = make_request(
+            "DescribeMapRun",
+            &json!({ "mapRunArn": map_run_arn }).to_string(),
+        );
+        let mr = body_json(&svc.describe_map_run(&req).unwrap());
+        assert_eq!(mr["status"], "SUCCEEDED");
+        assert_eq!(mr["itemCounts"]["total"], 3);
+        assert_eq!(mr["itemCounts"]["succeeded"], 3);
+        assert_eq!(mr["itemCounts"]["failed"], 0);
+        assert_eq!(mr["executionCounts"]["succeeded"], 3);
+    }
+
+    #[tokio::test]
+    async fn inline_map_does_not_create_map_run() {
+        let state = make_state();
+        let svc = StepFunctionsService::new(state.clone());
+        let execution_arn =
+            "arn:aws:states:us-east-1:123456789012:execution:inline-sm:exec-1".to_string();
+
+        // No ProcessorConfig.Mode => inline Map: AWS creates no MapRun.
+        let def = json!({
+            "StartAt": "M",
+            "States": {
+                "M": {
+                    "Type": "Map",
+                    "ItemsPath": "$.items",
+                    "ItemProcessor": {
+                        "StartAt": "Item",
+                        "States": { "Item": { "Type": "Pass", "End": true } }
+                    },
+                    "End": true
+                }
+            }
+        });
+
+        interpreter::execute_state_machine(
+            state.clone(),
+            execution_arn.clone(),
+            def.to_string(),
+            Some(r#"{"items":[1,2]}"#.to_string()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        let req = make_request(
+            "ListMapRuns",
+            &json!({ "executionArn": execution_arn }).to_string(),
+        );
+        let listed = body_json(&svc.list_map_runs(&req).unwrap());
+        assert!(listed["mapRuns"].as_array().unwrap().is_empty());
     }
 }
 

--- a/crates/fakecloud-stepfunctions/src/state.rs
+++ b/crates/fakecloud-stepfunctions/src/state.rs
@@ -92,6 +92,15 @@ pub struct MapRun {
     pub status: String,
     pub start_date: DateTime<Utc>,
     pub stop_date: Option<DateTime<Utc>>,
+    /// Total number of items the distributed Map iterated over.
+    #[serde(default)]
+    pub total_count: i64,
+    /// Iterations that completed successfully.
+    #[serde(default)]
+    pub succeeded_count: i64,
+    /// Iterations that failed.
+    #[serde(default)]
+    pub failed_count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Five confirmed **write-shape != read-shape** data-loss stubs: the table-driven generic engine stored request input verbatim, but the read path projected a differently-named / nested field, so the data silently disappeared. Each fix makes the write apply into the shape the read projects.

1. **IoT CreateThing/UpdateThing `attributePayload` -> DescribeThing/ListThings `attributes`** (HIGH). The input member `attributePayload` (`{attributes, merge}`) was stored verbatim; reads project a top-level `attributes` map, so nothing surfaced. Create/Update now unwrap `attributePayload.attributes` into the stored top-level `attributes`, honouring `merge` (overlay existing when true, replace when false; an empty-string value removes the attribute, matching AWS). DescribeThing + ListThings now round-trip.

2. **IoTWireless UpdateNetworkAnalyzerConfiguration delta lists** (MEDIUM). The update carries `WirelessDevicesToAdd/Remove`, `WirelessGatewaysToAdd/Remove`, `MulticastGroupsToAdd/Remove`; the read projects resolved `WirelessDevices`/`WirelessGateways`/`MulticastGroups`. The engine never applied the deltas. Update now folds add/remove deltas into the base membership lists so GetNetworkAnalyzerConfiguration reflects post-update membership.

3. **IoTWireless Associate\*WithMulticastGroup / WithFuotaTask + ListWirelessDevices filters** (MEDIUM). The association edges (`multicast-devices:<id>` / `fuota-devices:<id>`) were persisted but no read consumed them, and `ListWirelessDevices` ignored its modelled query filters. ListWirelessDevices is now served so the `multicastGroupId` / `fuotaTaskId` filters resolve through those edges (and `destinationName` / `deviceProfileId` / `serviceProfileId` / `wirelessDeviceType` are applied too). Disassociate removes membership.

4. **IoTWireless UpdateWirelessGateway LoRaWAN nesting** (LOW). The update carries top-level `JoinEuiFilters`/`NetIdFilters`/`MaxEirp`, but Get surfaces them nested inside `LoRaWAN`. Update now merges them into the stored `LoRaWAN` sub-object so GetWirelessGateway reflects them.

5. **StepFunctions DescribeMapRun/ListMapRuns never populated** (HIGH). `map_runs` was only read/cleared -- no insert existed, so distributed Map executions never created a MapRun (ListMapRuns always empty, DescribeMapRun always 404). A `DISTRIBUTED`-mode Map state now materialises a MapRun record at the point it runs, with **real** counts derived from the actual iteration the interpreter performs (total / succeeded / failed) plus status + start/stop dates; DescribeMapRun projects AWS-shaped `itemCounts`/`executionCounts`. Inline Map states create none, matching AWS. Counts are not faked.

## Test plan

- New round-trip tests, all green (`cargo test -p fakecloud-iot -p fakecloud-iotwireless -p fakecloud-stepfunctions`):
  - IoT: set `attributePayload` on create -> DescribeThing + ListThings return the attributes; UpdateThing merge (overlay + empty-string removal) and replace semantics.
  - IoTWireless: associate device with multicast group / fuota task -> filtered ListWirelessDevices returns only the associated device (and disassociate empties it); UpdateNetworkAnalyzerConfiguration deltas -> Get membership; UpdateWirelessGateway filters -> Get nested inside LoRaWAN.
  - StepFunctions: run a DISTRIBUTED Map execution -> ListMapRuns non-empty + DescribeMapRun returns the record with correct counts (total/succeeded/failed); inline Map creates no MapRun.
- `cargo clippy -p fakecloud-iot -p fakecloud-iotwireless -p fakecloud-stepfunctions --all-targets -- -D warnings` clean.
- `cargo fmt` clean.
- `/code-review` (medium): surfaced that MapRun stored the internal effective concurrency (40 default) rather than the modelled `MaxConcurrency` (0 = unlimited) -- fixed to report the configured value.

## Surface sync

No new API surface, operation, field, or SDK change: this only makes existing modelled operations faithfully round-trip. The one new state field is internal (MapRun iteration counts, `#[serde(default)]`, snapshot-compatible).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent data loss by aligning write shapes with read shapes in `fakecloud-iot` and `fakecloud-iotwireless`, and adds real `MapRun` records for distributed Step Functions Map states. Reads now return the data users set, and `ListMapRuns`/`DescribeMapRun` show accurate counts.

- **Bug Fixes**
  - IoT: `attributePayload.attributes` now stored as top-level `attributes`; honors `merge` (overlay/replace) and empty-string removal; `DescribeThing`/`ListThings` round-trip.
  - IoTWireless: `UpdateNetworkAnalyzerConfiguration` applies add/remove deltas to `WirelessDevices`/`WirelessGateways`/`MulticastGroups` so `Get` shows membership.
  - IoTWireless: `ListWirelessDevices` filters implemented (`multicastGroupId`/`fuotaTaskId` via association edges, plus `destinationName`/`deviceProfileId`/`serviceProfileId`/`wirelessDeviceType`); disassociate removes membership.
  - IoTWireless: `UpdateWirelessGateway` nests `JoinEuiFilters`/`NetIdFilters`/`MaxEirp` into `LoRaWAN` so `GetWirelessGateway` reflects them.
  - StepFunctions: DISTRIBUTED Map now creates a `MapRun` with real item/success/failure counts, status, and dates; inline Map creates none; `ListMapRuns`/`DescribeMapRun` return data; reports configured `MaxConcurrency` (0 = unlimited).

<sup>Written for commit 51fc97f7dd6618512ae5169eb1b8e78c72e92070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

