### PR TITLE
fix(glue): real TableVersion delete/lookup, parallel GetPartitions, observable ResumeWorkflowRun + job field persistence (bug-hunt)

### DIFF
--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -1199,6 +1199,7 @@ mod tests {
             table_type: Some("EXTERNAL_TABLE".to_string()),
             parameters: std::collections::BTreeMap::new(),
             partitions: std::collections::BTreeMap::new(),
+            catalog_id: "123456789012".to_string(),
         }
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
@@ -97,6 +97,7 @@ impl ResourceProvisioner {
             fakecloud_glue::Table {
                 name: name.clone(),
                 database_name: db_name.clone(),
+                catalog_id: self.account_id.clone(),
                 description: input
                     .get("Description")
                     .and_then(|v| v.as_str())

--- a/crates/fakecloud-glue/src/catalog.rs
+++ b/crates/fakecloud-glue/src/catalog.rs
@@ -231,9 +231,12 @@ impl GlueService {
                     .collect()
             })
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(
-            json!({ "UserDefinedFunctions": list }),
-        ))
+        let (page, token) = crate::common::paginate_body(&body, list);
+        let mut resp = json!({ "UserDefinedFunctions": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn update_user_defined_function(

--- a/crates/fakecloud-glue/src/common.rs
+++ b/crates/fakecloud-glue/src/common.rs
@@ -93,6 +93,25 @@ pub(crate) fn resource_arn(account: &str, region: &str, kind: &str, name: &str) 
     format!("arn:aws:glue:{region}:{account}:{kind}/{name}")
 }
 
+/// Paginate a Glue list op using the request's `MaxResults`/`NextToken`.
+///
+/// Uses the offset-token scheme in [`fakecloud_core::pagination::paginate`]:
+/// the token is the numeric offset of the next page. When `MaxResults` is
+/// absent the full remaining list (from any incoming offset) is returned in a
+/// single page with no continuation token — matching how AWS returns an
+/// unbounded page when the caller omits a page size.
+pub(crate) fn paginate_body(body: &Value, items: Vec<Value>) -> (Vec<Value>, Option<String>) {
+    let token = body.get("NextToken").and_then(|v| v.as_str());
+    let max = body
+        .get("MaxResults")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize);
+    match max {
+        Some(m) => fakecloud_core::pagination::paginate(&items, token, m),
+        None => fakecloud_core::pagination::paginate(&items, token, usize::MAX),
+    }
+}
+
 /// A small UUID-ish identifier (32 hex chars). Glue uses these for run ids,
 /// transform ids, etc.
 pub(crate) fn new_id() -> String {

--- a/crates/fakecloud-glue/src/connections.rs
+++ b/crates/fakecloud-glue/src/connections.rs
@@ -58,11 +58,27 @@ impl GlueService {
     pub(crate) fn get_connection(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let name = req_str(&body, "Name")?;
+        let hide_password = body
+            .get("HidePassword")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let accounts = self.state.read();
-        let c = accounts
+        let mut c = accounts
             .get(&req.account_id)
             .and_then(|s| s.connections.get(name))
+            .cloned()
             .ok_or_else(|| entity_not_found(format!("Connection {name} not found")))?;
+        // With HidePassword=true AWS strips the PASSWORD from ConnectionProperties
+        // (and any encrypted password) rather than returning it verbatim.
+        if hide_password {
+            if let Some(props) = c
+                .get_mut("ConnectionProperties")
+                .and_then(|v| v.as_object_mut())
+            {
+                props.remove("PASSWORD");
+                props.remove("ENCRYPTED_PASSWORD");
+            }
+        }
         Ok(AwsResponse::ok_json(json!({ "Connection": c })))
     }
 

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -82,12 +82,18 @@ impl GlueService {
     }
 
     pub(crate) fn get_crawlers(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
         let accounts = self.state.read();
         let crawlers: Vec<Value> = accounts
             .get(&req.account_id)
             .map(|s| s.crawlers.values().cloned().collect())
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({ "Crawlers": crawlers })))
+        let (page, token) = crate::common::paginate_body(&body, crawlers);
+        let mut resp = json!({ "Crawlers": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn batch_get_crawlers(

--- a/crates/fakecloud-glue/src/jobs.rs
+++ b/crates/fakecloud-glue/src/jobs.rs
@@ -68,6 +68,11 @@ pub(crate) fn job_to_json(j: &Job) -> Value {
         "SecurityConfiguration": j.security_configuration,
         "NotificationProperty": j.notification_property,
         "NonOverridableArguments": j.non_overridable_arguments,
+        "SourceControlDetails": j.source_control_details,
+        "CodeGenConfigurationNodes": j.code_gen_configuration_nodes,
+        "MaintenanceWindow": j.maintenance_window,
+        "LogUri": j.log_uri,
+        "AllocatedCapacity": j.allocated_capacity,
     })
 }
 
@@ -138,6 +143,11 @@ impl GlueService {
             security_configuration: body["SecurityConfiguration"].as_str().map(String::from),
             notification_property: opt_value(&body["NotificationProperty"]),
             non_overridable_arguments: parse_string_map(&body["NonOverridableArguments"]),
+            source_control_details: opt_value(&body["SourceControlDetails"]),
+            code_gen_configuration_nodes: opt_value(&body["CodeGenConfigurationNodes"]),
+            maintenance_window: body["MaintenanceWindow"].as_str().map(String::from),
+            log_uri: body["LogUri"].as_str().map(String::from),
+            allocated_capacity: body["AllocatedCapacity"].as_i64(),
         };
         state.jobs.insert(name.to_string(), job);
         Ok(AwsResponse::ok_json(json!({ "Name": name })))
@@ -155,21 +165,33 @@ impl GlueService {
     }
 
     pub(crate) fn get_jobs(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
         let accounts = self.state.read();
         let jobs: Vec<Value> = accounts
             .get(&req.account_id)
             .map(|s| s.jobs.values().map(job_to_json).collect())
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({ "Jobs": jobs })))
+        let (page, token) = crate::common::paginate_body(&body, jobs);
+        let mut resp = json!({ "Jobs": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn list_jobs(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
         let accounts = self.state.read();
-        let names: Vec<String> = accounts
+        let names: Vec<Value> = accounts
             .get(&req.account_id)
-            .map(|s| s.jobs.keys().cloned().collect())
+            .map(|s| s.jobs.keys().map(|k| json!(k)).collect())
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({ "JobNames": names })))
+        let (page, token) = crate::common::paginate_body(&body, names);
+        let mut resp = json!({ "JobNames": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn update_job(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -229,6 +251,21 @@ impl GlueService {
         }
         if update["NonOverridableArguments"].is_object() {
             job.non_overridable_arguments = parse_string_map(&update["NonOverridableArguments"]);
+        }
+        if !update["SourceControlDetails"].is_null() {
+            job.source_control_details = opt_value(&update["SourceControlDetails"]);
+        }
+        if !update["CodeGenConfigurationNodes"].is_null() {
+            job.code_gen_configuration_nodes = opt_value(&update["CodeGenConfigurationNodes"]);
+        }
+        if let Some(s) = update["MaintenanceWindow"].as_str() {
+            job.maintenance_window = Some(s.to_string());
+        }
+        if let Some(s) = update["LogUri"].as_str() {
+            job.log_uri = Some(s.to_string());
+        }
+        if let Some(n) = update["AllocatedCapacity"].as_i64() {
+            job.allocated_capacity = Some(n);
         }
         job.last_modified_on = Utc::now();
         Ok(AwsResponse::ok_json(json!({ "JobName": name })))

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -920,6 +920,12 @@ pub(crate) fn table_json(t: &Table) -> Value {
         "CreateTime": t.create_time.timestamp() as f64,
         "UpdateTime": t.update_time.timestamp() as f64,
     });
+    // Emit CatalogId only when populated: AWS omits absent members rather than
+    // returning an empty string, and tables restored from a pre-`catalog_id`
+    // snapshot carry an empty default.
+    if !t.catalog_id.is_empty() {
+        o["CatalogId"] = json!(t.catalog_id);
+    }
     if let Some(ref d) = t.description {
         o["Description"] = json!(d);
     }
@@ -942,6 +948,15 @@ pub(crate) fn table_json(t: &Table) -> Value {
         o["LastAccessTime"] = json!(la.timestamp() as f64);
     }
     o
+}
+
+/// The current (latest) archived VersionId for a table, defaulting to "1" for
+/// tables predating the version archive. Glue reports this on GetTable(s).
+fn current_table_version(st: &crate::state::GlueState, db: &str, table: &str) -> String {
+    st.table_version_ids(db, table)
+        .last()
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "1".to_string())
 }
 
 pub(crate) fn partition_json(p: &Partition) -> Value {
@@ -1038,13 +1053,19 @@ impl GlueService {
     }
 
     pub(crate) fn get_databases(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
         let accounts = self.state.read();
         let dbs: Vec<Value> = accounts
             .get(&req.account_id)
             .and_then(|s| s.dbs_in(&req.region))
             .map(|map| map.values().map(database_json).collect())
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({"DatabaseList": dbs})))
+        let (page, token) = crate::common::paginate_body(&body, dbs);
+        let mut resp = json!({ "DatabaseList": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn update_database(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1104,6 +1125,7 @@ impl GlueService {
         let table = Table {
             name: name.clone(),
             database_name: db_name.clone(),
+            catalog_id: req.account_id.clone(),
             description: input["Description"].as_str().map(|s| s.to_string()),
             owner: input["Owner"].as_str().map(|s| s.to_string()),
             create_time: now,
@@ -1145,7 +1167,9 @@ impl GlueService {
             .tables
             .get(name)
             .ok_or_else(|| entity_not_found(format!("Table {name} not found")))?;
-        Ok(AwsResponse::ok_json(json!({"Table": table_json(t)})))
+        let mut tj = table_json(t);
+        tj["VersionId"] = json!(current_table_version(state, db_name, name));
+        Ok(AwsResponse::ok_json(json!({"Table": tj})))
     }
 
     pub(crate) fn get_tables(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1161,19 +1185,24 @@ impl GlueService {
             .filter(|e| !e.is_empty())
             .and_then(|e| regex::Regex::new(e).ok());
         let accounts = self.state.read();
-        let tables: Vec<Value> = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.dbs_in(&req.region))
-            .and_then(|dbs| dbs.get(db_name))
-            .map(|db| {
-                db.tables
-                    .values()
-                    .filter(|t| name_filter.as_ref().is_none_or(|re| re.is_match(&t.name)))
-                    .map(table_json)
-                    .collect()
-            })
-            .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({"TableList": tables})))
+        let mut tables: Vec<Value> = Vec::new();
+        if let Some(s) = accounts.get(&req.account_id) {
+            if let Some(db) = s.dbs_in(&req.region).and_then(|dbs| dbs.get(db_name)) {
+                for t in db.tables.values() {
+                    if name_filter.as_ref().is_none_or(|re| re.is_match(&t.name)) {
+                        let mut tj = table_json(t);
+                        tj["VersionId"] = json!(current_table_version(s, db_name, &t.name));
+                        tables.push(tj);
+                    }
+                }
+            }
+        }
+        let (page, token) = crate::common::paginate_body(&body, tables);
+        let mut resp = json!({ "TableList": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn update_table(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1341,6 +1370,19 @@ impl GlueService {
             .as_str()
             .ok_or_else(|| missing("TableName"))?;
         let expression = body["Expression"].as_str().unwrap_or("");
+        // Parallel-scan support: when a `Segment{SegmentNumber, TotalSegments}`
+        // is supplied, each worker must see a disjoint slice of the matching
+        // partitions so the union across all segments equals the full set with
+        // no duplicates. Partition the deterministic (BTreeMap-ordered) match
+        // list by index modulo TotalSegments.
+        let segment = &body["Segment"];
+        let (segment_number, total_segments) = if segment.is_object() {
+            let total = segment["TotalSegments"].as_u64().unwrap_or(1).max(1);
+            let number = segment["SegmentNumber"].as_u64().unwrap_or(0);
+            (number, total)
+        } else {
+            (0, 1)
+        };
         let accounts = self.state.read();
         let parts: Vec<Value> = accounts
             .get(&req.account_id)
@@ -1358,11 +1400,20 @@ impl GlueService {
                             &p.values,
                         )
                     })
-                    .map(partition_json)
+                    .enumerate()
+                    .filter(|(i, _)| {
+                        total_segments == 1 || (*i as u64) % total_segments == segment_number
+                    })
+                    .map(|(_, p)| partition_json(p))
                     .collect()
             })
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({"Partitions": parts})))
+        let (page, token) = crate::common::paginate_body(&body, parts);
+        let mut resp = json!({ "Partitions": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn update_partition(

--- a/crates/fakecloud-glue/src/state.rs
+++ b/crates/fakecloud-glue/src/state.rs
@@ -187,6 +187,19 @@ pub struct Job {
     pub notification_property: Option<serde_json::Value>,
     #[serde(default)]
     pub non_overridable_arguments: BTreeMap<String, String>,
+    /// Standard Job fields that were previously accepted then dropped
+    /// (bug-hunt 2026-07-16). Round-tripped verbatim. `CodeGenConfigurationNodes`
+    /// is a large nested shape stored opaquely rather than dropped.
+    #[serde(default)]
+    pub source_control_details: Option<serde_json::Value>,
+    #[serde(default)]
+    pub code_gen_configuration_nodes: Option<serde_json::Value>,
+    #[serde(default)]
+    pub maintenance_window: Option<String>,
+    #[serde(default)]
+    pub log_uri: Option<String>,
+    #[serde(default)]
+    pub allocated_capacity: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -283,6 +296,9 @@ pub struct Database {
 pub struct Table {
     pub name: String,
     pub database_name: String,
+    /// Owning Data Catalog id (the account id). Reported on read as `CatalogId`.
+    #[serde(default)]
+    pub catalog_id: String,
     pub description: Option<String>,
     pub owner: Option<String>,
     pub create_time: DateTime<Utc>,

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -7,7 +7,9 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::common::{entity_not_found, new_id, now_ts, req_present, req_str, resource_arn};
+use crate::common::{
+    entity_not_found, error_detail, new_id, now_ts, req_present, req_str, resource_arn,
+};
 use crate::service::GlueService;
 
 impl GlueService {
@@ -748,22 +750,60 @@ impl GlueService {
         })))
     }
 
+    /// Build a `SourceControlDetails` object from the flat request fields the
+    /// two source-control ops accept (Provider/RepositoryName/…), so the job's
+    /// stored details reflect the last sync rather than being discarded.
+    fn source_control_details_from_body(body: &Value) -> Value {
+        let mut d = serde_json::Map::new();
+        for (src, dst) in [
+            ("Provider", "Provider"),
+            ("RepositoryName", "Repository"),
+            ("RepositoryOwner", "Owner"),
+            ("BranchName", "Branch"),
+            ("Folder", "Folder"),
+            ("CommitId", "LastCommitId"),
+            ("AuthStrategy", "AuthStrategy"),
+            ("AuthToken", "AuthToken"),
+        ] {
+            if let Some(v) = body.get(src) {
+                if !v.is_null() {
+                    d.insert(dst.to_string(), v.clone());
+                }
+            }
+        }
+        Value::Object(d)
+    }
+
+    /// Shared body for UpdateJobFromSourceControl / UpdateSourceControlFromJob:
+    /// both synchronise a job with its Git source-control repository and, per
+    /// AWS, persist the resulting `SourceControlDetails` on the job definition.
+    fn sync_job_source_control(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req.json_body();
+        let job_name = req_str(&body, "JobName")?.to_string();
+        let details = Self::source_control_details_from_body(&body);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let job = st
+            .jobs
+            .get_mut(&job_name)
+            .ok_or_else(|| entity_not_found(format!("Job {job_name} not found")))?;
+        job.source_control_details = Some(details);
+        job.last_modified_on = chrono::Utc::now();
+        Ok(AwsResponse::ok_json(json!({ "JobName": job_name })))
+    }
+
     pub(crate) fn update_job_from_source_control(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = req.json_body();
-        let job = body.get("JobName").and_then(|v| v.as_str()).unwrap_or("");
-        Ok(AwsResponse::ok_json(json!({ "JobName": job })))
+        self.sync_job_source_control(req)
     }
 
     pub(crate) fn update_source_control_from_job(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let body = req.json_body();
-        let job = body.get("JobName").and_then(|v| v.as_str()).unwrap_or("");
-        Ok(AwsResponse::ok_json(json!({ "JobName": job })))
+        self.sync_job_source_control(req)
     }
 
     // ===================== table versions =====================
@@ -798,8 +838,17 @@ impl GlueService {
         if let Some(tv) = st.table_versions.get(&tv_key) {
             return Ok(AwsResponse::ok_json(json!({ "TableVersion": tv })));
         }
-        // Fall back to synthesizing from the live table (tables created before
-        // the archive existed, or restored from an older snapshot).
+        // A specific VersionId was requested but isn't archived: AWS returns
+        // EntityNotFoundException. Never fabricate a phantom version by stamping
+        // the live table with the requested id.
+        if requested.is_some() {
+            return Err(entity_not_found(format!(
+                "Version {version} not found for table {table}"
+            )));
+        }
+        // No VersionId supplied and no archive exists: synthesize v1 from the
+        // live table (tables created before the archive existed, or restored
+        // from an older snapshot).
         let tbl = st
             .dbs_in(&req.region)
             .and_then(|dbs| dbs.get(db))
@@ -827,30 +876,34 @@ impl GlueService {
         };
         // Return the full archive, newest first (Glue orders descending).
         let ids = st.table_version_ids(db, table);
-        if !ids.is_empty() {
-            let versions: Vec<Value> = ids
-                .iter()
+        let versions: Vec<Value> = if !ids.is_empty() {
+            ids.iter()
                 .rev()
                 .filter_map(|n| {
                     st.table_versions
                         .get(&Self::tv_key(db, table, &n.to_string()))
                 })
                 .cloned()
-                .collect();
-            return Ok(AwsResponse::ok_json(json!({ "TableVersions": versions })));
-        }
-        // Fall back to a synthesized single version for pre-archive tables.
-        let versions = match st
-            .dbs_in(&req.region)
-            .and_then(|dbs| dbs.get(db))
-            .and_then(|d| d.tables.get(table))
-        {
-            Some(t) => vec![json!({
-                "Table": crate::service::table_json(t), "VersionId": "1",
-            })],
-            None => vec![],
+                .collect()
+        } else {
+            // Fall back to a synthesized single version for pre-archive tables.
+            match st
+                .dbs_in(&req.region)
+                .and_then(|dbs| dbs.get(db))
+                .and_then(|d| d.tables.get(table))
+            {
+                Some(t) => vec![json!({
+                    "Table": crate::service::table_json(t), "VersionId": "1",
+                })],
+                None => vec![],
+            }
         };
-        Ok(AwsResponse::ok_json(json!({ "TableVersions": versions })))
+        let (page, token) = crate::common::paginate_body(&body, versions);
+        let mut resp = json!({ "TableVersions": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn delete_table_version(
@@ -873,10 +926,35 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        req_str(&body, "DatabaseName")?;
-        req_str(&body, "TableName")?;
-        req_present(&body, "VersionIds")?;
-        Ok(AwsResponse::ok_json(json!({ "Errors": [] })))
+        let db = req_str(&body, "DatabaseName")?.to_string();
+        let table = req_str(&body, "TableName")?.to_string();
+        let version_ids: Vec<String> = req_present(&body, "VersionIds")?
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        // Actually remove each requested version; report a per-id
+        // `TableVersionError` for versions that don't exist (AWS shape).
+        let mut errors: Vec<Value> = Vec::new();
+        for vid in &version_ids {
+            let key = Self::tv_key(&db, &table, vid);
+            if st.table_versions.remove(&key).is_none() {
+                errors.push(json!({
+                    "TableName": table,
+                    "VersionId": vid,
+                    "ErrorDetail": error_detail(
+                        "EntityNotFoundException",
+                        format!("Version {vid} not found for table {table}"),
+                    ),
+                }));
+            }
+        }
+        Ok(AwsResponse::ok_json(json!({ "Errors": errors })))
     }
 
     // ===================== partition indexes & extra partition/table batches =====================
@@ -983,9 +1061,12 @@ impl GlueService {
                     .collect()
             })
             .unwrap_or_default();
-        Ok(AwsResponse::ok_json(json!({
-            "PartitionIndexDescriptorList": list,
-        })))
+        let (page, token) = crate::common::paginate_body(&body, list);
+        let mut resp = json!({ "PartitionIndexDescriptorList": page });
+        if let Some(t) = token {
+            resp["NextToken"] = json!(t);
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(crate) fn batch_delete_table(

--- a/crates/fakecloud-glue/src/tests.rs
+++ b/crates/fakecloud-glue/src/tests.rs
@@ -511,3 +511,295 @@ fn update_table_applies_view_text_and_retention() {
     assert_eq!(got["Table"]["ViewExpandedText"], "SELECT 2 FROM db.t");
     assert_eq!(got["Table"]["Retention"], 9);
 }
+
+// --- bug-hunt 2026-07-16 regressions ---
+
+/// Create a database `db` with table `t` (no partition keys), so version and
+/// partition tests share a fixture.
+fn setup_table(svc: &GlueService) {
+    svc.create_database(&req(
+        "CreateDatabase",
+        json!({"DatabaseInput": {"Name": "db"}}),
+    ))
+    .unwrap();
+    svc.create_table(&req(
+        "CreateTable",
+        json!({"DatabaseName": "db", "TableInput": {"Name": "t"}}),
+    ))
+    .unwrap();
+}
+
+#[test]
+fn get_table_version_missing_id_returns_not_found() {
+    let svc = GlueService::default();
+    setup_table(&svc);
+    // The initial version (1) is archived and returns real data.
+    let v1 = body_of(
+        svc.get_table_version(&req(
+            "GetTableVersion",
+            json!({"DatabaseName": "db", "TableName": "t", "VersionId": "1"}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(v1["TableVersion"]["VersionId"], "1");
+    // A phantom VersionId must 404 instead of returning the live table stamped
+    // with the bogus id.
+    let err = svc
+        .get_table_version(&req(
+            "GetTableVersion",
+            json!({"DatabaseName": "db", "TableName": "t", "VersionId": "9999"}),
+        ))
+        .err()
+        .unwrap();
+    assert!(format!("{err:?}").contains("EntityNotFound"));
+}
+
+#[test]
+fn batch_delete_table_version_removes_and_reports_errors() {
+    let svc = GlueService::default();
+    setup_table(&svc);
+    // UpdateTable archives version 2.
+    svc.update_table(&req(
+        "UpdateTable",
+        json!({"DatabaseName": "db", "TableInput": {"Name": "t", "Description": "v2"}}),
+    ))
+    .unwrap();
+    let versions = body_of(
+        svc.get_table_versions(&req(
+            "GetTableVersions",
+            json!({"DatabaseName": "db", "TableName": "t"}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(versions["TableVersions"].as_array().unwrap().len(), 2);
+
+    // Delete v1 (exists) and v9999 (missing).
+    let out = body_of(
+        svc.batch_delete_table_version(&req(
+            "BatchDeleteTableVersion",
+            json!({"DatabaseName": "db", "TableName": "t", "VersionIds": ["1", "9999"]}),
+        ))
+        .unwrap(),
+    );
+    let errors = out["Errors"].as_array().unwrap();
+    assert_eq!(errors.len(), 1, "only the missing id errors: {out}");
+    assert_eq!(errors[0]["VersionId"], "9999");
+    assert_eq!(
+        errors[0]["ErrorDetail"]["ErrorCode"],
+        "EntityNotFoundException"
+    );
+
+    // v1 is really gone; only v2 remains.
+    let versions = body_of(
+        svc.get_table_versions(&req(
+            "GetTableVersions",
+            json!({"DatabaseName": "db", "TableName": "t"}),
+        ))
+        .unwrap(),
+    );
+    let ids: Vec<&str> = versions["TableVersions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["VersionId"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["2"]);
+}
+
+#[test]
+fn get_partitions_parallel_scan_union_equals_full_set_no_dups() {
+    let svc = GlueService::default();
+    setup_table(&svc);
+    for i in 0..10 {
+        svc.create_partition(&req(
+            "CreatePartition",
+            json!({
+                "DatabaseName": "db",
+                "TableName": "t",
+                "PartitionInput": {"Values": [format!("p{i}")]}
+            }),
+        ))
+        .unwrap();
+    }
+    let total = 3u64;
+    let mut seen: Vec<String> = Vec::new();
+    for seg in 0..total {
+        let out = body_of(
+            svc.get_partitions(&req(
+                "GetPartitions",
+                json!({
+                    "DatabaseName": "db",
+                    "TableName": "t",
+                    "Segment": {"SegmentNumber": seg, "TotalSegments": total}
+                }),
+            ))
+            .unwrap(),
+        );
+        for p in out["Partitions"].as_array().unwrap() {
+            seen.push(p["Values"][0].as_str().unwrap().to_string());
+        }
+    }
+    seen.sort();
+    let unique: std::collections::BTreeSet<_> = seen.iter().cloned().collect();
+    assert_eq!(seen.len(), 10, "no duplicates across segments: {seen:?}");
+    assert_eq!(unique.len(), 10, "union covers the full set");
+}
+
+#[test]
+fn resume_workflow_run_returns_observable_run_id() {
+    let svc = GlueService::default();
+    svc.create_workflow(&req("CreateWorkflow", json!({"Name": "wf"})))
+        .unwrap();
+    let started = body_of(
+        svc.start_workflow_run(&req("StartWorkflowRun", json!({"Name": "wf"})))
+            .unwrap(),
+    );
+    let run_id = started["RunId"].as_str().unwrap().to_string();
+    let resumed = body_of(
+        svc.resume_workflow_run(&req(
+            "ResumeWorkflowRun",
+            json!({"Name": "wf", "RunId": run_id, "NodeIds": ["n1"]}),
+        ))
+        .unwrap(),
+    );
+    let new_id = resumed["RunId"].as_str().unwrap().to_string();
+    assert_ne!(new_id, "");
+    // The resumed run must be persisted and readable.
+    let got = body_of(
+        svc.get_workflow_run(&req(
+            "GetWorkflowRun",
+            json!({"Name": "wf", "RunId": new_id}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(got["Run"]["WorkflowRunId"], new_id);
+    assert_eq!(got["Run"]["Status"], "RUNNING");
+}
+
+#[test]
+fn create_job_persists_source_control_and_extra_fields() {
+    let svc = GlueService::default();
+    svc.create_job(&req(
+        "CreateJob",
+        json!({
+            "Name": "j",
+            "Role": "r",
+            "Command": {"Name": "glueetl"},
+            "LogUri": "s3://logs/j",
+            "MaintenanceWindow": "Sun:23:00",
+            "AllocatedCapacity": 5,
+            "SourceControlDetails": {"Provider": "GITHUB", "Repository": "repo", "Branch": "main"}
+        }),
+    ))
+    .unwrap();
+    let j = body_of(
+        svc.get_job(&req("GetJob", json!({"JobName": "j"})))
+            .unwrap(),
+    )["Job"]
+        .clone();
+    assert_eq!(j["LogUri"], "s3://logs/j");
+    assert_eq!(j["MaintenanceWindow"], "Sun:23:00");
+    assert_eq!(j["AllocatedCapacity"], 5);
+    assert_eq!(j["SourceControlDetails"]["Provider"], "GITHUB");
+
+    // UpdateJobFromSourceControl persists new SourceControlDetails.
+    svc.update_job_from_source_control(&req(
+        "UpdateJobFromSourceControl",
+        json!({
+            "JobName": "j",
+            "Provider": "GITHUB",
+            "RepositoryName": "repo2",
+            "BranchName": "dev",
+            "CommitId": "abc123"
+        }),
+    ))
+    .unwrap();
+    let j = body_of(
+        svc.get_job(&req("GetJob", json!({"JobName": "j"})))
+            .unwrap(),
+    )["Job"]
+        .clone();
+    assert_eq!(j["SourceControlDetails"]["Repository"], "repo2");
+    assert_eq!(j["SourceControlDetails"]["Branch"], "dev");
+    assert_eq!(j["SourceControlDetails"]["LastCommitId"], "abc123");
+}
+
+#[test]
+fn get_connection_hide_password_redacts() {
+    let svc = GlueService::default();
+    svc.create_connection(&req(
+        "CreateConnection",
+        json!({
+            "ConnectionInput": {
+                "Name": "c",
+                "ConnectionType": "JDBC",
+                "ConnectionProperties": {"USERNAME": "u", "PASSWORD": "secret"}
+            }
+        }),
+    ))
+    .unwrap();
+    // Default (HidePassword absent) returns the password verbatim.
+    let shown = body_of(
+        svc.get_connection(&req("GetConnection", json!({"Name": "c"})))
+            .unwrap(),
+    );
+    assert_eq!(
+        shown["Connection"]["ConnectionProperties"]["PASSWORD"],
+        "secret"
+    );
+    // HidePassword=true strips it.
+    let hidden = body_of(
+        svc.get_connection(&req(
+            "GetConnection",
+            json!({"Name": "c", "HidePassword": true}),
+        ))
+        .unwrap(),
+    );
+    assert!(hidden["Connection"]["ConnectionProperties"]["PASSWORD"].is_null());
+    assert_eq!(
+        hidden["Connection"]["ConnectionProperties"]["USERNAME"],
+        "u"
+    );
+}
+
+#[test]
+fn get_tables_pagination_round_trips_next_token() {
+    let svc = GlueService::default();
+    svc.create_database(&req(
+        "CreateDatabase",
+        json!({"DatabaseInput": {"Name": "db"}}),
+    ))
+    .unwrap();
+    for n in ["a", "b", "c"] {
+        svc.create_table(&req(
+            "CreateTable",
+            json!({"DatabaseName": "db", "TableInput": {"Name": n}}),
+        ))
+        .unwrap();
+    }
+    let page1 = body_of(
+        svc.get_tables(&req(
+            "GetTables",
+            json!({"DatabaseName": "db", "MaxResults": 2}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(page1["TableList"].as_array().unwrap().len(), 2);
+    let token = page1["NextToken"].as_str().unwrap().to_string();
+    // Each table reports CatalogId + VersionId.
+    assert_eq!(page1["TableList"][0]["CatalogId"], "123456789012");
+    assert_eq!(page1["TableList"][0]["VersionId"], "1");
+
+    let page2 = body_of(
+        svc.get_tables(&req(
+            "GetTables",
+            json!({"DatabaseName": "db", "MaxResults": 2, "NextToken": token}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(page2["TableList"].as_array().unwrap().len(), 1);
+    assert!(
+        page2["NextToken"].is_null(),
+        "last page has no token: {page2}"
+    );
+}

--- a/crates/fakecloud-glue/src/triggers.rs
+++ b/crates/fakecloud-glue/src/triggers.rs
@@ -394,15 +394,35 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        req_str(&body, "Name")?;
+        let name = req_str(&body, "Name")?.to_string();
         let run_id = req_str(&body, "RunId")?.to_string();
         let node_ids = req_present(&body, "NodeIds")?.clone();
+        let now = now_ts();
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id, &req.region);
-        st.workflow_runs
-            .get_mut(&run_id)
+        // Resuming mints a new WorkflowRun. It must be persisted so the returned
+        // RunId is observable via GetWorkflowRun / GetWorkflowRunProperties;
+        // previously the id was returned but never inserted and 404'd on read.
+        let original = st
+            .workflow_runs
+            .get(&run_id)
             .ok_or_else(|| entity_not_found(format!("WorkflowRun {run_id} not found")))?;
+        let props = original
+            .get("WorkflowRunProperties")
+            .cloned()
+            .unwrap_or(json!({}));
         let new_run = format!("wr_{}", new_id());
+        st.workflow_runs.insert(
+            new_run.clone(),
+            json!({
+                "Name": name,
+                "WorkflowRunId": new_run,
+                "WorkflowRunProperties": props,
+                "Status": "RUNNING",
+                "StartedOn": now,
+                "PreviousRunId": run_id,
+            }),
+        );
         Ok(AwsResponse::ok_json(json!({
             "RunId": new_run,
             "NodeIds": node_ids,


### PR DESCRIPTION
## Summary

Fixes a batch of confirmed Glue correctness / stub bugs (all in `fakecloud-glue`; one `fakecloud-cloudformation` ctor touched). No new API surface, no SDK change - these are correctness/round-trip fixes to already-modeled operations.

- **GetTableVersion phantom version** (`tail.rs`): a `VersionId` that isn't archived no longer returns the live table stamped with the bogus id. An explicit missing `VersionId` now returns `EntityNotFoundException`; the pre-archive synth fallback is kept only for the default (no-VersionId) case.
- **BatchDeleteTableVersion no-op** (`tail.rs`): now actually removes each requested version from `table_versions` and returns a per-id `TableVersionError` (`{TableName, VersionId, ErrorDetail}`) for ids that don't exist, instead of always returning `{"Errors":[]}`.
- **GetPartitions ignored Segment/TotalSegments** (`service.rs`): parallel-scan `Segment{SegmentNumber, TotalSegments}` is now honored - matching partitions are partitioned deterministically (index modulo TotalSegments) so the union across all segments equals the full set with no duplicates.
- **ResumeWorkflowRun unobservable RunId** (`triggers.rs`): the minted run is now inserted into `workflow_runs` (mirroring StartWorkflowRun, copying the source run's properties + a `PreviousRunId`), so `GetWorkflowRun`/`GetWorkflowRunProperties` on the returned id succeed instead of 404ing.
- **CreateJob dropped fields + source-control no-ops** (`jobs.rs`, `tail.rs`, `state.rs`): `SourceControlDetails`, `CodeGenConfigurationNodes` (stored opaquely), `MaintenanceWindow`, `LogUri`, `AllocatedCapacity` are now persisted on CreateJob/UpdateJob and emitted by GetJob. `UpdateJobFromSourceControl`/`UpdateSourceControlFromJob` now persist the `SourceControlDetails` they're given (mapped from the flat request fields) instead of only echoing `JobName`.
- **Minor omissions + pagination** (`service.rs`, `connections.rs`, `catalog.rs`, `crawlers.rs`, `jobs.rs`, `tail.rs`):
  - `table_json` now emits `CatalogId` and `VersionId` (`get_table`/`get_tables` inject the current archived version).
  - `GetConnection` honors `HidePassword`: strips `PASSWORD`/`ENCRYPTED_PASSWORD` from `ConnectionProperties` when true.
  - Real offset-token pagination (honor `MaxResults`, emit + accept a round-trippable `NextToken`) added to GetTables, GetDatabases, GetPartitions, GetJobs, ListJobs, GetCrawlers, GetUserDefinedFunctions, GetTableVersions, GetPartitionIndexes - via a shared `common::paginate_body` wrapping `fakecloud_core::pagination::paginate`. No ops left unpaginated from the list.

## Test plan

- New regression tests in `fakecloud-glue/src/tests.rs`: GetTableVersion(missing id) -> EntityNotFound; BatchDeleteTableVersion removes + errors on missing + GetTableVersions no longer returns them; GetPartitions parallel-scan union == full set with no dups; ResumeWorkflowRun id then GetWorkflowRun succeeds; CreateJob + UpdateJobFromSourceControl round-trip source-control/log-uri/etc.; GetConnection HidePassword redacts; paginated GetTables round-trips its NextToken (and asserts CatalogId/VersionId).
- `cargo test -p fakecloud-glue` -> 36 passed.
- `cargo build -p fakecloud --tests` (struct fields added to Job/Table) -> clean.
- `cargo clippy -p fakecloud-glue -p fakecloud-cloudformation --all-targets -- -D warnings` -> clean.
- `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Glue correctness gaps in `fakecloud-glue` and adds real pagination across list APIs. Table versions now behave like AWS, partitions honor parallel scan, workflow resumes return a persisted run, and jobs/connection fields round-trip as expected.

- **Bug Fixes**
  - Table versions: `GetTableVersion` with a missing id now returns `EntityNotFoundException`; default (no `VersionId`) still synthesizes v1 for pre-archive tables. `BatchDeleteTableVersion` now removes requested versions and returns per-id errors for missing ones. `GetTable`/`GetTables` include the current `VersionId`.
  - Partitions: `GetPartitions` honors `Segment{SegmentNumber, TotalSegments}` with deterministic, disjoint slices (union = full set, no duplicates).
  - Workflows: `ResumeWorkflowRun` persists the new run (with `PreviousRunId`), so `GetWorkflowRun`/`GetWorkflowRunProperties` succeed.
  - Jobs: `CreateJob`/`UpdateJob` now persist `SourceControlDetails`, `CodeGenConfigurationNodes`, `MaintenanceWindow`, `LogUri`, and `AllocatedCapacity`. `UpdateJobFromSourceControl`/`UpdateSourceControlFromJob` persist `SourceControlDetails` built from the flat request fields.
  - Connections: `GetConnection` honors `HidePassword` by redacting `PASSWORD`/`ENCRYPTED_PASSWORD`.
  - Tables: Responses now include `CatalogId`; table creation via `fakecloud-cloudformation` and service sets it to the account id.

- **Pagination**
  - Added offset-token pagination (honors `MaxResults`, round-trippable `NextToken`) to `GetTables`, `GetDatabases`, `GetPartitions`, `GetJobs`, `ListJobs`, `GetCrawlers`, `GetUserDefinedFunctions`, `GetTableVersions`, and `GetPartitionIndexes` via a shared helper.

<sup>Written for commit 1470e3920433bce5fc4e214693afafa0a724fa72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

