### PR TITLE
fix(ec2): report platformDetails and usageOperation in instance XML

### DIFF
--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -21,13 +21,27 @@ fn validate_image_strings(req: &AwsRequest) -> Result<(), AwsServiceError> {
 
 const FIXED_TIME: &str = "2024-01-01T00:00:00.000Z";
 
+/// Map a stored AMI `platform` value to the AWS `platformDetails` billing
+/// label. Note the two fields differ in casing on the wire: the `<platform>`
+/// element is the lowercase `windows`, while `platformDetails` is the
+/// capitalized billing string (`Windows`, `Linux/UNIX`). An unknown platform
+/// falls back to `Linux/UNIX`; any already-canonical value passes through.
+pub(crate) fn platform_details_label(raw_platform: Option<&str>) -> String {
+    match raw_platform {
+        Some(p) if p.eq_ignore_ascii_case("windows") => "Windows".to_string(),
+        Some(p) => p.to_string(),
+        None => "Linux/UNIX".to_string(),
+    }
+}
+
 fn image_xml(i: &Image, tags: &[Tag], owner: &str) -> String {
     // Effective owner: the AMI's own owner_id when set (seeded public AMIs),
     // else the requesting account (user-registered AMIs are owned by creator).
     let owner_id = i.owner_id.as_deref().unwrap_or(owner);
     let creation_date = i.creation_date.as_deref().unwrap_or(FIXED_TIME);
     let root_device_name = i.root_device_name.as_deref().unwrap_or("/dev/xvda");
-    let platform_details = i.platform.as_deref().unwrap_or("Linux/UNIX");
+    let platform_details = platform_details_label(i.platform.as_deref());
+    let platform_details = platform_details.as_str();
     let owner_alias_xml = i
         .owner_alias
         .as_deref()

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -71,11 +71,11 @@ fn arch_for(state: &Ec2State, image_id: &str) -> String {
 /// catalogue (`Windows` for Windows images), defaulting to `Linux/UNIX` when
 /// the AMI isn't known — the same contract as [`image_xml`]'s platform fields.
 fn platform_for(state: &Ec2State, image_id: &str) -> String {
-    state
+    let raw = state
         .images
         .get(image_id)
-        .and_then(|img| img.platform.clone())
-        .unwrap_or_else(|| "Linux/UNIX".to_string())
+        .and_then(|img| img.platform.as_deref());
+    super::image::platform_details_label(raw)
 }
 
 fn instance_xml(
@@ -2412,8 +2412,42 @@ mod modify_tests {
                 .unwrap(),
         );
         assert!(out.contains("<platform>windows</platform>"), "got: {out}");
+        // platformDetails is the capitalized billing label, distinct from the
+        // lowercase `<platform>` wire element.
         assert!(
-            out.contains("<platformDetails>windows</platformDetails>"),
+            out.contains("<platformDetails>Windows</platformDetails>"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("<usageOperation>RunInstances:0002</usageOperation>"),
+            "got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_instances_reports_platform_details_on_reservation() {
+        let svc = Ec2Service::new();
+        // Seeded Windows Server AMI -> the RunInstances reservation body carries
+        // the Windows billing label + RunInstances:0002 (covers the second
+        // render path, distinct from DescribeInstances).
+        let out = body(
+            run_instances(
+                &svc,
+                &req(
+                    "RunInstances",
+                    &[
+                        ("ImageId", "ami-0a1b2c3d4e5f60006"),
+                        ("MinCount", "1"),
+                        ("MaxCount", "1"),
+                    ],
+                ),
+            )
+            .await
+            .unwrap(),
+        );
+        assert!(out.contains("<platform>windows</platform>"), "got: {out}");
+        assert!(
+            out.contains("<platformDetails>Windows</platformDetails>"),
             "got: {out}"
         );
         assert!(

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -67,12 +67,24 @@ fn arch_for(state: &Ec2State, image_id: &str) -> String {
         .unwrap_or_else(|| "x86_64".to_string())
 }
 
+/// Resolve an instance's `platformDetails` from its AMI in the seeded/owned
+/// catalogue (`Windows` for Windows images), defaulting to `Linux/UNIX` when
+/// the AMI isn't known — the same contract as [`image_xml`]'s platform fields.
+fn platform_for(state: &Ec2State, image_id: &str) -> String {
+    state
+        .images
+        .get(image_id)
+        .and_then(|img| img.platform.clone())
+        .unwrap_or_else(|| "Linux/UNIX".to_string())
+}
+
 fn instance_xml(
     i: &Instance,
     tags: &[Tag],
     owner: &str,
     sg_names: &HashMap<String, String>,
     architecture: &str,
+    platform_details: &str,
 ) -> String {
     let groups: Vec<String> = i
         .security_group_ids
@@ -125,6 +137,22 @@ fn instance_xml(
         i.enable_resource_name_dns_a_record,
         i.enable_resource_name_dns_aaaa_record,
     );
+    // Windows instances additionally report `<platform>windows</platform>` and
+    // a Windows usage operation, mirroring `image_xml`.
+    let platform_xml = if platform_details.eq_ignore_ascii_case("windows") {
+        format!(
+            "{}{}{}",
+            ec2_elem("platform", "windows"),
+            ec2_elem("platformDetails", platform_details),
+            ec2_elem("usageOperation", "RunInstances:0002"),
+        )
+    } else {
+        format!(
+            "{}{}",
+            ec2_elem("platformDetails", platform_details),
+            ec2_elem("usageOperation", "RunInstances"),
+        )
+    };
     let tenancy = i.placement_tenancy.as_deref().unwrap_or("default");
     let placement_group = i
         .placement_group_name
@@ -132,7 +160,7 @@ fn instance_xml(
         .map(|g| ec2_elem("groupName", g))
         .unwrap_or_default();
     format!(
-        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("instanceId", &i.instance_id),
         ec2_elem("imageId", &i.image_id),
         state_xml("instanceState", i.state_code, &i.state_name),
@@ -146,6 +174,7 @@ fn instance_xml(
         ec2_elem("launchTime", &i.launch_time),
         ec2_elem("amiLaunchIndex", &i.ami_launch_index.to_string()),
         ec2_elem("architecture", architecture),
+        platform_xml,
         ec2_elem("rootDeviceType", "ebs"),
         ec2_elem("rootDeviceName", "/dev/xvda"),
         ec2_elem("virtualizationType", "hvm"),
@@ -443,7 +472,15 @@ pub(crate) async fn run_instances(
             );
             let tags = state.tags_for(id).to_vec();
             let architecture = arch_for(state, &inst.image_id);
-            rendered.push(instance_xml(&inst, &tags, &owner, &sg_names, &architecture));
+            let platform_details = platform_for(state, &inst.image_id);
+            rendered.push(instance_xml(
+                &inst,
+                &tags,
+                &owner,
+                &sg_names,
+                &architecture,
+                &platform_details,
+            ));
             state.instances.insert(id.clone(), inst);
         }
     }
@@ -1188,6 +1225,7 @@ pub(crate) fn describe_instances(
                 &owner,
                 &sg_names,
                 &arch_for(state, &i.image_id),
+                &platform_for(state, &i.image_id),
             ));
     }
     let reservations: Vec<String> = order
@@ -2331,6 +2369,57 @@ mod modify_tests {
                 .unwrap(),
         );
         assert!(out.contains("<instanceId>i-1</instanceId>"), "got: {out}");
+    }
+
+    #[test]
+    fn describe_instances_reports_linux_platform_details() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        // "ami-1" is not in the catalogue, so platformDetails falls back to
+        // Linux/UNIX — the same default as image_xml.
+        let out = body(
+            describe_instances(&svc, &req("DescribeInstances", &[("InstanceId.1", "i-1")]))
+                .unwrap(),
+        );
+        assert!(
+            out.contains("<platformDetails>Linux/UNIX</platformDetails>"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("<usageOperation>RunInstances</usageOperation>"),
+            "got: {out}"
+        );
+        assert!(!out.contains("<platform>windows</platform>"), "got: {out}");
+    }
+
+    #[test]
+    fn describe_instances_reports_windows_platform() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        {
+            let mut accounts = svc.state.write();
+            let inst = accounts
+                .get_mut("000000000000")
+                .unwrap()
+                .instances
+                .get_mut("i-1")
+                .unwrap();
+            // Seeded Windows Server AMI (platform = windows).
+            inst.image_id = "ami-0a1b2c3d4e5f60006".into();
+        }
+        let out = body(
+            describe_instances(&svc, &req("DescribeInstances", &[("InstanceId.1", "i-1")]))
+                .unwrap(),
+        );
+        assert!(out.contains("<platform>windows</platform>"), "got: {out}");
+        assert!(
+            out.contains("<platformDetails>windows</platformDetails>"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("<usageOperation>RunInstances:0002</usageOperation>"),
+            "got: {out}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
`DescribeInstances` and `RunInstances` responses miss `platformDetails`, `platform`, and `usageOperation`. Real AWS always returns them for instances. `image_xml` already reports them for AMIs, so instances were the odd one out.

## Fix

- Added `platform_for()` next to `arch_for()` in `crates/fakecloud-ec2/src/service/instance.rs`. It resolves the platform from the instance's AMI in the catalogue and falls back to `Linux/UNIX` for unknown AMIs — same contract as `image_xml`.
- `instance_xml` now renders `platformDetails` and `usageOperation` (`RunInstances`, or `RunInstances:0002` for Windows), plus `<platform>windows</platform>` for Windows AMIs.
- Both render paths (the RunInstances reservation and DescribeInstances) pass the resolved value.

## Tests

- `describe_instances_reports_linux_platform_details` — unknown AMI falls back to `Linux/UNIX` + `RunInstances`, no `platform` element
- `describe_instances_reports_windows_platform` — seeded Windows Server AMI yields `platform`, `platformDetails`, `RunInstances:0002`

`cargo test -p fakecloud-ec2` (151 passed), clippy with `-D warnings`, and `cargo fmt --check` are clean. I also built the Docker image from this branch and checked with the AWS CLI: `describe-instances` now returns `"PlatformDetails": "Linux/UNIX"`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `platformDetails` and `usageOperation` to EC2 instance XML for `RunInstances` and `DescribeInstances`, matching AWS. Windows now reports `<platform>windows</platform>`, capitalized `platformDetails` ("Windows"), and `RunInstances:0002`; AMI XML applies the same rules.

- **Bug Fixes**
  - Added `platform_for()` in `crates/fakecloud-ec2` to resolve platform from the instance AMI; defaults to `Linux/UNIX`.
  - Introduced shared `platform_details_label()` and used in `image_xml` and `instance_xml` so `platformDetails` uses capitalized billing labels; non-Windows uses `RunInstances`.
  - Applied to both `RunInstances` and `DescribeInstances`; tests added for Linux fallback, Windows values, and the `RunInstances` reservation body.

<sup>Written for commit b0abe5ef8938147c1fba60ddb9fa5a35db933d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

