### PR TITLE
fix(cloudwatch,ec2): honor AlarmTypes + drop NaN datapoints + error on missing Describe ids + paginate/filter (bug-hunt)

### DIFF
--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -1284,6 +1284,12 @@ impl CloudWatchService {
             let mut timestamps: Vec<String> = Vec::new();
             let mut values: Vec<f64> = Vec::new();
             for (ts, v) in series.iter() {
+                // AWS emits no datapoint for a NaN/infinite result (e.g. a
+                // metric-math divide-by-zero); dropping it here keeps NaN/Inf
+                // off both the XML and JSON wire.
+                if !v.is_finite() {
+                    continue;
+                }
                 timestamps.push(ts.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
                 values.push(*v);
             }
@@ -1500,6 +1506,19 @@ impl CloudWatchService {
                 filter_names.push(v.clone());
             }
         }
+        // AWS defaults DescribeAlarms to MetricAlarm only; when AlarmTypes is
+        // supplied it returns exactly the requested types (MetricAlarm and/or
+        // CompositeAlarm). Absent -> metric alarms only.
+        let alarm_types = collect_member_values(req, "AlarmTypes");
+        for t in &alarm_types {
+            if t != "MetricAlarm" && t != "CompositeAlarm" {
+                return Err(invalid_param(format!(
+                    "AlarmTypes has an invalid value '{t}'"
+                )));
+            }
+        }
+        let want_metric = alarm_types.is_empty() || alarm_types.iter().any(|t| t == "MetricAlarm");
+        let want_composite = alarm_types.iter().any(|t| t == "CompositeAlarm");
         validate_len(req, "AlarmNamePrefix", 1, 255)?;
         validate_len(req, "ActionPrefix", 1, 1024)?;
         validate_len(req, "ChildrenOfAlarmName", 1, 255)?;
@@ -1555,34 +1574,40 @@ impl CloudWatchService {
         }
         let mut combined: Vec<(bool, String)> = Vec::new();
         if let Some(acct) = state.get(&req.account_id) {
-            if let Some(alarms) = acct.alarms_in(&req.region) {
-                for alarm in alarms.values() {
-                    if matches(
-                        &alarm.alarm_name,
-                        alarm.state_value.as_str(),
-                        [
-                            &alarm.alarm_actions,
-                            &alarm.ok_actions,
-                            &alarm.insufficient_data_actions,
-                        ],
-                    ) {
-                        combined.push((false, render_alarm(alarm)));
+            if want_metric {
+                if let Some(alarms) = acct.alarms_in(&req.region) {
+                    for alarm in alarms.values() {
+                        if matches(
+                            &alarm.alarm_name,
+                            alarm.state_value.as_str(),
+                            [
+                                &alarm.alarm_actions,
+                                &alarm.ok_actions,
+                                &alarm.insufficient_data_actions,
+                            ],
+                        ) {
+                            combined.push((false, render_alarm(alarm)));
+                        }
                     }
                 }
             }
-            if let Some(composites) = acct.composite_alarms_in(&req.region) {
-                for alarm in composites.values() {
-                    if matches(
-                        &alarm.alarm_name,
-                        alarm.state_value.as_str(),
-                        [
-                            &alarm.alarm_actions,
-                            &alarm.ok_actions,
-                            &alarm.insufficient_data_actions,
-                        ],
-                    ) {
-                        combined
-                            .push((true, crate::composite_alarms::render_composite_alarm(alarm)));
+            if want_composite {
+                if let Some(composites) = acct.composite_alarms_in(&req.region) {
+                    for alarm in composites.values() {
+                        if matches(
+                            &alarm.alarm_name,
+                            alarm.state_value.as_str(),
+                            [
+                                &alarm.alarm_actions,
+                                &alarm.ok_actions,
+                                &alarm.insufficient_data_actions,
+                            ],
+                        ) {
+                            combined.push((
+                                true,
+                                crate::composite_alarms::render_composite_alarm(alarm),
+                            ));
+                        }
                     }
                 }
             }

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -237,13 +237,31 @@ async fn composite_alarm_in_describe_alarms() {
         &[("AlarmName", "comp"), ("AlarmRule", "ALARM(x)")],
     )
     .await;
-    let described = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "comp")]).await;
+    // AWS returns only metric alarms by default; composite alarms must be
+    // requested explicitly via AlarmTypes.
+    let described = call(
+        &svc,
+        "DescribeAlarms",
+        &[
+            ("AlarmNames.member.1", "comp"),
+            ("AlarmTypes.member.1", "CompositeAlarm"),
+        ],
+    )
+    .await;
     let b = body_of(&described);
     assert!(b.contains("<AlarmRule>ALARM(x)</AlarmRule>"));
     assert!(b.contains("<CompositeAlarms>"));
 
     call(&svc, "DeleteAlarms", &[("AlarmNames.member.1", "comp")]).await;
-    let after = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "comp")]).await;
+    let after = call(
+        &svc,
+        "DescribeAlarms",
+        &[
+            ("AlarmNames.member.1", "comp"),
+            ("AlarmTypes.member.1", "CompositeAlarm"),
+        ],
+    )
+    .await;
     assert!(!body_of(&after).contains("ALARM(x)"));
 }
 
@@ -398,7 +416,15 @@ async fn composite_alarm_reflects_children_states() {
         ],
     )
     .await;
-    let desc = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "comp2")]).await;
+    let desc = call(
+        &svc,
+        "DescribeAlarms",
+        &[
+            ("AlarmNames.member.1", "comp2"),
+            ("AlarmTypes.member.1", "CompositeAlarm"),
+        ],
+    )
+    .await;
     let b = body_of(&desc);
     assert!(
         b.contains("<CompositeAlarms>") && b.contains("<StateValue>ALARM</StateValue>"),
@@ -416,7 +442,15 @@ async fn composite_alarm_reflects_children_states() {
         ],
     )
     .await;
-    let desc = call(&svc, "DescribeAlarms", &[("AlarmNames.member.1", "comp2")]).await;
+    let desc = call(
+        &svc,
+        "DescribeAlarms",
+        &[
+            ("AlarmNames.member.1", "comp2"),
+            ("AlarmTypes.member.1", "CompositeAlarm"),
+        ],
+    )
+    .await;
     assert!(body_of(&desc).contains("<StateValue>OK</StateValue>"));
 }
 

--- a/crates/fakecloud-conformance/tests/cloudwatch.rs
+++ b/crates/fakecloud-conformance/tests/cloudwatch.rs
@@ -508,9 +508,11 @@ async fn cloudwatch_composite_alarm() {
         .await
         .unwrap();
 
+    // AWS returns only metric alarms unless AlarmTypes includes CompositeAlarm.
     let described = client
         .describe_alarms()
         .alarm_names("conf-composite")
+        .alarm_types(aws_sdk_cloudwatch::types::AlarmType::CompositeAlarm)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -3627,12 +3627,17 @@ async fn ec2_deregister_image() {
     let c = s.ec2_client().await;
     let id = make_ami(&c).await;
     c.deregister_image().image_id(&id).send().await.unwrap();
-    // The deregistered AMI is gone. (A no-filter DescribeImages is NOT empty —
-    // every account sees the seeded public AMI catalogue, as in real AWS — so
-    // assert on the specific id rather than the whole image set.)
-    assert!(c
+    // The deregistered AMI is gone. Requesting it explicitly by id is a hard
+    // error on real AWS (InvalidAMIID.NotFound), not a silently-empty result.
+    let err = c.describe_images().image_ids(&id).send().await.unwrap_err();
+    assert!(
+        format!("{:?}", err).contains("InvalidAMIID.NotFound"),
+        "expected InvalidAMIID.NotFound, got: {err:?}"
+    );
+    // A no-filter DescribeImages is NOT empty — every account still sees the
+    // seeded public AMI catalogue, as in real AWS.
+    assert!(!c
         .describe_images()
-        .image_ids(&id)
         .send()
         .await
         .unwrap()

--- a/crates/fakecloud-e2e/tests/cloudwatch.rs
+++ b/crates/fakecloud-e2e/tests/cloudwatch.rs
@@ -749,3 +749,140 @@ async fn describe_alarm_history_records_transitions() {
         "a StateUpdate history item must be recorded"
     );
 }
+
+// bug-cluster: DescribeAlarms honors AlarmTypes. AWS returns only metric alarms
+// by default; composite alarms appear only when AlarmTypes includes them.
+#[tokio::test]
+async fn describe_alarms_honors_alarm_types() {
+    use aws_sdk_cloudwatch::types::AlarmType;
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+
+    cw.put_metric_alarm()
+        .alarm_name("m-alarm")
+        .namespace("App")
+        .metric_name("Errors")
+        .statistic(Statistic::Sum)
+        .period(60)
+        .evaluation_periods(1)
+        .threshold(1.0)
+        .comparison_operator(ComparisonOperator::GreaterThanThreshold)
+        .send()
+        .await
+        .expect("put metric alarm");
+    cw.put_composite_alarm()
+        .alarm_name("c-alarm")
+        .alarm_rule("ALARM(m-alarm)")
+        .send()
+        .await
+        .expect("put composite alarm");
+
+    // Default: metric alarms only, no composite alarms.
+    let default = cw.describe_alarms().send().await.expect("default");
+    assert_eq!(default.metric_alarms().len(), 1);
+    assert!(
+        default.composite_alarms().is_empty(),
+        "default DescribeAlarms must not return composite alarms"
+    );
+
+    // AlarmTypes = CompositeAlarm: only the composite alarm.
+    let composite = cw
+        .describe_alarms()
+        .alarm_types(AlarmType::CompositeAlarm)
+        .send()
+        .await
+        .expect("composite only");
+    assert!(composite.metric_alarms().is_empty());
+    assert_eq!(composite.composite_alarms().len(), 1);
+
+    // Both types requested: both returned.
+    let both = cw
+        .describe_alarms()
+        .alarm_types(AlarmType::MetricAlarm)
+        .alarm_types(AlarmType::CompositeAlarm)
+        .send()
+        .await
+        .expect("both");
+    assert_eq!(both.metric_alarms().len(), 1);
+    assert_eq!(both.composite_alarms().len(), 1);
+}
+
+// bug-cluster: a metric-math divide-by-zero yields NaN internally; AWS emits no
+// datapoint for a NaN/infinite result, so no NaN must reach the wire.
+#[tokio::test]
+async fn get_metric_data_drops_nan_from_divide_by_zero() {
+    let server = TestServer::start().await;
+    let cw = server.cloudwatch_client().await;
+    let now = chrono::Utc::now();
+
+    // A=10 at t; B is never put (its series is empty), but even a present zero
+    // divisor must not surface NaN. Put A and a zero-valued B at the same time.
+    for (name, v) in [("A", 10.0_f64), ("B", 0.0)] {
+        cw.put_metric_data()
+            .namespace("NanNs")
+            .metric_data(
+                MetricDatum::builder()
+                    .metric_name(name)
+                    .value(v)
+                    .timestamp(AwsDateTime::from_secs(now.timestamp()))
+                    .build(),
+            )
+            .send()
+            .await
+            .expect("put");
+    }
+
+    let mk_stat = |name: &str| {
+        MetricStat::builder()
+            .metric(
+                CwMetric::builder()
+                    .namespace("NanNs")
+                    .metric_name(name)
+                    .build(),
+            )
+            .period(60)
+            .stat("Sum")
+            .build()
+    };
+
+    let resp = cw
+        .get_metric_data()
+        .start_time(AwsDateTime::from_secs(now.timestamp() - 600))
+        .end_time(AwsDateTime::from_secs(now.timestamp() + 600))
+        .metric_data_queries(
+            MetricDataQuery::builder()
+                .id("a")
+                .metric_stat(mk_stat("A"))
+                .return_data(false)
+                .build(),
+        )
+        .metric_data_queries(
+            MetricDataQuery::builder()
+                .id("b")
+                .metric_stat(mk_stat("B"))
+                .return_data(false)
+                .build(),
+        )
+        .metric_data_queries(MetricDataQuery::builder().id("e").expression("a/b").build())
+        .send()
+        .await
+        .expect("metric data");
+
+    let results = resp.metric_data_results();
+    let e = results
+        .iter()
+        .find(|r| r.id() == Some("e"))
+        .expect("e result");
+    // The divide-by-zero datapoint is dropped entirely — no value, and nothing
+    // that is NaN or infinite.
+    assert!(
+        e.values().iter().all(|v| v.is_finite()),
+        "no NaN/infinite datapoint may reach the wire: {:?}",
+        e.values()
+    );
+    assert!(
+        e.values().is_empty(),
+        "divide-by-zero must produce no datapoint: {:?}",
+        e.values()
+    );
+}

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -258,6 +258,18 @@ pub(crate) fn describe_images(
             &empty
         }
     };
+    // An explicitly-requested ImageId that does not exist (e.g. one that was
+    // deregistered) is a hard error on AWS (InvalidAMIID.NotFound), not a
+    // silently-empty result. A `disabled` image is still present and returns
+    // normally; only genuinely-absent (or recycle-binned) ids error.
+    for id in &wanted {
+        if !state.images.get(id).is_some_and(|i| !i.in_recycle_bin) {
+            return Err(crate::service_helpers::not_found(
+                "InvalidAMIID.NotFound",
+                id,
+            ));
+        }
+    }
     let mut items: Vec<String> = state
         .images
         .values()
@@ -346,6 +358,7 @@ fn img_match(i: &Image, tags: &[Tag], filters: &[Filter]) -> bool {
                 .map(|_| vec!["windows".to_string()])
                 .unwrap_or_default(),
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
+            "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
                     tags.iter()
@@ -1241,6 +1254,51 @@ mod tests {
             &req("DisableImage", &[("ImageId", "ami-nope")]),
         ));
         assert_eq!(err.code(), "InvalidAMIID.NotFound");
+    }
+
+    #[test]
+    fn describe_images_explicit_missing_id_errors() {
+        use crate::test_support::{ec2_request as req, err_of};
+        let svc = crate::service::Ec2Service::new();
+        seed_image(&svc, "ami-x");
+        let err = err_of(super::describe_images(
+            &svc,
+            &req("DescribeImages", &[("ImageId.1", "ami-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidAMIID.NotFound");
+    }
+
+    #[test]
+    fn describe_images_tag_value_filter() {
+        use crate::test_support::ec2_request as req;
+        let svc = crate::service::Ec2Service::new();
+        seed_image(&svc, "ami-x");
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.tags.insert(
+                "ami-x".to_string(),
+                vec![crate::state::Tag {
+                    key: "role".into(),
+                    value: "base".into(),
+                }],
+            );
+        }
+        let body = String::from_utf8(
+            super::describe_images(
+                &svc,
+                &req(
+                    "DescribeImages",
+                    &[("Filter.1.Name", "tag-value"), ("Filter.1.Value.1", "base")],
+                ),
+            )
+            .unwrap()
+            .body
+            .expect_bytes()
+            .to_vec(),
+        )
+        .unwrap();
+        assert!(body.contains("<imageId>ami-x</imageId>"), "{body}");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -1382,6 +1382,7 @@ fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter], architecture: &str
             "key-name" => i.key_name.clone().into_iter().collect(),
             "architecture" => vec![architecture.to_string()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
+            "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
                     tags.iter()

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -457,6 +457,23 @@ pub(crate) fn describe_security_groups(
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
+    // An explicitly-requested group id / name that does not exist is a hard
+    // error on AWS (InvalidGroup.NotFound), not a silently-empty result.
+    for id in &wanted_ids {
+        if !state.security_groups.contains_key(id) {
+            return Err(sg_not_found(id));
+        }
+    }
+    for name in &wanted_names {
+        if !state
+            .security_groups
+            .values()
+            .any(|g| &g.group_name == name)
+        {
+            return Err(sg_not_found(name));
+        }
+    }
+
     let mut items: Vec<String> = state
         .security_groups
         .values()
@@ -493,6 +510,7 @@ fn sg_matches(g: &SecurityGroup, tags: &[Tag], filters: &[Filter]) -> bool {
             "vpc-id" => vec![g.vpc_id.clone()],
             "description" => vec![g.description.clone()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
+            "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
                     tags.iter()
@@ -1463,5 +1481,54 @@ mod modify_tests {
         .unwrap();
         let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(!body.contains("vpc-abc"), "association not removed: {body}");
+    }
+
+    #[test]
+    fn describe_security_groups_explicit_missing_id_errors() {
+        let svc = Ec2Service::new();
+        seed_group(&svc, base_rule());
+        let err = crate::test_support::err_of(describe_security_groups(
+            &svc,
+            &req("DescribeSecurityGroups", &[("GroupId.1", "sg-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidGroup.NotFound");
+    }
+
+    #[test]
+    fn describe_security_groups_explicit_missing_name_errors() {
+        let svc = Ec2Service::new();
+        seed_group(&svc, base_rule());
+        let err = crate::test_support::err_of(describe_security_groups(
+            &svc,
+            &req("DescribeSecurityGroups", &[("GroupName.1", "nope")]),
+        ));
+        assert_eq!(err.code(), "InvalidGroup.NotFound");
+    }
+
+    #[test]
+    fn describe_security_groups_tag_value_filter() {
+        let svc = Ec2Service::new();
+        seed_group(&svc, base_rule());
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.tags.insert(
+                "sg-1".to_string(),
+                vec![Tag {
+                    key: "team".into(),
+                    value: "core".into(),
+                }],
+            );
+        }
+        let resp = describe_security_groups(
+            &svc,
+            &req(
+                "DescribeSecurityGroups",
+                &[("Filter.1.Name", "tag-value"), ("Filter.1.Value.1", "core")],
+            ),
+        )
+        .unwrap();
+        let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(body.contains("<groupId>sg-1</groupId>"), "{body}");
     }
 }

--- a/crates/fakecloud-ec2/src/service/subnet.rs
+++ b/crates/fakecloud-ec2/src/service/subnet.rs
@@ -6,8 +6,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_enum,
-    validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, not_found, paginate, parse_filters, require,
+    validate_enum, validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Subnet, SubnetCidrReservation, Tag};
 
@@ -303,6 +303,14 @@ pub(crate) fn describe_subnets(
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
+    // An explicitly-requested SubnetId that does not exist is a hard error on
+    // AWS (InvalidSubnetID.NotFound), not a silently-empty result.
+    for id in &wanted {
+        if !state.subnets.contains_key(id) {
+            return Err(not_found("InvalidSubnetID.NotFound", id));
+        }
+    }
+
     let mut items: Vec<String> = state
         .subnets
         .values()
@@ -312,7 +320,20 @@ pub(crate) fn describe_subnets(
         .collect();
     items.sort();
 
-    let body = ec2_list("subnetSet", &items);
+    // DescribeSubnets is a `paginated` operation in the model; honor MaxResults
+    // + NextToken instead of always returning the full set.
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("subnetSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeSubnets",
         &req.request_id,
@@ -341,6 +362,7 @@ fn subnet_matches(s: &Subnet, tags: &[Tag], filters: &[Filter]) -> bool {
             "availability-zone" => vec![s.availability_zone.clone()],
             "state" => vec![s.state.clone()],
             "default-for-az" => vec![s.default_for_az.to_string()],
+            "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             "ipv6-cidr-block-association.association-id" => s
                 .ipv6_cidr_block
                 .as_ref()
@@ -552,4 +574,89 @@ pub(crate) fn get_subnet_cidr_reservations(
         &req.request_id,
         &body,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    fn body_of(resp: AwsResponse) -> String {
+        String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
+    }
+
+    /// Create a subnet in `vpc_id` with `cidr` and return its id.
+    fn make_subnet(svc: &Ec2Service, vpc_id: &str, cidr: &str) -> String {
+        let body = body_of(
+            create_subnet(
+                svc,
+                &req("CreateSubnet", &[("VpcId", vpc_id), ("CidrBlock", cidr)]),
+            )
+            .unwrap(),
+        );
+        body.split("<subnetId>")
+            .nth(1)
+            .and_then(|s| s.split("</subnetId>").next())
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn describe_subnets_explicit_missing_id_errors() {
+        let svc = Ec2Service::new();
+        make_subnet(&svc, "vpc-test", "10.0.1.0/24");
+        let err = err_of(describe_subnets(
+            &svc,
+            &req("DescribeSubnets", &[("SubnetId.1", "subnet-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidSubnetID.NotFound");
+    }
+
+    #[test]
+    fn describe_subnets_paginates() {
+        let svc = Ec2Service::new();
+        // Seed enough subnets (plus the default subnets) to force a second page
+        // at the minimum MaxResults of 5.
+        for i in 0..6 {
+            make_subnet(&svc, "vpc-test", &format!("10.0.{i}.0/24"));
+        }
+        let body = body_of(
+            describe_subnets(&svc, &req("DescribeSubnets", &[("MaxResults", "5")])).unwrap(),
+        );
+        assert!(body.contains("<nextToken>"), "expected a NextToken: {body}");
+    }
+
+    #[test]
+    fn describe_subnets_tag_value_filter() {
+        let svc = Ec2Service::new();
+        let id = make_subnet(&svc, "vpc-test", "10.0.9.0/24");
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.tags.insert(
+                id.clone(),
+                vec![Tag {
+                    key: "tier".into(),
+                    value: "public".into(),
+                }],
+            );
+        }
+        let body = body_of(
+            describe_subnets(
+                &svc,
+                &req(
+                    "DescribeSubnets",
+                    &[
+                        ("Filter.1.Name", "tag-value"),
+                        ("Filter.1.Value.1", "public"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(
+            body.contains(&format!("<subnetId>{id}</subnetId>")),
+            "{body}"
+        );
+    }
 }

--- a/crates/fakecloud-ec2/src/service/volume.rs
+++ b/crates/fakecloud-ec2/src/service/volume.rs
@@ -165,6 +165,13 @@ pub(crate) fn describe_volumes(
     let accounts = svc.state.read();
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    // An explicitly-requested VolumeId that does not exist (or is in the
+    // recycle bin) is a hard error on AWS, not a silently-empty result.
+    for id in &wanted {
+        if !state.volumes.get(id).is_some_and(|v| !v.in_recycle_bin) {
+            return Err(not_found("InvalidVolume.NotFound", id));
+        }
+    }
     let mut items: Vec<String> = state
         .volumes
         .values()
@@ -204,6 +211,7 @@ fn vol_match(v: &Volume, tags: &[Tag], filters: &[Filter]) -> bool {
             "encrypted" => vec![v.encrypted.to_string()],
             "size" => vec![v.size.to_string()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
+            "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
                     tags.iter()
@@ -834,6 +842,65 @@ mod tests {
             &req("DescribeVolumes", &[("MaxResults", "1001")]),
         ));
         assert_eq!(err.code(), "InvalidParameterValue");
+    }
+
+    #[test]
+    fn describe_volumes_explicit_missing_id_errors() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "available", false);
+        let err = err_of(describe_volumes(
+            &svc,
+            &req("DescribeVolumes", &[("VolumeId.1", "vol-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidVolume.NotFound");
+    }
+
+    #[test]
+    fn describe_volumes_no_id_empty_ok() {
+        // No explicit id + no match => empty result, never an error.
+        let svc = Ec2Service::new();
+        let body = body_of(describe_volumes(&svc, &req("DescribeVolumes", &[])).unwrap());
+        assert!(body.contains("<volumeSet"), "{body}");
+    }
+
+    #[test]
+    fn describe_volumes_tag_value_filter() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "available", false);
+        {
+            let mut accounts = svc.state.write();
+            let st = accounts.get_or_create("000000000000");
+            st.tags.insert(
+                "vol-1".to_string(),
+                vec![Tag {
+                    key: "env".into(),
+                    value: "prod".into(),
+                }],
+            );
+        }
+        let body = body_of(
+            describe_volumes(
+                &svc,
+                &req(
+                    "DescribeVolumes",
+                    &[("Filter.1.Name", "tag-value"), ("Filter.1.Value.1", "prod")],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(body.contains("<volumeId>vol-1</volumeId>"), "{body}");
+        // A non-matching tag-value excludes it.
+        let empty = body_of(
+            describe_volumes(
+                &svc,
+                &req(
+                    "DescribeVolumes",
+                    &[("Filter.1.Name", "tag-value"), ("Filter.1.Value.1", "dev")],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(!empty.contains("<volumeId>vol-1</volumeId>"), "{empty}");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/vpc.rs
+++ b/crates/fakecloud-ec2/src/service/vpc.rs
@@ -6,8 +6,8 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    filter_value_matches, gen_id, indexed_list, parse_filters, require, validate_enum,
-    validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, not_found, paginate, parse_filters, require,
+    validate_enum, validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Tag, Vpc, VpcCidrAssoc};
 
@@ -99,6 +99,7 @@ fn vpc_matches(vpc: &Vpc, tags: &[Tag], filters: &[Filter]) -> bool {
                 vpc.ipv6_cidr_block.clone().into_iter().collect()
             }
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
+            "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
                     tags.iter()
@@ -244,6 +245,14 @@ pub(crate) fn describe_vpcs(
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
 
+    // An explicitly-requested VpcId that does not exist is a hard error on AWS
+    // (InvalidVpcID.NotFound), not a silently-empty result.
+    for id in &wanted {
+        if !state.vpcs.contains_key(id) {
+            return Err(not_found("InvalidVpcID.NotFound", id));
+        }
+    }
+
     let mut items: Vec<String> = state
         .vpcs
         .values()
@@ -253,7 +262,20 @@ pub(crate) fn describe_vpcs(
         .collect();
     items.sort();
 
-    let body = ec2_list("vpcSet", &items);
+    // DescribeVpcs is a `paginated` operation in the model; honor MaxResults +
+    // NextToken instead of always returning the full set.
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("vpcSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond("DescribeVpcs", &req.request_id, &body))
 }
 
@@ -469,4 +491,79 @@ pub(crate) fn disassociate_vpc_cidr_block(
 
 fn bool_attr(params: &std::collections::HashMap<String, String>, key: &str) -> Option<bool> {
     params.get(key).map(|v| v == "true")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    fn body_of(resp: AwsResponse) -> String {
+        String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
+    }
+
+    /// Create a VPC and return its id.
+    fn make_vpc(svc: &Ec2Service, cidr: &str) -> String {
+        let body = body_of(create_vpc(svc, &req("CreateVpc", &[("CidrBlock", cidr)])).unwrap());
+        body.split("<vpcId>")
+            .nth(1)
+            .and_then(|s| s.split("</vpcId>").next())
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn describe_vpcs_explicit_missing_id_errors() {
+        let svc = Ec2Service::new();
+        make_vpc(&svc, "10.9.0.0/16");
+        let err = err_of(describe_vpcs(
+            &svc,
+            &req("DescribeVpcs", &[("VpcId.1", "vpc-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidVpcID.NotFound");
+    }
+
+    #[test]
+    fn describe_vpcs_paginates() {
+        let svc = Ec2Service::new();
+        // Seed enough VPCs (plus the default VPC) to force a second page at the
+        // minimum MaxResults of 5.
+        for i in 0..6 {
+            make_vpc(&svc, &format!("10.{i}.0.0/16"));
+        }
+        let body =
+            body_of(describe_vpcs(&svc, &req("DescribeVpcs", &[("MaxResults", "5")])).unwrap());
+        assert!(body.contains("<nextToken>"), "expected a NextToken: {body}");
+    }
+
+    #[test]
+    fn describe_vpcs_tag_value_filter() {
+        let svc = Ec2Service::new();
+        let id = make_vpc(&svc, "10.8.0.0/16");
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.tags.insert(
+                id.clone(),
+                vec![Tag {
+                    key: "env".into(),
+                    value: "staging".into(),
+                }],
+            );
+        }
+        let body = body_of(
+            describe_vpcs(
+                &svc,
+                &req(
+                    "DescribeVpcs",
+                    &[
+                        ("Filter.1.Name", "tag-value"),
+                        ("Filter.1.Value.1", "staging"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(body.contains(&format!("<vpcId>{id}</vpcId>")), "{body}");
+    }
 }


### PR DESCRIPTION
Fixes a cluster of MED correctness bugs in CloudWatch and EC2 Describe operations found during a bug-hunt.

## CloudWatch (`fakecloud-cloudwatch`)

1. **DescribeAlarms now honors `AlarmTypes`.** Previously `AlarmTypes` was never parsed, so the response always rendered both `MetricAlarms` and `CompositeAlarms`. Per AWS, the default is metric alarms only; composite alarms are returned only when `AlarmTypes` includes `CompositeAlarm`. Now parses `AlarmTypes.member.N`, defaults to `["MetricAlarm"]`, validates values, and filters output (and pagination) accordingly.

2. **Metric-math divide-by-zero no longer emits NaN datapoints.** A `x/0` expression produced `f64::NAN`, which rendered as `<member>NaN</member>` in XML and a `"NaN"` string inside a numeric array in JSON. AWS emits no datapoint for a NaN/infinite result. `GetMetricData` now drops non-finite results before rendering, keeping NaN/Inf off both the XML and JSON wire.

## EC2 (`fakecloud-ec2`)

3. **Describe ops error on an explicitly-requested nonexistent id.** `DescribeVolumes` / `DescribeSecurityGroups` / `DescribeSubnets` / `DescribeVpcs` / `DescribeImages` silently returned empty when a specific id was requested (only `DescribeInstances` raised). They now return the correct `Invalid*.NotFound` error (`InvalidVolume.NotFound`, `InvalidGroup.NotFound`, `InvalidSubnetID.NotFound`, `InvalidVpcID.NotFound`, `InvalidAMIID.NotFound`) through the ec2Query error path, matching `DescribeInstances`. Filter-based / list-all queries still return empty (correct).

4. **`DescribeSubnets` and `DescribeVpcs` now paginate.** Both are `paginated` in the model but validated `MaxResults` while always returning the full set. They now honor `MaxResults` + `NextToken`, mirroring `DescribeInstances`/`DescribeVolumes`.

5. **`tag-value` filter now supported.** The default filter arm returned `false`, so a valid `tag-value` filter excluded everything. Added the `tag-value` key (matches any tag whose value is in the filter values) to `vol_match` / `inst_match` / `sg_matches` / `subnet_matches` / `vpc_matches` / `img_match`.

## Conformance note

Two existing tests encoded the old (buggy) DescribeAlarms default of returning composites without `AlarmTypes`, and one conformance test (`cloudwatch_composite_alarm`) plus the `ec2_deregister_image` test encoded the old silent-empty behavior. All were updated to reflect real AWS behavior (request composites explicitly via `AlarmTypes`; expect `InvalidAMIID.NotFound` for a deregistered id). Model-derived checksums are unaffected.

## Tests
- New in-crate unit tests for each EC2 Describe (missing-id error, `tag-value` filter, subnet/vpc pagination).
- New CloudWatch E2E tests: `describe_alarms_honors_alarm_types` and `get_metric_data_drops_nan_from_divide_by_zero`.
- `cargo nextest run -p fakecloud-conformance -E 'test(cloudwatch)'` -> 15/15 pass.
- Targeted EC2 Describe conformance (`ec2_describe_{vpcs,subnets,security_groups,volumes,images}`, `ec2_deregister_image`) -> 7/7 pass.
- CloudWatch E2E suite -> 17/17 pass.
- `cargo clippy --all-targets -- -D warnings` clean on touched crates; `cargo fmt --all` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several AWS-compatibility gaps in CloudWatch and EC2: correct alarm filtering, safe metric-math output, proper Describe* errors, pagination, and tag-value filtering. Brings `fakecloud-cloudwatch` and `fakecloud-ec2` in line with real AWS behavior.

- **Bug Fixes**
  - `fakecloud-cloudwatch`: DescribeAlarms now honors AlarmTypes; default is MetricAlarm only. Filtering and pagination respect requested types.
  - `fakecloud-cloudwatch`: GetMetricData drops non-finite results (NaN/Inf), e.g., from divide-by-zero, so no NaN reaches the wire.
  - `fakecloud-ec2`: DescribeVolumes/SecurityGroups/Subnets/Vpcs/Images now return the correct Invalid*.NotFound error when an explicitly requested id/name is missing. Filter-only and list-all calls still return empty.
  - `fakecloud-ec2`: DescribeSubnets and DescribeVpcs paginate via MaxResults/NextToken.
  - `fakecloud-ec2`: Added tag-value filter support for volumes, instances, security groups, subnets, VPCs, and images.

<sup>Written for commit 7c41b8fba8144bd902c7445b6055097009923653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

