### PR TITLE
fix(wafv2,verifiedpermissions,rds): enforce rule-group blocking + Cedar schema + persist DBCluster safety flags

### DIFF
--- a/crates/fakecloud-elbv2/src/dataplane.rs
+++ b/crates/fakecloud-elbv2/src/dataplane.rs
@@ -23,7 +23,7 @@ use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_wafv2::evaluator::{
     evaluate_detailed as waf_evaluate_detailed, WafAction, WafRequest,
 };
-use fakecloud_wafv2::{IpSet, RegexPatternSet, SharedWafv2State, WebAcl};
+use fakecloud_wafv2::{IpSet, RegexPatternSet, RuleGroup, SharedWafv2State, WebAcl};
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
@@ -794,7 +794,13 @@ pub(crate) fn evaluate_waf_outcome(
         country: None,
         body_size_bytes: body.len() as u64,
     };
-    let detailed = waf_evaluate_detailed(&req, &snap.web_acl, &snap.ipsets, &snap.regex_sets);
+    let detailed = waf_evaluate_detailed(
+        &req,
+        &snap.web_acl,
+        &snap.ipsets,
+        &snap.regex_sets,
+        &snap.rule_groups,
+    );
     if !detailed.count_rules.is_empty() {
         if let Some(metrics) = count_metrics {
             let mut m = metrics.lock();
@@ -867,6 +873,7 @@ struct WafSnapshot {
     web_acl: WebAcl,
     ipsets: std::collections::HashMap<String, IpSet>,
     regex_sets: std::collections::HashMap<String, RegexPatternSet>,
+    rule_groups: std::collections::HashMap<String, RuleGroup>,
 }
 
 fn waf_snapshot_for_lb(waf_state: &SharedWafv2State, lb_arn: &str) -> Option<WafSnapshot> {
@@ -888,10 +895,16 @@ fn waf_snapshot_for_lb(waf_state: &SharedWafv2State, lb_arn: &str) -> Option<Waf
             .values()
             .map(|s| (s.arn.clone(), s.clone()))
             .collect();
+        let rule_groups: std::collections::HashMap<String, RuleGroup> = account
+            .rule_groups
+            .values()
+            .map(|g| (g.arn.clone(), g.clone()))
+            .collect();
         return Some(WafSnapshot {
             web_acl: web_acl.clone(),
             ipsets,
             regex_sets,
+            rule_groups,
         });
     }
     None

--- a/crates/fakecloud-rds/src/extras/cluster_actions.rs
+++ b/crates/fakecloud-rds/src/extras/cluster_actions.rs
@@ -71,6 +71,134 @@ pub(super) fn cluster_engine(entry: &Value) -> &str {
     entry["Engine"].as_str().unwrap_or("aurora-postgresql")
 }
 
+/// Persist the create-time cluster input fields that `CreateDBCluster`
+/// otherwise dropped. Mirrors the set `ModifyDBCluster` stores (and
+/// `db_cluster_member_xml` renders) plus the create-only fields (`KmsKeyId`,
+/// `DatabaseName`, `EngineMode`, `DBSubnetGroupName`), so that safety-relevant
+/// flags such as `DeletionProtection` / `StorageEncrypted` survive a create
+/// without needing a follow-up modify.
+///
+/// Values are coerced to the same JSON shapes the renderer expects: `int_keys`
+/// become numbers, `bool_keys` become booleans, everything else stays a string.
+pub(super) fn apply_create_cluster_params(
+    obj: &mut serde_json::Map<String, Value>,
+    req: &AwsRequest,
+) {
+    // (input param name, persisted JSON key). Distinct where AWS renames the
+    // field in its response shape (e.g. EnableIAMDatabaseAuthentication ->
+    // IAMDatabaseAuthenticationEnabled).
+    let scalar_inputs: &[(&str, &str)] = &[
+        ("DatabaseName", "DatabaseName"),
+        ("KmsKeyId", "KmsKeyId"),
+        ("StorageEncrypted", "StorageEncrypted"),
+        ("DeletionProtection", "DeletionProtection"),
+        ("BackupRetentionPeriod", "BackupRetentionPeriod"),
+        ("PreferredBackupWindow", "PreferredBackupWindow"),
+        ("PreferredMaintenanceWindow", "PreferredMaintenanceWindow"),
+        ("DBSubnetGroupName", "DBSubnetGroup"),
+        ("DBClusterParameterGroupName", "DBClusterParameterGroupName"),
+        ("StorageType", "StorageType"),
+        ("AllocatedStorage", "AllocatedStorage"),
+        ("Iops", "Iops"),
+        ("DBClusterInstanceClass", "DBClusterInstanceClass"),
+        ("EngineMode", "EngineMode"),
+        ("NetworkType", "NetworkType"),
+        ("CopyTagsToSnapshot", "CopyTagsToSnapshot"),
+        (
+            "EnableIAMDatabaseAuthentication",
+            "IAMDatabaseAuthenticationEnabled",
+        ),
+        ("AutoMinorVersionUpgrade", "AutoMinorVersionUpgrade"),
+        ("BacktrackWindow", "BacktrackWindow"),
+        ("EnableHttpEndpoint", "HttpEndpointEnabled"),
+        ("Domain", "Domain"),
+        ("DomainIAMRoleName", "DomainIAMRoleName"),
+        ("MonitoringInterval", "MonitoringInterval"),
+        ("MonitoringRoleArn", "MonitoringRoleArn"),
+        ("PerformanceInsightsKMSKeyId", "PerformanceInsightsKMSKeyId"),
+        (
+            "PerformanceInsightsRetentionPeriod",
+            "PerformanceInsightsRetentionPeriod",
+        ),
+        ("EnablePerformanceInsights", "PerformanceInsightsEnabled"),
+        ("ManageMasterUserPassword", "ManageMasterUserPassword"),
+        ("MasterUserSecretKmsKeyId", "MasterUserSecretKmsKeyId"),
+        ("CACertificateIdentifier", "CACertificateIdentifier"),
+        (
+            "ServerlessV2ScalingConfiguration.MinCapacity",
+            "ServerlessV2ScalingConfiguration.MinCapacity",
+        ),
+        (
+            "ServerlessV2ScalingConfiguration.MaxCapacity",
+            "ServerlessV2ScalingConfiguration.MaxCapacity",
+        ),
+    ];
+    let int_keys: &[&str] = &[
+        "BackupRetentionPeriod",
+        "AllocatedStorage",
+        "Iops",
+        "BacktrackWindow",
+        "MonitoringInterval",
+        "PerformanceInsightsRetentionPeriod",
+    ];
+    let bool_keys: &[&str] = &[
+        "StorageEncrypted",
+        "DeletionProtection",
+        "CopyTagsToSnapshot",
+        "IAMDatabaseAuthenticationEnabled",
+        "AutoMinorVersionUpgrade",
+        "HttpEndpointEnabled",
+        "PerformanceInsightsEnabled",
+        "ManageMasterUserPassword",
+    ];
+
+    for (param_name, json_key) in scalar_inputs {
+        if let Some(v) = get_param(req, param_name) {
+            let value = if int_keys.contains(json_key) {
+                v.parse::<i64>().map(|n| json!(n)).unwrap_or(json!(v))
+            } else if bool_keys.contains(json_key) {
+                match v.as_str() {
+                    "true" => json!(true),
+                    "false" => json!(false),
+                    _ => json!(v),
+                }
+            } else {
+                json!(v)
+            };
+            obj.insert((*json_key).to_string(), value);
+        }
+    }
+
+    // VpcSecurityGroupIds.VpcSecurityGroupId.N (list)
+    let mut sg_ids = Vec::new();
+    for index in 1.. {
+        let key = format!("VpcSecurityGroupIds.VpcSecurityGroupId.{index}");
+        match get_param(req, &key) {
+            Some(v) => sg_ids.push(Value::String(v)),
+            None => break,
+        }
+    }
+    if !sg_ids.is_empty() {
+        obj.insert("VpcSecurityGroupIds".to_string(), Value::Array(sg_ids));
+    }
+
+    // EnableCloudwatchLogsExports.member.N (list)
+    let mut logs = Vec::new();
+    for index in 1.. {
+        let key = format!("EnableCloudwatchLogsExports.member.{index}");
+        match get_param(req, &key) {
+            Some(v) => logs.push(Value::String(v)),
+            None => break,
+        }
+    }
+    if !logs.is_empty() {
+        obj.insert(
+            "EnabledCloudwatchLogsExports".to_string(),
+            Value::Array(logs),
+        );
+    }
+}
+
 /// `ModifyDBCluster`: accept the full set of mutable cluster fields and
 /// persist them on the stored cluster entry. Mirrors the M1
 /// `ModifyDBInstance` scope — every settable cluster field on the AWS

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -138,7 +138,7 @@ impl RdsService {
                 let port = get_param(req, "Port")
                     .and_then(|p| p.parse::<i64>().ok())
                     .unwrap_or(if engine.contains("mysql") { 3306 } else { 5432 });
-                let entry = json!({
+                let mut entry = json!({
                     "DBClusterIdentifier": id, "DBClusterArn": arn,
                     "DbClusterResourceId": new_cluster_resource_id(),
                     "Status": "available", "Engine": engine,
@@ -147,6 +147,13 @@ impl RdsService {
                     "ReaderEndpoint": format!("{id}.cluster-ro-xxx.{region}.rds.amazonaws.com"),
                     "Port": port, "MasterUsername": get_param(req, "MasterUsername").unwrap_or_else(|| "postgres".to_string()),
                 });
+                // Persist the remaining create-time input fields (safety flags
+                // like DeletionProtection / StorageEncrypted, KmsKeyId,
+                // BackupRetentionPeriod, DatabaseName, ...) that were otherwise
+                // dropped until a follow-up ModifyDBCluster.
+                if let Some(obj) = entry.as_object_mut() {
+                    apply_create_cluster_params(obj, req);
+                }
                 {
                     let mut accounts = write_state!();
                     let state = accounts.get_or_create(&aid);

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -2266,3 +2266,76 @@ fn start_activity_stream_accepts_alias() {
     let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
     assert!(body.contains("<KmsKeyId>arn:aws:kms:us-east-1:000000000000:alias/aws/rds</KmsKeyId>"));
 }
+
+#[test]
+fn create_db_cluster_persists_safety_fields() {
+    // Regression: CreateDBCluster dropped DeletionProtection / StorageEncrypted
+    // / KmsKeyId / BackupRetentionPeriod / DatabaseName until a follow-up
+    // ModifyDBCluster. They must be persisted at create time and echoed by both
+    // CreateDBCluster and DescribeDBClusters.
+    let svc = svc();
+    let resp = svc
+        .handle_extra_action(&req(
+            "CreateDBCluster",
+            &[
+                ("DBClusterIdentifier", "secure"),
+                ("Engine", "aurora-postgresql"),
+                ("DeletionProtection", "true"),
+                ("StorageEncrypted", "true"),
+                (
+                    "KmsKeyId",
+                    "arn:aws:kms:us-east-1:000000000000:key/abcd-1234",
+                ),
+                ("BackupRetentionPeriod", "14"),
+                ("DatabaseName", "appdb"),
+            ],
+        ))
+        .expect("CreateDBCluster");
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        body.contains("<DeletionProtection>true</DeletionProtection>"),
+        "create body missing DeletionProtection: {body}"
+    );
+    assert!(
+        body.contains("<StorageEncrypted>true</StorageEncrypted>"),
+        "create body missing StorageEncrypted: {body}"
+    );
+    assert!(
+        body.contains("<KmsKeyId>arn:aws:kms:us-east-1:000000000000:key/abcd-1234</KmsKeyId>"),
+        "create body missing KmsKeyId: {body}"
+    );
+    assert!(
+        body.contains("<BackupRetentionPeriod>14</BackupRetentionPeriod>"),
+        "create body missing BackupRetentionPeriod: {body}"
+    );
+    assert!(
+        body.contains("<DatabaseName>appdb</DatabaseName>"),
+        "create body missing DatabaseName: {body}"
+    );
+
+    // The same values must survive into DescribeDBClusters.
+    let dr = svc
+        .handle_extra_action(&req("DescribeDBClusters", &[]))
+        .unwrap();
+    let dbody = String::from_utf8(dr.body.expect_bytes().to_vec()).unwrap();
+    assert!(
+        dbody.contains("<DeletionProtection>true</DeletionProtection>"),
+        "describe missing DeletionProtection: {dbody}"
+    );
+    assert!(
+        dbody.contains("<StorageEncrypted>true</StorageEncrypted>"),
+        "describe missing StorageEncrypted: {dbody}"
+    );
+    assert!(
+        dbody.contains("<KmsKeyId>arn:aws:kms:us-east-1:000000000000:key/abcd-1234</KmsKeyId>"),
+        "describe missing KmsKeyId: {dbody}"
+    );
+    assert!(
+        dbody.contains("<BackupRetentionPeriod>14</BackupRetentionPeriod>"),
+        "describe missing BackupRetentionPeriod: {dbody}"
+    );
+    assert!(
+        dbody.contains("<DatabaseName>appdb</DatabaseName>"),
+        "describe missing DatabaseName: {dbody}"
+    );
+}

--- a/crates/fakecloud-server/src/runtime.rs
+++ b/crates/fakecloud-server/src/runtime.rs
@@ -317,9 +317,14 @@ pub(crate) fn wafv2_evaluate_admin(
                 .values()
                 .map(|s| (s.arn.clone(), s.clone()))
                 .collect();
-        (acl, ip_sets, regex_sets)
+        let rule_groups: std::collections::HashMap<String, fakecloud_wafv2::RuleGroup> = account
+            .rule_groups
+            .values()
+            .map(|g| (g.arn.clone(), g.clone()))
+            .collect();
+        (acl, ip_sets, regex_sets, rule_groups)
     };
-    let (acl, ip_sets, regex_sets) = snapshot;
+    let (acl, ip_sets, regex_sets, rule_groups) = snapshot;
     let Some(acl) = acl else {
         return bad("WebACL not found");
     };
@@ -338,6 +343,7 @@ pub(crate) fn wafv2_evaluate_admin(
         &request,
         &ip_sets,
         &regex_sets,
+        &rule_groups,
         rate_limiter,
         now_epoch_secs,
     );

--- a/crates/fakecloud-verifiedpermissions/src/cedar.rs
+++ b/crates/fakecloud-verifiedpermissions/src/cedar.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 use cedar_policy::{
     Authorizer, Context, Decision, Entities, EntityId, EntityTypeName, EntityUid, Policy, PolicyId,
-    PolicySet, Request, SlotId, Template,
+    PolicySet, Request, Schema, SlotId, Template,
 };
 use serde_json::{json, Map, Value};
 
@@ -41,16 +41,32 @@ pub fn evaluate(
     context: Option<&Value>,
     entities: Option<&Value>,
 ) -> Result<AuthzResult, String> {
+    // Load the policy store's Cedar schema (if any) so schema-typed evaluation
+    // works: action groups, `memberOf` entity hierarchies and typed attributes
+    // all require the schema to be threaded through entity parsing, context
+    // parsing and request validation. Without it, policies that rely on the
+    // schema produce spurious DENYs.
+    let (schema, schema_err) = build_schema(store);
+
     let principal_uid = entity_uid(principal)?;
     let action_uid = action_uid(action)?;
     let resource_uid = entity_uid(resource)?;
     let ctx = build_context(context)?;
-    let ents = build_entities(entities)?;
+    let ents = build_entities(entities, schema.as_ref())?;
 
     let (policy_set, mut errors) = build_policy_set(store);
+    if let Some(e) = schema_err {
+        errors.push(e);
+    }
 
-    let request = Request::new(principal_uid, action_uid, resource_uid, ctx, None)
-        .map_err(|e| format!("invalid authorization request: {e}"))?;
+    let request = Request::new(
+        principal_uid,
+        action_uid,
+        resource_uid,
+        ctx,
+        schema.as_ref(),
+    )
+    .map_err(|e| format!("invalid authorization request: {e}"))?;
     let response = Authorizer::new().is_authorized(&request, &policy_set, &ents);
 
     let decision = match response.decision() {
@@ -72,6 +88,24 @@ pub fn evaluate(
         determining_policies,
         errors,
     })
+}
+
+/// Parse the policy store's stored Cedar schema (the `cedarJson` blob from
+/// `PutSchema`) into a [`Schema`]. Returns `(None, None)` when no schema is
+/// attached, `(Some(schema), None)` on success, and `(None, Some(error))` when
+/// a stored schema fails to parse — in which case evaluation proceeds without
+/// it and the error is surfaced in the response `errors`.
+fn build_schema(store: &StoredPolicyStore) -> (Option<Schema>, Option<String>) {
+    let Some(stored) = &store.schema else {
+        return (None, None);
+    };
+    match Schema::from_json_str(&stored.cedar_json) {
+        Ok(schema) => (Some(schema), None),
+        Err(e) => (
+            None,
+            Some(format!("policy store schema failed to parse: {e}")),
+        ),
+    }
 }
 
 /// Build the Cedar `PolicySet` for a store, returning any policies that failed
@@ -191,20 +225,35 @@ fn build_context(cd: Option<&Value>) -> Result<Context, String> {
     Ok(Context::empty())
 }
 
-fn build_entities(ed: Option<&Value>) -> Result<Entities, String> {
-    let Some(ed) = ed else {
-        return Ok(Entities::empty());
+fn build_entities(ed: Option<&Value>, schema: Option<&Schema>) -> Result<Entities, String> {
+    // Resolve the caller-supplied entities to a Cedar entities-JSON array.
+    // When none are provided we still parse an empty array *through the schema*
+    // so that schema-defined `Action` entities (and their action-group
+    // ancestors) are injected — otherwise `action in Action::"group"` scopes
+    // never match. See `Entities::from_json_value`: the schema is a source of
+    // Action entities added to the parsed set.
+    let json = match ed {
+        Some(ed) => {
+            if let Some(list) = ed.get("entityList").and_then(Value::as_array) {
+                Value::Array(list.iter().map(entity_item_to_cedar).collect())
+            } else if let Some(cedar_json) = ed.get("cedarJson").and_then(Value::as_str) {
+                serde_json::from_str(cedar_json)
+                    .map_err(|e| format!("invalid entities cedarJson: {e}"))?
+            } else {
+                Value::Array(Vec::new())
+            }
+        }
+        None => Value::Array(Vec::new()),
     };
-    if let Some(list) = ed.get("entityList").and_then(Value::as_array) {
-        let json = Value::Array(list.iter().map(entity_item_to_cedar).collect());
-        return Entities::from_json_value(json, None).map_err(|e| format!("invalid entities: {e}"));
+    // Without a schema and with no entities, keep the cheap empty path.
+    if schema.is_none() {
+        if let Value::Array(a) = &json {
+            if a.is_empty() {
+                return Ok(Entities::empty());
+            }
+        }
     }
-    if let Some(cedar_json) = ed.get("cedarJson").and_then(Value::as_str) {
-        let json: Value = serde_json::from_str(cedar_json)
-            .map_err(|e| format!("invalid entities cedarJson: {e}"))?;
-        return Entities::from_json_value(json, None).map_err(|e| format!("invalid entities: {e}"));
-    }
-    Ok(Entities::empty())
+    Entities::from_json_value(json, schema).map_err(|e| format!("invalid entities: {e}"))
 }
 
 /// Convert a Verified Permissions `EntityItem` into the Cedar entity JSON form
@@ -296,7 +345,7 @@ fn attribute_to_cedar(v: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{StoredPolicy, StoredPolicyStore};
+    use crate::state::{StoredPolicy, StoredPolicyStore, StoredSchema};
     use chrono::Utc;
     use std::collections::BTreeMap;
 
@@ -423,5 +472,111 @@ mod tests {
         )
         .unwrap();
         assert_eq!(without.decision, "DENY");
+    }
+
+    #[test]
+    fn schema_action_group_membership_enables_allow() {
+        // The policy permits any action that is a member of the `readOnly`
+        // action group. That membership is defined only in the schema, so
+        // authorization of `Action::"view"` depends on the schema being loaded.
+        let schema = r#"{
+            "": {
+                "entityTypes": { "User": {}, "Photo": {} },
+                "actions": {
+                    "readOnly": {},
+                    "view": {
+                        "memberOf": [{ "id": "readOnly" }],
+                        "appliesTo": {
+                            "principalTypes": ["User"],
+                            "resourceTypes": ["Photo"]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let mut store = store_with_policies(vec![(
+            "grp",
+            r#"permit(principal, action in Action::"readOnly", resource);"#,
+        )]);
+
+        let principal = json!({ "entityType": "User", "entityId": "alice" });
+        let action = json!({ "actionType": "Action", "actionId": "view" });
+        let resource = json!({ "entityType": "Photo", "entityId": "vacation" });
+
+        // Without the schema, the action-group membership is unknown, so the
+        // `action in Action::"readOnly"` scope never matches -> spurious DENY.
+        let denied = evaluate(&store, &principal, &action, &resource, None, None).unwrap();
+        assert_eq!(denied.decision, "DENY");
+
+        // With the schema loaded, `view memberOf readOnly` is populated and the
+        // policy matches.
+        store.schema = Some(StoredSchema {
+            cedar_json: schema.to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+        let allowed = evaluate(&store, &principal, &action, &resource, None, None).unwrap();
+        assert_eq!(allowed.decision, "ALLOW");
+        assert_eq!(allowed.determining_policies, vec!["grp".to_string()]);
+        assert!(
+            allowed.errors.is_empty(),
+            "unexpected errors: {:?}",
+            allowed.errors
+        );
+    }
+
+    #[test]
+    fn schema_entity_hierarchy_memberof_enables_allow() {
+        // A policy scoped to a Group principal must ALLOW a User that is a
+        // member of that group. The parent relationship is supplied on the
+        // entity, but the schema declares the `memberOfTypes` relation so the
+        // typed hierarchy is validated when entities are parsed with the schema.
+        let schema = r#"{
+            "": {
+                "entityTypes": {
+                    "User": { "memberOfTypes": ["Group"] },
+                    "Group": {},
+                    "Photo": {}
+                },
+                "actions": {
+                    "view": {
+                        "appliesTo": {
+                            "principalTypes": ["User"],
+                            "resourceTypes": ["Photo"]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let mut store = store_with_policies(vec![(
+            "grp",
+            r#"permit(principal in Group::"admins", action == Action::"view", resource);"#,
+        )]);
+        store.schema = Some(StoredSchema {
+            cedar_json: schema.to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+
+        let entities = json!({
+            "entityList": [
+                {
+                    "identifier": { "entityType": "User", "entityId": "alice" },
+                    "attributes": {},
+                    "parents": [ { "entityType": "Group", "entityId": "admins" } ]
+                }
+            ]
+        });
+        let r = evaluate(
+            &store,
+            &json!({ "entityType": "User", "entityId": "alice" }),
+            &json!({ "actionType": "Action", "actionId": "view" }),
+            &json!({ "entityType": "Photo", "entityId": "vacation" }),
+            None,
+            Some(&entities),
+        )
+        .unwrap();
+        assert_eq!(r.decision, "ALLOW", "errors: {:?}", r.errors);
+        assert_eq!(r.determining_policies, vec!["grp".to_string()]);
     }
 }

--- a/crates/fakecloud-wafv2/src/evaluator.rs
+++ b/crates/fakecloud-wafv2/src/evaluator.rs
@@ -33,7 +33,7 @@ use percent_encoding::percent_decode_str;
 use regex::Regex;
 use serde_json::Value;
 
-use crate::state::{IpSet, RegexPatternSet, WebAcl};
+use crate::state::{IpSet, RegexPatternSet, RuleGroup, WebAcl};
 
 /// HTTP header name (lowercased) the test admin endpoint uses to inject a
 /// synthetic geo country code into the request. Real GeoIP lookup is out of
@@ -188,8 +188,9 @@ pub fn evaluate(
     web_acl: &WebAcl,
     ipsets: &HashMap<String, IpSet>,
     regex_sets: &HashMap<String, RegexPatternSet>,
+    rule_groups: &HashMap<String, RuleGroup>,
 ) -> WafAction {
-    evaluate_detailed(req, web_acl, ipsets, regex_sets).action
+    evaluate_detailed(req, web_acl, ipsets, regex_sets, rule_groups).action
 }
 
 /// Like [`evaluate`] but also reports the names of rules whose
@@ -200,8 +201,17 @@ pub fn evaluate_detailed(
     web_acl: &WebAcl,
     ipsets: &HashMap<String, IpSet>,
     regex_sets: &HashMap<String, RegexPatternSet>,
+    rule_groups: &HashMap<String, RuleGroup>,
 ) -> WafEvaluation {
-    let verdict = evaluate_inner(req, web_acl, ipsets, regex_sets, None, current_epoch_secs());
+    let verdict = evaluate_inner(
+        req,
+        web_acl,
+        ipsets,
+        regex_sets,
+        rule_groups,
+        None,
+        current_epoch_secs(),
+    );
     WafEvaluation {
         action: verdict.action,
         count_rules: verdict.count_rules,
@@ -214,11 +224,13 @@ pub fn evaluate_detailed(
 ///
 /// `now_epoch_secs` is taken as a parameter so tests can drive the
 /// rate-based clock deterministically.
+#[allow(clippy::too_many_arguments)]
 pub fn evaluate_web_acl(
     web_acl: &WebAcl,
     request: &WafRequest,
     ipsets: &HashMap<String, IpSet>,
     regex_sets: &HashMap<String, RegexPatternSet>,
+    rule_groups: &HashMap<String, RuleGroup>,
     rate_limiter: &RateLimiter,
     now_epoch_secs: i64,
 ) -> WafVerdict {
@@ -227,6 +239,7 @@ pub fn evaluate_web_acl(
         web_acl,
         ipsets,
         regex_sets,
+        rule_groups,
         Some(rate_limiter),
         now_epoch_secs,
     )
@@ -239,8 +252,9 @@ impl WebAcl {
         req: &WafRequest,
         ipsets: &HashMap<String, IpSet>,
         regex_sets: &HashMap<String, RegexPatternSet>,
+        rule_groups: &HashMap<String, RuleGroup>,
     ) -> WafAction {
-        evaluate(req, self, ipsets, regex_sets)
+        evaluate(req, self, ipsets, regex_sets, rule_groups)
     }
 
     /// Convenience wrapper around [`evaluate_detailed`] for callers
@@ -250,8 +264,9 @@ impl WebAcl {
         req: &WafRequest,
         ipsets: &HashMap<String, IpSet>,
         regex_sets: &HashMap<String, RegexPatternSet>,
+        rule_groups: &HashMap<String, RuleGroup>,
     ) -> WafEvaluation {
-        evaluate_detailed(req, self, ipsets, regex_sets)
+        evaluate_detailed(req, self, ipsets, regex_sets, rule_groups)
     }
 }
 
@@ -263,11 +278,13 @@ fn current_epoch_secs() -> i64 {
         .unwrap_or(0)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn evaluate_inner(
     req: &WafRequest,
     web_acl: &WebAcl,
     ipsets: &HashMap<String, IpSet>,
     regex_sets: &HashMap<String, RegexPatternSet>,
+    rule_groups: &HashMap<String, RuleGroup>,
     rate_limiter: Option<&RateLimiter>,
     now_epoch_secs: i64,
 ) -> WafVerdict {
@@ -282,6 +299,42 @@ fn evaluate_inner(
         let Some(stmt) = rule.get("Statement") else {
             continue;
         };
+        // Customer RuleGroupReferenceStatement rules delegate their terminal
+        // decision to the referenced rule group's own rules (they carry an
+        // `OverrideAction`, not an `Action`). Handle them before the generic
+        // statement dispatch so a matching Block rule inside the group blocks.
+        if let Some(rg_ref) = stmt.get("RuleGroupReferenceStatement") {
+            if let Some(term) = eval_rule_group_reference(
+                rule,
+                rg_ref,
+                req,
+                ipsets,
+                regex_sets,
+                rule_groups,
+                rate_limiter,
+                now_epoch_secs,
+                &mut labels,
+                &mut emitted_labels,
+                &mut count_rules,
+            ) {
+                add_rule_labels(rule, &mut labels, &mut emitted_labels);
+                return WafVerdict {
+                    action: term.action,
+                    terminating_rule_id: Some(term.rule_id),
+                    labels: emitted_labels,
+                    blocked: matches!(
+                        term.action,
+                        WafAction::Block | WafAction::Captcha | WafAction::Challenge
+                    ),
+                    count_rules,
+                    custom_response_body_key: term.body_key,
+                    custom_response_status: term.status,
+                };
+            }
+            // No terminal action produced by the group — it is non-terminal
+            // for the WebACL, continue to the next rule.
+            continue;
+        }
         let ctx = StmtCtx {
             req,
             ipsets,
@@ -299,15 +352,7 @@ fn evaluate_inner(
             continue;
         }
         // Add labels produced by this rule so subsequent rules can match.
-        if let Some(arr) = rule.get("RuleLabels").and_then(Value::as_array) {
-            for label in arr {
-                if let Some(name) = label.get("Name").and_then(Value::as_str) {
-                    if labels.insert(name.to_owned()) {
-                        emitted_labels.push(name.to_owned());
-                    }
-                }
-            }
-        }
+        add_rule_labels(rule, &mut labels, &mut emitted_labels);
         if let Some(action) = rule.get("Action").and_then(rule_action) {
             // Count is non-terminal: keep evaluating subsequent rules but
             // record the rule for metrics.
@@ -332,8 +377,10 @@ fn evaluate_inner(
                 custom_response_status: status,
             };
         }
-        // Rule with OverrideAction (rule group reference) doesn't terminate
-        // here either since we don't expand rule groups in this batch.
+        // A rule that matched but carries only an OverrideAction (e.g. a
+        // managed rule group reference without an explicit terminal Action)
+        // does not terminate here; customer rule group references are expanded
+        // and terminated above.
     }
 
     let default = default_action(web_acl);
@@ -346,6 +393,151 @@ fn evaluate_inner(
         custom_response_body_key: None,
         custom_response_status: None,
     }
+}
+
+/// Insert every `RuleLabels[].Name` produced by `rule` into the shared label
+/// set, tracking newly-added labels in `emitted_labels` (in insertion order).
+fn add_rule_labels(rule: &Value, labels: &mut HashSet<String>, emitted_labels: &mut Vec<String>) {
+    if let Some(arr) = rule.get("RuleLabels").and_then(Value::as_array) {
+        for label in arr {
+            if let Some(name) = label.get("Name").and_then(Value::as_str) {
+                if labels.insert(name.to_owned()) {
+                    emitted_labels.push(name.to_owned());
+                }
+            }
+        }
+    }
+}
+
+/// Terminal outcome produced by evaluating a referenced customer rule group.
+struct GroupTerminal {
+    action: WafAction,
+    rule_id: String,
+    body_key: Option<String>,
+    status: Option<u16>,
+}
+
+/// Evaluate a customer `RuleGroupReferenceStatement`.
+///
+/// Looks up the referenced [`RuleGroup`] by ARN and evaluates its rules in
+/// `Priority` order against the request, reusing the same statement machinery
+/// as inline WebACL rules. Honors:
+///
+/// - the reference's `OverrideAction`: `Count` converts every inner rule's
+///   action to `Count` (test/monitor mode); `None` lets inner actions apply.
+/// - `RuleActionOverrides`: per-rule action replacement by rule name.
+/// - `ExcludedRules` (legacy): named inner rules are forced to `Count`.
+///
+/// Returns `Some(GroupTerminal)` when an inner rule matches with a terminal
+/// (non-`Count`) action, or `None` when nothing terminal fired (including a
+/// missing rule group — AWS validates the reference at association time, so at
+/// evaluation a missing group is a no-op rather than a match).
+#[allow(clippy::too_many_arguments)]
+fn eval_rule_group_reference(
+    outer_rule: &Value,
+    rg_ref: &Value,
+    req: &WafRequest,
+    ipsets: &HashMap<String, IpSet>,
+    regex_sets: &HashMap<String, RegexPatternSet>,
+    rule_groups: &HashMap<String, RuleGroup>,
+    rate_limiter: Option<&RateLimiter>,
+    now_epoch_secs: i64,
+    labels: &mut HashSet<String>,
+    emitted_labels: &mut Vec<String>,
+    count_rules: &mut Vec<String>,
+) -> Option<GroupTerminal> {
+    let arn = rg_ref.get("ARN").and_then(Value::as_str)?;
+    let group = rule_groups.get(arn)?;
+
+    // OverrideAction {Count:{}} on the reference forces every inner rule to
+    // Count (nothing terminates). {None:{}} is the pass-through default.
+    let force_count = outer_rule
+        .get("OverrideAction")
+        .and_then(Value::as_object)
+        .map(|o| o.contains_key("Count"))
+        .unwrap_or(false);
+
+    let overrides = rg_ref.get("RuleActionOverrides").and_then(Value::as_array);
+    let excluded: HashSet<&str> = rg_ref
+        .get("ExcludedRules")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e.get("Name").and_then(Value::as_str))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut inner_rules: Vec<&Value> = group.rules.iter().collect();
+    inner_rules.sort_by_key(|r| r.get("Priority").and_then(Value::as_i64).unwrap_or(0));
+
+    for inner in inner_rules {
+        let Some(stmt) = inner.get("Statement") else {
+            continue;
+        };
+        let name = inner
+            .get("Name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+
+        let matched = {
+            let ctx = StmtCtx {
+                req,
+                ipsets,
+                regex_sets,
+                labels: &*labels,
+                rule_id: name.clone(),
+                rate_limiter,
+                now_epoch_secs,
+            };
+            eval_statement(stmt, &ctx)
+        };
+        if !matched {
+            continue;
+        }
+
+        add_rule_labels(inner, labels, emitted_labels);
+
+        // Resolve the effective action for this inner rule.
+        let mut action = if excluded.contains(name.as_str()) {
+            WafAction::Count
+        } else if let Some(ov) = override_action_for(overrides, &name) {
+            ov
+        } else {
+            inner
+                .get("Action")
+                .and_then(rule_action)
+                .unwrap_or(WafAction::Count)
+        };
+        if force_count {
+            action = WafAction::Count;
+        }
+
+        if action == WafAction::Count {
+            count_rules.push(name);
+            continue;
+        }
+
+        let (body_key, status) = block_custom_response(inner);
+        return Some(GroupTerminal {
+            action,
+            rule_id: name,
+            body_key,
+            status,
+        });
+    }
+    None
+}
+
+/// Resolve a `RuleActionOverrides` entry for the inner rule named `name`.
+fn override_action_for(overrides: Option<&Vec<Value>>, name: &str) -> Option<WafAction> {
+    let overrides = overrides?;
+    overrides
+        .iter()
+        .find(|o| o.get("Name").and_then(Value::as_str) == Some(name))
+        .and_then(|o| o.get("ActionToUse"))
+        .and_then(rule_action)
 }
 
 fn block_custom_response(rule: &Value) -> (Option<String>, Option<u16>) {
@@ -456,8 +648,10 @@ fn eval_statement(stmt: &Value, ctx: &StmtCtx) -> bool {
         return eval_managed_rule_group(s, ctx.req);
     }
 
-    // RuleGroupReferenceStatement is intentionally unimplemented in W1 —
-    // the customer-defined rule group expansion is a follow-up.
+    // RuleGroupReferenceStatement is expanded at the top level of the WebACL
+    // loop (see `eval_rule_group_reference`), not here — AWS does not allow a
+    // rule group reference nested inside a logical statement, so reaching this
+    // arm means the reference is malformed; treat it as a non-match.
     false
 }
 
@@ -1132,7 +1326,13 @@ mod tests {
             json!({"Allow": {}}),
             vec![byte_match_uri_contains("/admin", json!({"Block": {}}))],
         );
-        let action = evaluate(&req("/admin/users"), &acl, &HashMap::new(), &HashMap::new());
+        let action = evaluate(
+            &req("/admin/users"),
+            &acl,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
         assert_eq!(action, WafAction::Block);
     }
 
@@ -1142,7 +1342,13 @@ mod tests {
             json!({"Allow": {}}),
             vec![byte_match_uri_contains("/admin", json!({"Block": {}}))],
         );
-        let action = evaluate(&req("/public"), &acl, &HashMap::new(), &HashMap::new());
+        let action = evaluate(
+            &req("/public"),
+            &acl,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
         assert_eq!(action, WafAction::Allow);
     }
 
@@ -1169,12 +1375,18 @@ mod tests {
         let mut r = req("/admin");
         r.method = "POST";
         assert_eq!(
-            evaluate(&r, &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(&r, &acl, &HashMap::new(), &HashMap::new(), &HashMap::new()),
             WafAction::Block,
             "POST /admin EXACTLY should block"
         );
         assert_eq!(
-            evaluate(&req("/admin/users"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin/users"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Allow,
             "/admin/users is not EXACTLY /admin"
         );
@@ -1210,7 +1422,10 @@ mod tests {
         );
         let mut r = req("/");
         r.source_ip = IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3));
-        assert_eq!(evaluate(&r, &acl, &sets, &HashMap::new()), WafAction::Block);
+        assert_eq!(
+            evaluate(&r, &acl, &sets, &HashMap::new(), &HashMap::new()),
+            WafAction::Block
+        );
     }
 
     #[test]
@@ -1228,20 +1443,26 @@ mod tests {
         let mut r = req("/");
         r.country = Some("DE");
         assert_eq!(
-            evaluate(&r, &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(&r, &acl, &HashMap::new(), &HashMap::new(), &HashMap::new()),
             WafAction::Block,
             "country=DE matches"
         );
         let mut r2 = req("/");
         r2.country = Some("US");
         assert_eq!(
-            evaluate(&r2, &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(&r2, &acl, &HashMap::new(), &HashMap::new(), &HashMap::new()),
             WafAction::Allow,
             "country=US does not match"
         );
         // No country -> no match
         assert_eq!(
-            evaluate(&req("/"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Allow,
             "missing country header -> no match"
         );
@@ -1268,6 +1489,7 @@ mod tests {
                 &req("/api/v2/admin"),
                 &acl,
                 &HashMap::new(),
+                &HashMap::new(),
                 &HashMap::new()
             ),
             WafAction::Block
@@ -1276,6 +1498,7 @@ mod tests {
             evaluate(
                 &req("/api/v2/admin/x"),
                 &acl,
+                &HashMap::new(),
                 &HashMap::new(),
                 &HashMap::new()
             ),
@@ -1305,7 +1528,13 @@ mod tests {
             })],
         );
         assert_eq!(
-            evaluate(&req("/admin"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Allow
         );
     }
@@ -1331,7 +1560,13 @@ mod tests {
             })],
         );
         assert_eq!(
-            evaluate(&req("/admin/x"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin/x"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
     }
@@ -1357,7 +1592,13 @@ mod tests {
         );
         // Inner ByteMatch fails, NOT inverts to true -> Block.
         assert_eq!(
-            evaluate(&req("/public"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/public"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
     }
@@ -1398,7 +1639,13 @@ mod tests {
             })],
         );
         assert_eq!(
-            evaluate(&req("/internal/x"), &acl, &HashMap::new(), &sets),
+            evaluate(
+                &req("/internal/x"),
+                &acl,
+                &HashMap::new(),
+                &sets,
+                &HashMap::new()
+            ),
             WafAction::Block
         );
     }
@@ -1407,7 +1654,13 @@ mod tests {
     fn default_action_block_when_no_rules_match_and_default_block() {
         let acl = make_acl(json!({"Block": {}}), vec![]);
         assert_eq!(
-            evaluate(&req("/anything"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/anything"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
     }
@@ -1424,7 +1677,13 @@ mod tests {
             }],
         );
         assert_eq!(
-            evaluate(&req("/admin/x"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin/x"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
     }
@@ -1460,7 +1719,13 @@ mod tests {
             ],
         );
         assert_eq!(
-            evaluate(&req("/admin/x"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin/x"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
     }
@@ -1487,13 +1752,19 @@ mod tests {
         let mut r = req("/upload");
         r.body_size_bytes = 2048;
         assert_eq!(
-            evaluate(&r, &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(&r, &acl, &HashMap::new(), &HashMap::new(), &HashMap::new()),
             WafAction::Block
         );
         let mut r_small = req("/upload");
         r_small.body_size_bytes = 512;
         assert_eq!(
-            evaluate(&r_small, &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &r_small,
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Allow
         );
     }
@@ -1517,11 +1788,23 @@ mod tests {
         );
         // /api is 4 bytes -> blocks
         assert_eq!(
-            evaluate(&req("/api"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/api"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
         assert_eq!(
-            evaluate(&req("/admin"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Allow
         );
     }
@@ -1548,12 +1831,28 @@ mod tests {
         r.source_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         // First 1000 requests should be allowed.
         for _ in 0..1000 {
-            let v = evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, now);
+            let v = evaluate_web_acl(
+                &acl,
+                &r,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now,
+            );
             assert_eq!(v.action, WafAction::Allow);
             assert!(!v.blocked);
         }
         // 1001st must trigger the block.
-        let v = evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, now);
+        let v = evaluate_web_acl(
+            &acl,
+            &r,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &limiter,
+            now,
+        );
         assert_eq!(v.action, WafAction::Block);
         assert_eq!(v.terminating_rule_id.as_deref(), Some("rate"));
         assert!(v.blocked);
@@ -1578,13 +1877,45 @@ mod tests {
         let limiter = RateLimiter::new();
         let r = req("/api");
         let t0 = 1_700_000_000;
-        evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, t0);
-        evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, t0);
-        let v3 = evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, t0);
+        evaluate_web_acl(
+            &acl,
+            &r,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &limiter,
+            t0,
+        );
+        evaluate_web_acl(
+            &acl,
+            &r,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &limiter,
+            t0,
+        );
+        let v3 = evaluate_web_acl(
+            &acl,
+            &r,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &limiter,
+            t0,
+        );
         assert_eq!(v3.action, WafAction::Block, "3rd in window blocks");
         // Roll the clock past the window — counters expire, request is allowed again.
         let later = t0 + 301;
-        let v4 = evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, later);
+        let v4 = evaluate_web_acl(
+            &acl,
+            &r,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &limiter,
+            later,
+        );
         assert_eq!(v4.action, WafAction::Allow, "after window rolls, allowed");
     }
 
@@ -1612,23 +1943,59 @@ mod tests {
         b.source_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
         // 1st request from each IP allowed.
         assert_eq!(
-            evaluate_web_acl(&acl, &a, &HashMap::new(), &HashMap::new(), &limiter, now).action,
+            evaluate_web_acl(
+                &acl,
+                &a,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now
+            )
+            .action,
             WafAction::Allow
         );
         assert_eq!(
-            evaluate_web_acl(&acl, &b, &HashMap::new(), &HashMap::new(), &limiter, now).action,
+            evaluate_web_acl(
+                &acl,
+                &b,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now
+            )
+            .action,
             WafAction::Allow
         );
         // 2nd from a blocks, but b's counter is independent.
         assert_eq!(
-            evaluate_web_acl(&acl, &a, &HashMap::new(), &HashMap::new(), &limiter, now).action,
+            evaluate_web_acl(
+                &acl,
+                &a,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now
+            )
+            .action,
             WafAction::Block
         );
         // b's second still goes over its own limit too (Limit=1, so 2nd
         // blocks). The check is that it isn't *prematurely* blocked by a's
         // bucket — we already proved the first b succeeded above.
         assert_eq!(
-            evaluate_web_acl(&acl, &b, &HashMap::new(), &HashMap::new(), &limiter, now).action,
+            evaluate_web_acl(
+                &acl,
+                &b,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now
+            )
+            .action,
             WafAction::Block
         );
     }
@@ -1657,6 +2024,7 @@ mod tests {
         let v = evaluate_web_acl(
             &acl,
             &req("/"),
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &limiter,
@@ -1693,6 +2061,7 @@ mod tests {
         let v = evaluate_web_acl(
             &acl,
             &req("/"),
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &limiter,
@@ -1745,7 +2114,16 @@ mod tests {
         };
         let acl_no = mk_acl("NO_MATCH");
         assert_eq!(
-            evaluate_web_acl(&acl_no, &r, &HashMap::new(), &HashMap::new(), &limiter, 0).action,
+            evaluate_web_acl(
+                &acl_no,
+                &r,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                0
+            )
+            .action,
             WafAction::Allow,
             "malformed XFF + NO_MATCH falls through"
         );
@@ -1754,6 +2132,7 @@ mod tests {
             evaluate_web_acl(
                 &acl_match,
                 &r,
+                &HashMap::new(),
                 &HashMap::new(),
                 &HashMap::new(),
                 &limiter,
@@ -1796,11 +2175,29 @@ mod tests {
             body_size_bytes: 0,
         };
         assert_eq!(
-            evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, now).action,
+            evaluate_web_acl(
+                &acl,
+                &r,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now
+            )
+            .action,
             WafAction::Allow
         );
         assert_eq!(
-            evaluate_web_acl(&acl, &r, &HashMap::new(), &HashMap::new(), &limiter, now).action,
+            evaluate_web_acl(
+                &acl,
+                &r,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &limiter,
+                now
+            )
+            .action,
             WafAction::Block
         );
     }
@@ -1822,15 +2219,33 @@ mod tests {
             })],
         );
         assert_eq!(
-            evaluate(&req("/admin/users"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/admin/users"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
         assert_eq!(
-            evaluate(&req("/wp-admin"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/wp-admin"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Block
         );
         assert_eq!(
-            evaluate(&req("/index.html"), &acl, &HashMap::new(), &HashMap::new()),
+            evaluate(
+                &req("/index.html"),
+                &acl,
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new()
+            ),
             WafAction::Allow
         );
     }
@@ -1845,6 +2260,7 @@ mod tests {
         let v = evaluate_web_acl(
             &acl,
             &req("/admin/x"),
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &limiter,
@@ -1864,6 +2280,7 @@ mod tests {
         let v = evaluate_web_acl(
             &acl,
             &req("/admin/x"),
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &limiter,
@@ -1909,6 +2326,7 @@ mod tests {
             &req("/admin/x"),
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
             &limiter,
             0,
         );
@@ -1944,11 +2362,204 @@ mod tests {
             &req("/admin"),
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
             &limiter,
             0,
         );
         assert_eq!(v.action, WafAction::Block);
         assert_eq!(v.custom_response_status, Some(429));
         assert_eq!(v.custom_response_body_key.as_deref(), Some("rate-limited"));
+    }
+
+    // --- Customer RuleGroupReferenceStatement expansion ---------------------
+
+    const RG_ARN: &str = "arn:aws:wafv2:us-east-1:000000000000:regional/rulegroup/rg/rgid";
+
+    fn make_rule_group(rules: Vec<Value>) -> RuleGroup {
+        RuleGroup {
+            id: "rgid".into(),
+            name: "rg".into(),
+            arn: RG_ARN.into(),
+            scope: "REGIONAL".into(),
+            capacity: 10,
+            description: None,
+            rules,
+            visibility_config: json!({}),
+            lock_token: "lt".into(),
+            label_namespace: "awswaf:000000000000:rulegroup:rg:".into(),
+            custom_response_bodies: BTreeMap::new(),
+            available_labels: Vec::new(),
+            consumed_labels: Vec::new(),
+            created_time: Utc::now(),
+        }
+    }
+
+    fn rule_group_ref_rule(overrides: Value) -> Value {
+        let mut stmt = json!({ "ARN": RG_ARN });
+        if let Value::Object(extra) = overrides {
+            for (k, v) in extra {
+                stmt[k] = v;
+            }
+        }
+        json!({
+            "Name": "rg-ref",
+            "Priority": 0,
+            "OverrideAction": {"None": {}},
+            "VisibilityConfig": {},
+            "Statement": {"RuleGroupReferenceStatement": stmt},
+        })
+    }
+
+    fn groups_map(g: RuleGroup) -> HashMap<String, RuleGroup> {
+        let mut m = HashMap::new();
+        m.insert(g.arn.clone(), g);
+        m
+    }
+
+    #[test]
+    fn customer_rule_group_reference_blocks_matching_request() {
+        // The referenced group's only rule blocks /admin; the WebACL delegates
+        // entirely to the group. A matching request must be blocked.
+        let group = make_rule_group(vec![byte_match_uri_contains(
+            "/admin",
+            json!({"Block": {}}),
+        )]);
+        let acl = make_acl(json!({"Allow": {}}), vec![rule_group_ref_rule(json!({}))]);
+        let groups = groups_map(group);
+        let limiter = RateLimiter::new();
+
+        let v = evaluate_web_acl(
+            &acl,
+            &req("/admin/users"),
+            &HashMap::new(),
+            &HashMap::new(),
+            &groups,
+            &limiter,
+            0,
+        );
+        assert_eq!(v.action, WafAction::Block, "group Block rule must block");
+        assert!(v.blocked);
+        assert_eq!(v.terminating_rule_id.as_deref(), Some("r"));
+
+        // A non-matching request falls through to the WebACL default (Allow).
+        let v2 = evaluate_web_acl(
+            &acl,
+            &req("/public"),
+            &HashMap::new(),
+            &HashMap::new(),
+            &groups,
+            &limiter,
+            0,
+        );
+        assert_eq!(v2.action, WafAction::Allow);
+    }
+
+    #[test]
+    fn customer_rule_group_override_to_count_does_not_block() {
+        // OverrideAction {Count:{}} converts every inner action to Count.
+        let group = make_rule_group(vec![byte_match_uri_contains(
+            "/admin",
+            json!({"Block": {}}),
+        )]);
+        let acl = make_acl(
+            json!({"Allow": {}}),
+            vec![rule_group_ref_rule(json!({}))
+                .as_object()
+                .cloned()
+                .map(|mut o| {
+                    o.insert("OverrideAction".into(), json!({"Count": {}}));
+                    Value::Object(o)
+                })
+                .unwrap()],
+        );
+        let groups = groups_map(group);
+        let limiter = RateLimiter::new();
+        let v = evaluate_web_acl(
+            &acl,
+            &req("/admin/users"),
+            &HashMap::new(),
+            &HashMap::new(),
+            &groups,
+            &limiter,
+            0,
+        );
+        assert_eq!(v.action, WafAction::Allow, "Count override must not block");
+        assert!(v.count_rules.contains(&"r".to_string()));
+    }
+
+    #[test]
+    fn customer_rule_group_action_override_flips_block_to_count() {
+        // RuleActionOverrides on the reference replaces the inner rule's Block
+        // action with Count for the rule named "r".
+        let group = make_rule_group(vec![byte_match_uri_contains(
+            "/admin",
+            json!({"Block": {}}),
+        )]);
+        let acl = make_acl(
+            json!({"Allow": {}}),
+            vec![rule_group_ref_rule(json!({
+                "RuleActionOverrides": [
+                    {"Name": "r", "ActionToUse": {"Count": {}}}
+                ]
+            }))],
+        );
+        let groups = groups_map(group);
+        let limiter = RateLimiter::new();
+        let v = evaluate_web_acl(
+            &acl,
+            &req("/admin/users"),
+            &HashMap::new(),
+            &HashMap::new(),
+            &groups,
+            &limiter,
+            0,
+        );
+        assert_eq!(v.action, WafAction::Allow);
+        assert!(v.count_rules.contains(&"r".to_string()));
+    }
+
+    #[test]
+    fn customer_rule_group_excluded_rule_is_forced_to_count() {
+        let group = make_rule_group(vec![byte_match_uri_contains(
+            "/admin",
+            json!({"Block": {}}),
+        )]);
+        let acl = make_acl(
+            json!({"Allow": {}}),
+            vec![rule_group_ref_rule(json!({
+                "ExcludedRules": [{"Name": "r"}]
+            }))],
+        );
+        let groups = groups_map(group);
+        let limiter = RateLimiter::new();
+        let v = evaluate_web_acl(
+            &acl,
+            &req("/admin/users"),
+            &HashMap::new(),
+            &HashMap::new(),
+            &groups,
+            &limiter,
+            0,
+        );
+        assert_eq!(v.action, WafAction::Allow);
+        assert!(v.count_rules.contains(&"r".to_string()));
+    }
+
+    #[test]
+    fn customer_rule_group_missing_reference_is_no_match() {
+        // AWS validates the reference at association time; at eval a missing
+        // group is a no-op, falling through to the WebACL default action.
+        let acl = make_acl(json!({"Allow": {}}), vec![rule_group_ref_rule(json!({}))]);
+        let limiter = RateLimiter::new();
+        let v = evaluate_web_acl(
+            &acl,
+            &req("/admin/users"),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &limiter,
+            0,
+        );
+        assert_eq!(v.action, WafAction::Allow);
     }
 }

--- a/crates/fakecloud-wafv2/src/inspection.rs
+++ b/crates/fakecloud-wafv2/src/inspection.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use crate::evaluator::{
     evaluate_web_acl, RateLimiter, WafAction, WafRequest, WafVerdict, FAKECLOUD_GEO_COUNTRY_HEADER,
 };
-use crate::state::{IpSet, RegexPatternSet, SharedWafv2State, WebAcl};
+use crate::state::{IpSet, RegexPatternSet, RuleGroup, SharedWafv2State, WebAcl};
 
 /// Default cap on the request-body bytes inspected by
 /// [`evaluate_request`]. Matches AWS WAF's free-tier inspection limit
@@ -188,6 +188,7 @@ struct ResourceSnapshot {
     web_acl: WebAcl,
     ipsets: HashMap<String, IpSet>,
     regex_sets: HashMap<String, RegexPatternSet>,
+    rule_groups: HashMap<String, RuleGroup>,
 }
 
 fn snapshot_for_resource(state: &SharedWafv2State, resource_arn: &str) -> Option<ResourceSnapshot> {
@@ -209,10 +210,16 @@ fn snapshot_for_resource(state: &SharedWafv2State, resource_arn: &str) -> Option
             .values()
             .map(|s| (s.arn.clone(), s.clone()))
             .collect();
+        let rule_groups: HashMap<String, RuleGroup> = account
+            .rule_groups
+            .values()
+            .map(|g| (g.arn.clone(), g.clone()))
+            .collect();
         return Some(ResourceSnapshot {
             web_acl: web_acl.clone(),
             ipsets,
             regex_sets,
+            rule_groups,
         });
     }
     None
@@ -267,6 +274,7 @@ pub fn evaluate_request(
         &req,
         &snapshot.ipsets,
         &snapshot.regex_sets,
+        &snapshot.rule_groups,
         rate_limiter,
         now_epoch_secs,
     );


### PR DESCRIPTION
Fixes a cluster of three security/safety-relevant wrong-output bugs in disjoint crates. Every fix ships with a regression test.

## 1. HIGH (security bypass) — WAFv2 customer rule-group references never blocked
`crates/fakecloud-wafv2/src/evaluator.rs` returned `false` for every customer `RuleGroupReferenceStatement` (commented "intentionally unimplemented in W1"). A WebACL delegating its blocking to a customer rule group therefore let ALL traffic through, reachable from the ALB / API Gateway v1+v2 / CloudFront data planes.

- `evaluate_inner` now expands `RuleGroupReferenceStatement` at the top of the WebACL rule loop (these rules carry `OverrideAction`, not `Action`, so the terminal decision comes from the group's own rules).
- Looks up the referenced `RuleGroup` by ARN, evaluates its rules in `Priority` order reusing the existing statement machinery, and honors:
  - `OverrideAction {Count:{}}` (forces every inner action to Count / monitor mode),
  - `RuleActionOverrides` (per-rule action replacement),
  - `ExcludedRules` (legacy; forces the named rule to Count).
- A missing referenced group is a no-op at eval time (AWS validates the reference at association time) — falls through to the WebACL default.
- Rule-group access is threaded through the two real data-plane entry points (`evaluate_web_acl`, used by apigw v1/v2 + the introspection endpoint; and `evaluate_detailed`, used by the ELBv2 ALB path) plus their snapshots (`inspection.rs`, `runtime.rs`, `elbv2/dataplane.rs`).

Tests: `customer_rule_group_reference_blocks_matching_request` (+ Count-override, action-override, excluded-rule, and missing-reference variants).

## 2. MED — VerifiedPermissions ignored the stored Cedar schema
`crates/fakecloud-verifiedpermissions/src/cedar.rs` round-tripped the schema via PutSchema/GetSchema but always passed `None` to the authorizer, producing spurious DENYs for policies relying on schema-defined action groups / `memberOf` hierarchies.

- Added `build_schema` to parse the stored `cedarJson` into a `cedar_policy::Schema`.
- The schema is now passed to `Entities::from_json_value` (which injects the schema's `Action` entities and their action-group ancestors — required for `action in Action::"group"` scopes) and to `Request::new` (typed request validation).
- Entities are parsed through the schema even when the caller supplies none, so schema-defined action entities are always present.
- A schema that fails to parse degrades gracefully: evaluation proceeds without it and the parse error is surfaced in the response `errors` (never aborts).

Note: with a schema stored, evaluation is now correctly stricter (requests/entities must conform to the schema). No existing test stores a schema during authorization, so nothing regresses.

Tests: `schema_action_group_membership_enables_allow`, `schema_entity_hierarchy_memberof_enables_allow`.

## 3. MED — RDS CreateDBCluster dropped safety-relevant fields
`crates/fakecloud-rds/src/extras/mod.rs` persisted ~9 fields at create and silently dropped `DeletionProtection`, `StorageEncrypted`, `KmsKeyId`, `BackupRetentionPeriod`, `DatabaseName`, and more — even though `ModifyDBCluster` persists them and `db_cluster_member_xml` renders them. A user setting `DeletionProtection`/`StorageEncrypted` at create silently lost it until a follow-up Modify.

- Added `apply_create_cluster_params` (in `cluster_actions.rs`), which persists the full create-time input set with the same int/bool coercion `ModifyDBCluster` uses, plus create-only fields (`KmsKeyId`, `DatabaseName`, `EngineMode`, `DBSubnetGroupName`) and the `VpcSecurityGroupIds` / `EnableCloudwatchLogsExports` / ServerlessV2 scaling lists. `CreateDBCluster` now applies it to the new entry.

Test: `create_db_cluster_persists_safety_fields` (create then DescribeDBClusters reflects DeletionProtection + StorageEncrypted + KmsKeyId + BackupRetentionPeriod + DatabaseName).

## Verification
- `cargo test` green: fakecloud-wafv2 (50), fakecloud-verifiedpermissions (29), fakecloud-rds (256), fakecloud-elbv2 (29).
- `cargo clippy --all-targets` clean on all touched crates + the server binary.
- `cargo fmt --all` applied; server binary builds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three security/safety bugs: WAFv2 customer rule-group references now block as expected, VerifiedPermissions honors the stored Cedar schema, and RDS CreateDBCluster persists safety flags at create time.

- **Bug Fixes**
  - `fakecloud-wafv2`: Expand `RuleGroupReferenceStatement` and evaluate the referenced group’s rules (priority order), honoring `OverrideAction` Count, `RuleActionOverrides`, and `ExcludedRules`. Thread rule-group snapshots through `fakecloud-elbv2` and the admin evaluator. Added tests for block/count/override/excluded and missing reference.
  - `fakecloud-verifiedpermissions`: Load the stored Cedar `cedarJson` into a `Schema` and pass it to entities and request parsing so action groups and `memberOf` work. If schema parsing fails, proceed without it and surface the error in `errors`. Behavior is stricter when a schema exists.
  - `fakecloud-rds`: Persist full create-time fields for `CreateDBCluster`, including `DeletionProtection`, `StorageEncrypted`, `KmsKeyId`, `BackupRetentionPeriod`, `DatabaseName`, plus lists like `VpcSecurityGroupIds` and `EnableCloudwatchLogsExports`. Matches `ModifyDBCluster` coercions. Added regression test.

<sup>Written for commit 9a883f7fd4b7b0f18ebfe954376ecb1956e482dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

