### PR TITLE
fix(secretsmanager,ssm): enforce field exclusivity + AllowedPattern + ARN acceptance (bug-hunt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6796,6 +6796,7 @@ dependencies = [
  "http 1.4.0",
  "md5",
  "parking_lot",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/fakecloud-secretsmanager/src/rotation.rs
+++ b/crates/fakecloud-secretsmanager/src/rotation.rs
@@ -113,6 +113,10 @@ pub async fn check_and_rotate(
                     };
                     secret.versions.insert(version_id.clone(), version);
                     secret.current_version_id = Some(version_id.clone());
+                    // Prune deprecated versions (no staging labels) so they
+                    // don't leak, matching PutSecretValue / UpdateSecret /
+                    // RotateSecret.
+                    secret.versions.retain(|_, v| !v.stages.is_empty());
                 }
                 version_created = true;
             }

--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -232,6 +232,29 @@ impl SecretsManagerService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
+        // A name that is scheduled for deletion can't be recreated while its
+        // recovery window is still open — AWS returns InvalidRequestException
+        // (not ResourceExistsException). Once the recovery window has elapsed
+        // the secret is treated as purged, so lazily remove it here and allow
+        // the create to proceed with a fresh secret.
+        if let Some((deleted, elapsed)) = state
+            .secrets
+            .get(&input.name)
+            .map(|s| (s.deleted, secret_recovery_window_elapsed(s, Utc::now())))
+        {
+            if deleted {
+                if elapsed {
+                    state.secrets.remove(&input.name);
+                } else {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidRequestException",
+                        "You can't create this secret because a secret with this name is already scheduled for deletion.",
+                    ));
+                }
+            }
+        }
+
         if let Some(existing) = state.secrets.get(&input.name) {
             if let Some(ref token) = input.client_request_token {
                 let existing_plaintext = existing.versions.get(token).and_then(|v| {
@@ -498,6 +521,10 @@ impl SecretsManagerService {
                 "You must provide either SecretString or SecretBinary.",
             ));
         }
+        // SecretString and SecretBinary are mutually exclusive.
+        if secret_string.is_some() && secret_binary.is_some() {
+            return Err(both_secret_fields_error());
+        }
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -677,6 +704,11 @@ impl SecretsManagerService {
         let secret_string = body["SecretString"].as_str().map(|s| s.to_string());
         let secret_binary = parse_secret_binary(&body)?;
 
+        // SecretString and SecretBinary are mutually exclusive.
+        if secret_string.is_some() && secret_binary.is_some() {
+            return Err(both_secret_fields_error());
+        }
+
         let version_id = if secret_string.is_some() || secret_binary.is_some() {
             let vid = body["ClientRequestToken"]
                 .as_str()
@@ -736,6 +768,10 @@ impl SecretsManagerService {
             secret.versions.insert(vid.clone(), version);
             secret.current_version_id = Some(vid.clone());
             secret.last_changed_at = now;
+            // Prune deprecated versions (no staging labels) so they don't leak,
+            // matching PutSecretValue. Demoting AWSCURRENT can strip the last
+            // label off the previously-previous version.
+            secret.versions.retain(|_, v| !v.stages.is_empty());
             Some(vid)
         } else {
             secret.last_changed_at = Utc::now();
@@ -1161,6 +1197,9 @@ impl SecretsManagerService {
         validate_optional_range_i64("maxResults", body["MaxResults"].as_i64(), 1, 100)?;
         let max_results = body["MaxResults"].as_i64().unwrap_or(100) as usize;
         let next_token = body["NextToken"].as_str();
+        // IncludeDeprecated defaults to false: a deprecated version (one with no
+        // staging labels) is hidden unless the caller explicitly asks for it.
+        let include_deprecated = body["IncludeDeprecated"].as_bool().unwrap_or(false);
 
         let accounts = self.state.read();
         let empty = SecretsManagerState::new(&req.account_id, &req.region);
@@ -1169,7 +1208,11 @@ impl SecretsManagerService {
 
         // Stable order so the NextToken (a version id) resumes deterministically:
         // newest first by CreatedDate, version id as a tiebreaker.
-        let mut versions: Vec<&_> = secret.versions.values().collect();
+        let mut versions: Vec<&_> = secret
+            .versions
+            .values()
+            .filter(|v| include_deprecated || !v.stages.is_empty())
+            .collect();
         versions.sort_by(|a, b| {
             b.created_at
                 .cmp(&a.created_at)
@@ -1498,6 +1541,9 @@ impl SecretsManagerService {
                         };
                         secret.versions.insert(version_id.clone(), version);
                         secret.current_version_id = Some(version_id.clone());
+                        // Prune deprecated versions (no staging labels) so they
+                        // don't leak, matching PutSecretValue / UpdateSecret.
+                        secret.versions.retain(|_, v| !v.stages.is_empty());
                         // The value has now actually rotated (synchronously), so
                         // this is the point where LastRotatedDate is stamped. The
                         // Lambda path does not claim completion here because the
@@ -2231,13 +2277,19 @@ impl CreateSecretInput {
         validate_optional_string_length("kmsKeyId", body["KmsKeyId"].as_str(), 0, 2048)?;
         validate_optional_string_length("secretString", body["SecretString"].as_str(), 1, 65536)?;
 
+        let secret_string = body["SecretString"].as_str().map(|s| s.to_string());
+        let secret_binary = parse_secret_binary(body)?;
+        if secret_string.is_some() && secret_binary.is_some() {
+            return Err(both_secret_fields_error());
+        }
+
         Ok(Self {
             name,
             client_request_token: body["ClientRequestToken"].as_str().map(|s| s.to_string()),
             description: body["Description"].as_str().map(|s| s.to_string()),
             kms_key_id: body["KmsKeyId"].as_str().map(|s| s.to_string()),
-            secret_string: body["SecretString"].as_str().map(|s| s.to_string()),
-            secret_binary: parse_secret_binary(body)?,
+            secret_string,
+            secret_binary,
             tags: parse_tags(&body["Tags"]),
             add_replica_regions: body["AddReplicaRegions"]
                 .as_array()

--- a/crates/fakecloud-secretsmanager/src/service_helpers.rs
+++ b/crates/fakecloud-secretsmanager/src/service_helpers.rs
@@ -55,6 +55,19 @@ pub(crate) fn demote_current_to_previous(
     }
 }
 
+/// The error AWS returns when a request supplies both `SecretString` and
+/// `SecretBinary`. The two are mutually exclusive on CreateSecret,
+/// PutSecretValue and UpdateSecret — a value can be a string or binary, never
+/// both — so a request carrying both is rejected rather than storing (and
+/// later returning) both.
+pub(crate) fn both_secret_fields_error() -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidParameterException",
+        "You can't specify both the SecretString and SecretBinary in the same request.",
+    )
+}
+
 /// Decode the optional `SecretBinary` field. Returns an error when the field is
 /// present but not valid base64, matching AWS which rejects an undecodable
 /// `SecretBinary` rather than silently dropping it (which would let a caller

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -3123,3 +3123,261 @@ async fn test_scheduled_deletion_expires_on_read() {
     );
     assert!(err.to_string().contains("marked for deletion"));
 }
+
+// ── Field exclusivity: SecretString + SecretBinary are mutually exclusive ──
+
+#[tokio::test]
+async fn create_secret_rejects_both_string_and_binary() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    let err = expect_err(
+        svc.handle(make_request(
+            "CreateSecret",
+            r#"{"Name": "both", "SecretString": "s", "SecretBinary": "dGVzdA=="}"#,
+        ))
+        .await,
+    );
+    assert!(
+        err.to_string().contains("InvalidParameterException"),
+        "got {err}"
+    );
+    assert!(
+        err.to_string().contains("SecretString and SecretBinary"),
+        "got {err}"
+    );
+}
+
+#[tokio::test]
+async fn put_secret_value_rejects_both_string_and_binary() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "excl", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let err = expect_err(
+        svc.handle(make_request(
+            "PutSecretValue",
+            r#"{"SecretId": "excl", "SecretString": "s", "SecretBinary": "dGVzdA=="}"#,
+        ))
+        .await,
+    );
+    assert!(
+        err.to_string().contains("InvalidParameterException"),
+        "got {err}"
+    );
+}
+
+#[tokio::test]
+async fn update_secret_rejects_both_string_and_binary() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "excl-upd", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let err = expect_err(
+        svc.handle(make_request(
+            "UpdateSecret",
+            r#"{"SecretId": "excl-upd", "SecretString": "s", "SecretBinary": "dGVzdA=="}"#,
+        ))
+        .await,
+    );
+    assert!(
+        err.to_string().contains("InvalidParameterException"),
+        "got {err}"
+    );
+}
+
+// ── CreateSecret of a name scheduled for deletion ──
+
+#[tokio::test]
+async fn create_secret_scheduled_for_deletion_returns_invalid_request() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state);
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "sched-del", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+    svc.handle(make_request("DeleteSecret", r#"{"SecretId": "sched-del"}"#))
+        .await
+        .unwrap();
+
+    // Recreating a still-pending-deletion name is InvalidRequestException,
+    // NOT ResourceExistsException.
+    let err = expect_err(
+        svc.handle(make_request(
+            "CreateSecret",
+            r#"{"Name": "sched-del", "SecretString": "v2"}"#,
+        ))
+        .await,
+    );
+    assert!(
+        err.to_string().contains("InvalidRequestException"),
+        "got {err}"
+    );
+    assert!(
+        err.to_string().contains("scheduled for deletion"),
+        "got {err}"
+    );
+}
+
+#[tokio::test]
+async fn create_secret_after_recovery_window_elapsed_recreates() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "elapsed", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+    svc.handle(make_request("DeleteSecret", r#"{"SecretId": "elapsed"}"#))
+        .await
+        .unwrap();
+
+    // Force the recovery window into the past.
+    {
+        let mut accts = state.write();
+        accts
+            .default_mut()
+            .secrets
+            .get_mut("elapsed")
+            .unwrap()
+            .deletion_date = Some(Utc::now() - chrono::Duration::days(1));
+    }
+
+    // The elapsed secret is purged and a fresh secret is created.
+    let resp = svc
+        .handle(make_request(
+            "CreateSecret",
+            r#"{"Name": "elapsed", "SecretString": "v2"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let resp = svc
+        .handle(make_request("GetSecretValue", r#"{"SecretId": "elapsed"}"#))
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["SecretString"], "v2");
+}
+
+// ── Deprecated version pruning + ListSecretVersionIds IncludeDeprecated ──
+
+#[tokio::test]
+async fn update_secret_prunes_deprecated_versions() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "prune", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+    // v2: v1 -> AWSPREVIOUS, v2 -> AWSCURRENT.
+    svc.handle(make_request(
+        "UpdateSecret",
+        r#"{"SecretId": "prune", "SecretString": "v2"}"#,
+    ))
+    .await
+    .unwrap();
+    // v3: v2 -> AWSPREVIOUS, v1 loses AWSPREVIOUS (deprecated) and is pruned.
+    svc.handle(make_request(
+        "UpdateSecret",
+        r#"{"SecretId": "prune", "SecretString": "v3"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let accts = state.read();
+    let secret = accts.default_ref().secrets.get("prune").unwrap();
+    assert_eq!(
+        secret.versions.len(),
+        2,
+        "the deprecated (no-stage) version must be pruned, leaving AWSCURRENT + AWSPREVIOUS"
+    );
+    assert!(
+        secret.versions.values().all(|v| !v.stages.is_empty()),
+        "no version may be left without staging labels"
+    );
+}
+
+#[tokio::test]
+async fn list_secret_version_ids_honors_include_deprecated() {
+    let state = make_state();
+    let svc = SecretsManagerService::new(state.clone());
+
+    svc.handle(make_request(
+        "CreateSecret",
+        r#"{"Name": "listdep", "SecretString": "v1"}"#,
+    ))
+    .await
+    .unwrap();
+
+    // Inject a deprecated version (no staging labels) directly.
+    {
+        let mut accts = state.write();
+        let secret = accts.default_mut().secrets.get_mut("listdep").unwrap();
+        secret.versions.insert(
+            "deprecated-vid".to_string(),
+            SecretVersion {
+                version_id: "deprecated-vid".to_string(),
+                secret_string: Some("old".to_string()),
+                secret_binary: None,
+                stages: vec![],
+                created_at: Utc::now(),
+            },
+        );
+    }
+
+    // Default (IncludeDeprecated absent -> false): deprecated version hidden.
+    let resp = svc
+        .handle(make_request(
+            "ListSecretVersionIds",
+            r#"{"SecretId": "listdep"}"#,
+        ))
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let versions = body["Versions"].as_array().unwrap();
+    assert_eq!(
+        versions.len(),
+        1,
+        "deprecated version must be hidden by default"
+    );
+    assert!(versions.iter().all(|v| v["VersionId"] != "deprecated-vid"));
+
+    // IncludeDeprecated=true: deprecated version shown.
+    let resp = svc
+        .handle(make_request(
+            "ListSecretVersionIds",
+            r#"{"SecretId": "listdep", "IncludeDeprecated": true}"#,
+        ))
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let versions = body["Versions"].as_array().unwrap();
+    assert_eq!(
+        versions.len(),
+        2,
+        "deprecated version must be shown when requested"
+    );
+    assert!(versions.iter().any(|v| v["VersionId"] == "deprecated-vid"));
+}

--- a/crates/fakecloud-ssm/Cargo.toml
+++ b/crates/fakecloud-ssm/Cargo.toml
@@ -18,6 +18,7 @@ http = { workspace = true }
 md5 = "0.8"
 sha2 = { workspace = true }
 parking_lot = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -374,11 +374,54 @@ fn build_param_history_value(
         "DataType": param.data_type,
     });
     if hist.param_type == "SecureString" && !with_decryption {
-        v["Value"] = json!("****");
+        // Mask consistently with the current-version representation
+        // (`param_to_json`) and GetParameterHistory (`history_entry_json`):
+        // return the `kms:<key-id>:<value>` envelope, not a bare `****`, so a
+        // client parsing the `kms:` form works whether it pulled the current
+        // version or an older one out of history. Use the same key-id fallback
+        // as `history_entry_json` so both history paths render identically.
+        let key_id = hist.key_id.as_deref().unwrap_or("alias/aws/ssm");
+        v["Value"] = json!(format!("kms:{}:{}", key_id, hist.value));
     } else {
         v["Value"] = json!(hist.value);
     }
     v
+}
+
+/// Validate a parameter value against an ``AllowedPattern`` regular
+/// expression. AWS rejects a ``PutParameter`` whose value does not satisfy the
+/// parameter's ``AllowedPattern`` (a ``ValidationException`` that
+/// ``put_parameter`` remaps to the declared ``InvalidAllowedPatternException``).
+/// The pattern is applied unanchored — AWS's own documented examples carry
+/// explicit `^...$` anchors, so the caller is responsible for anchoring; adding
+/// our own anchors would wrongly reject values against intentionally-unanchored
+/// patterns. A malformed pattern is likewise rejected.
+fn validate_value_against_allowed_pattern(
+    value: &str,
+    pattern: &str,
+) -> Result<(), AwsServiceError> {
+    if pattern.is_empty() {
+        return Ok(());
+    }
+    let re = regex::Regex::new(pattern).map_err(|_| {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!("The AllowedPattern {pattern} is not a valid regular expression."),
+        )
+    })?;
+    if re.is_match(value) {
+        Ok(())
+    } else {
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            format!(
+                "Parameter value {value} failed to satisfy constraint: \
+                 AllowedPattern: {pattern}"
+            ),
+        ))
+    }
 }
 
 /// All fields of a ``PutParameter`` request, already parsed and validated.
@@ -604,6 +647,12 @@ fn apply_overwrite(
     if input.key_id.is_some() {
         existing.key_id = input.key_id;
     }
+    // A new AllowedPattern supplied on overwrite replaces the stored one; the
+    // value was already validated against the effective pattern in
+    // `put_parameter`. Omitting AllowedPattern preserves the existing one.
+    if input.allowed_pattern.is_some() {
+        existing.allowed_pattern = input.allowed_pattern;
+    }
     if input.data_type_explicit {
         existing.data_type = input.data_type;
     }
@@ -727,6 +776,22 @@ impl SsmService {
                     ),
                     "InvalidAllowedPatternException",
                 ));
+            }
+        }
+
+        // Enforce AllowedPattern against the plaintext value BEFORE any KMS
+        // encryption (a SecureString value is validated in the clear). The
+        // effective pattern is the one supplied in this request, or — when the
+        // request omits it on an overwrite — the pattern already stored on the
+        // parameter, matching AWS which keeps validating against a previously
+        // set AllowedPattern.
+        {
+            let effective_pattern = input.allowed_pattern.clone().or_else(|| {
+                lookup_param(&state.parameters, &input.name).and_then(|e| e.allowed_pattern.clone())
+            });
+            if let Some(pattern) = effective_pattern {
+                validate_value_against_allowed_pattern(&input.value, &pattern)
+                    .map_err(|e| remap_validation_to(e, "InvalidAllowedPatternException"))?;
             }
         }
 
@@ -1126,6 +1191,25 @@ impl SsmService {
             if let Some(raw_name) = name_val.as_str() {
                 // Deduplicate
                 if !seen_names.insert(raw_name.to_string()) {
+                    continue;
+                }
+
+                // Handle ARN-style names directly. An ARN contains many colons
+                // that would otherwise trip parse_param_selector into
+                // ParamSelector::Invalid, landing the parameter in
+                // InvalidParameters even though GetParameter accepts the same
+                // ARN. Apply the same ARN->name normalization here.
+                if raw_name.starts_with("arn:aws:ssm:") {
+                    match resolve_param_by_name_or_arn(state, raw_name) {
+                        Ok(param) => parameters.push(self.render_param_to_json(
+                            param,
+                            true,
+                            with_decryption,
+                            &req.region,
+                            &req.account_id,
+                        )),
+                        Err(_) => invalid.push(raw_name.to_string()),
+                    }
                     continue;
                 }
 

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -5198,3 +5198,153 @@ fn maintenance_window_task_persists_invocation_params() {
         120
     );
 }
+
+// ── AllowedPattern enforcement (bug-hunt) ──
+
+#[test]
+fn put_parameter_allowed_pattern_accepts_matching_value() {
+    let svc = make_service();
+    let req = make_request(
+        "PutParameter",
+        json!({"Name": "/ap/ok", "Value": "12345", "Type": "String", "AllowedPattern": "^\\d+$"}),
+    );
+    let resp = svc.put_parameter(&req).unwrap();
+    assert_eq!(resp.status, http::StatusCode::OK);
+}
+
+#[test]
+fn put_parameter_allowed_pattern_rejects_non_matching_value() {
+    let svc = make_service();
+    let req = make_request(
+        "PutParameter",
+        json!({"Name": "/ap/bad", "Value": "abc", "Type": "String", "AllowedPattern": "^\\d+$"}),
+    );
+    expect_err_code(svc.put_parameter(&req), "InvalidAllowedPatternException");
+}
+
+#[test]
+fn put_parameter_allowed_pattern_enforced_on_overwrite_against_stored_pattern() {
+    let svc = make_service();
+    // Create with a numeric-only pattern.
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/ap/ow", "Value": "1", "Type": "String", "AllowedPattern": "^\\d+$"}),
+    ))
+    .unwrap();
+
+    // Overwrite omitting AllowedPattern still validates against the stored one.
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/ap/ow", "Value": "999", "Type": "String", "Overwrite": true}),
+    ))
+    .unwrap();
+
+    // A non-matching overwrite value is rejected.
+    expect_err_code(
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/ap/ow", "Value": "nope", "Type": "String", "Overwrite": true}),
+        )),
+        "InvalidAllowedPatternException",
+    );
+}
+
+#[test]
+fn put_parameter_overwrite_applies_new_allowed_pattern() {
+    let svc = make_service();
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/ap/new", "Value": "1", "Type": "String", "AllowedPattern": "^\\d+$"}),
+    ))
+    .unwrap();
+
+    // Overwrite with a new alpha-only pattern and a matching value.
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/ap/new", "Value": "hello", "Type": "String", "Overwrite": true, "AllowedPattern": "^[a-z]+$"}),
+    ))
+    .unwrap();
+
+    // The new pattern is now the effective one: a numeric value is rejected.
+    expect_err_code(
+        svc.put_parameter(&make_request(
+            "PutParameter",
+            json!({"Name": "/ap/new", "Value": "123", "Type": "String", "Overwrite": true}),
+        )),
+        "InvalidAllowedPatternException",
+    );
+}
+
+// ── Historical SecureString masking is consistent with the current version ──
+
+#[test]
+fn get_parameter_history_version_masks_securestring_with_kms_form() {
+    let svc = make_service();
+    // Create then overwrite a SecureString so version 1 lands in history.
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/sec/p", "Value": "secret1", "Type": "SecureString"}),
+    ))
+    .unwrap();
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/sec/p", "Value": "secret2", "Type": "SecureString", "Overwrite": true}),
+    ))
+    .unwrap();
+
+    // Current version (no decryption) uses the kms:<key>:<value> form.
+    let cur = svc
+        .get_parameter(&make_request("GetParameter", json!({"Name": "/sec/p"})))
+        .unwrap();
+    let cur: Value = serde_json::from_slice(cur.body.expect_bytes()).unwrap();
+    let cur_val = cur["Parameter"]["Value"].as_str().unwrap();
+    assert!(
+        cur_val.starts_with("kms:"),
+        "current value should be masked as kms:...; got {cur_val}"
+    );
+
+    // A historical version (fetched via :1 selector) masks the SAME way,
+    // not with a bare "****".
+    let hist = svc
+        .get_parameter(&make_request("GetParameter", json!({"Name": "/sec/p:1"})))
+        .unwrap();
+    let hist: Value = serde_json::from_slice(hist.body.expect_bytes()).unwrap();
+    let hist_val = hist["Parameter"]["Value"].as_str().unwrap();
+    assert!(
+        hist_val.starts_with("kms:"),
+        "historical value must mask consistently with the current version; got {hist_val}"
+    );
+    assert_ne!(hist_val, "****");
+}
+
+// ── GetParameters accepts a full ARN like GetParameter does ──
+
+#[test]
+fn get_parameters_resolves_full_arn() {
+    let svc = make_service();
+    svc.put_parameter(&make_request(
+        "PutParameter",
+        json!({"Name": "/arn/p", "Value": "v", "Type": "String"}),
+    ))
+    .unwrap();
+
+    // Read the ARN back from GetParameter.
+    let g = svc
+        .get_parameter(&make_request("GetParameter", json!({"Name": "/arn/p"})))
+        .unwrap();
+    let g: Value = serde_json::from_slice(g.body.expect_bytes()).unwrap();
+    let arn = g["Parameter"]["ARN"].as_str().unwrap().to_string();
+    assert!(
+        arn.starts_with("arn:aws:ssm:"),
+        "expected an ARN, got {arn}"
+    );
+
+    // GetParameters with that full ARN must resolve, not land in InvalidParameters.
+    let resp = svc
+        .get_parameters(&make_request("GetParameters", json!({"Names": [arn]})))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Parameters"].as_array().unwrap().len(), 1);
+    assert!(body["InvalidParameters"].as_array().unwrap().is_empty());
+    assert_eq!(body["Parameters"][0]["Value"], "v");
+}


### PR DESCRIPTION
Fixes a cluster of MED correctness bugs in Secrets Manager and SSM found during a bug hunt.

## Secrets Manager (`fakecloud-secretsmanager`)

1. **SecretString + SecretBinary mutual exclusivity.** CreateSecret / PutSecretValue / UpdateSecret only rejected when *both* fields were absent; supplying both stored both and GetSecretValue returned both. Now rejects with `InvalidParameterException` ("You can't specify both the SecretString and SecretBinary in the same request.").

2. **CreateSecret on a name scheduled for deletion.** Previously returned `ResourceExistsException`. AWS returns `InvalidRequestException` ("...already scheduled for deletion.") while the recovery window is open, and once the window has elapsed treats the secret as purged. Both cases are now handled (lazy purge + recreate).

3. **Deprecated (empty-stage) version leak.** Empty-stage versions were pruned in PutSecretValue but not in UpdateSecret, no-Lambda RotateSecret, or scheduled rotation; ListSecretVersionIds also ignored `IncludeDeprecated`. Now prunes on all mutation paths and honors `IncludeDeprecated` (default false hides deprecated versions).

## SSM (`fakecloud-ssm`)

4. **AllowedPattern never enforced.** PutParameter parsed/stored/echoed AllowedPattern but never validated the value against it, and `apply_overwrite` dropped a new AllowedPattern. Now compiles the pattern (unanchored, matching AWS's documented `^...$`-anchored examples) and rejects a non-matching value on both create and overwrite (validated on the plaintext before SecureString encryption); a new AllowedPattern is applied on overwrite.

5. **Historical SecureString masking inconsistent.** GetParameter/GetParameters on a specific historical version returned `****` while the current version and GetParameterHistory returned the `kms:<key>:<value>` envelope. History now masks with the same `kms:` form so clients parse consistently across versions.

6. **GetParameters rejected ARNs GetParameter accepts.** A full parameter ARN landed in `InvalidParameters` in GetParameters. Now applies the same ARN->name normalization GetParameter uses.

## Tests
- New unit regression tests for all six fixes (`service_tests.rs`, `service/tests.rs`).
- Conformance: `cargo nextest run -p fakecloud-conformance -E 'test(secret)'` -> 10/10 pass; `-E 'test(ssm)'` -> 69/69 pass.
- `cargo clippy --all-targets -D warnings` clean on both crates; `cargo fmt` applied.

No false positives; all six were verified real against `aws-models/ssm.json` and the code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple correctness gaps in `fakecloud-secretsmanager` and `fakecloud-ssm` to match AWS behavior. Improves validation, version handling, masking, and ARN support.

- **Bug Fixes**
  - Secrets Manager: reject requests that include both SecretString and SecretBinary (CreateSecret/PutSecretValue/UpdateSecret).
  - Secrets Manager: Creating a secret while the same name is scheduled for deletion now returns InvalidRequest; after the recovery window, recreate is allowed.
  - Secrets Manager: prune deprecated versions (no staging labels) on all mutation paths; ListSecretVersionIds respects IncludeDeprecated (default false).
  - SSM: enforce AllowedPattern on create and overwrite against the plaintext value; new patterns apply on overwrite.
  - SSM: historical SecureString values now mask as kms:<key>:<value>, matching the current version format.
  - SSM: GetParameters now accepts full parameter ARNs like GetParameter.
  - Tests: added regression tests for all changes; conformance suites pass.

<sup>Written for commit c92712d0f87b40a73b0a58c2e4104ecaf7e68450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

