### PR TITLE
docs: ADOPTERS.md + Who's using section + download/stars badges

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,9 +2,9 @@
 
 Teams and people using fakecloud. Self-reported and opt-in.
 
-Using it? Add yourself: open a PR editing this file, or comment on the
-["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324)
-issue. You can ask to be removed at any time.
+Using it? Preferred: open a PR adding a row below. If a PR is inconvenient,
+comment on the ["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324)
+issue instead. Opt-in; you can ask to be removed at any time.
 
 | Organization / project | How they use fakecloud |
 |------------------------|------------------------|

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,11 @@
+# Adopters
+
+Teams and people using fakecloud. Self-reported and opt-in.
+
+Using it? Add yourself: open a PR editing this file, or comment on the
+["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324)
+issue. You can ask to be removed at any time.
+
+| Organization / project | How they use fakecloud |
+|------------------------|------------------------|
+| (none yet) |  |

--- a/README.md
+++ b/README.md
@@ -250,9 +250,10 @@ Use fakecloud as a local AWS emulator for integration tests.
 
 Early days, and the list is just getting started. If you or your team use
 fakecloud in CI, local dev, or tests, add yourself to [ADOPTERS.md](ADOPTERS.md)
-with a one-line note on how you use it: open a PR, or comment on the
+with a one-line note on how you use it. Preferred: open a PR. If that is
+inconvenient, comment on the
 ["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324)
-issue. Self-reported and opt-in only.
+issue instead. Self-reported and opt-in only.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
   <a href="https://fakecloud.dev"><img src="https://img.shields.io/badge/docs-fakecloud.dev-green" alt="Docs"></a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/fakecloud"><img src="https://img.shields.io/npm/dm/fakecloud?label=npm%20downloads" alt="npm downloads"></a>
+  <a href="https://pypi.org/project/fakecloud/"><img src="https://img.shields.io/pypi/dm/fakecloud?label=pypi%20downloads" alt="PyPI downloads"></a>
+  <a href="https://crates.io/crates/fakecloud"><img src="https://img.shields.io/crates/d/fakecloud?label=crates.io%20downloads" alt="crates.io downloads"></a>
+  <a href="https://formulae.brew.sh/formula/fakecloud"><img src="https://img.shields.io/homebrew/installs/dm/fakecloud?label=brew%20installs" alt="Homebrew installs"></a>
+  <a href="https://github.com/faiscadev/fakecloud/stargazers"><img src="https://img.shields.io/github/stars/faiscadev/fakecloud" alt="GitHub stars"></a>
+</p>
+
 ---
 
 fakecloud is a free, open-source local AWS emulator for integration testing and local development. Single binary, no account, no auth token, no paid tier. Point your AWS SDK at `http://localhost:4566` and it works.
@@ -237,6 +245,14 @@ Use fakecloud as a local AWS emulator for integration tests.
 - **[Guides](https://fakecloud.dev/docs/guides)** — in-depth how-tos (testing Bedrock, cross-service integration, CI setup)
 - **[Reference](https://fakecloud.dev/docs/reference)** — configuration, introspection endpoints, persistence, [image signature verification](https://fakecloud.dev/docs/reference/security/#image-supply-chain-cosign--trivy)
 - **[Blog](https://fakecloud.dev/blog)** — essays and hot takes on testing, AWS, and AI-assisted development
+
+## Who's using fakecloud
+
+Early days, and the list is just getting started. If you or your team use
+fakecloud in CI, local dev, or tests, add yourself to [ADOPTERS.md](ADOPTERS.md)
+with a one-line note on how you use it: open a PR, or comment on the
+["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324)
+issue. Self-reported and opt-in only.
 
 ## Contributing
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -266,4 +266,23 @@
     </div>
   </div>
 </section>
+
+<section id="community">
+  <div class="container">
+    <h2 class="section-title">Who's using fakecloud</h2>
+    <p class="section-sub">Early days, and the list is just getting started. Using fakecloud in CI, local dev, or tests? Add your team on GitHub. The numbers below are package downloads and stars, not a user count.</p>
+    <p style="text-align: center;">
+      <a href="https://www.npmjs.com/package/fakecloud"><img src="https://img.shields.io/npm/dm/fakecloud?label=npm%20downloads" alt="npm downloads"></a>
+      <a href="https://pypi.org/project/fakecloud/"><img src="https://img.shields.io/pypi/dm/fakecloud?label=pypi%20downloads" alt="PyPI downloads"></a>
+      <a href="https://formulae.brew.sh/formula/fakecloud"><img src="https://img.shields.io/homebrew/installs/dm/fakecloud?label=brew%20installs" alt="Homebrew installs"></a>
+      <a href="https://crates.io/crates/fakecloud"><img src="https://img.shields.io/crates/d/fakecloud?label=crates.io%20downloads" alt="crates.io downloads"></a>
+      <a href="https://github.com/faiscadev/fakecloud/stargazers"><img src="https://img.shields.io/github/stars/faiscadev/fakecloud" alt="GitHub stars"></a>
+    </p>
+    <p style="text-align: center;">
+      <a href="https://github.com/faiscadev/fakecloud/blob/main/ADOPTERS.md">See adopters</a>
+      &middot;
+      <a href="https://github.com/faiscadev/fakecloud/issues/2324">Add your team</a>
+    </p>
+  </div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary

Adds an honest, opt-in "who's using" surface to the README and the landing page, plus real usage metrics as auto-updating badges.

- **README metrics badges**: npm/PyPI/crates.io downloads, Homebrew installs, GitHub stars. All shields.io badges that self-update, so they never go stale, and each is labeled as downloads/installs/stars, not "users".
- **README "Who's using fakecloud" section**: links `ADOPTERS.md` and the pinned #2324 issue. Kept separate from the metrics so "who" and "how much" never blur.
- **ADOPTERS.md**: self-reported, opt-in adopter list (CNCF/kyverno-style table). Empty to start, on purpose. Add via PR or the pinned issue.
- **Landing page (`website/templates/index.html`)**: matching "Who's using" section with the same badges and adopter links, with an explicit note that the numbers are package downloads and stars, not a user count.

No fabricated logos, no "trusted by N companies", no inflated stats. Consistent with the honest positioning (built solo, heavy LLM, nothing ships on trust).

Real numbers today (for context, badges show live): npm ~9k/mo, PyPI ~5k/mo, Homebrew ~350/mo, 481 stars.

Pinned issue for collection: #2324.

## Test plan
- `zola build` succeeds; the new section renders in the built landing page.
- Badge URLs are standard shields.io endpoints (verified reachable).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in "Who's using fakecloud" section to the README and website, plus live badges for downloads and stars. Helps users find adopters and see real, auto-updating metrics.

- **New Features**
  - `ADOPTERS.md`: self-reported adopter list; linked from README and landing page. Preferred: open a PR to add yourself; otherwise use pinned issue #2324.
  - README: new badge row for `npm`/`PyPI`/`crates.io` downloads, Homebrew installs, and GitHub stars (auto-updating via `shields.io`).
  - Website: matching "Who's using" section with badges and links; explicitly notes these are downloads/stars, not a user count.

<sup>Written for commit e6c745f0f95f3814ab4866d21d738d333cdde71a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

