### PR TITLE
fix(dynamodb,iam,kms): validate DDB sets + echo STS federation fields + reject KMS NumberOfBytes=0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5831,6 +5831,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
@@ -110,7 +110,34 @@ pub(crate) fn validate_item_attribute_values(
     Ok(())
 }
 
-fn validate_attribute_value(v: &Value) -> Result<(), AwsServiceError> {
+/// Reject an empty DynamoDB set (`SS`/`NS`/`BS`). AWS returns a
+/// `ValidationException` — storing an empty set corrupts later
+/// `ADD`/`DELETE`/`size()` semantics.
+fn validate_set_not_empty(kind: &str, is_empty: bool) -> Result<(), AwsServiceError> {
+    if is_empty {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!("One or more parameter values were invalid: An {kind} set may not be empty"),
+        ));
+    }
+    Ok(())
+}
+
+/// Build the `ValidationException` AWS returns when a set contains duplicate
+/// members. The collection is echoed back the way AWS renders it.
+fn duplicate_set(members: &[&str]) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "ValidationException",
+        format!(
+            "One or more parameter values were invalid: Input collection [{}] contains duplicates",
+            members.join(", ")
+        ),
+    )
+}
+
+pub(crate) fn validate_attribute_value(v: &Value) -> Result<(), AwsServiceError> {
     let Some((tag, val)) = v.as_object().and_then(|o| o.iter().next()) else {
         return Ok(());
     };
@@ -128,11 +155,62 @@ fn validate_attribute_value(v: &Value) -> Result<(), AwsServiceError> {
                 return Err(bad_number(s));
             }
         }
+        "SS" => {
+            let members: Vec<&str> = val
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(|el| el.as_str().unwrap_or_default())
+                .collect();
+            validate_set_not_empty("string", members.is_empty())?;
+            let mut seen = std::collections::HashSet::new();
+            for m in &members {
+                if !seen.insert(*m) {
+                    return Err(duplicate_set(&members));
+                }
+            }
+        }
         "NS" => {
-            for el in val.as_array().into_iter().flatten() {
-                let s = el.as_str().unwrap_or_default();
+            let members: Vec<&str> = val
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(|el| el.as_str().unwrap_or_default())
+                .collect();
+            validate_set_not_empty("number", members.is_empty())?;
+            let mut seen = std::collections::HashSet::new();
+            for s in &members {
                 if !is_valid_number(s) {
                     return Err(bad_number(s));
+                }
+                // Number-set members are deduped by numeric value, so `"1"` and
+                // `"1.0"` collide. `canonical_number` never returns `None` here
+                // because `is_valid_number` already passed.
+                let canon = canonical_number(s).unwrap_or_else(|| (*s).to_string());
+                if !seen.insert(canon) {
+                    return Err(duplicate_set(&members));
+                }
+            }
+        }
+        "BS" => {
+            use base64::Engine;
+            let members: Vec<&str> = val
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(|el| el.as_str().unwrap_or_default())
+                .collect();
+            validate_set_not_empty("binary", members.is_empty())?;
+            // Dedup by decoded bytes so distinct base64 encodings of the same
+            // value still collide; fall back to the raw string when a member
+            // is not valid base64 (left for the codec layer to reject).
+            let mut seen = std::collections::HashSet::new();
+            for m in &members {
+                let key = base64::engine::general_purpose::STANDARD
+                    .decode(m)
+                    .unwrap_or_else(|_| m.as_bytes().to_vec());
+                if !seen.insert(key) {
+                    return Err(duplicate_set(&members));
                 }
             }
         }
@@ -286,6 +364,74 @@ mod attr_value_validation_tests {
             ("n".to_string(), json!({"N": "3.14"})),
             ("s".to_string(), json!({"S": "hi"})),
             ("ns".to_string(), json!({"NS": ["1", "2.5"]})),
+        ]);
+        assert!(validate_item_attribute_values(&item).is_ok());
+    }
+
+    fn err_of(v: serde_json::Value) -> AwsServiceError {
+        let item: HashMap<String, AttributeValue> = HashMap::from([("a".to_string(), v)]);
+        validate_item_attribute_values(&item).unwrap_err()
+    }
+
+    #[test]
+    fn rejects_empty_sets() {
+        for (v, kind) in [
+            (json!({"SS": []}), "string"),
+            (json!({"NS": []}), "number"),
+            (json!({"BS": []}), "binary"),
+        ] {
+            let err = err_of(v);
+            assert_eq!(err.code(), "ValidationException");
+            assert!(
+                err.message()
+                    .contains(&format!("An {kind} set may not be empty")),
+                "unexpected message for {kind}: {}",
+                err.message()
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_string_set() {
+        let err = err_of(json!({"SS": ["a", "a"]}));
+        assert_eq!(err.code(), "ValidationException");
+        assert!(
+            err.message().contains("contains duplicates"),
+            "{}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn rejects_numeric_value_duplicate_number_set() {
+        // "1" and "1.0" are the same numeric value -> duplicate.
+        let err = err_of(json!({"NS": ["1", "1.0"]}));
+        assert_eq!(err.code(), "ValidationException");
+        assert!(
+            err.message().contains("contains duplicates"),
+            "{}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_binary_set() {
+        // Both decode to the same bytes.
+        let err = err_of(json!({"BS": ["aGVsbG8=", "aGVsbG8="]}));
+        assert_eq!(err.code(), "ValidationException");
+        assert!(
+            err.message().contains("contains duplicates"),
+            "{}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn accepts_valid_sets() {
+        let item: HashMap<String, AttributeValue> = HashMap::from([
+            ("ss".to_string(), json!({"SS": ["a", "b", "c"]})),
+            ("ns".to_string(), json!({"NS": ["1", "2", "3.5"]})),
+            ("bs".to_string(), json!({"BS": ["aGVsbG8=", "d29ybGQ="]})),
         ]);
         assert!(validate_item_attribute_values(&item).is_ok());
     }

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -75,6 +75,21 @@ pub(crate) fn is_valid_number(s: &str) -> bool {
     normalize_decimal(s).is_some()
 }
 
+/// Canonical decimal form of a DynamoDB Number, so numerically-equal literals
+/// (`"1"`, `"1.0"`, `"1e0"`) collapse to one key. Used to detect duplicate
+/// members in a Number Set (`NS`), which AWS compares by numeric value rather
+/// than string. Returns `None` for a malformed number.
+pub(crate) fn canonical_number(s: &str) -> Option<String> {
+    let (neg, (int_part, frac_part)) = normalize_decimal(s)?;
+    let sign = if neg { "-" } else { "" };
+    let int_str = if int_part.is_empty() { "0" } else { &int_part };
+    if frac_part.is_empty() {
+        Some(format!("{sign}{int_str}"))
+    } else {
+        Some(format!("{sign}{int_str}.{frac_part}"))
+    }
+}
+
 /// Decompose a decimal string into `(is_negative, (int_digits, frac_digits))`
 /// with insignificant zeros stripped so the magnitude compare is purely
 /// lexical. Returns `None` for non-numeric input; negative zero normalizes

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -11,8 +11,8 @@ use super::{
     evaluate_condition_with_return, extract_key, get_table, get_table_mut,
     parse_expression_attribute_names, parse_expression_attribute_values, project_item,
     require_object, require_str, resolve_write_condition, return_consumed_mode, return_icm_mode,
-    validate_item_attribute_values, validate_key_attributes_in_key, validate_key_in_item,
-    AttributeValue, DynamoDbService,
+    validate_attribute_value, validate_item_attribute_values, validate_key_attributes_in_key,
+    validate_key_in_item, AttributeValue, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -364,6 +364,20 @@ impl DynamoDbService {
         let condition =
             resolve_write_condition(&body, &mut expr_attr_names, &mut expr_attr_values)?;
         let update_expression = body["UpdateExpression"].as_str();
+
+        // Validate the attribute values an UpdateExpression / AttributeUpdates
+        // will write (empty or duplicate SS/BS/NS, malformed numbers) before
+        // they corrupt the item — matches PutItem's item validation.
+        for v in expr_attr_values.values() {
+            validate_attribute_value(v)?;
+        }
+        if let Some(updates) = body["AttributeUpdates"].as_object() {
+            for upd in updates.values() {
+                if let Some(v) = upd.get("Value") {
+                    validate_attribute_value(v)?;
+                }
+            }
+        }
 
         let existing_idx = table.find_item_index(&key);
 

--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -388,6 +388,130 @@ async fn sts_assume_role_with_web_identity() {
 }
 
 #[tokio::test]
+async fn sts_assume_role_with_web_identity_echoes_token_fields() {
+    use base64::Engine;
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    server
+        .iam_client()
+        .await
+        .create_role()
+        .role_name("web-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // A JWT with `sub`/`aud` and an AWS source_identity claim but no `iss`,
+    // so it doesn't require a registered OIDC provider. `Provider` is then
+    // sourced from the ProviderId parameter (OAuth 2.0 behaviour).
+    let b64u = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = b64u.encode(br#"{"alg":"none","typ":"JWT"}"#);
+    let payload = b64u.encode(
+        br#"{"sub":"user-abc-123","aud":"my-client-id","https://aws.amazon.com/source_identity":"alice"}"#,
+    );
+    let token = format!("{header}.{payload}.sig");
+
+    let resp = client
+        .assume_role_with_web_identity()
+        .role_arn("arn:aws:iam::123456789012:role/web-role")
+        .role_session_name("web-session")
+        .web_identity_token(token)
+        .provider_id("my-idp.example.com")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.subject_from_web_identity_token(), Some("user-abc-123"));
+    assert_eq!(resp.audience(), Some("my-client-id"));
+    assert_eq!(resp.provider(), Some("my-idp.example.com"));
+    assert_eq!(resp.source_identity(), Some("alice"));
+}
+
+#[tokio::test]
+async fn sts_assume_role_with_saml_echoes_assertion_fields() {
+    use base64::Engine;
+    let server = TestServer::start().await;
+    let client = server.sts_client().await;
+    server
+        .iam_client()
+        .await
+        .create_role()
+        .role_name("saml-role")
+        .assume_role_policy_document(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithSAML"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let assertion_xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml:Issuer>https://idp.example.com/shibboleth</saml:Issuer>
+  <saml:Assertion>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">SamlExampleUser</saml:NameID>
+    </saml:Subject>
+    <saml:Conditions>
+      <saml:AudienceRestriction>
+        <saml:Audience>https://signin.aws.amazon.com/saml</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/SourceIdentity">
+        <saml:AttributeValue>bob</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>"#;
+    let assertion = base64::engine::general_purpose::STANDARD.encode(assertion_xml);
+
+    let resp = client
+        .assume_role_with_saml()
+        .role_arn("arn:aws:iam::123456789012:role/saml-role")
+        .principal_arn("arn:aws:iam::123456789012:saml-provider/MyIdP")
+        .saml_assertion(assertion)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.subject(), Some("SamlExampleUser"));
+    assert_eq!(resp.subject_type(), Some("transient"));
+    assert_eq!(resp.issuer(), Some("https://idp.example.com/shibboleth"));
+    assert_eq!(resp.audience(), Some("https://signin.aws.amazon.com/saml"));
+    assert_eq!(resp.source_identity(), Some("bob"));
+    // NameQualifier is a non-empty hash derived from issuer + account + provider.
+    assert!(resp.name_qualifier().is_some_and(|q| !q.is_empty()));
+}
+
+#[tokio::test]
+async fn sts_assume_role_echoes_source_identity() {
+    let server = TestServer::start().await;
+    let sts = server.sts_client().await;
+    let iam = server.iam_client().await;
+
+    let trust_policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":["sts:AssumeRole","sts:SetSourceIdentity"]}]}"#;
+    iam.create_role()
+        .role_name("src-role")
+        .assume_role_policy_document(trust_policy)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = sts
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/src-role")
+        .role_session_name("src-session")
+        .source_identity("carol")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.source_identity(), Some("carol"));
+}
+
+#[tokio::test]
 async fn sts_assume_role_returns_correct_arn() {
     let server = TestServer::start().await;
     let sts = server.sts_client().await;

--- a/crates/fakecloud-iam/Cargo.toml
+++ b/crates/fakecloud-iam/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 flate2 = { workspace = true }
+sha1 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fakecloud-iam/src/sts_service/assume.rs
+++ b/crates/fakecloud-iam/src/sts_service/assume.rs
@@ -302,9 +302,13 @@ impl StsService {
             assumed_role_id: &role_id,
             account_id: &account_id,
             partition,
-            creds: &creds,
+            creds: Some(&creds),
             expiration: &expiration,
             request_id: &req.request_id,
+            // SourceIdentity is echoed back so it survives across role
+            // chaining (AWS returns it whenever the caller supplied one).
+            source_identity: req.query_params.get("SourceIdentity").map(|s| s.as_str()),
+            ..Default::default()
         });
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }
@@ -605,6 +609,22 @@ impl StsService {
             },
         );
 
+        // Echo the token-derived fields AWS returns. `Provider` is the token's
+        // `iss` for OIDC ID tokens, or the `ProviderId` parameter for OAuth 2.0
+        // access tokens. `Audience` is the token's client-id claim; AWS returns
+        // a single value, so surface the first. `SourceIdentity` comes from the
+        // AWS-namespaced JWT claim when the IdP set one.
+        let subject_from_web_identity_token = jwt.as_ref().and_then(|c| c.sub.as_deref());
+        let provider = jwt
+            .as_ref()
+            .and_then(|c| c.iss.as_deref())
+            .or(provider_id_param.as_deref());
+        let audience = jwt.as_ref().and_then(|c| c.aud.first().map(|s| s.as_str()));
+        let source_identity = jwt
+            .as_ref()
+            .and_then(|c| c.raw.get("https://aws.amazon.com/source_identity"))
+            .and_then(|v| v.as_str());
+
         let xml = xml_responses::assume_role_with_web_identity_response(
             &xml_responses::AssumedRoleInfo {
                 role_arn,
@@ -612,9 +632,14 @@ impl StsService {
                 assumed_role_id: &role_id,
                 account_id: &account_id,
                 partition,
-                creds: &creds,
+                creds: Some(&creds),
                 expiration: &expiration,
                 request_id: &req.request_id,
+                subject_from_web_identity_token,
+                provider,
+                audience,
+                source_identity,
+                ..Default::default()
             },
         );
         Ok(AwsResponse::xml(StatusCode::OK, xml))
@@ -827,15 +852,35 @@ impl StsService {
             },
         );
 
+        // NameQualifier is a hash over the issuer, account, and SAML provider
+        // friendly name (AWS pseudocode:
+        // `BASE64(SHA1(Issuer + AccountId + "/" + ProviderName))`). It requires
+        // an Issuer claim, so it stays absent when the assertion carries none.
+        let saml_provider_name = principal_arn
+            .rsplit("saml-provider/")
+            .next()
+            .unwrap_or(principal_arn);
+        let name_qualifier = saml_claims
+            .issuer
+            .as_deref()
+            .map(|iss| super::compute_saml_name_qualifier(iss, &account_id, saml_provider_name));
+
         let xml = xml_responses::assume_role_with_saml_response(&xml_responses::AssumedRoleInfo {
             role_arn,
             role_session_name: &role_session_name,
             assumed_role_id: &role_id,
             account_id: &account_id,
             partition,
-            creds: &creds,
+            creds: Some(&creds),
             expiration: &expiration,
             request_id: &req.request_id,
+            subject: saml_claims.subject.as_deref(),
+            subject_type: saml_claims.subject_type.as_deref(),
+            issuer: saml_claims.issuer.as_deref(),
+            audience: saml_claims.audience.as_deref(),
+            name_qualifier: name_qualifier.as_deref(),
+            source_identity: saml_claims.source_identity.as_deref(),
+            ..Default::default()
         });
         Ok(AwsResponse::xml(StatusCode::OK, xml))
     }

--- a/crates/fakecloud-iam/src/sts_service/mod.rs
+++ b/crates/fakecloud-iam/src/sts_service/mod.rs
@@ -455,11 +455,20 @@ fn extract_account_from_arn(arn: &str) -> Option<String> {
 struct SamlClaims {
     issuer: Option<String>,
     audience: Option<String>,
+    /// The `<NameID>` text — STS returns this as `Subject`.
+    subject: Option<String>,
+    /// The `<NameID Format="...">` value with the standard
+    /// `urn:oasis:names:tc:SAML:*:nameid-format:` prefix stripped — STS
+    /// returns this as `SubjectType` (e.g. `transient`, `persistent`).
+    subject_type: Option<String>,
+    /// The `https://aws.amazon.com/SAML/Attributes/SourceIdentity` attribute
+    /// value, if the IdP included it — STS echoes it as `SourceIdentity`.
+    source_identity: Option<String>,
 }
 
-/// Pull `Issuer` and `Audience` out of a base64-encoded SAML assertion.
-/// Returns whatever fields could be extracted (both fields are optional);
-/// callers decide what to do when one is missing.
+/// Pull the response-relevant claims out of a base64-encoded SAML assertion.
+/// Returns whatever fields could be extracted (all optional); callers decide
+/// what to do when one is missing.
 fn extract_saml_claims(saml_b64: &str) -> SamlClaims {
     use base64::Engine;
     let mut claims = SamlClaims::default();
@@ -473,7 +482,105 @@ fn extract_saml_claims(saml_b64: &str) -> SamlClaims {
     };
     claims.issuer = extract_xml_text_after(&xml_str, "Issuer");
     claims.audience = extract_xml_text_after(&xml_str, "Audience");
+    claims.subject = extract_xml_text_after(&xml_str, "NameID");
+    claims.subject_type = extract_nameid_format(&xml_str);
+    claims.source_identity = extract_saml_attribute(
+        &xml_str,
+        "https://aws.amazon.com/SAML/Attributes/SourceIdentity",
+    );
     claims
+}
+
+/// Compute the STS `NameQualifier` for an `AssumeRoleWithSAML` response.
+/// AWS defines it as `BASE64(SHA1(Issuer + AccountId + "/" + ProviderName))`
+/// where `ProviderName` is the friendly name (last ARN component) of the SAML
+/// provider. Uniquely identifies a user together with `Subject`.
+pub(super) fn compute_saml_name_qualifier(
+    issuer: &str,
+    account_id: &str,
+    provider_name: &str,
+) -> String {
+    use base64::Engine;
+    use sha1::{Digest, Sha1};
+    let mut hasher = Sha1::new();
+    hasher.update(issuer.as_bytes());
+    hasher.update(account_id.as_bytes());
+    hasher.update(b"/");
+    hasher.update(provider_name.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(hasher.finalize())
+}
+
+/// Extract the `Format` attribute of the first `<NameID>` element and strip the
+/// standard SAML name-id-format URI prefix, matching how STS surfaces
+/// `SubjectType` (`urn:oasis:names:tc:SAML:2.0:nameid-format:transient`
+/// becomes `transient`). Defaults to `transient` when a NameID is present with
+/// no Format, per AWS.
+fn extract_nameid_format(xml: &str) -> Option<String> {
+    let mut search_from = 0;
+    while let Some(idx) = xml[search_from..].find('<') {
+        let abs = search_from + idx;
+        let after_lt = &xml[abs + 1..];
+        let tag_start = after_lt
+            .split_once(':')
+            .map(|(_pfx, rest)| rest)
+            .unwrap_or(after_lt);
+        if let Some(after_name) = tag_start.strip_prefix("NameID") {
+            let terminator = after_name.chars().next();
+            if matches!(terminator, Some(' ' | '\t' | '\n' | '>' | '/')) {
+                // The NameID opening tag runs up to the next '>'.
+                let gt = after_lt.find('>')?;
+                let open_tag = &after_lt[..gt];
+                let format = extract_attr_value(open_tag, "Format")
+                    .map(|f| strip_nameid_format_prefix(&f))
+                    .unwrap_or_else(|| "transient".to_string());
+                return Some(format);
+            }
+        }
+        search_from = abs + 1;
+    }
+    None
+}
+
+/// Strip the `urn:oasis:names:tc:SAML:<ver>:nameid-format:` prefix from a
+/// NameID Format URI, returning the trailing token (e.g. `transient`).
+fn strip_nameid_format_prefix(format: &str) -> String {
+    match format.rsplit_once("nameid-format:") {
+        Some((_, tail)) if !tail.is_empty() => tail.to_string(),
+        _ => format.to_string(),
+    }
+}
+
+/// Read the value of `attr="..."` (or `attr='...'`) from an opening-tag body.
+fn extract_attr_value(open_tag: &str, attr: &str) -> Option<String> {
+    let key = open_tag.find(attr)?;
+    let rest = &open_tag[key + attr.len()..];
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix('=')?.trim_start();
+    let quote = rest.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let body = &rest[1..];
+    let end = body.find(quote)?;
+    Some(body[..end].to_string())
+}
+
+/// Extract a SAML `<Attribute Name="...">` element's first `<AttributeValue>`
+/// text. Used to surface AWS-namespaced attributes like `SourceIdentity`.
+fn extract_saml_attribute(xml: &str, attribute_name: &str) -> Option<String> {
+    let pos = xml.find(attribute_name)?;
+    let after = &xml[pos..];
+    let av_start = after.find("AttributeValue")?;
+    let after_av = &after[av_start..];
+    let gt_pos = after_av.find('>')?;
+    let value_start = &after_av[gt_pos + 1..];
+    let lt_pos = value_start.find('<')?;
+    let value = value_start[..lt_pos].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
 }
 
 /// Find the first occurrence of an opening tag with `local_name` (with or
@@ -754,6 +861,62 @@ mod tests {
             Some("111111111111".to_string())
         );
         assert_eq!(extract_account_from_arn("invalid"), None);
+    }
+
+    #[test]
+    fn saml_claims_extracts_subject_and_source_identity() {
+        use base64::Engine;
+        let xml = r#"<Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+          <saml:Issuer>https://idp.test/shibboleth</saml:Issuer>
+          <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">jdoe</saml:NameID>
+          <saml:Audience>https://signin.aws.amazon.com/saml</saml:Audience>
+          <saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/SourceIdentity">
+            <saml:AttributeValue>jdoe-src</saml:AttributeValue>
+          </saml:Attribute>
+        </Response>"#;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(xml);
+        let claims = extract_saml_claims(&b64);
+        assert_eq!(
+            claims.issuer.as_deref(),
+            Some("https://idp.test/shibboleth")
+        );
+        assert_eq!(
+            claims.audience.as_deref(),
+            Some("https://signin.aws.amazon.com/saml")
+        );
+        assert_eq!(claims.subject.as_deref(), Some("jdoe"));
+        assert_eq!(claims.subject_type.as_deref(), Some("persistent"));
+        assert_eq!(claims.source_identity.as_deref(), Some("jdoe-src"));
+    }
+
+    #[test]
+    fn nameid_format_defaults_to_transient_when_absent() {
+        assert_eq!(
+            extract_nameid_format("<NameID>bob</NameID>").as_deref(),
+            Some("transient")
+        );
+        assert_eq!(
+            extract_nameid_format(
+                r#"<saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">a@b</saml:NameID>"#
+            )
+            .as_deref(),
+            Some("emailAddress")
+        );
+    }
+
+    #[test]
+    fn name_qualifier_is_deterministic_base64_sha1() {
+        // BASE64(SHA1("https://example.com/saml" + "123456789012" + "/MySAMLIdP")).
+        let q =
+            compute_saml_name_qualifier("https://example.com/saml", "123456789012", "MySAMLIdP");
+        // SHA1 -> 20 bytes -> 28-char base64 with one '=' pad.
+        assert_eq!(q.len(), 28);
+        assert!(q.ends_with('='));
+        // Deterministic.
+        assert_eq!(
+            q,
+            compute_saml_name_qualifier("https://example.com/saml", "123456789012", "MySAMLIdP")
+        );
     }
 
     #[test]

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -605,15 +605,38 @@ impl StsCredentials {
 }
 
 /// Inputs shared by all assume-role variants used to build an STS XML response.
+///
+/// The optional fields carry values decoded from the request (a JWT for
+/// WebIdentity, a SAML assertion for SAML, or the `SourceIdentity` parameter
+/// for AssumeRole). AWS echoes these back in the response, and the value must
+/// survive so callers can read `SubjectFromWebIdentityToken`, `Provider`,
+/// `Subject`, etc., and so `SourceIdentity` persists across role chaining.
+/// Each field is only rendered by the builder(s) whose response shape declares
+/// it in the STS model.
+#[derive(Default)]
 pub struct AssumedRoleInfo<'a> {
     pub role_arn: &'a str,
     pub role_session_name: &'a str,
     pub assumed_role_id: &'a str,
     pub account_id: &'a str,
     pub partition: &'a str,
-    pub creds: &'a StsCredentials,
+    pub creds: Option<&'a StsCredentials>,
     pub expiration: &'a str,
     pub request_id: &'a str,
+    /// Echoed by AssumeRole / AssumeRoleWithWebIdentity / AssumeRoleWithSAML.
+    pub source_identity: Option<&'a str>,
+    // --- AssumeRoleWithWebIdentity ---
+    /// The token's `sub` claim.
+    pub subject_from_web_identity_token: Option<&'a str>,
+    /// The token's `iss` claim (or the `ProviderId` parameter for OAuth 2.0).
+    pub provider: Option<&'a str>,
+    // --- AssumeRoleWithWebIdentity + AssumeRoleWithSAML share `Audience` ---
+    pub audience: Option<&'a str>,
+    // --- AssumeRoleWithSAML ---
+    pub subject: Option<&'a str>,
+    pub subject_type: Option<&'a str>,
+    pub issuer: Option<&'a str>,
+    pub name_qualifier: Option<&'a str>,
 }
 
 impl AssumedRoleInfo<'_> {
@@ -624,10 +647,24 @@ impl AssumedRoleInfo<'_> {
             self.partition, self.account_id, role_name, self.role_session_name
         )
     }
+
+    fn creds(&self) -> &StsCredentials {
+        self.creds.expect("AssumedRoleInfo.creds must be set")
+    }
+
+    /// Render one optional `<Tag>value</Tag>` line, XML-escaped, or nothing.
+    fn opt_element(tag: &str, value: Option<&str>) -> String {
+        match value {
+            Some(v) => format!("\n    <{tag}>{}</{tag}>", xml_escape(v)),
+            None => String::new(),
+        }
+    }
 }
 
 pub fn assume_role_response(info: &AssumedRoleInfo<'_>) -> String {
     let assumed_role_arn = info.assumed_role_arn();
+    let creds = info.creds();
+    let source_identity = AssumedRoleInfo::opt_element("SourceIdentity", info.source_identity);
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
@@ -641,15 +678,15 @@ pub fn assume_role_response(info: &AssumedRoleInfo<'_>) -> String {
     <AssumedRoleUser>
       <AssumedRoleId>{role_id}:{session}</AssumedRoleId>
       <Arn>{assumed_role_arn}</Arn>
-    </AssumedRoleUser>
+    </AssumedRoleUser>{source_identity}
   </AssumeRoleResult>
   <ResponseMetadata>
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
 </AssumeRoleResponse>"#,
-        access_key_id = info.creds.access_key_id,
-        secret_access_key = info.creds.secret_access_key,
-        session_token = info.creds.session_token,
+        access_key_id = creds.access_key_id,
+        secret_access_key = creds.secret_access_key,
+        session_token = creds.session_token,
         role_id = info.assumed_role_id,
         assumed_role_arn = assumed_role_arn,
         session = info.role_session_name,
@@ -660,6 +697,15 @@ pub fn assume_role_response(info: &AssumedRoleInfo<'_>) -> String {
 
 pub fn assume_role_with_web_identity_response(info: &AssumedRoleInfo<'_>) -> String {
     let assumed_role_arn = info.assumed_role_arn();
+    let creds = info.creds();
+    // Fields decoded from the web identity token; AWS echoes each back.
+    let subject = AssumedRoleInfo::opt_element(
+        "SubjectFromWebIdentityToken",
+        info.subject_from_web_identity_token,
+    );
+    let audience = AssumedRoleInfo::opt_element("Audience", info.audience);
+    let provider = AssumedRoleInfo::opt_element("Provider", info.provider);
+    let source_identity = AssumedRoleInfo::opt_element("SourceIdentity", info.source_identity);
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
@@ -673,15 +719,15 @@ pub fn assume_role_with_web_identity_response(info: &AssumedRoleInfo<'_>) -> Str
     <AssumedRoleUser>
       <AssumedRoleId>{assumed_role_id}:{session}</AssumedRoleId>
       <Arn>{assumed_role_arn}</Arn>
-    </AssumedRoleUser>
+    </AssumedRoleUser>{subject}{audience}{provider}{source_identity}
   </AssumeRoleWithWebIdentityResult>
   <ResponseMetadata>
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
 </AssumeRoleWithWebIdentityResponse>"#,
-        access_key_id = info.creds.access_key_id,
-        secret_access_key = info.creds.secret_access_key,
-        session_token = info.creds.session_token,
+        access_key_id = creds.access_key_id,
+        secret_access_key = creds.secret_access_key,
+        session_token = creds.session_token,
         assumed_role_id = info.assumed_role_id,
         assumed_role_arn = assumed_role_arn,
         session = info.role_session_name,
@@ -692,6 +738,14 @@ pub fn assume_role_with_web_identity_response(info: &AssumedRoleInfo<'_>) -> Str
 
 pub fn assume_role_with_saml_response(info: &AssumedRoleInfo<'_>) -> String {
     let assumed_role_arn = info.assumed_role_arn();
+    let creds = info.creds();
+    // Fields decoded from the SAML assertion; AWS echoes each back.
+    let subject = AssumedRoleInfo::opt_element("Subject", info.subject);
+    let subject_type = AssumedRoleInfo::opt_element("SubjectType", info.subject_type);
+    let issuer = AssumedRoleInfo::opt_element("Issuer", info.issuer);
+    let audience = AssumedRoleInfo::opt_element("Audience", info.audience);
+    let name_qualifier = AssumedRoleInfo::opt_element("NameQualifier", info.name_qualifier);
+    let source_identity = AssumedRoleInfo::opt_element("SourceIdentity", info.source_identity);
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <AssumeRoleWithSAMLResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
@@ -705,15 +759,15 @@ pub fn assume_role_with_saml_response(info: &AssumedRoleInfo<'_>) -> String {
     <AssumedRoleUser>
       <AssumedRoleId>{assumed_role_id}:{session}</AssumedRoleId>
       <Arn>{assumed_role_arn}</Arn>
-    </AssumedRoleUser>
+    </AssumedRoleUser>{subject}{subject_type}{issuer}{audience}{name_qualifier}{source_identity}
   </AssumeRoleWithSAMLResult>
   <ResponseMetadata>
     <RequestId>{request_id}</RequestId>
   </ResponseMetadata>
 </AssumeRoleWithSAMLResponse>"#,
-        access_key_id = info.creds.access_key_id,
-        secret_access_key = info.creds.secret_access_key,
-        session_token = info.creds.session_token,
+        access_key_id = creds.access_key_id,
+        secret_access_key = creds.secret_access_key,
+        session_token = creds.session_token,
         assumed_role_id = info.assumed_role_id,
         assumed_role_arn = assumed_role_arn,
         session = info.role_session_name,

--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -834,7 +834,13 @@ pub(crate) fn data_key_size_from_body(body: &Value) -> Result<usize, AwsServiceE
             format!("1 validation error detected: Value '{spec}' at 'keySpec' failed to satisfy constraint: Member must satisfy enum value set: [AES_256, AES_128]"),
         )),
         (None, Some(n)) => {
-            if n > 1024 {
+            if n < 1 {
+                Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ValidationException",
+                    format!("1 validation error detected: Value '{n}' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"),
+                ))
+            } else if n > 1024 {
                 Err(AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "ValidationException",
@@ -1018,5 +1024,48 @@ mod key_spec_usage_tests {
         assert!(validate_key_spec_usage("SYMMETRIC_DEFAULT", "SIGN_VERIFY").is_err());
         // secp256k1 supports signing only.
         assert!(validate_key_spec_usage("ECC_SECG_P256K1", "KEY_AGREEMENT").is_err());
+    }
+}
+
+#[cfg(test)]
+mod data_key_size_tests {
+    use super::data_key_size_from_body;
+    use serde_json::json;
+
+    #[test]
+    fn number_of_bytes_zero_rejected() {
+        // AWS models NumberOfBytes as @range(min:1,max:1024); 0 is a
+        // ValidationException, not a 200 with an empty data key.
+        let err = data_key_size_from_body(&json!({"NumberOfBytes": 0})).unwrap_err();
+        assert_eq!(err.code(), "ValidationException");
+        assert!(
+            err.message().contains("greater than or equal to 1"),
+            "unexpected message: {}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn number_of_bytes_valid_accepted() {
+        assert_eq!(
+            data_key_size_from_body(&json!({"NumberOfBytes": 32})).unwrap(),
+            32
+        );
+        // Boundaries.
+        assert_eq!(
+            data_key_size_from_body(&json!({"NumberOfBytes": 1})).unwrap(),
+            1
+        );
+        assert_eq!(
+            data_key_size_from_body(&json!({"NumberOfBytes": 1024})).unwrap(),
+            1024
+        );
+    }
+
+    #[test]
+    fn number_of_bytes_over_max_rejected() {
+        let err = data_key_size_from_body(&json!({"NumberOfBytes": 1025})).unwrap_err();
+        assert_eq!(err.code(), "ValidationException");
+        assert!(err.message().contains("less than or equal to 1024"));
     }
 }


### PR DESCRIPTION
Fixes a cluster of MED correctness bugs across three disjoint crates (DynamoDB, STS-in-IAM, KMS), each with regression tests.

## 1. DynamoDB — PutItem/UpdateItem never validated SS/BS/NS sets
`validate_attribute_value` had no `SS`/`BS` arm and the `NS` arm only checked numeric format, so empty sets and sets with duplicate members were stored silently, corrupting later `ADD`/`DELETE`/`size()` semantics.

- Reject empty `SS`/`NS`/`BS` sets with `ValidationException` ("An <kind> set may not be empty").
- Reject duplicate members: strings by value, numbers by numeric value (`"1"` == `"1.0"` via new `canonical_number`), binary by decoded bytes.
- Wired into UpdateItem too: validate `ExpressionAttributeValues` and legacy `AttributeUpdates` values before they mutate the item.

## 2. STS — AssumeRoleWith{WebIdentity,SAML} omitted response fields; SourceIdentity never echoed
The XML builders emitted only `Credentials` + `AssumedRoleUser`, discarding values already decoded from the token/assertion.

- WebIdentity now emits `SubjectFromWebIdentityToken`, `Audience`, `Provider` (iss, or ProviderId for OAuth 2.0), and `SourceIdentity` (from the AWS-namespaced JWT claim).
- SAML now emits `Subject`, `SubjectType` (NameID Format, prefix-stripped), `Issuer`, `Audience`, `NameQualifier` (`BASE64(SHA1(Issuer+Account+"/"+ProviderName))`), and `SourceIdentity` (from the AWS SAML attribute).
- AssumeRole now echoes `SourceIdentity` so it survives role chaining.

## 3. KMS — GenerateDataKey/GenerateDataKeyWithoutPlaintext accepted NumberOfBytes=0
`data_key_size_from_body` only rejected `n > 1024`; `n=0` returned 200 with an empty data key. AWS models `NumberOfBytes` as `@range(min:1,max:1024)`. Now rejects `< 1` with `ValidationException`, consistent with `GenerateRandom`.

## Tests
- DynamoDB: unit tests for empty/duplicate SS/NS/BS (incl. numeric-value and decoded-byte dedup) + valid sets pass.
- STS: unit tests for SAML claim/NameID-format/NameQualifier extraction; E2E tests asserting WebIdentity, SAML, and AssumeRole echo the new fields.
- KMS: unit tests for NumberOfBytes 0 (reject), 1/32/1024 (accept), 1025 (reject).

## Verification
- `cargo nextest run -p fakecloud-conformance` for `sts_assume_role*`, `kms_generate_data_key*`, `dynamodb_update_item`: 8/8 pass.
- New E2E tests: 3/3 pass. New unit tests pass.
- `cargo clippy --all-targets -D warnings` (touched crates) + `cargo fmt --all` clean.

No false positives — all three bugs confirmed against the Smithy models in `aws-models/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three correctness gaps across `fakecloud-dynamodb`, `fakecloud-iam` (STS), and `fakecloud-kms`. We now reject invalid DynamoDB sets, echo missing STS federation fields, and validate KMS data key sizes to match AWS.

- Bug Fixes
  - DynamoDB: Validate `SS`/`NS`/`BS` in `PutItem` and `UpdateItem` (including `ExpressionAttributeValues` and `AttributeUpdates`): reject empty sets and duplicates (strings by value, numbers by numeric value via canonicalization, binaries by decoded bytes).
  - STS: Echo federation fields. WebIdentity: `SubjectFromWebIdentityToken`, `Audience`, `Provider`, `SourceIdentity`. SAML: `Subject`, `SubjectType`, `Issuer`, `Audience`, `NameQualifier` (BASE64(SHA1(issuer+account+"/"+providerName))), `SourceIdentity`. AssumeRole: echo `SourceIdentity`.
  - KMS: `GenerateDataKey` and `GenerateDataKeyWithoutPlaintext` now reject `NumberOfBytes < 1` with `ValidationException` (AWS-consistent).

<sup>Written for commit 15ed0554ef1d948f58cf16dc33311ae04c86dacc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

