### PR TITLE
docs(readme): trim big tables to teasers + links, rework Who's using, seeding banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Works as a drop-in for LocalStack in CI, with Terraform (`endpoints` block), CDK
 - **Real cross-service wiring.** EventBridge -> Step Functions, S3 -> Lambda, SES inbound -> S3/SNS/Lambda, and 15+ more integrations execute end-to-end.
 - **Real infrastructure for stateful services.** Lambda (23 runtimes), RDS (Postgres/MySQL/MariaDB/Oracle/SQL Server/Db2), ElastiCache (Redis/Valkey/Memcached), ECS, and EC2 run as real containers. Use Docker (default) or native Kubernetes Pods via `FAKECLOUD_CONTAINER_BACKEND=k8s`. See the [Kubernetes backend guide](https://fakecloud.dev/docs/guides/kubernetes-backend/).
 - **Single binary.** ~19 MB, ~10 MiB idle, ~300ms startup. No Docker needed to run fakecloud itself.
-- **Full Bedrock surface.** 214 ops across 4 APIs with real `InvokeModel`/`Converse` streaming, guardrails, agents, and flows. Configurable responses + fault injection for deterministic tests. See [`/bedrock-emulator/`](https://fakecloud.dev/bedrock-emulator/).
+- **Full Bedrock surface.** 216 ops across 4 APIs with real `InvokeModel`/`Converse` streaming, guardrails, agents, and flows. Configurable responses + fault injection for deterministic tests. See [`/bedrock-emulator/`](https://fakecloud.dev/bedrock-emulator/).
 - **First-party test SDKs** for TypeScript, Python, Go, PHP, Java, and Rust. Assert on what your code called without raw HTTP.
 - **Opt-in SigV4 verification and IAM enforcement.** Off by default so tests just work; `--verify-sigv4` for real signature checking and `--iam soft|strict` for policy evaluation across IAM/STS/SQS/SNS/S3. See [security docs](https://fakecloud.dev/docs/reference/security/).
 - **Run your app unmodified.** An app that expects an instance/task role resolves the AWS SDK default credential chain against fakecloud with no static keys and no code change: point `AWS_CONTAINER_CREDENTIALS_FULL_URI` at `/_fakecloud/credentials`. See [Run an app unmodified](https://fakecloud.dev/docs/guides/instance-credentials/).
@@ -62,7 +62,7 @@ Works as a drop-in for LocalStack in CI, with Terraform (`endpoints` block), CDK
 
 105 services, 7,379 operations, and true 100% conformance across every implemented service.
 
-Highlights: S3, DynamoDB, SQS, SNS, EventBridge, Lambda, IAM, STS, KMS, Secrets Manager, CloudFormation, SES, Cognito, Kinesis, RDS (6 real engines), ElastiCache, ECS/ECR, EC2 (767 ops), Step Functions, API Gateway v1/v2, Bedrock (214 ops), and 80+ more.
+Highlights: S3, DynamoDB, SQS, SNS, EventBridge, Lambda, IAM, STS, KMS, Secrets Manager, CloudFormation, SES, Cognito, Kinesis, RDS (6 real engines), ElastiCache, ECS/ECR, EC2, Step Functions, API Gateway v1/v2, Bedrock, and 80+ more.
 
 Full list with per-service op counts, control-plane vs data-plane coverage, and known limitations:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ fakecloud is a free, open-source local AWS emulator for integration testing and 
 
 In March 2026, LocalStack replaced its open-source Community Edition with a proprietary image that requires an account and auth token. fakecloud exists so teams can keep a fully local AWS testing workflow without one.
 
+<!-- Seeding banner: remove once ADOPTERS.md has ~5 entries. -->
+> [!NOTE]
+> **Using fakecloud?** Add your team to [ADOPTERS.md](ADOPTERS.md). Takes 30 seconds, and it helps others see it is real.
+
 ## Quick start
 
 ```sh
@@ -56,109 +60,29 @@ Works as a drop-in for LocalStack in CI, with Terraform (`endpoints` block), CDK
 
 ## Supported services
 
-105 services, 7,379 operations, true 100% conformance across every implemented service. Notes below are one-liners; the [parity matrix](https://fakecloud.dev/docs/parity/) has full control-plane vs data-plane coverage and known limitations per service.
+105 services, 7,379 operations, and true 100% conformance across every implemented service.
 
-| Service                   | Ops | Notes |
-| ------------------------- | --- | ----- |
-| S3                        | 107 | Versioning, lifecycle, notifications, multipart, replication, website, real SSE-KMS |
-| SQS                       | 23  | FIFO, DLQs, long polling, batch, real KMS encrypt/decrypt |
-| SNS                       | 42  | Fan-out to SQS/Lambda/HTTP, filter policies, KMS audit-trail |
-| EventBridge               | 57  | Pattern matching, schedules, archives, replay, API destinations |
-| EventBridge Scheduler     | 12  | at/rate/cron, SQS targets, DLQ routing, one-shot self-delete |
-| Lambda                    | 70  | Real Docker, 23 runtimes, ESM with FilterCriteria + partial-batch failure |
-| DynamoDB                  | 57  | Transactions, PartiQL, backups, global tables, streams, SSE-KMS |
-| IAM                       | 176 | Users, roles, policies, groups, OIDC/SAML, PassRole trust enforcement |
-| STS                       | 11  | AssumeRole, session tokens, federation |
-| SSM                       | 146 | Parameters, documents, commands, maintenance, patch baselines, SecureString KMS |
-| Secrets Manager           | 23  | Versioning, rotation via Lambda, replication, real KMS encrypt/decrypt |
-| CloudWatch Logs           | 113 | Groups, streams, subscription filters, query language |
-| CloudWatch                | 46  | Metrics + composite alarms, dashboards, anomaly detectors, insight rules, metric streams |
-| KMS                       | 53  | Encryption, aliases, grants, real ECDH, key import, cross-service hook |
-| CloudFormation            | 90  | Template parsing, resource provisioning, custom resources |
-| Cloud Control API         | 8   | Uniform CRUD-L over CloudFormation resource types, JSON Patch updates, request tracking |
-| SES (v2 + v1 inbound)     | 110 | Sending, templates, DKIM, real receipt rule execution |
-| Cognito User Pools        | 122 | Pools, clients, MFA, IdPs, full auth flows, 12 Lambda triggers, email->SES SMS->SNS |
-| Kinesis                   | 39  | Streams, records, shard iterators, retention |
-| RDS                       | 163 | Real Postgres/MySQL/MariaDB/Oracle/SQL Server/Db2, `aws_lambda`/`aws_s3` extensions, Aurora lambda bridge |
-| RDS Data API              | 6   | Real SQL on the backing Postgres/MySQL container, typed params/results incl. `bytea`/`BLOB`, transactions, batch |
-| Redshift                  | 141 | Full control plane: clusters, snapshots, parameter/subnet groups, snapshot schedules, endpoint access, logging, cross-region snapshot-copy config, tagging |
-| Database Migration Service | 119 | Full control plane: replication instances/tasks/endpoints, subnet groups, event subscriptions, certificates, serverless replication configs, data providers, instance profiles, migration projects, schema conversion, Fleet Advisor, tagging; persisted. No data-migration engine |
-| Transfer Family           | 71  | Full control plane: SFTP/FTPS/FTP/AS2 servers (start/stop settle state), users + SSH keys, host keys, accesses, workflows + executions, agreements, connectors (`TestConnection`, file transfer, directory listing, remote delete/move), profiles, certificates, security policies, web apps, `TestIdentityProvider`, tagging; persisted. No SFTP/AS2 transport engine |
-| CloudTrail                | 60  | Full control plane: trails (logging status toggles `IsLogging`), event + insight selectors, CloudTrail Lake event data stores (restore, ingestion, federation), channels, imports, Lake queries, dashboards, resource policies, org delegated admins, tagging; persisted. `LookupEvents` returns empty — no event-recording engine |
-| CodeConnections           | 27  | Full control plane (successor to CodeStar Connections): connections (created `PENDING` per the real console-handshake default), self-managed hosts, repository links, CloudFormation Git-sync configurations, sync-status/blocker read surface, tagging; persisted. No third-party OAuth handshake or Git-sync engine |
-| Aurora DSQL               | 16  | Serverless distributed Postgres control plane: clusters, resource policies, change streams to Kinesis, multi-region, tagging |
-| Resource Groups           | 23  | Groups by tag/CloudFormation-stack query, explicit membership, group configuration, tagging, account settings, tag-sync tasks |
-| Resource Groups Tagging API | 9 | Cross-service tag reads/writes, compliance summary, tag reports, backed by a real cross-service tag index |
-| ElastiCache               | 75  | Real Redis, Valkey, Memcached via Docker |
-| MemoryDB                  | 45  | Full control plane: clusters, shards, ACLs, users, parameter/subnet groups, snapshots, multi-region clusters; persisted |
-| EKS                       | 65  | Complete control plane: clusters (incl. connected register/deregister), node groups, Fargate profiles, add-ons, access entries + policies, OIDC identity-provider configs, pod-identity associations, upgrade insights, capabilities, encryption config, EKS Anywhere subscriptions; config/version updates with tracking, cluster-version/add-on/access-policy catalogues, tagging; persisted, `CREATING` -> `ACTIVE` on describe |
-| MWAA (Managed Airflow)    | 12  | Full control plane: environments (`CREATING` -> `AVAILABLE`, `UPDATING`, `DELETING` settle on read), CLI/web-login access tokens, `InvokeRestApi`, internal `PublishMetrics`, ARN tagging; persisted. Airflow web-server/DAG data plane is a later batch |
-| Amazon S3 Glacier         | 33  | Complete surface with a real data plane: vaults, archive upload/delete storing the real bytes + a computed SHA-256 tree hash, multipart uploads assembled into a stored archive, retrieval + inventory jobs that settle to `Succeeded` on read so `GetJobOutput` returns the exact uploaded bytes (or a JSON inventory), vault lock state machine, notifications, access policy, tags, data-retrieval policy, provisioned capacity; persisted (archives survive restart) |
-| AWS Backup                | 109 | Complete control plane: backup plans (+ versions) + selections, vaults (standard/logically-air-gapped/restore-access) with notifications/policies/lock, recovery points, backup/copy/restore/scan jobs (progressed to a terminal state; `StartBackupJob` records a synthetic recovery point `DescribeRecoveryPoint` resolves), frameworks, report plans + jobs, legal holds, restore testing, tiering, protected resources, tags, global/region settings; persisted. No real backup engine (all 109 ops) |
-| OpenSearch Service        | 93  | Complete Amazon OpenSearch Service control plane sharing one domain store with Elasticsearch Service (both sign as `es`): domains (create/describe/delete/config persist; `Processing=false`/`Created=true` settle on describe), packages, VPC endpoints, cross-cluster connections, applications + capabilities, per-domain data sources + indices, direct-query data sources, reserved instances, tags, catalogues; persisted. No real cluster spawned (all 93 ops) |
-| AWS AppConfig             | 58  | Complete surface across `appconfig` (56 ops) + `appconfigdata` (2 ops): applications, environments, configuration profiles, hosted configuration versions (raw bytes + content type stored/returned verbatim, auto-incrementing version), custom + AWS-predefined deployment strategies, deployments (settle to `COMPLETE`), extensions + associations, experiments, account settings, `ValidateConfiguration`, tags; persisted. Real data plane: `StartConfigurationSession` -> `GetLatestConfiguration` serves the deployed bytes |
-| Elasticsearch Service     | 51  | Complete legacy Amazon Elasticsearch Service (`es`, 2015-01-01) over the SAME shared domain store — a domain created through either API is one entity, surfaced via `ElasticsearchDomainStatus`; persisted (all 51 ops) |
-| Cloud Map                 | 30  | Complete AWS Cloud Map (`servicediscovery`) control plane + discovery: namespaces, services, instances (register/deregister/health), `DiscoverInstances`/`DiscoverInstancesRevision`, tagging; async operation model (mutations return an `OperationId` that settles `SUCCESS` on `GetOperation`); persisted (all 30 ops) |
-| Step Functions            | 37  | Full ASL interpreter, Lambda/SQS/SNS/EventBridge/DynamoDB tasks |
-| API Gateway v1            | 124 | REST APIs, integrations incl. real Lambda proxy, authorizers (Lambda + Cognito JWT) |
-| API Gateway v2            | 103 | HTTP APIs, routes, developer portals, authorizers (Lambda + Cognito JWT) |
-| Bedrock                   | 101 | Foundation models, guardrails, custom models, invocation/eval jobs |
-| Bedrock Runtime           | 10  | InvokeModel, Converse, streaming, configurable responses, fault inject |
-| Bedrock Agent             | 72  | Agents, aliases, action groups, knowledge bases, ingestion, prompt mgmt, flows |
-| Bedrock Agent Runtime     | 31  | InvokeAgent, Retrieve, RetrieveAndGenerate, InvokeFlow, streaming |
-| ECR                       | 58  | Full API, real OCI v2 push/pull, lifecycle, scanning, pull-through |
-| ECS                       | 76  | Full API, real task execution, services + rolling deploys, task sets, ECS Exec |
-| Elastic Load Balancing v2 | 51  | ALB/NLB/GWLB control plane, mTLS trust stores, in-process HTTP data plane for ALBs |
-| CloudFront                | 147 | Distributions, functions, policies, KVS, FLE, connection groups; full config round-trip |
-| Route 53                  | 71  | Full control plane: zones, RRsets, health checks, traffic policies, DNSSEC, VPC assoc |
-| Route 53 Resolver         | 72  | Resolver endpoints (real VPC/subnet/SG validation), rules, query logging, DNS Firewall |
-| WAF v2                    | 55  | Full control plane: WebACLs/RuleGroups/IPSets, CheckCapacity, managed rule catalog |
-| Application Auto Scaling  | 14  | Scalable targets + step/target/predictive policies + scheduled actions, 13 namespaces |
-| Athena                    | 70  | Workgroups, data catalogs, query executions (synthesized results), notebooks, sessions |
-| ACM (Certificate Manager) | 17  | Public-cert lifecycle, DNS/EMAIL validation, import/export, tags |
-| Glue                      | 265 | Full control plane; Data Catalog shared with Athena; execution synthesized (no Spark) |
-| Firehose                  | 12  | Delivery stream control plane; data plane stops at acknowledgement |
-| Organizations             | 63  | Full control plane, real SCP enforcement under `FAKECLOUD_IAM=strict` |
-| EC2                       | 767 | Full 767-op control plane; instances run as real Docker/Podman/k8s with per-subnet isolation |
+Highlights: S3, DynamoDB, SQS, SNS, EventBridge, Lambda, IAM, STS, KMS, Secrets Manager, CloudFormation, SES, Cognito, Kinesis, RDS (6 real engines), ElastiCache, ECS/ECR, EC2 (767 ops), Step Functions, API Gateway v1/v2, Bedrock (214 ops), and 80+ more.
 
-Per-service docs and feature matrices: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services).
+Full list with per-service op counts, control-plane vs data-plane coverage, and known limitations:
+
+- Parity matrix: [fakecloud.dev/docs/parity](https://fakecloud.dev/docs/parity/)
+- Per-service docs: [fakecloud.dev/docs/services](https://fakecloud.dev/docs/services)
 
 ## Compared to LocalStack Community
 
-| Feature                   | fakecloud                                                              | LocalStack Community (post-March 2026) |
-| ------------------------- | --------------------------------------------------------------------- | -------------------------------------- |
-| License                   | AGPL-3.0                                                               | Proprietary |
-| Auth required             | No                                                                     | Yes (account + token) |
-| Commercial use            | Free                                                                   | Paid plans only |
-| Docker required           | No (standalone binary)                                                 | Yes |
-| Startup time              | ~300ms                                                                 | ~3s |
-| Idle memory               | ~10 MiB                                                                | ~150 MiB |
-| Install size              | ~19 MB binary                                                          | ~1 GB Docker image |
-| Test assertion SDKs       | TypeScript, Python, Go, PHP, Java, Rust                               | Python, Java |
-| Cognito User Pools        | 122 ops                                                                | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| SES v2 + inbound          | Full send/templates/DKIM + real receipt-rule execution               | Paid only / [stored but never executed](https://docs.localstack.cloud/user-guide/aws/ses/) |
-| RDS                       | 163 ops, 6 real engines via Docker, lambda + s3 extensions           | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| RDS Data API              | 6 ops, real SQL + typed results + transactions on the RDS container  | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Redshift                  | 141 ops, full control plane free (clusters, snapshots, endpoint access, logging) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Database Migration Service | 119 ops, full control plane free (replication instances/tasks/endpoints, subnet groups, serverless configs, schema conversion) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Transfer Family           | 71 ops, full control plane free (servers, users, SSH/host keys, accesses, workflows, agreements, connectors, profiles, certificates, web apps) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| CloudTrail                | 60 ops, full control plane free (trails, logging status, event/insight selectors, Lake event data stores, channels, imports, queries, dashboards) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Aurora DSQL               | 16 ops, full control plane free (clusters, policies, streams, tagging) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Resource Groups           | 23 ops, groups + queries + membership + tag-sync, free | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Resource Groups Tagging API | 9 ops, cross-service tag reads/writes + reports, free | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| ElastiCache               | 75 ops, real Redis/Valkey/Memcached                                  | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| MemoryDB                  | 45 ops, full control plane free                                      | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| EKS                       | Full control plane free (all 65 ops: clusters, node groups, Fargate, add-ons, access entries, IdP configs, pod identity, insights, capabilities, EKS Anywhere) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Amazon S3 Glacier         | Full surface free with a real data plane (all 33 ops: vaults, archives with SHA-256 tree hashes, multipart uploads, retrieval + inventory jobs, vault lock, notifications, policies, tags, provisioned capacity) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| AWS Backup                | Full control plane free (all 109 ops: plans, vaults, recovery points, backup/copy/restore/scan jobs, frameworks, report plans, legal holds, restore testing, tiering) | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| OpenSearch Service        | Full control plane free (all 93 ops)                                | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Elasticsearch Service     | Full control plane free (all 51 ops)                                | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Cloud Map                 | Full control plane + discovery free (all 30 ops)                    | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| API Gateway v1 / v2       | 124 / 103 ops, real Lambda proxy data plane                          | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Bedrock                   | 214 ops across 4 APIs                                                 | Not available |
-| ECR / ECS                 | 58 / 76 ops, real `docker push`/`pull`, real task execution         | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| Elastic Load Balancing v2 | 51 ops incl. mTLS + in-process HTTP data plane                       | [Paid only](https://docs.localstack.cloud/references/licensing/) |
-| CloudFront                | 147 ops, full distribution config round-trip                         | [Paid only](https://docs.localstack.cloud/references/licensing/) |
+Since March 2026, LocalStack's Community image requires an account and token, and most services are paid-only. fakecloud stays fully free and local.
+
+| | fakecloud | LocalStack Community (post-March 2026) |
+| --- | --- | --- |
+| License | AGPL-3.0, free for commercial use | Proprietary, paid plans |
+| Auth | None | Account + token required |
+| Footprint | ~19 MB binary, ~10 MiB idle, ~300ms start, no Docker | ~1 GB image, ~150 MiB idle, ~3s start, Docker required |
+| Conformance | true 100% (248,319 Smithy variants) | partial |
+| Paywalled services | None (RDS, Cognito, SES, ElastiCache, ECS/ECR, EKS, Redshift, and more are all free) | Many core services paid-only |
+| Test-assertion SDKs | TypeScript, Python, Go, PHP, Java, Rust | Python, Java |
+
+Full feature-by-feature comparison: [fakecloud.dev/vs/localstack](https://fakecloud.dev/vs/localstack/).
 
 > Performance numbers measured on Apple M1 via `time fakecloud`, `ps -o rss`, `ls -lh`.
 
@@ -248,12 +172,9 @@ Use fakecloud as a local AWS emulator for integration tests.
 
 ## Who's using fakecloud
 
-Early days, and the list is just getting started. If you or your team use
-fakecloud in CI, local dev, or tests, add yourself to [ADOPTERS.md](ADOPTERS.md)
-with a one-line note on how you use it. Preferred: open a PR. If that is
-inconvenient, comment on the
-["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324)
-issue instead. Self-reported and opt-in only.
+See the current list in [ADOPTERS.md](ADOPTERS.md). It is early days, so it is short for now.
+
+Using fakecloud? Add your team: the preferred way is a quick PR adding a row to ADOPTERS.md. If a PR is inconvenient, comment on the ["Who's using fakecloud?"](https://github.com/faiscadev/fakecloud/issues/2324) issue instead. Self-reported and opt-in.
 
 ## Contributing
 

--- a/scripts/check-doc-counts.sh
+++ b/scripts/check-doc-counts.sh
@@ -174,6 +174,13 @@ EXCEPTIONS=(
     # vs/localstack.md aliases redirect legacy blog slugs that have "500ms" in
     # the URL itself. They're URLs we have to match verbatim, not performance claims.
     "website/content/vs/localstack.md:startup_ms:500"
+    # Comparison tables quote the COMPETITOR's performance numbers next to ours.
+    # The metric checks extract every number on the line and can't attribute it,
+    # so a competitor's figure that collides with one of our metric kinds is
+    # whitelisted here. "~150 MiB idle" is LocalStack's idle RSS in the README
+    # footprint-comparison row (ours is ~10 MiB, stated in the same row and in
+    # "Why fakecloud").
+    "README.md:idle_mem_mib:150"
     # "AWS AppConfig: 58 operations" is a DIFFERENT service from AWS Config; the
     # per-service regex matches the "Config" tail of "AppConfig". AppConfig's 58
     # op count is correct in its own context.


### PR DESCRIPTION
## Summary

README slims from 259 to ~197 lines. The two largest tables move to teaser + link (the full versions already live on the site, so this de-duplicates rather than dropping content), the "Who's using" section leads with the list, and a temporary seeding banner invites adopters.

- **Supported services**: ~60-row table -> headline (105 services / 7,379 ops / 100% conformance) + a highlights line (keeps service-name keywords for SEO) + links to the [parity matrix](https://fakecloud.dev/docs/parity/) and [per-service docs](https://fakecloud.dev/docs/services).
- **Compared to LocalStack**: ~34-row table -> a 6-row highlight (the strongest diffs) + link to the full [fakecloud.dev/vs/localstack](https://fakecloud.dev/vs/localstack/) comparison.
- **Who's using fakecloud**: now leads with the ADOPTERS.md list (answers the question), then how to get on it.
- **Seeding banner**: a `[!NOTE]` callout inviting adopters while the list is empty, framed as an invite (not an empty list). An HTML comment marks it for removal once ADOPTERS.md has ~5 entries.

No content is lost: the exhaustive service table and full comparison are the canonical versions on fakecloud.dev.

## Test plan
- Docs-only change; link targets verified to exist (`website/content/vs/localstack.md`, parity/services pages already linked elsewhere).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the README by replacing big tables with short teasers and links, reordered “Who’s using” to lead with `ADOPTERS.md`, and added a temporary seeding banner. This removes duplicate content, keeps full details on the site, and cuts ~100 lines.

- **Refactors**
  - Supported services: headline + highlights with links; dropped per‑service op parentheticals to avoid drift; corrected Bedrock surface to 216 ops.
  - Compared to LocalStack: 6-row highlight + link to full comparison page.
  - Who’s using: lead with `ADOPTERS.md`; add `[!NOTE]` seeding banner with removal comment.
  - CI/doc-counts: whitelist README `idle_mem_mib:150` (competitor figure) to pass metric checks.

<sup>Written for commit 1b8b43772580196cfa0e4c70b5a44f85556ee108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

