### PR TITLE
fix(route53,iam): case-insensitive record names + zone filters + tag validation + DeleteUser conflicts

### DIFF
--- a/crates/fakecloud-e2e/tests/iam.rs
+++ b/crates/fakecloud-e2e/tests/iam.rs
@@ -4231,3 +4231,161 @@ async fn iam_create_instance_profile_govcloud_partition() {
         "expected aws-us-gov partition ARN, got: {arn}"
     );
 }
+
+// ─── Regression tests: bug-hunt correctness cluster (2026-07-19) ─────
+
+/// CreateUser / TagUser enforce the same tag validation the role/policy paths
+/// do: >50 tags and case-insensitive duplicate keys are rejected with
+/// InvalidInput.
+#[tokio::test]
+async fn iam_user_tag_validation_rejects_bad_input() {
+    use aws_sdk_iam::types::Tag;
+
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    // 51 tags on CreateUser -> InvalidInput.
+    let mut create = client.create_user().user_name("tagval-user");
+    for i in 0..51 {
+        create = create.tags(
+            Tag::builder()
+                .key(format!("k{i}"))
+                .value("v")
+                .build()
+                .unwrap(),
+        );
+    }
+    let err = create.send().await.unwrap_err();
+    assert!(
+        format!("{err:?}").contains("InvalidInput"),
+        "51 tags on CreateUser must be InvalidInput: {err:?}"
+    );
+
+    // A valid user, then a TagUser with case-insensitive duplicate keys.
+    client
+        .create_user()
+        .user_name("tagval-user2")
+        .send()
+        .await
+        .unwrap();
+    let err = client
+        .tag_user()
+        .user_name("tagval-user2")
+        .tags(Tag::builder().key("Env").value("a").build().unwrap())
+        .tags(Tag::builder().key("env").value("b").build().unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("InvalidInput"),
+        "duplicate tag keys on TagUser must be InvalidInput: {err:?}"
+    );
+}
+
+/// CreateInstanceProfile enforces tag validation too.
+#[tokio::test]
+async fn iam_instance_profile_tag_validation_rejects_bad_input() {
+    use aws_sdk_iam::types::Tag;
+
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    let mut create = client
+        .create_instance_profile()
+        .instance_profile_name("tagval-ip");
+    for i in 0..51 {
+        create = create.tags(
+            Tag::builder()
+                .key(format!("k{i}"))
+                .value("v")
+                .build()
+                .unwrap(),
+        );
+    }
+    let err = create.send().await.unwrap_err();
+    assert!(
+        format!("{err:?}").contains("InvalidInput"),
+        "51 tags on CreateInstanceProfile must be InvalidInput: {err:?}"
+    );
+}
+
+/// DeleteUser returns DeleteConflict when the user still has a login profile.
+#[tokio::test]
+async fn iam_delete_user_conflicts_on_login_profile() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("del-conflict-user")
+        .send()
+        .await
+        .unwrap();
+    client
+        .create_login_profile()
+        .user_name("del-conflict-user")
+        .password("S3cureP@ss!")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .delete_user()
+        .user_name("del-conflict-user")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("DeleteConflict"),
+        "DeleteUser with a login profile must be DeleteConflict: {err:?}"
+    );
+
+    // Deleting the login profile first unblocks the user delete.
+    client
+        .delete_login_profile()
+        .user_name("del-conflict-user")
+        .send()
+        .await
+        .unwrap();
+    client
+        .delete_user()
+        .user_name("del-conflict-user")
+        .send()
+        .await
+        .expect("delete after removing login profile");
+}
+
+/// AttachUserPolicy rejects a bogus AWS-managed ARN that isn't in the catalog.
+#[tokio::test]
+async fn iam_attach_user_policy_rejects_bogus_managed_arn() {
+    let server = TestServer::start().await;
+    let client = server.iam_client().await;
+
+    client
+        .create_user()
+        .user_name("attach-bogus-user")
+        .send()
+        .await
+        .unwrap();
+
+    let err = client
+        .attach_user_policy()
+        .user_name("attach-bogus-user")
+        .policy_arn("arn:aws:iam::aws:policy/DoesNotExist")
+        .send()
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("NoSuchEntity"),
+        "attaching a bogus managed policy must be NoSuchEntity: {err:?}"
+    );
+
+    // A real managed policy still attaches.
+    client
+        .attach_user_policy()
+        .user_name("attach-bogus-user")
+        .policy_arn("arn:aws:iam::aws:policy/AdministratorAccess")
+        .send()
+        .await
+        .expect("real managed policy attaches");
+}

--- a/crates/fakecloud-e2e/tests/route53.rs
+++ b/crates/fakecloud-e2e/tests/route53.rs
@@ -852,3 +852,306 @@ async fn test_dns_answer_alias_target_resolves_against_s3_bucket_state() {
         .parse::<std::net::Ipv4Addr>()
         .is_ok());
 }
+
+// ─── Regression tests: bug-hunt correctness cluster (2026-07-19) ─────
+
+/// Record names are lowercased on store and matched case-insensitively, so a
+/// mixed-case CREATE surfaces lowercased in ListResourceRecordSets (no
+/// Terraform perpetual diff) and a differently-cased DELETE still matches.
+#[tokio::test]
+async fn record_names_are_case_insensitive() {
+    let server = TestServer::start().await;
+    let r53 = server.route53_client().await;
+
+    let create = r53
+        .create_hosted_zone()
+        .name("ci.example.com")
+        .caller_reference("e2e-ci-names")
+        .send()
+        .await
+        .expect("create");
+    let zone_id = create.hosted_zone().unwrap().id().to_string();
+
+    // CREATE with a mixed-case name.
+    let mixed = ResourceRecordSet::builder()
+        .name("API.ci.example.com.")
+        .r#type(RrType::A)
+        .ttl(60)
+        .resource_records(
+            ResourceRecord::builder()
+                .value("203.0.113.5")
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    r53.change_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .change_batch(
+            ChangeBatch::builder()
+                .changes(
+                    Change::builder()
+                        .action(ChangeAction::Create)
+                        .resource_record_set(mixed.clone())
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("create mixed-case record");
+
+    // The stored + listed name is lowercased.
+    let list = r53
+        .list_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .send()
+        .await
+        .expect("list");
+    let names: Vec<&str> = list
+        .resource_record_sets()
+        .iter()
+        .map(|r| r.name())
+        .collect();
+    assert!(
+        names.contains(&"api.ci.example.com."),
+        "expected lowercased name, got {names:?}"
+    );
+    assert!(!names.contains(&"API.ci.example.com."));
+
+    // A duplicate CREATE with different casing must be rejected as already-existing.
+    let dup = r53
+        .change_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .change_batch(
+            ChangeBatch::builder()
+                .changes(
+                    Change::builder()
+                        .action(ChangeAction::Create)
+                        .resource_record_set(
+                            ResourceRecordSet::builder()
+                                .name("api.CI.example.com.")
+                                .r#type(RrType::A)
+                                .ttl(60)
+                                .resource_records(
+                                    ResourceRecord::builder()
+                                        .value("203.0.113.6")
+                                        .build()
+                                        .unwrap(),
+                                )
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await;
+    assert!(
+        dup.is_err(),
+        "case-variant duplicate CREATE must be rejected"
+    );
+
+    // DELETE with yet another casing (and matching value/TTL) succeeds.
+    let del = ResourceRecordSet::builder()
+        .name("Api.Ci.Example.Com.")
+        .r#type(RrType::A)
+        .ttl(60)
+        .resource_records(
+            ResourceRecord::builder()
+                .value("203.0.113.5")
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    r53.change_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .change_batch(
+            ChangeBatch::builder()
+                .changes(
+                    Change::builder()
+                        .action(ChangeAction::Delete)
+                        .resource_record_set(del)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await
+        .expect("case-insensitive delete must match");
+
+    let list = r53
+        .list_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .send()
+        .await
+        .expect("list after delete");
+    let names: Vec<&str> = list
+        .resource_record_sets()
+        .iter()
+        .map(|r| r.name())
+        .collect();
+    assert!(!names.contains(&"api.ci.example.com."));
+}
+
+/// ListHostedZones honors the `hostedzonetype` and `delegationsetid` filters.
+#[tokio::test]
+async fn list_hosted_zones_filters_by_type_and_delegation_set() {
+    use aws_sdk_route53::types::HostedZoneType;
+
+    let server = TestServer::start().await;
+    let r53 = server.route53_client().await;
+
+    // A reusable delegation set to tie one zone to.
+    let ds = r53
+        .create_reusable_delegation_set()
+        .caller_reference("e2e-filter-ds")
+        .send()
+        .await
+        .expect("create delegation set");
+    let ds_id = ds.delegation_set().unwrap().id().unwrap().to_string();
+
+    // Public zone bound to the delegation set.
+    let pub_zone = r53
+        .create_hosted_zone()
+        .name("public-filter.example.com")
+        .caller_reference("e2e-filter-public")
+        .delegation_set_id(&ds_id)
+        .send()
+        .await
+        .expect("create public zone");
+    let pub_id = pub_zone.hosted_zone().unwrap().id().to_string();
+
+    // Private zone (marked private via the config flag), no delegation set.
+    let priv_zone = r53
+        .create_hosted_zone()
+        .name("private-filter.example.com")
+        .caller_reference("e2e-filter-private")
+        .hosted_zone_config(HostedZoneConfig::builder().private_zone(true).build())
+        .send()
+        .await
+        .expect("create private zone");
+    let priv_id = priv_zone.hosted_zone().unwrap().id().to_string();
+
+    // Filter to private zones only.
+    let privates = r53
+        .list_hosted_zones()
+        .hosted_zone_type(HostedZoneType::PrivateHostedZone)
+        .send()
+        .await
+        .expect("list private");
+    let ids: Vec<&str> = privates.hosted_zones().iter().map(|z| z.id()).collect();
+    assert!(ids.iter().any(|id| *id == priv_id));
+    assert!(!ids.iter().any(|id| *id == pub_id));
+
+    // Filter by delegation set id -> only the public zone bound to it.
+    let by_ds = r53
+        .list_hosted_zones()
+        .delegation_set_id(&ds_id)
+        .send()
+        .await
+        .expect("list by delegation set");
+    let ids: Vec<&str> = by_ds.hosted_zones().iter().map(|z| z.id()).collect();
+    assert!(ids.iter().any(|id| *id == pub_id));
+    assert!(!ids.iter().any(|id| *id == priv_id));
+}
+
+/// AliasTarget is mutually exclusive with ResourceRecords and with TTL.
+#[tokio::test]
+async fn alias_target_mutually_exclusive_with_records_and_ttl() {
+    let server = TestServer::start().await;
+    let r53 = server.route53_client().await;
+
+    let create = r53
+        .create_hosted_zone()
+        .name("alias-excl.example.com")
+        .caller_reference("e2e-alias-excl")
+        .send()
+        .await
+        .expect("create");
+    let zone_id = create.hosted_zone().unwrap().id().to_string();
+
+    // AliasTarget + ResourceRecords together -> rejected.
+    let both = ResourceRecordSet::builder()
+        .name("a.alias-excl.example.com.")
+        .r#type(RrType::A)
+        .alias_target(
+            AliasTarget::builder()
+                .hosted_zone_id("Z2FDTNDATAQYW2")
+                .dns_name("example.cloudfront.net")
+                .evaluate_target_health(false)
+                .build()
+                .unwrap(),
+        )
+        .resource_records(
+            ResourceRecord::builder()
+                .value("203.0.113.9")
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let res = r53
+        .change_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .change_batch(
+            ChangeBatch::builder()
+                .changes(
+                    Change::builder()
+                        .action(ChangeAction::Create)
+                        .resource_record_set(both)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await;
+    assert!(
+        res.is_err(),
+        "AliasTarget + ResourceRecords must be rejected"
+    );
+
+    // AliasTarget + TTL together -> rejected.
+    let with_ttl = ResourceRecordSet::builder()
+        .name("b.alias-excl.example.com.")
+        .r#type(RrType::A)
+        .ttl(300)
+        .alias_target(
+            AliasTarget::builder()
+                .hosted_zone_id("Z2FDTNDATAQYW2")
+                .dns_name("example.cloudfront.net")
+                .evaluate_target_health(false)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let res = r53
+        .change_resource_record_sets()
+        .hosted_zone_id(&zone_id)
+        .change_batch(
+            ChangeBatch::builder()
+                .changes(
+                    Change::builder()
+                        .action(ChangeAction::Create)
+                        .resource_record_set(with_ttl)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .send()
+        .await;
+    assert!(res.is_err(), "AliasTarget + TTL must be rejected");
+}

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -644,9 +644,16 @@ impl IamService {
             ));
         }
 
-        // Check policy exists (allow AWS managed policies). Mirrors the
-        // existence check in attach_role_policy / attach_user_policy.
-        if !policy_arn.contains(":aws:policy/") && !state.policies.contains_key(&policy_arn) {
+        // Check the policy exists. Mirrors attach_role_policy / attach_user_policy:
+        // an AWS-managed ARN must resolve in the managed-policy catalog (a bogus
+        // `arn:aws:iam::aws:policy/DoesNotExist` is NoSuchEntity, not silently
+        // accepted); a customer-managed ARN must exist in state.
+        let policy_exists = if policy_arn.contains(":aws:policy/") {
+            crate::managed_policies::lookup(&policy_arn).is_some()
+        } else {
+            state.policies.contains_key(&policy_arn)
+        };
+        if !policy_exists {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",

--- a/crates/fakecloud-iam/src/iam_service/instance_profiles.rs
+++ b/crates/fakecloud-iam/src/iam_service/instance_profiles.rs
@@ -8,7 +8,7 @@ use crate::state::IamInstanceProfile;
 
 use super::{
     empty_response, generate_id, paginated_tags_response, parse_tag_keys, parse_tags,
-    partition_for_region, tags_xml, url_encode, IamService,
+    partition_for_region, tags_xml, url_encode, validate_tags, validate_untag_keys, IamService,
 };
 use fakecloud_core::query::required_param;
 
@@ -25,6 +25,7 @@ impl IamService {
             .cloned()
             .unwrap_or_else(|| "/".to_string());
         let tags = parse_tags(&req.query_params);
+        validate_tags(&tags, 0)?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -309,6 +310,15 @@ impl IamService {
             )
         })?;
 
+        // Enforce the 50-tag ceiling against the post-merge total (mirrors
+        // TagRole/TagPolicy).
+        let existing_count = ip
+            .tags
+            .iter()
+            .filter(|t| !new_tags.iter().any(|nt| nt.key == t.key))
+            .count();
+        validate_tags(&new_tags, existing_count)?;
+
         for new_tag in new_tags {
             if let Some(existing) = ip.tags.iter_mut().find(|t| t.key == new_tag.key) {
                 existing.value = new_tag.value;
@@ -327,6 +337,7 @@ impl IamService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let name = required_param(&req.query_params, "InstanceProfileName")?;
         let tag_keys = parse_tag_keys(&req.query_params);
+        validate_untag_keys(&tag_keys)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -586,8 +586,16 @@ impl IamService {
             ));
         }
 
-        // Check policy exists (allow AWS managed policies)
-        if !policy_arn.contains(":aws:policy/") && !state.policies.contains_key(&policy_arn) {
+        // Check the policy exists. An AWS-managed ARN must resolve in the
+        // managed-policy catalog (a bogus `arn:aws:iam::aws:policy/DoesNotExist`
+        // is NoSuchEntity, not silently accepted); a customer-managed ARN must
+        // exist in state.
+        let policy_exists = if policy_arn.contains(":aws:policy/") {
+            crate::managed_policies::lookup(&policy_arn).is_some()
+        } else {
+            state.policies.contains_key(&policy_arn)
+        };
+        if !policy_exists {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -11,7 +11,8 @@ use crate::xml_responses;
 use super::{
     empty_response, extract_access_key, generate_id, generate_long_id, parse_tag_keys, parse_tags,
     partition_for_region, required_param_with_code, resolve_calling_user, tags_xml, url_encode,
-    validate_optional_string_length_with_code, validate_string_length_with_code, IamService,
+    validate_optional_string_length_with_code, validate_string_length_with_code, validate_tags,
+    validate_untag_keys, IamService,
 };
 use fakecloud_core::query::required_param;
 
@@ -68,6 +69,50 @@ fn ensure_user_can_be_deleted(state: &IamState, user_name: &str) -> Result<(), A
             StatusCode::CONFLICT,
             "DeleteConflict",
             "Cannot delete entity, must delete policies first.".to_string(),
+        ));
+    }
+
+    if state.login_profiles.contains_key(user_name) {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must delete login profile first.".to_string(),
+        ));
+    }
+
+    if state
+        .signing_certificates
+        .get(user_name)
+        .is_some_and(|c| !c.is_empty())
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must delete signing certificates first.".to_string(),
+        ));
+    }
+
+    if state
+        .ssh_public_keys
+        .get(user_name)
+        .is_some_and(|k| !k.is_empty())
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must delete SSH public keys first.".to_string(),
+        ));
+    }
+
+    if state
+        .virtual_mfa_devices
+        .values()
+        .any(|d| d.user.as_deref() == Some(user_name))
+    {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::CONFLICT,
+            "DeleteConflict",
+            "Cannot delete entity, must deactivate MFA device first.".to_string(),
         ));
     }
 
@@ -163,6 +208,7 @@ impl IamService {
             .cloned()
             .unwrap_or_else(|| "/".to_string());
         let tags = parse_tags(&req.query_params);
+        validate_tags(&tags, 0)?;
         let permissions_boundary = req.query_params.get("PermissionsBoundary").cloned();
 
         let partition = partition_for_region(&req.region);
@@ -287,6 +333,7 @@ impl IamService {
         state.user_inline_policies.remove(&user_name);
         state.login_profiles.remove(&user_name);
         state.signing_certificates.remove(&user_name);
+        state.ssh_public_keys.remove(&user_name);
 
         let xml = empty_response("DeleteUser", &req.request_id);
         Ok(AwsResponse::xml(StatusCode::OK, xml))
@@ -443,6 +490,16 @@ impl IamService {
             )
         })?;
 
+        // Count existing tags that won't be overwritten by the new tags, so the
+        // 50-tag ceiling is enforced against the post-merge total (mirrors
+        // TagRole/TagPolicy).
+        let existing_count = user
+            .tags
+            .iter()
+            .filter(|t| !new_tags.iter().any(|nt| nt.key == t.key))
+            .count();
+        validate_tags(&new_tags, existing_count)?;
+
         for new_tag in new_tags {
             if let Some(existing) = user.tags.iter_mut().find(|t| t.key == new_tag.key) {
                 existing.value = new_tag.value;
@@ -461,6 +518,7 @@ impl IamService {
         let user_name = required_param_with_code(&req.query_params, "UserName", "NoSuchEntity")?;
         validate_string_length_with_code("userName", &user_name, 1, 64, "NoSuchEntity")?;
         let tag_keys = parse_tag_keys(&req.query_params);
+        validate_untag_keys(&tag_keys)?;
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
 
@@ -1562,8 +1620,16 @@ impl IamService {
             ));
         }
 
-        // Check policy exists (allow AWS managed policies)
-        if !policy_arn.contains(":aws:policy/") && !state.policies.contains_key(&policy_arn) {
+        // Check the policy exists. An AWS-managed ARN must resolve in the
+        // managed-policy catalog (a bogus `arn:aws:iam::aws:policy/DoesNotExist`
+        // is NoSuchEntity, not silently accepted); a customer-managed ARN must
+        // exist in state.
+        let policy_exists = if policy_arn.contains(":aws:policy/") {
+            crate::managed_policies::lookup(&policy_arn).is_some()
+        } else {
+            state.policies.contains_key(&policy_arn)
+        };
+        if !policy_exists {
             return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "NoSuchEntity",

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -60,6 +60,12 @@ pub(crate) fn default_zone_records(name: &str, name_servers: &[String]) -> Vec<R
 
 pub(crate) fn normalize_rrset(r: &ResourceRecordSet) -> ResourceRecordSet {
     let mut out = r.clone();
+    // Route 53 lowercases record names on store and matches them
+    // case-insensitively. Normalizing to lowercase here keeps stored records
+    // canonical (so `ListResourceRecordSets` doesn't echo mixed case back and
+    // cause a Terraform perpetual diff) and makes CREATE duplicate-detection
+    // and DELETE/UPSERT matching case-insensitive.
+    out.name = out.name.to_ascii_lowercase();
     if !out.name.ends_with('.') {
         out.name.push('.');
     }
@@ -67,7 +73,12 @@ pub(crate) fn normalize_rrset(r: &ResourceRecordSet) -> ResourceRecordSet {
 }
 
 pub(crate) fn rrset_matches(a: &ResourceRecordSet, b: &ResourceRecordSet) -> bool {
-    a.name == b.name && a.record_type == b.record_type && a.set_identifier == b.set_identifier
+    // Compare names case-insensitively — AWS treats DNS names as
+    // case-insensitive, and older stored records (e.g. default SOA/NS seeded
+    // from a mixed-case zone name) may not be lowercased.
+    a.name.eq_ignore_ascii_case(&b.name)
+        && a.record_type == b.record_type
+        && a.set_identifier == b.set_identifier
 }
 
 /// Sorted multiset of a record set's values (resource records + an alias
@@ -131,6 +142,21 @@ pub(crate) fn validate_rrset_in_zone(
     if !has_values && r.alias_target.is_none() {
         return Err(invalid_change_batch(format!(
             "Invalid resource record set [name='{}', type='{}']: must specify either ResourceRecords or AliasTarget",
+            r.name, r.record_type
+        )));
+    }
+    // AliasTarget is mutually exclusive with both ResourceRecords and TTL: an
+    // alias record's target is resolved dynamically, so AWS rejects a record
+    // that also carries literal values or a TTL with InvalidChangeBatch.
+    if r.alias_target.is_some() && has_values {
+        return Err(invalid_change_batch(format!(
+            "Invalid resource record set [name='{}', type='{}']: may not specify both AliasTarget and ResourceRecords",
+            r.name, r.record_type
+        )));
+    }
+    if r.alias_target.is_some() && r.ttl.is_some() {
+        return Err(invalid_change_batch(format!(
+            "Invalid resource record set [name='{}', type='{}']: may not specify a TTL for an alias record",
             r.name, r.record_type
         )));
     }

--- a/crates/fakecloud-route53/src/service/hosted_zones.rs
+++ b/crates/fakecloud-route53/src/service/hosted_zones.rs
@@ -224,6 +224,22 @@ impl Route53Service {
             .map(|a| a.hosted_zones.values().cloned().collect())
             .unwrap_or_default();
         drop(state);
+        // Apply the server-side filters AWS supports: `delegationsetid` keeps
+        // only zones assigned to that reusable delegation set, and
+        // `hostedzonetype=PrivateHostedZone` keeps only private zones. Without
+        // these, private/public zones leaked across a filtered query and the
+        // page counts were wrong.
+        if let Some(ds_id) = req
+            .query_params
+            .get("delegationsetid")
+            .filter(|s| !s.is_empty())
+        {
+            let ds_id = strip_zone_prefix(ds_id);
+            zones.retain(|z| z.delegation_set_id.as_deref() == Some(ds_id.as_str()));
+        }
+        if req.query_params.get("hostedzonetype").map(|s| s.as_str()) == Some("PrivateHostedZone") {
+            zones.retain(|z| z.private_zone);
+        }
         zones.sort_by(|a, b| a.id.cmp(&b.id));
 
         // Paginate on marker (the next zone id) + maxitems.


### PR DESCRIPTION
Fixes a cluster of MED correctness bugs in Route53 and IAM found during bug-hunt, batched into one PR (two crates).

## Route53 (`fakecloud-route53`)

1. **Record names not lowercased / matched case-insensitively.** `normalize_rrset` now lowercases record names on store (matching AWS), and `rrset_matches` compares names with `eq_ignore_ascii_case`. Fixes (a) mixed-case names echoed back in `ListResourceRecordSets` causing Terraform perpetual diffs, (b) CREATE duplicate-detection bypass, (c) DELETE/UPSERT failing to match a differently-cased existing record. Trailing-dot behavior preserved.

2. **`ListHostedZones` ignored `delegationsetid` and `hostedzonetype`.** The handler validated but never applied these filters, leaking private/public zones across a filtered query and producing wrong page counts. Now filters by `hostedzonetype=PrivateHostedZone` and `delegationsetid` before pagination.

3. **Missing AliasTarget mutual-exclusion validation.** `validate_rrset_in_zone` now rejects a record carrying both `AliasTarget` and `ResourceRecords`, and an alias record carrying a `TTL`, with `InvalidChangeBatch` (matching AWS).

## IAM (`fakecloud-iam`)

4. **User + instance-profile tag ops skipped tag validation.** `CreateUser`/`TagUser`/`UntagUser` and `CreateInstanceProfile`/`TagInstanceProfile`/`UntagInstanceProfile` now call the same `validate_tags`/`validate_untag_keys` the role/policy paths use (>50 tags, key/value length, case-insensitive duplicate keys, invalid chars -> `InvalidInput`).

5. **`DeleteUser` didn't return `DeleteConflict` for login profile / signing certs / SSH keys / MFA.** `ensure_user_can_be_deleted` now also blocks on a login profile, signing certificates, SSH public keys, and assigned MFA devices with `DeleteConflict`. Also cleans up previously-orphaned `ssh_public_keys` on delete.

6. **`Attach{User,Role,Group}Policy` accepted any bogus AWS-managed ARN.** The existence check only skipped state lookup for any ARN containing `:aws:policy/`. Now an AWS-managed ARN must resolve in the managed-policy catalog (`managed_policies::lookup`); a bogus `arn:aws:iam::aws:policy/DoesNotExist` returns `NoSuchEntity`.

No false positives — all six were verified real and fixed.

## Tests
- 3 new Route53 E2E tests (`crates/fakecloud-e2e/tests/route53.rs`): case-insensitive record names, zone type/delegation-set filters, alias mutual-exclusion. All 16 route53 e2e pass.
- 4 new IAM E2E tests (`crates/fakecloud-e2e/tests/iam.rs`): user/instance-profile tag validation, DeleteUser login-profile conflict, attach bogus managed ARN. All 93 iam e2e pass.
- Conformance (source of truth): `cargo nextest run -p fakecloud-conformance -E 'test(route53)' -E 'test(iam)'` -> 54/54 passed.
- `cargo clippy -p fakecloud-route53 -p fakecloud-iam -p fakecloud-e2e --all-targets -- -D warnings` clean; `cargo fmt --all` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several correctness issues in `fakecloud-route53` and `fakecloud-iam`. Improves DNS record matching, zone filtering, tag and policy validation, and DeleteUser conflict handling.

- Bug Fixes
  - Route53
    - Lowercase record names on store and match case-insensitively; trailing dot preserved.
    - `ListHostedZones` applies `hostedzonetype=PrivateHostedZone` and `delegationsetid` filters before pagination.
    - Reject alias records that include `ResourceRecords` or a `TTL` (`InvalidChangeBatch`).
  - IAM
    - Enforce tag validation for users and instance profiles: >50 tags, case-insensitive duplicate keys, length/char rules -> `InvalidInput`.
    - `DeleteUser` returns `DeleteConflict` when login profile, signing certs, SSH keys, or MFA exist; also cleans up SSH keys on delete.
    - `Attach{User,Role,Group}Policy` validates AWS-managed ARNs against the catalog; bogus `arn:aws:iam::aws:policy/...` -> `NoSuchEntity`.

<sup>Written for commit 635dcadd8e6bf68d2a3159668db2ab2efe3968d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

