### PR TITLE
fix(release): publish fakecloud-elasticache after its s3 dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,6 @@ jobs:
           publish fakecloud-dsql
           publish fakecloud-resource-groups  # only core/persistence/aws deps
           publish fakecloud-resource-groups-tagging  # only core/persistence/aws deps
-          publish fakecloud-elasticache
           publish fakecloud-elasticbeanstalk # only core/persistence/aws deps
           publish fakecloud-memorydb         # only core/persistence/aws deps
           publish fakecloud-kinesisanalyticsv2 # only core/persistence/aws deps
@@ -275,6 +274,7 @@ jobs:
 
           # Layer 4: depend on layer 3a/3b crates
           publish fakecloud-s3             # depends on kms
+          publish fakecloud-elasticache    # depends on s3
           publish fakecloud-route53resolver  # depends on ec2, s3 (ImportFirewallDomains)
           publish fakecloud-acmpca         # depends on s3 (audit-report delivery), acm, kms
           publish fakecloud-ecr            # depends on iam, kms


### PR DESCRIPTION
## Summary
`fakecloud-elasticache` gained a dependency on `fakecloud-s3`, but the `release.yml` publish list still ordered it in layer 1 — before `fakecloud-s3` (layer 4). During the v0.41.1 release the `Publish Crates` job failed with `failed to select a version for the requirement fakecloud-s3 = "^0.41.1"` because s3 hadn't been published yet. (v0.41.1 crates were published out-of-band via a defer-and-retry local publish; this fixes the pipeline so future releases don't hit it.)

Moves `publish fakecloud-elasticache` to just after `publish fakecloud-s3`. Verified the entire publish order is now topologically valid — every crate's `fakecloud-*` deps publish before it.

## Test plan
- Script check: for each crate in the publish list, all its `fakecloud-*` dependencies appear earlier → 0 violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders the release workflow to publish `fakecloud-elasticache` immediately after `fakecloud-s3`, fixing the dependency order that caused publish failures. The publish list is now topologically valid so every `fakecloud-*` dependency is published before its dependents.

<sup>Written for commit e51c5f56509d155510ce052562d4cd0ea4725c45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

