### PR TITLE
fix(sqs,sns,kinesis): msg-attr parsing + batch failures + GetRecords size cap

### DIFF
--- a/crates/fakecloud-e2e/tests/kinesis.rs
+++ b/crates/fakecloud-e2e/tests/kinesis.rs
@@ -855,3 +855,89 @@ async fn kinesis_get_records_returns_child_shards_after_split() {
         assert!(c.hash_key_range().is_some());
     }
 }
+
+/// GetRecords caps a single response at 10 MiB of record data even when the
+/// Limit (record count) would allow more, and NextShardIterator resumes after
+/// the truncation point. Regression: the batch was previously sliced purely by
+/// record COUNT, so a high Limit could return far more than 10 MiB.
+#[tokio::test]
+async fn kinesis_get_records_caps_response_at_ten_mib() {
+    let server = TestServer::start().await;
+    let client = server.kinesis_client().await;
+
+    client
+        .create_stream()
+        .stream_name("big-read")
+        .shard_count(1)
+        .send()
+        .await
+        .unwrap();
+
+    // Put 15 records of ~900 KiB each (under the 1 MiB per-record limit).
+    // Total ~13.5 MiB, so a single GetRecords must truncate below 10 MiB.
+    let record_size = 900 * 1024;
+    let payload = vec![b'x'; record_size];
+    let mut shard_id = String::new();
+    for i in 0..15 {
+        let out = client
+            .put_record()
+            .stream_name("big-read")
+            .partition_key(format!("k{i}"))
+            .data(Blob::new(payload.clone()))
+            .send()
+            .await
+            .unwrap();
+        shard_id = out.shard_id().to_string();
+    }
+
+    let iterator = client
+        .get_shard_iterator()
+        .stream_name("big-read")
+        .shard_id(&shard_id)
+        .shard_iterator_type(ShardIteratorType::TrimHorizon)
+        .send()
+        .await
+        .unwrap();
+
+    // Request all 15 with a high Limit; the response must be capped by size.
+    let first = client
+        .get_records()
+        .shard_iterator(iterator.shard_iterator().unwrap())
+        .limit(10000)
+        .send()
+        .await
+        .unwrap();
+
+    let returned = first.records().len();
+    assert!(
+        returned < 15,
+        "GetRecords must truncate below the full 15-record set, got {returned}"
+    );
+    assert!(returned >= 1, "at least one record must be returned");
+    let total_bytes: usize = first
+        .records()
+        .iter()
+        .map(|r| r.data().as_ref().len())
+        .sum();
+    assert!(
+        total_bytes <= 10 * 1024 * 1024,
+        "response data {total_bytes} bytes exceeds the 10 MiB cap"
+    );
+    let next = first
+        .next_shard_iterator()
+        .expect("truncated batch must return a resumable NextShardIterator");
+
+    // Resume: the remaining records come back on the next call.
+    let second = client
+        .get_records()
+        .shard_iterator(next)
+        .limit(10000)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        returned + second.records().len(),
+        15,
+        "resuming the iterator returns the remaining records"
+    );
+}

--- a/crates/fakecloud-e2e/tests/sns.rs
+++ b/crates/fakecloud-e2e/tests/sns.rs
@@ -875,6 +875,93 @@ async fn sns_publish_batch() {
     assert!(resp.failed().is_empty());
 }
 
+/// A PublishBatch with one valid entry and one invalid entry (malformed
+/// `MessageStructure=json`) must report the invalid entry in `Failed` while the
+/// valid one succeeds — the invalid entry fails only itself instead of aborting
+/// the whole batch with a 400/500 (the old behaviour propagated the parse error
+/// out of the handler). Regression for the always-empty `Failed` list.
+#[tokio::test]
+async fn sns_publish_batch_reports_per_entry_failures() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("batch-fail-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    use aws_sdk_sns::types::PublishBatchRequestEntry;
+    let entries = vec![
+        PublishBatchRequestEntry::builder()
+            .id("ok")
+            .message("valid message")
+            .build()
+            .unwrap(),
+        PublishBatchRequestEntry::builder()
+            .id("bad")
+            .message("this is not json")
+            .message_structure("json")
+            .build()
+            .unwrap(),
+    ];
+
+    let resp = client
+        .publish_batch()
+        .topic_arn(&topic_arn)
+        .set_publish_batch_request_entries(Some(entries))
+        .send()
+        .await
+        .expect("batch must not fail wholesale when a single entry is invalid");
+
+    assert_eq!(resp.successful().len(), 1);
+    assert_eq!(resp.successful()[0].id(), Some("ok"));
+
+    assert_eq!(resp.failed().len(), 1);
+    let failed = &resp.failed()[0];
+    assert_eq!(failed.id(), "bad");
+    assert_eq!(failed.code(), "InvalidParameter");
+    assert!(failed.sender_fault());
+}
+
+/// Request-level validation: a duplicate batch entry Id fails the whole request
+/// with BatchEntryIdsNotDistinct, and a malformed Id with InvalidBatchEntryId.
+#[tokio::test]
+async fn sns_publish_batch_rejects_invalid_entry_ids() {
+    let server = TestServer::start().await;
+    let client = server.sns_client().await;
+
+    let topic = client
+        .create_topic()
+        .name("batch-id-topic")
+        .send()
+        .await
+        .unwrap();
+    let topic_arn = topic.topic_arn().unwrap().to_string();
+
+    use aws_sdk_sns::types::PublishBatchRequestEntry;
+
+    // Malformed Id (contains a space) -> InvalidBatchEntryId.
+    let bad_id_entries = vec![PublishBatchRequestEntry::builder()
+        .id("has space")
+        .message("m")
+        .build()
+        .unwrap()];
+    let err = client
+        .publish_batch()
+        .topic_arn(&topic_arn)
+        .set_publish_batch_request_entries(Some(bad_id_entries))
+        .send()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.into_service_error().meta().code(),
+        Some("InvalidBatchEntryId")
+    );
+}
+
 #[tokio::test]
 async fn sns_platform_application_lifecycle() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-e2e/tests/sqs.rs
+++ b/crates/fakecloud-e2e/tests/sqs.rs
@@ -2036,3 +2036,86 @@ async fn sqs_set_visibility_timeout_out_of_range_rejected() {
     assert_eq!(recv.messages().len(), 1);
     assert_eq!(recv.messages()[0].body().unwrap(), "still-alive");
 }
+
+/// Query-protocol (form-encoded) ReceiveMessage must return the message
+/// attributes a client selects via `MessageAttributeName.N=All`. The modern
+/// AWS SDK uses the JSON protocol, so this drives the query protocol directly
+/// with a form-encoded body — the shape AWS Java SDK v1 / legacy botocore emit.
+/// Regression: parse_body previously dropped `MessageAttributeName.N`, so
+/// query-protocol clients got zero attributes back.
+#[tokio::test]
+async fn sqs_query_protocol_receive_returns_message_attributes() {
+    let server = TestServer::start().await;
+    let client = server.sqs_client().await;
+
+    let created = client
+        .create_queue()
+        .queue_name("qp-attr-queue")
+        .send()
+        .await
+        .unwrap();
+    let queue_url = created.queue_url().unwrap().to_string();
+
+    // Send a message carrying a message attribute (via the SDK / JSON protocol).
+    client
+        .send_message()
+        .queue_url(&queue_url)
+        .message_body("hello")
+        .message_attributes(
+            "trace-id",
+            MessageAttributeValue::builder()
+                .data_type("String")
+                .string_value("abc-123")
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Receive via the raw query protocol, selecting all message attributes. The
+    // Authorization header's credential scope (`.../sqs/...`) is how the request
+    // is routed to SQS; auth is not enforced by default.
+    let body = format!(
+        "Action=ReceiveMessage&Version=2012-11-05&QueueUrl={}&MaxNumberOfMessages=1&MessageAttributeName.1=All",
+        urlencoding_encode(&queue_url)
+    );
+    let resp = reqwest::Client::new()
+        .post(server.endpoint())
+        .header("content-type", "application/x-www-form-urlencoded")
+        .header(
+            "authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260101/us-east-1/sqs/aws4_request, SignedHeaders=host, Signature=deadbeef",
+        )
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "status {}", resp.status());
+    let xml = resp.text().await.unwrap();
+
+    // The attribute the SendMessage set must be echoed back in the XML.
+    assert!(
+        xml.contains("<Name>trace-id</Name>"),
+        "message attribute name missing from query-protocol response: {xml}"
+    );
+    assert!(
+        xml.contains("<StringValue>abc-123</StringValue>"),
+        "message attribute value missing from query-protocol response: {xml}"
+    );
+}
+
+/// Minimal percent-encoding for the queue URL used in the form body above
+/// (encodes the reserved characters that appear in an SQS queue URL).
+fn urlencoding_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -609,7 +609,27 @@ impl KinesisService {
         {
             start_index += 1;
         }
-        let end_index = shard.records.len().min(start_index.saturating_add(limit));
+        // AWS caps a single GetRecords response at min(Limit records, 10 MiB of
+        // data), whichever comes first, and lets NextShardIterator resume after
+        // the truncation point. Slicing purely by record COUNT (the old
+        // behaviour) could return a batch far larger than 10 MiB. Accumulate
+        // record byte sizes and stop before the batch would exceed the cap —
+        // but always include at least the first record so a full shard never
+        // yields an empty batch with a live iterator (which stalls consumers).
+        const MAX_GET_RECORDS_BYTES: usize = 10 * 1024 * 1024;
+        let mut end_index = start_index;
+        let mut accumulated_bytes: usize = 0;
+        while end_index < shard.records.len() && end_index - start_index < limit {
+            let record = &shard.records[end_index];
+            let record_bytes = record.data.len() + record.partition_key.len();
+            if end_index > start_index
+                && accumulated_bytes.saturating_add(record_bytes) > MAX_GET_RECORDS_BYTES
+            {
+                break;
+            }
+            accumulated_bytes = accumulated_bytes.saturating_add(record_bytes);
+            end_index += 1;
+        }
         let records: Vec<Value> = shard.records[start_index..end_index]
             .iter()
             .map(|record| {

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
+use fakecloud_aws::xml::xml_escape;
 use fakecloud_core::delivery::DeliveryBus;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
@@ -378,6 +379,56 @@ impl SnsService {
             ));
         }
 
+        // Validate: every entry Id must be a non-empty string of at most 80
+        // alphanumeric / hyphen / underscore characters. AWS rejects the whole
+        // batch with InvalidBatchEntryId (request-level, not per-entry) when any
+        // Id is malformed.
+        if let Some(bad) = entries.iter().map(|e| e.0.as_str()).find(|id| {
+            id.is_empty()
+                || id.len() > 80
+                || !id
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        }) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidBatchEntryId",
+                format!(
+                    "A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long. Batch entry id '{bad}' is invalid."
+                ),
+            ));
+        }
+
+        // Validate: the combined size of all message bodies plus their message
+        // attributes must not exceed 256 KiB. AWS rejects the whole batch with
+        // BatchRequestTooLong (request-level) rather than truncating.
+        let total_batch_size: usize = entries
+            .iter()
+            .enumerate()
+            .map(|(idx, e)| {
+                let attrs = parse_batch_message_attributes(req, idx + 1);
+                let attr_size: usize = attrs
+                    .iter()
+                    .map(|(name, attr)| {
+                        name.len()
+                            + attr.data_type.len()
+                            + attr.string_value.as_ref().map_or(0, |s| s.len())
+                            + attr.binary_value.as_ref().map_or(0, |b| b.len())
+                    })
+                    .sum();
+                e.1.len() + attr_size
+            })
+            .sum();
+        if total_batch_size > 262_144 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BatchRequestTooLong",
+                format!(
+                    "The length of all the messages put together is more than the limit. Batch request size is {total_batch_size} bytes; the limit is 262144 bytes."
+                ),
+            ));
+        }
+
         // FIFO: all entries must have MessageGroupId — this is a top-level error
         if is_fifo && entries.iter().any(|e| e.3.is_none()) {
             return Err(AwsServiceError::aws_error(
@@ -398,7 +449,7 @@ impl SnsService {
         }
 
         let mut successful = Vec::new();
-        let failed: Vec<String> = Vec::new();
+        let mut failed: Vec<String> = Vec::new();
 
         for (idx, (id, message, subject, group_id, dedup_id, structure)) in
             entries.iter().enumerate()
@@ -406,9 +457,30 @@ impl SnsService {
             // Parse per-entry message attributes
             let batch_attrs = parse_batch_message_attributes(req, idx + 1);
 
-            // Validate MessageStructure=json
+            // Per-entry validation: an invalid entry fails only ITSELF (populating
+            // the Failed list), it does not abort the whole batch. AWS reports
+            // each failure as a BatchResultErrorEntry with Id/Code/Message and
+            // SenderFault=true for client-side errors.
+
+            // Empty / missing Message.
+            if message.is_empty() {
+                failed.push(batch_error_member(
+                    id,
+                    "InvalidParameter",
+                    "Invalid parameter: Empty message",
+                    true,
+                ));
+                continue;
+            }
+
+            // Malformed MessageStructure=json: fail this entry only rather than
+            // aborting the whole batch with a 400/500 (the old `?` propagated the
+            // error out of publish_batch entirely).
             if structure.as_deref() == Some("json") {
-                validate_message_structure_json(message)?;
+                if let Err(e) = validate_message_structure_json(message) {
+                    failed.push(batch_error_member(id, e.code(), &e.message(), true));
+                    continue;
+                }
             }
 
             // FIFO dedup + sequence minting, mirroring single Publish. A
@@ -534,9 +606,10 @@ impl SnsService {
                 .unwrap_or_default();
             successful.push(format!(
                 r#"    <member>
-      <Id>{id}</Id>
+      <Id>{}</Id>
       <MessageId>{msg_id}</MessageId>{sequence_xml}
-    </member>"#
+    </member>"#,
+                xml_escape(id)
             ));
         }
 
@@ -1121,6 +1194,24 @@ pub(crate) fn build_dlq_envelope(
         "SubscriptionArn": subscription_arn,
     }))
     .unwrap_or_else(|_| original_body.to_string())
+}
+
+/// Render one `<member>` of a `PublishBatch` `Failed` list
+/// (a `BatchResultErrorEntry`). `sender_fault` is true for client-caused
+/// errors (invalid parameters) and false for server-side failures.
+fn batch_error_member(id: &str, code: &str, message: &str, sender_fault: bool) -> String {
+    format!(
+        r#"    <member>
+      <Id>{}</Id>
+      <Code>{}</Code>
+      <Message>{}</Message>
+      <SenderFault>{}</SenderFault>
+    </member>"#,
+        xml_escape(id),
+        xml_escape(code),
+        xml_escape(message),
+        sender_fault
+    )
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-sqs/src/helpers.rs
+++ b/crates/fakecloud-sqs/src/helpers.rs
@@ -599,6 +599,28 @@ pub(crate) fn parse_body(req: &AwsRequest) -> Value {
         if !attr_names.is_empty() {
             map.insert("AttributeNames".to_string(), Value::Array(attr_names));
         }
+        // Handle MessageAttributeName.N patterns (used by ReceiveMessage in
+        // query protocol to select which message attributes to return, e.g.
+        // MessageAttributeName.1=All). Query-protocol SendMessage attributes
+        // are parsed elsewhere but the receive-side selector list was dropped,
+        // so AWS Java SDK v1 / legacy botocore clients requesting `All` got
+        // ZERO message attributes back. Same contiguous enumeration as above.
+        let mut msg_attr_names = Vec::new();
+        let mut i = 1;
+        loop {
+            let key = format!("MessageAttributeName.{i}");
+            match req.query_params.get(&key) {
+                Some(val) => msg_attr_names.push(Value::String(val.clone())),
+                None => break,
+            }
+            i += 1;
+        }
+        if !msg_attr_names.is_empty() {
+            map.insert(
+                "MessageAttributeNames".to_string(),
+                Value::Array(msg_attr_names),
+            );
+        }
         // Handle batch entry patterns: *Entry.N.Field or *.N.Field
         // e.g. SendMessageBatchRequestEntry.1.Id=foo&SendMessageBatchRequestEntry.1.MessageBody=bar
         // Also: DeleteMessageBatchRequestEntry.1.Id=...&DeleteMessageBatchRequestEntry.1.ReceiptHandle=...

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -3384,6 +3384,45 @@ fn set_queue_attributes_reads_more_than_twenty_individual_pairs() {
 }
 
 #[test]
+fn receive_message_parses_query_protocol_message_attribute_names() {
+    // Query-protocol ReceiveMessage selects which message attributes to return
+    // via MessageAttributeName.N (e.g. MessageAttributeName.1=All). parse_body
+    // must surface these into the `MessageAttributeNames` list so the receive
+    // handler returns them — otherwise AWS Java SDK v1 / legacy botocore clients
+    // get ZERO message attributes back.
+    let req = make_query_request(
+        "ReceiveMessage",
+        &[
+            ("QueueUrl", "http://localhost/123456789012/q"),
+            ("MessageAttributeName.1", "All"),
+        ],
+    );
+    let parsed = parse_body(&req);
+    let names = parsed["MessageAttributeNames"].as_array().unwrap();
+    assert_eq!(names.len(), 1);
+    assert_eq!(names[0], "All");
+}
+
+#[test]
+fn receive_message_message_attribute_names_enumeration_is_contiguous() {
+    // Multiple named selectors enumerate contiguously and stop at the first gap,
+    // matching how SDKs serialize the list.
+    let req = make_query_request(
+        "ReceiveMessage",
+        &[
+            ("QueueUrl", "http://localhost/123456789012/q"),
+            ("MessageAttributeName.1", "alpha"),
+            ("MessageAttributeName.2", "beta"),
+            ("MessageAttributeName.4", "delta"),
+        ],
+    );
+    let parsed = parse_body(&req);
+    let names = parsed["MessageAttributeNames"].as_array().unwrap();
+    assert_eq!(names.len(), 2);
+    assert_eq!(names[1], "beta");
+}
+
+#[test]
 fn attribute_name_enumeration_stops_at_first_gap() {
     // Contiguous enumeration: a hole at index 3 stops the scan (matches how
     // AWS SDKs serialize the list — always 1..N contiguous).


### PR DESCRIPTION
Cluster of MED correctness bugs across three disjoint crates, found by bug-hunt.

## 1. SQS query-protocol ReceiveMessage dropped message attributes
`parse_body` mapped `AttributeName.N` (system attrs) but had no handling for `MessageAttributeName.N`, so the `receive_message` handler read a missing `MessageAttributeNames` key. Query-protocol clients (AWS Java SDK v1, legacy botocore) requesting `MessageAttributeName.1=All` got **zero** message attributes back, while the JSON-protocol path returned them (asymmetric).

Fix: `parse_body` now enumerates `MessageAttributeName.N` into the `MessageAttributeNames` list (same contiguous enumeration as the sibling `AttributeName.N` parsing), so query-protocol ReceiveMessage returns the attributes a SendMessage set.

## 2. SNS PublishBatch: no per-entry failure reporting or request-level validation
`let failed: Vec<String> = Vec::new();` was immutable, so `Failed`/`BatchResultErrorEntry` was **always empty**. A malformed `MessageStructure=json` entry aborted the whole batch via `?` (propagating out of the handler) instead of failing just that entry, and empty `Message` was silently accepted. No 256 KiB total-size or `InvalidBatchEntryId` charset check.

Fix:
- Per-entry validation populates `Failed` with `BatchResultErrorEntry` (Id/Code/Message/SenderFault=true) — an invalid entry (empty Message, malformed `MessageStructure=json`) fails only itself.
- Request-level checks added: `InvalidBatchEntryId` (Id must be non-empty, <=80 chars, `[A-Za-z0-9_-]`) and `BatchRequestTooLong` (combined message + attribute bytes > 256 KiB), matching AWS error codes.
- Entry Ids are now XML-escaped in the response.

## 3. Kinesis GetRecords ignored the 10 MiB response-size cap
`end_index = records.len().min(start_index + limit)` sliced purely by record **count**. AWS caps GetRecords at `min(Limit records, 10 MiB data)`, whichever comes first, truncating the batch and letting `NextShardIterator` resume.

Fix: accumulate record byte sizes and stop before the batch would exceed 10 MiB, always including at least the first record (so a full shard never yields an empty batch with a live iterator), with sequence progression preserved via the resuming iterator.

## Tests
- SQS: unit tests on `parse_body` (`MessageAttributeName.N` -> list, contiguous stop-at-gap) + E2E driving the raw query protocol end-to-end (SendMessage attr via SDK, ReceiveMessage via form-encoded body -> attributes echoed in XML).
- SNS: E2E `sns_publish_batch_reports_per_entry_failures` (1 valid + 1 invalid -> 1 Successful + 1 Failed, not a whole-batch error) and `sns_publish_batch_rejects_invalid_entry_ids` (InvalidBatchEntryId).
- Kinesis: E2E `kinesis_get_records_caps_response_at_ten_mib` (15 x ~900 KiB records -> single GetRecords truncated <=10 MiB, iterator resumes to return the rest).

All local checks green: new unit + E2E tests, the 5 relevant conformance tests (sns_publish_batch, sqs_receive_message[_nonexistent_queue_returns_error], kinesis_get_records, kinesis_tag_resource_lifecycle), `cargo clippy --all-targets -D warnings` on touched crates, `cargo fmt --all`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correctness gaps in `fakecloud-sqs`, `fakecloud-sns`, and `fakecloud-kinesis`. Query-protocol SQS now returns selected message attributes, SNS PublishBatch reports per-entry failures and enforces limits, and Kinesis GetRecords respects the 10 MiB cap.

- Bug Fixes
  - `fakecloud-sqs`: Parse `MessageAttributeName.N` into `MessageAttributeNames` for ReceiveMessage (query protocol), so clients requesting `All` get message attributes.
  - `fakecloud-sns`: PublishBatch now reports per-entry failures (populates `Failed`), treats empty messages and malformed `MessageStructure=json` as per-entry errors, adds request-level `InvalidBatchEntryId` (charset/<=80) and `BatchRequestTooLong` (256 KiB) checks, and XML-escapes entry Ids.
  - `fakecloud-kinesis`: Enforce GetRecords response cap of min(Limit, 10 MiB) by accumulated bytes; always return at least one record; `NextShardIterator` resumes after truncation.

<sup>Written for commit 3a07811bab8efeb642ccde54bcdbf145646f64a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

