### PR TITLE
fix(ec2,lambda): ec2Query error envelope + version-qualified ListFunctions pagination

### DIFF
--- a/crates/fakecloud-aws/src/ec2query.rs
+++ b/crates/fakecloud-aws/src/ec2query.rs
@@ -19,7 +19,56 @@
 //! tests below round-trip the rendered XML through a minimal parser to lock the
 //! structure in. See [`crate::xml::xml_escape`] for content escaping.
 
+use bytes::Bytes;
+use http::StatusCode;
+
 use crate::xml::xml_escape;
+
+/// Build an `ec2Query` error response.
+///
+/// EC2's error envelope differs from awsQuery's `<ErrorResponse>` shape in
+/// three load-bearing ways the AWS SDKs deserialize strictly against:
+///
+/// ```xml
+/// <?xml version="1.0" encoding="UTF-8"?>
+/// <Response>
+///   <Errors>
+///     <Error>
+///       <Code>InvalidInstanceID.NotFound</Code>
+///       <Message>The instance ID 'i-123' does not exist</Message>
+///     </Error>
+///   </Errors>
+///   <RequestID>{request_id}</RequestID>
+/// </Response>
+/// ```
+///
+/// 1. The root element is `<Response>` (not `<ErrorResponse>`).
+/// 2. Errors nest inside an `<Errors>` wrapper, and each `<Error>` carries only
+///    `<Code>` + `<Message>` — there is NO `<Type>` element (awsQuery emits one).
+/// 3. The request id element is `<RequestID>` (capital I-D), not `<RequestId>`.
+///
+/// aws-sdk-go-v2 (Terraform), aws-sdk-js v3, aws-sdk-rust, and aws-sdk-java v2
+/// read the error code via `Response > Errors > Error > Code` and the id via
+/// `RequestID`; the awsQuery `<ErrorResponse>` shape leaves both empty for them,
+/// breaking `InvalidInstanceID.NotFound` / `DependencyViolation` branching and
+/// request-id-based retries. Only botocore/CLI are lenient enough to recover the
+/// code from the wrong shape.
+pub fn ec2_error_response(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    request_id: &str,
+) -> (StatusCode, String, Bytes) {
+    let body = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <Response><Errors><Error><Code>{code}</Code><Message>{message}</Message></Error></Errors>\
+         <RequestID>{rid}</RequestID></Response>",
+        code = xml_escape(code),
+        message = xml_escape(message),
+        rid = xml_escape(request_id),
+    );
+    (status, "text/xml".to_string(), Bytes::from(body))
+}
 
 /// The EC2 response namespace. Note the trailing slash — EC2 emits it on the
 /// wire even though the Smithy model's `xmlNamespace` uri omits it.
@@ -199,6 +248,50 @@ mod tests {
             ec2_bool("ebsOptimized", false),
             "<ebsOptimized>false</ebsOptimized>"
         );
+    }
+
+    #[test]
+    fn error_response_uses_ec2query_envelope_not_awsquery() {
+        let (status, content_type, body) = ec2_error_response(
+            StatusCode::BAD_REQUEST,
+            "InvalidInstanceID.NotFound",
+            "The instance ID 'i-123' does not exist",
+            "req-42",
+        );
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(content_type, "text/xml");
+        let xml = String::from_utf8(body.to_vec()).unwrap();
+        // Root <Response>, NOT awsQuery's <ErrorResponse>.
+        assert!(xml.contains("<Response>"), "{xml}");
+        assert!(!xml.contains("<ErrorResponse>"), "{xml}");
+        // <Errors> wrapper around each <Error>.
+        assert!(xml.contains("<Errors><Error>"), "{xml}");
+        // Code + Message, but NO <Type> element (awsQuery emits Sender/Receiver).
+        assert!(
+            xml.contains("<Code>InvalidInstanceID.NotFound</Code>"),
+            "{xml}"
+        );
+        assert!(
+            xml.contains("<Message>The instance ID &apos;i-123&apos; does not exist</Message>")
+                || xml.contains("<Message>The instance ID 'i-123' does not exist</Message>"),
+            "{xml}"
+        );
+        assert!(!xml.contains("<Type>"), "{xml}");
+        // Capital-ID <RequestID>, not <RequestId>.
+        assert!(xml.contains("<RequestID>req-42</RequestID>"), "{xml}");
+        assert!(!xml.contains("<RequestId>"), "{xml}");
+    }
+
+    #[test]
+    fn error_response_escapes_special_chars_in_message() {
+        let (_, _, body) = ec2_error_response(
+            StatusCode::BAD_REQUEST,
+            "InvalidParameterValue",
+            "a<b>&c",
+            "r-1",
+        );
+        let xml = String::from_utf8(body.to_vec()).unwrap();
+        assert!(xml.contains("<Message>a&lt;b&gt;&amp;c</Message>"), "{xml}");
     }
 
     #[test]

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -12593,6 +12593,62 @@ async fn ec2_raw(server: &TestServer, body: &str) -> reqwest::Response {
     resp
 }
 
+/// EC2 error responses must use the `ec2Query` error envelope, NOT the
+/// `awsQuery` `<ErrorResponse>` shape the other Query-protocol services use.
+/// aws-sdk-go-v2 (Terraform), aws-sdk-js v3, aws-sdk-rust and aws-sdk-java v2
+/// parse the error code via `Response > Errors > Error > Code` and the id via
+/// `RequestID`; the wrong envelope leaves both empty, breaking
+/// `InvalidInstanceID.NotFound` branching and request-id retries.
+#[tokio::test]
+async fn ec2_error_uses_ec2query_envelope() {
+    let server = TestServer::start().await;
+    let resp = reqwest::Client::new()
+        .post(server.endpoint())
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header("Authorization", EC2_RAW_AUTH)
+        .body("Action=DescribeInstances&Version=2016-11-15&InstanceId.1=i-0123456789abcdef0")
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "DescribeInstances on a bogus id must return a client error, got {}",
+        resp.status()
+    );
+    let body = resp.text().await.unwrap();
+
+    // ec2Query envelope: root <Response>, <Errors> wrapper, <Code>/<Message>,
+    // capital-ID <RequestID>. NONE of the awsQuery markers may appear.
+    assert!(
+        body.contains("<Response>"),
+        "missing <Response> root: {body}"
+    );
+    assert!(
+        body.contains("<Errors><Error>"),
+        "missing <Errors><Error> wrapper: {body}"
+    );
+    assert!(
+        body.contains("<Code>InvalidInstanceID.NotFound</Code>"),
+        "missing/incorrect error code: {body}"
+    );
+    assert!(
+        body.contains("<RequestID>"),
+        "missing capital-ID <RequestID>: {body}"
+    );
+    assert!(
+        !body.contains("<ErrorResponse>"),
+        "leaked awsQuery <ErrorResponse> root: {body}"
+    );
+    assert!(
+        !body.contains("<Type>"),
+        "leaked awsQuery <Type> element: {body}"
+    );
+    assert!(
+        !body.contains("<RequestId>"),
+        "leaked awsQuery lower-d <RequestId>: {body}"
+    );
+}
+
 #[test_action(
     "ec2",
     "CreateCapacityReservationCancellationQuote",

--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -471,9 +471,13 @@ pub async fn dispatch(
         );
     }
 
-    // Merge query params with form body params for Query protocol
+    // Merge query params with form body params for the Query family (awsQuery
+    // and ec2Query share identical form-encoded request bodies).
     let mut all_params = query_params;
-    if detected.protocol == AwsProtocol::Query {
+    if matches!(
+        detected.protocol,
+        AwsProtocol::Query | AwsProtocol::Ec2Query
+    ) {
         let body_params = protocol::parse_query_body(&body_bytes);
         for (k, v) in body_params {
             all_params.entry(k).or_insert(v);
@@ -508,7 +512,10 @@ pub async fn dispatch(
         raw_path: path,
         raw_query,
         method: parts.method,
-        is_query_protocol: detected.protocol == AwsProtocol::Query,
+        is_query_protocol: matches!(
+            detected.protocol,
+            AwsProtocol::Query | AwsProtocol::Ec2Query
+        ),
         access_key_id,
         principal: caller_principal,
     };
@@ -1170,8 +1177,17 @@ fn build_error_response_with_fields(
     extra_fields: &[(String, String)],
 ) -> Response<Body> {
     let (status, content_type, body) = match protocol {
+        // awsQuery services (SQS, SNS, IAM, STS, RDS, ELBv2, CloudWatch,
+        // AutoScaling, ...) share the `<ErrorResponse>` envelope.
         AwsProtocol::Query => {
             fakecloud_aws::error::xml_error_response(status, code, message, request_id)
+        }
+        // EC2 uses the distinct ec2Query error envelope
+        // (`<Response><Errors><Error>...</Errors><RequestID>`). Only EC2 is
+        // classified `Ec2Query`, so the other Query-protocol services above are
+        // untouched.
+        AwsProtocol::Ec2Query => {
+            fakecloud_aws::ec2query::ec2_error_response(status, code, message, request_id)
         }
         AwsProtocol::Rest => fakecloud_aws::error::s3_xml_error_response_with_fields(
             status,

--- a/crates/fakecloud-core/src/protocol.rs
+++ b/crates/fakecloud-core/src/protocol.rs
@@ -8,6 +8,16 @@ pub enum AwsProtocol {
     /// Query protocol: form-encoded body, Action param, XML response.
     /// Used by: SQS, SNS, IAM, STS.
     Query,
+    /// EC2 Query protocol: a variant of Query. Requests are wire-identical to
+    /// `Query` (form-encoded body, `Action` param), but responses — including
+    /// errors — use EC2's distinct XML envelope. Where `Query`/awsQuery emits
+    /// `<ErrorResponse><Error><Type/><Code/><Message/></Error><RequestId/>`,
+    /// ec2Query emits `<Response><Errors><Error><Code/><Message/></Error></Errors><RequestID/></Response>`
+    /// (root `<Response>`, an `<Errors>` wrapper, no `<Type>`, and capital-ID
+    /// `<RequestID>`). The AWS SDKs (aws-sdk-go-v2/Terraform, aws-sdk-js v3,
+    /// aws-sdk-rust, aws-sdk-java v2) parse EC2 error codes strictly against
+    /// this shape. Used by: EC2.
+    Ec2Query,
     /// JSON protocol: JSON body, X-Amz-Target header, JSON response.
     /// Used by: SSM, EventBridge, DynamoDB, SecretsManager, KMS, CloudWatch Logs.
     Json,
@@ -17,6 +27,17 @@ pub enum AwsProtocol {
     /// REST-JSON protocol: HTTP method + path-based routing, JSON responses.
     /// Used by: Lambda, SES v2.
     RestJson,
+}
+
+/// Pick the Query-family protocol for a resolved service. EC2 speaks the
+/// `ec2Query` variant (distinct error/response envelope); every other
+/// Action-param service uses plain `awsQuery`.
+fn query_protocol_for(service: &str) -> AwsProtocol {
+    if service == "ec2" {
+        AwsProtocol::Ec2Query
+    } else {
+        AwsProtocol::Query
+    }
 }
 
 /// Services that use REST protocol with XML responses (detected from SigV4 credential scope).
@@ -156,10 +177,11 @@ pub fn detect_service_headers_only(
             .or_else(|| infer_service_from_action(action))
             .or_else(|| parse_routing_host_from_headers(headers).map(|h| h.service));
         if let Some(service) = service {
+            let protocol = query_protocol_for(&service);
             return Some(DetectedRequest {
                 service,
                 action: action.clone(),
-                protocol: AwsProtocol::Query,
+                protocol,
             });
         }
     }
@@ -224,10 +246,11 @@ pub fn detect_service(
             .or_else(|| infer_service_from_action(action))
             .or_else(|| parse_routing_host_from_headers(headers).map(|h| h.service));
         if let Some(service) = service {
+            let protocol = query_protocol_for(&service);
             return Some(DetectedRequest {
                 service,
                 action: action.clone(),
-                protocol: AwsProtocol::Query,
+                protocol,
             });
         }
     }
@@ -241,10 +264,11 @@ pub fn detect_service(
                 .or_else(|| infer_service_from_action(action))
                 .or_else(|| parse_routing_host_from_headers(headers).map(|h| h.service));
             if let Some(service) = service {
+                let protocol = query_protocol_for(&service);
                 return Some(DetectedRequest {
                     service,
                     action: action.clone(),
-                    protocol: AwsProtocol::Query,
+                    protocol,
                 });
             }
         }

--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -397,32 +397,59 @@ impl LambdaService {
         let empty = LambdaState::new(account_id, "");
         let state = accounts.get(account_id).unwrap_or(&empty);
         let all_versions = function_version == Some("ALL");
-        let mut functions: Vec<Value> = state
-            .functions
-            .values()
-            .map(|f| self.function_config_json(f))
-            .collect();
+        let mut functions: Vec<Value> = if all_versions {
+            // FunctionVersion=ALL qualifies the $LATEST row's FunctionArn with
+            // `:$LATEST` (matching ListVersionsByFunction), so it is distinct
+            // from every numbered version's `:N` ARN below and from the bare
+            // ARN the default (non-ALL) listing returns.
+            state
+                .functions
+                .values()
+                .map(|f| {
+                    let mut cfg = self.function_config_json(f);
+                    cfg["FunctionArn"] = json!(format!("{}:$LATEST", f.function_arn));
+                    cfg
+                })
+                .collect()
+        } else {
+            state
+                .functions
+                .values()
+                .map(|f| self.function_config_json(f))
+                .collect()
+        };
         if all_versions {
             // FunctionVersion=ALL also lists every published numbered version,
-            // not just $LATEST.
+            // not just $LATEST. Each numbered snapshot stores the bare ARN, so
+            // qualify it with `:N` here (as PublishVersion / ListVersionsByFunction
+            // do). Without this, every version of one function shares the same
+            // bare ARN and the pagination marker — which is the last returned
+            // row's ARN — resolves back to the FIRST version each call, so a
+            // function with more versions than MaxItems never advances the
+            // marker (infinite loop) and rows are repeated + skipped.
             for snaps in state.function_version_snapshots.values() {
                 for snap in snaps.values() {
-                    functions.push(self.function_config_json(snap));
+                    let mut cfg = self.function_config_json(snap);
+                    cfg["FunctionArn"] = json!(format!("{}:{}", snap.function_arn, snap.version));
+                    cfg["MasterArn"] = json!(snap.function_arn);
+                    functions.push(cfg);
                 }
             }
-            // Order by function name, then $LATEST ahead of ascending versions.
-            functions.sort_by(|a, b| {
-                let an = a["FunctionName"].as_str().unwrap_or_default();
-                let bn = b["FunctionName"].as_str().unwrap_or_default();
-                an.cmp(bn)
-                    .then_with(|| version_sort_key(a).cmp(&version_sort_key(b)))
-            });
+            // `paginate_marker` sorts by the marker key (`farn_key`, the
+            // version-qualified ARN), which orders rows by function name and
+            // then by `$LATEST` ahead of the numbered versions (':' precedes the
+            // digits so `:$LATEST` sorts before `:N`). No separate pre-sort is
+            // needed.
         }
 
         // Honor Marker/MaxItems. AWS orders ListFunctions by FunctionName and
         // carries NextMarker as a string even on the final page (empty there).
-        // With ALL versions, key on the ARN (unique per version) so duplicate
-        // function names don't collide in the pagination marker.
+        // With ALL versions the marker must be unique per row so a function with
+        // more versions than MaxItems still advances the marker. The
+        // version-qualified ARN (set above) is unique per row and wire-safe;
+        // keying on the bare (unqualified) ARN would repeat across a function's
+        // versions and wedge pagination (infinite loop / repeated + skipped
+        // rows).
         let key: fn(&Value) -> String = if all_versions { farn_key } else { fname_key };
         let (page, next_marker) = super::paginate_marker(functions, marker, max_items, key);
         let response = json!({
@@ -438,15 +465,14 @@ fn fname_key(f: &Value) -> String {
     f["FunctionName"].as_str().unwrap_or_default().to_string()
 }
 
+/// Pagination marker key: the function's `FunctionArn`.
+///
+/// For `ListFunctions(FunctionVersion=ALL)` the caller qualifies every row's ARN
+/// (`:$LATEST` / `:N`) before this key is applied, so the ARN is UNIQUE per row.
+/// That uniqueness is load-bearing: the pagination marker is the last returned
+/// row's key, and a marker that repeats across a function's versions never
+/// advances — a function with more versions than `MaxItems` would loop forever /
+/// repeat + skip rows if the bare (unqualified) ARN were used.
 fn farn_key(f: &Value) -> String {
     f["FunctionArn"].as_str().unwrap_or_default().to_string()
-}
-
-/// Sort key for ListFunctions(ALL): `$LATEST` first (0), then numbered versions
-/// in ascending numeric order.
-fn version_sort_key(f: &Value) -> (u8, u64) {
-    match f["Version"].as_str() {
-        Some("$LATEST") | None => (0, 0),
-        Some(v) => (1, v.parse::<u64>().unwrap_or(u64::MAX)),
-    }
 }

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1469,6 +1469,85 @@ async fn list_functions_paginates_by_marker_and_max_items() {
 }
 
 #[tokio::test]
+async fn list_functions_all_versions_paginates_through_every_version_once() {
+    // Regression: with FunctionVersion=ALL, $LATEST and all numbered versions
+    // of one function used to share the same bare (unqualified) ARN. The
+    // pagination marker (last returned row's ARN) then resolved back to the
+    // FIRST version each call, so a function with more versions than MaxItems
+    // never advanced the marker -> infinite loop / repeated + skipped rows.
+    use serde_json::Value;
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "pager").await;
+
+    // Publish 4 numbered versions. PublishVersion is idempotent while $LATEST
+    // is unchanged, so mutate the config before each publish to force a new
+    // numbered version. Together with $LATEST that is 5 rows, all sharing the
+    // same bare ARN before the fix.
+    for i in 0..4 {
+        let body = json!({ "Description": format!("rev-{i}") });
+        let req = make_request(
+            Method::PUT,
+            "/2015-03-31/functions/pager/configuration",
+            &body.to_string(),
+        );
+        svc.handle(req).await.unwrap();
+        let req = make_request(Method::POST, "/2015-03-31/functions/pager/versions", "{}");
+        svc.handle(req).await.unwrap();
+    }
+
+    // Walk the whole list one row at a time (MaxItems=1). Every version ARN
+    // must appear exactly once and the walk must terminate (empty NextMarker).
+    let mut seen_arns: Vec<String> = Vec::new();
+    let mut marker: Option<String> = None;
+    // Hard cap iterations so a regression fails as a bounded assertion rather
+    // than hanging the test suite.
+    for _ in 0..50 {
+        let resp = svc
+            .list_functions("123456789012", Some("ALL"), marker.as_deref(), Some(1))
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let page = v["Functions"].as_array().unwrap();
+        assert!(page.len() <= 1, "MaxItems=1 must cap page size");
+        for f in page {
+            seen_arns.push(f["FunctionArn"].as_str().unwrap().to_string());
+        }
+        let next = v["NextMarker"].as_str().unwrap_or("");
+        if next.is_empty() {
+            marker = None;
+            break;
+        }
+        marker = Some(next.to_string());
+    }
+    assert!(
+        marker.is_none(),
+        "pagination did not terminate within the iteration cap (infinite-loop regression)"
+    );
+
+    // Exactly 5 rows ($LATEST + v1..v4), each ARN unique, none repeated/skipped.
+    let mut unique = seen_arns.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        seen_arns.len(),
+        "a version was returned more than once: {seen_arns:?}"
+    );
+    assert_eq!(
+        seen_arns.len(),
+        5,
+        "expected $LATEST + 4 numbered versions, got {seen_arns:?}"
+    );
+    let base = "arn:aws:lambda:us-east-1:123456789012:function:pager";
+    for suffix in ["$LATEST", "1", "2", "3", "4"] {
+        let want = format!("{base}:{suffix}");
+        assert!(
+            seen_arns.contains(&want),
+            "missing version-qualified ARN {want} in {seen_arns:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn function_without_environment_omits_environment_block() {
     // AWS omits the Environment block entirely for a function created without
     // environment variables. Emitting `{"Variables":{}}` made the Terraform


### PR DESCRIPTION
Two client-breaking HIGH correctness bugs, batched into one PR.

## FIX 1 — EC2 errors used the wrong (awsQuery) XML envelope

EC2 error responses fell through to the generic awsQuery renderer, emitting:

```xml
<ErrorResponse><Error><Type>Sender</Type><Code>..</Code><Message>..</Message></Error><RequestId>..</RequestId></ErrorResponse>
```

AWS's **ec2Query** protocol uses a different shape:

```xml
<Response><Errors><Error><Code>..</Code><Message>..</Message></Error></Errors><RequestID>..</RequestID></Response>
```

Root `<Response>`, an `<Errors>` wrapper, **no `<Type>`**, and **`<RequestID>`** (capital ID) not `<RequestId>`. aws-sdk-go-v2 (Terraform), aws-sdk-js v3, aws-sdk-rust and aws-sdk-java v2 parse the code via `Response > Errors > Error > Code` and the id via `RequestID`, so every EC2 error handed them an **empty Code + empty RequestID** — breaking `InvalidInstanceID.NotFound` / `DependencyViolation` branching and request-id retries. Only botocore/CLI are lenient (why conformance + tfacc passed before).

**Fix:** add a dedicated `AwsProtocol::Ec2Query` variant (EC2 only; requests are wire-identical to Query, so it also feeds `parse_query_body` and `is_query_protocol`) and route its error path to a new `ec2query::ec2_error_response` renderer. Every other Query-protocol service (SQS/SNS/IAM/STS/RDS/ELBv2/CloudWatch/AutoScaling/...) stays on the awsQuery `<ErrorResponse>` renderer — verified untouched.

## FIX 2 — Lambda ListFunctions(FunctionVersion=ALL) infinite loop / dup+skip

The ALL-mode pagination marker keyed on the **bare unqualified function ARN**, which `$LATEST` and every numbered version share. The `NextMarker` (last row's ARN) therefore resolved back to the **first** version of that group each call, so a function with more versions than `MaxItems` never advanced the marker (infinite loop) and rows were repeated + skipped.

**Fix:** qualify each ALL-mode row's `FunctionArn` (`:$LATEST` / `:N`, exactly as `PublishVersion` / `ListVersionsByFunction` do), making the marker unique per row. Default (non-ALL) listing is unchanged.

## Verification

- Runtime (curl against the built binary): EC2 `DescribeInstances` on a bad id now returns the ec2Query `<Response><Errors>...<RequestID>` envelope; IAM `GetRole` on a missing role still returns the awsQuery `<ErrorResponse>...<RequestId>` envelope.
- `cargo nextest run -p fakecloud-conformance` — `ec2_error_uses_ec2query_envelope` PASS, and 17 ELBv2 (awsQuery) tests PASS unchanged (18/18).
- New tests: ec2Query error-renderer unit tests; EC2 error-envelope conformance assertion; Lambda ALL-versions pagination walk (MaxItems=1 through every version exactly once, terminates).
- `cargo clippy` (touched crates, `--all-targets -D warnings`) clean; `cargo fmt --all`.

Note on the conformance probe: `extract_aws_error_code` finds the first `<Code>` regardless of wrapper, so it parses both envelopes — no conformance baseline change, and no gaming (the wire shape genuinely changed for real SDKs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EC2 to emit the correct ec2Query error envelope and fixes Lambda ListFunctions(FunctionVersion=ALL) pagination by version-qualifying ARNs. This restores correct SDK error parsing and prevents infinite loops and duplication in ALL-mode listings.

- **Bug Fixes**
  - EC2: Added `AwsProtocol::Ec2Query` and routed its errors to an EC2-specific renderer that emits `<Response><Errors><Error><Code/><Message/></Error></Errors><RequestID/>`. Other Query services keep the awsQuery `<ErrorResponse>` shape.
  - Lambda: For `ListFunctions` with `FunctionVersion=ALL`, each row’s `FunctionArn` is now version-qualified (`:$LATEST` or `:N`) and pagination keys on that ARN, ensuring unique markers per row. Default (non-ALL) listing is unchanged.

<sup>Written for commit e7ac8fd99be8c637cb0bcad5ab13c41a9458e643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

