### PR TITLE
fix(sagemaker,logs,route53resolver,stepfunctions): persist Action-verb outputs + dropped Put/Update fields (bug-hunt)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cwlogs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cwlogs.rs
@@ -220,12 +220,18 @@ impl ResourceProvisioner {
                     .get("Unit")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                let dimensions = t.get("Dimensions").and_then(|v| v.as_object()).map(|m| {
+                    m.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                        .collect()
+                });
                 transformations.push(MetricTransformation {
                     metric_name,
                     metric_namespace,
                     metric_value,
                     default_value,
                     unit,
+                    dimensions,
                 });
             }
         }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/logs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/logs.rs
@@ -127,6 +127,12 @@ impl ResourceProvisioner {
             })
             .unwrap_or_default();
 
+        let query_language = props
+            .get("QueryLanguage")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| Some("CWLI".to_string()));
+
         let id = Uuid::new_v4().to_string();
         let qd = QueryDefinition {
             query_definition_id: id.clone(),
@@ -134,6 +140,7 @@ impl ResourceProvisioner {
             query_string,
             log_group_names,
             last_modified: Utc::now().timestamp_millis(),
+            query_language,
         };
 
         let mut logs_accounts = self.logs_state.write();

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
@@ -270,6 +270,24 @@ impl ResourceProvisioner {
                         .collect()
                 })
                 .unwrap_or_default(),
+            outpost_arn: props
+                .get("OutpostArn")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            preferred_instance_type: props
+                .get("PreferredInstanceType")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            dns64_enabled: props.get("Dns64Enabled").and_then(|v| v.as_bool()),
+            ipv6_internet_access_enabled: props
+                .get("Ipv6InternetAccessEnabled")
+                .and_then(|v| v.as_bool()),
+            rni_enhanced_metrics_enabled: props
+                .get("RniEnhancedMetricsEnabled")
+                .and_then(|v| v.as_bool()),
+            target_name_server_metrics_enabled: props
+                .get("TargetNameServerMetricsEnabled")
+                .and_then(|v| v.as_bool()),
         };
         let ip_count = endpoint.ip_address_count;
         let direction_att = endpoint.direction.clone();
@@ -365,6 +383,10 @@ impl ResourceProvisioner {
             share_status: "NOT_SHARED".to_string(),
             creation_time: now_rfc3339(),
             modification_time: now_rfc3339(),
+            delegation_record: props
+                .get("DelegationRecord")
+                .and_then(|v| v.as_str())
+                .map(String::from),
         };
         let tags = self.r53r_tags(props);
         {
@@ -662,6 +684,16 @@ impl ResourceProvisioner {
                 modification_time: now_rfc3339(),
                 firewall_domain_redirection_action: None,
                 qtype: r.get("Qtype").and_then(|v| v.as_str()).map(String::from),
+                dns_threat_protection: r
+                    .get("DnsThreatProtection")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                confidence_threshold: r
+                    .get("ConfidenceThreshold")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                firewall_rule_type: r.get("FirewallRuleType").filter(|v| !v.is_null()).cloned(),
+                firewall_threat_protection_id: None,
             });
         }
         let rule_count = rules.len() as i64;

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
@@ -57,6 +57,7 @@ impl ResourceProvisioner {
             logging_configuration,
             tracing_configuration,
             description: String::new(),
+            encryption_configuration: props.get("EncryptionConfiguration").cloned(),
         };
 
         let mut accounts = self.stepfunctions_state.write();

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -8,6 +8,30 @@ use super::{dd_config_json, infer_delivery_destination_type};
 use super::{require_str, LogsService};
 use crate::state::{Delivery, DeliveryDestination, DeliverySource};
 
+/// Render a stored `Delivery` to the wire `delivery` shape, echoing every
+/// persisted optional member (`recordFields` / `fieldDelimiter` /
+/// `s3DeliveryConfiguration`) so `GetDelivery` and `DescribeDeliveries` agree.
+fn delivery_to_json(d: &Delivery) -> Value {
+    let mut delivery_json = json!({
+        "id": d.id,
+        "deliverySourceName": d.delivery_source_name,
+        "deliveryDestinationArn": d.delivery_destination_arn,
+        "deliveryDestinationType": d.delivery_destination_type,
+        "arn": d.arn,
+        "tags": d.tags,
+    });
+    if !d.record_fields.is_empty() {
+        delivery_json["recordFields"] = json!(d.record_fields);
+    }
+    if let Some(ref delim) = d.field_delimiter {
+        delivery_json["fieldDelimiter"] = json!(delim);
+    }
+    if let Some(ref s3) = d.s3_delivery_configuration {
+        delivery_json["s3DeliveryConfiguration"] = s3.clone();
+    }
+    delivery_json
+}
+
 impl LogsService {
     // ---- Delivery Destinations ----
 
@@ -742,36 +766,19 @@ impl LogsService {
             delivery_destination_arn: delivery_destination_arn.clone(),
             delivery_destination_type: dest_type.to_string(),
             arn: arn.clone(),
-            tags: tags.clone(),
-            field_delimiter: field_delimiter.clone(),
-            record_fields: record_fields.clone(),
+            tags,
+            field_delimiter,
+            record_fields,
             s3_delivery_configuration: if s3_delivery_config.is_null() {
                 None
             } else {
-                Some(s3_delivery_config.clone())
+                Some(s3_delivery_config)
             },
             created_at: chrono::Utc::now().timestamp_millis(),
         };
 
+        let delivery_json = delivery_to_json(&delivery);
         state.deliveries.insert(delivery_id.clone(), delivery);
-
-        let mut delivery_json = json!({
-            "id": delivery_id,
-            "deliverySourceName": delivery_source_name,
-            "deliveryDestinationArn": delivery_destination_arn,
-            "deliveryDestinationType": dest_type,
-            "arn": arn,
-            "tags": tags,
-        });
-        if !record_fields.is_empty() {
-            delivery_json["recordFields"] = json!(record_fields);
-        }
-        if let Some(ref delim) = field_delimiter {
-            delivery_json["fieldDelimiter"] = json!(delim);
-        }
-        if !s3_delivery_config.is_null() {
-            delivery_json["s3DeliveryConfiguration"] = s3_delivery_config;
-        }
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -805,23 +812,7 @@ impl LogsService {
             )
         })?;
 
-        let mut delivery_json = json!({
-            "id": d.id,
-            "deliverySourceName": d.delivery_source_name,
-            "deliveryDestinationArn": d.delivery_destination_arn,
-            "deliveryDestinationType": d.delivery_destination_type,
-            "arn": d.arn,
-            "tags": d.tags,
-        });
-        if !d.record_fields.is_empty() {
-            delivery_json["recordFields"] = json!(d.record_fields);
-        }
-        if let Some(ref delim) = d.field_delimiter {
-            delivery_json["fieldDelimiter"] = json!(delim);
-        }
-        if let Some(ref s3) = d.s3_delivery_configuration {
-            delivery_json["s3DeliveryConfiguration"] = s3.clone();
-        }
+        let delivery_json = delivery_to_json(d);
         Ok(AwsResponse::json(
             StatusCode::OK,
             serde_json::to_string(&json!({ "delivery": delivery_json })).unwrap(),
@@ -839,20 +830,7 @@ impl LogsService {
         let accounts = self.state.read();
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let deliveries: Vec<Value> = state
-            .deliveries
-            .values()
-            .map(|d| {
-                json!({
-                    "id": d.id,
-                    "deliverySourceName": d.delivery_source_name,
-                    "deliveryDestinationArn": d.delivery_destination_arn,
-                    "deliveryDestinationType": d.delivery_destination_type,
-                    "arn": d.arn,
-                    "tags": d.tags,
-                })
-            })
-            .collect();
+        let deliveries: Vec<Value> = state.deliveries.values().map(delivery_to_json).collect();
 
         Ok(AwsResponse::json(
             StatusCode::OK,
@@ -1315,6 +1293,68 @@ mod tests {
         let resp = svc.describe_deliveries(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["deliveries"].as_array().unwrap().is_empty());
+    }
+
+    // DescribeDeliveries must echo the same recordFields / fieldDelimiter /
+    // s3DeliveryConfiguration that GetDelivery returns (bug-hunt 2026-07-19).
+    #[test]
+    fn describe_deliveries_echoes_record_fields_and_delimiter() {
+        let svc = make_service();
+        create_group(&svc, "dd-grp");
+        let req = make_request(
+            "DescribeLogGroups",
+            json!({ "logGroupNamePrefix": "dd-grp" }),
+        );
+        let resp = svc.describe_log_groups(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let group_arn = body["logGroups"][0]["arn"].as_str().unwrap().to_string();
+
+        svc.put_delivery_source(&make_request(
+            "PutDeliverySource",
+            json!({ "name": "dd-src", "resourceArn": group_arn, "logType": "APPLICATION_LOGS" }),
+        ))
+        .unwrap();
+        svc.put_delivery_destination(&make_request(
+            "PutDeliveryDestination",
+            json!({
+                "name": "dd-dest",
+                "deliveryDestinationConfiguration": { "destinationResourceArn": "arn:aws:s3:::dd-bucket" }
+            }),
+        ))
+        .unwrap();
+        let resp = svc
+            .get_delivery_destination(&make_request(
+                "GetDeliveryDestination",
+                json!({ "name": "dd-dest" }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let dest_arn = body["deliveryDestination"]["arn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        svc.create_delivery(&make_request(
+            "CreateDelivery",
+            json!({
+                "deliverySourceName": "dd-src",
+                "deliveryDestinationArn": dest_arn,
+                "recordFields": ["timestamp", "message"],
+                "fieldDelimiter": "|",
+                "s3DeliveryConfiguration": { "suffixPath": "logs/" }
+            }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .describe_deliveries(&make_request("DescribeDeliveries", json!({})))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let d = &body["deliveries"][0];
+        assert_eq!(d["recordFields"][0], "timestamp");
+        assert_eq!(d["recordFields"][1], "message");
+        assert_eq!(d["fieldDelimiter"], "|");
+        assert_eq!(d["s3DeliveryConfiguration"]["suffixPath"], "logs/");
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/filters.rs
+++ b/crates/fakecloud-logs/src/service/filters.rs
@@ -282,6 +282,11 @@ impl LogsService {
                 metric_value: t["metricValue"].as_str().unwrap_or("").to_string(),
                 default_value: t["defaultValue"].as_f64(),
                 unit: t["unit"].as_str().map(str::to_string),
+                dimensions: t["dimensions"].as_object().map(|m| {
+                    m.iter()
+                        .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                        .collect()
+                }),
             })
             .collect();
 
@@ -375,6 +380,9 @@ impl LogsService {
                         });
                         if let Some(dv) = t.default_value {
                             obj["defaultValue"] = json!(dv);
+                        }
+                        if let Some(ref dims) = t.dimensions {
+                            obj["dimensions"] = json!(dims);
                         }
                         obj
                     })
@@ -671,6 +679,36 @@ mod tests {
         let resp = svc.describe_metric_filters(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["metricFilters"].as_array().unwrap().is_empty());
+    }
+
+    // PutMetricFilter persists metricTransformation.dimensions; describe echoes
+    // them (bug-hunt 2026-07-19).
+    #[test]
+    fn metric_filter_persists_dimensions() {
+        let svc = make_service();
+        create_group(&svc, "mf-dim");
+        let req = make_request(
+            "PutMetricFilter",
+            json!({
+                "logGroupName": "mf-dim",
+                "filterName": "dim-filter",
+                "filterPattern": "[ip, id, user]",
+                "metricTransformations": [{
+                    "metricName": "Requests",
+                    "metricNamespace": "MyApp",
+                    "metricValue": "1",
+                    "dimensions": { "User": "$user", "IP": "$ip" }
+                }],
+            }),
+        );
+        svc.put_metric_filter(&req).unwrap();
+
+        let req = make_request("DescribeMetricFilters", json!({ "logGroupName": "mf-dim" }));
+        let resp = svc.describe_metric_filters(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let dims = &body["metricFilters"][0]["metricTransformations"][0]["dimensions"];
+        assert_eq!(dims["User"], "$user");
+        assert_eq!(dims["IP"], "$ip");
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/service/misc.rs
+++ b/crates/fakecloud-logs/src/service/misc.rs
@@ -261,6 +261,8 @@ impl LogsService {
             table_body: table_body.to_string(),
             creation_time: now,
             last_modified_time: now,
+            description: body["description"].as_str().map(str::to_string),
+            kms_key_id: body["kmsKeyId"].as_str().map(str::to_string),
         };
 
         let mut accounts = self.state.write();
@@ -284,17 +286,25 @@ impl LogsService {
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         match state.lookup_tables.get(lookup_table_arn) {
-            Some(t) => Ok(AwsResponse::json(
-                StatusCode::OK,
-                serde_json::to_string(&json!({
+            Some(t) => {
+                let mut out = json!({
                     "lookupTableName": t.lookup_table_name,
                     "lookupTableArn": t.arn,
                     "tableBody": t.table_body,
                     "creationTime": t.creation_time,
                     "lastModifiedTime": t.last_modified_time,
-                }))
-                .unwrap(),
-            )),
+                });
+                if let Some(ref d) = t.description {
+                    out["description"] = json!(d);
+                }
+                if let Some(ref k) = t.kms_key_id {
+                    out["kmsKeyId"] = json!(k);
+                }
+                Ok(AwsResponse::json(
+                    StatusCode::OK,
+                    serde_json::to_string(&out).unwrap(),
+                ))
+            }
             None => Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ResourceNotFoundException",
@@ -362,6 +372,12 @@ impl LogsService {
         match state.lookup_tables.get_mut(lookup_table_arn) {
             Some(t) => {
                 t.table_body = table_body.to_string();
+                if let Some(d) = body["description"].as_str() {
+                    t.description = Some(d.to_string());
+                }
+                if let Some(k) = body["kmsKeyId"].as_str() {
+                    t.kms_key_id = Some(k.to_string());
+                }
                 t.last_modified_time = Utc::now().timestamp_millis();
                 Ok(AwsResponse::json(StatusCode::OK, "{}"))
             }
@@ -418,6 +434,10 @@ impl LogsService {
         .to_string();
         let now = Utc::now().timestamp_millis();
 
+        // `state` is the caller's desired ENABLED/DISABLED setting; live AWS
+        // defaults it to ENABLED when omitted.
+        let desired_state = body["state"].as_str().unwrap_or("ENABLED").to_string();
+
         let sq = ScheduledQuery {
             name: name.to_string(),
             arn: arn.clone(),
@@ -428,6 +448,11 @@ impl LogsService {
             status: "ACTIVE".to_string(),
             creation_time: now,
             last_modified_time: now,
+            description: body["description"].as_str().map(str::to_string),
+            timezone: body["timezone"].as_str().map(str::to_string),
+            schedule_start_time: body["scheduleStartTime"].as_i64(),
+            schedule_end_time: body["scheduleEndTime"].as_i64(),
+            state: Some(desired_state.clone()),
         };
 
         let mut accounts = self.state.write();
@@ -436,7 +461,8 @@ impl LogsService {
 
         Ok(AwsResponse::json(
             StatusCode::OK,
-            serde_json::to_string(&json!({ "scheduledQueryArn": arn })).unwrap(),
+            serde_json::to_string(&json!({ "scheduledQueryArn": arn, "state": desired_state }))
+                .unwrap(),
         ))
     }
 
@@ -451,18 +477,37 @@ impl LogsService {
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
         match state.scheduled_queries.get(identifier) {
-            Some(sq) => Ok(AwsResponse::json(
-                StatusCode::OK,
-                serde_json::to_string(&json!({
+            Some(sq) => {
+                let mut out = json!({
                     "scheduledQueryArn": sq.arn,
                     "name": sq.name,
                     "queryString": sq.query_string,
                     "queryLanguage": sq.query_language,
                     "scheduleExpression": sq.schedule_expression,
                     "executionRoleArn": sq.execution_role_arn,
-                }))
-                .unwrap(),
-            )),
+                    "creationTime": sq.creation_time,
+                    "lastUpdatedTime": sq.last_modified_time,
+                });
+                if let Some(ref d) = sq.description {
+                    out["description"] = json!(d);
+                }
+                if let Some(ref tz) = sq.timezone {
+                    out["timezone"] = json!(tz);
+                }
+                if let Some(t) = sq.schedule_start_time {
+                    out["scheduleStartTime"] = json!(t);
+                }
+                if let Some(t) = sq.schedule_end_time {
+                    out["scheduleEndTime"] = json!(t);
+                }
+                if let Some(ref s) = sq.state {
+                    out["state"] = json!(s);
+                }
+                Ok(AwsResponse::json(
+                    StatusCode::OK,
+                    serde_json::to_string(&out).unwrap(),
+                ))
+            }
             None => Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
                 "ResourceNotFoundException",
@@ -550,6 +595,21 @@ impl LogsService {
                 sq.query_language = query_language.to_string();
                 sq.schedule_expression = schedule_expression.to_string();
                 sq.execution_role_arn = execution_role_arn.to_string();
+                if let Some(d) = body["description"].as_str() {
+                    sq.description = Some(d.to_string());
+                }
+                if let Some(tz) = body["timezone"].as_str() {
+                    sq.timezone = Some(tz.to_string());
+                }
+                if let Some(t) = body["scheduleStartTime"].as_i64() {
+                    sq.schedule_start_time = Some(t);
+                }
+                if let Some(t) = body["scheduleEndTime"].as_i64() {
+                    sq.schedule_end_time = Some(t);
+                }
+                if let Some(st) = body["state"].as_str() {
+                    sq.state = Some(st.to_string());
+                }
                 sq.last_modified_time = Utc::now().timestamp_millis();
                 Ok(AwsResponse::json(StatusCode::OK, "{}"))
             }
@@ -1252,6 +1312,118 @@ mod tests {
         let resp = svc.list_scheduled_queries(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["scheduledQueries"].as_array().unwrap().is_empty());
+    }
+
+    // CreateLookupTable persists description + kmsKeyId; GetLookupTable echoes
+    // them (bug-hunt 2026-07-19).
+    #[test]
+    fn lookup_table_persists_description_and_kms_key() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateLookupTable",
+            json!({
+                "lookupTableName": "t",
+                "tableBody": "key,value\na,b",
+                "description": "my table",
+                "kmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/abc"
+            }),
+        );
+        let resp = svc.create_lookup_table(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let arn = body["lookupTableArn"].as_str().unwrap().to_string();
+
+        let req = make_request("GetLookupTable", json!({ "lookupTableArn": arn.clone() }));
+        let resp = svc.get_lookup_table(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["description"].as_str().unwrap(), "my table");
+        assert_eq!(
+            body["kmsKeyId"].as_str().unwrap(),
+            "arn:aws:kms:us-east-1:123456789012:key/abc"
+        );
+
+        // UpdateLookupTable merges a new description.
+        let req = make_request(
+            "UpdateLookupTable",
+            json!({ "lookupTableArn": arn.clone(), "tableBody": "key,value\nc,d", "description": "updated" }),
+        );
+        svc.update_lookup_table(&req).unwrap();
+        let req = make_request("GetLookupTable", json!({ "lookupTableArn": arn }));
+        let resp = svc.get_lookup_table(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["description"].as_str().unwrap(), "updated");
+    }
+
+    // CreateScheduledQuery persists description/timezone/schedule times/state;
+    // GetScheduledQuery echoes them and an update can disable it (bug-hunt
+    // 2026-07-19).
+    #[test]
+    fn scheduled_query_persists_optional_fields_and_state() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateScheduledQuery",
+            json!({
+                "name": "sq",
+                "queryString": "fields @timestamp",
+                "queryLanguage": "CWLI",
+                "scheduleExpression": "rate(1 hour)",
+                "executionRoleArn": "arn:aws:iam::123456789012:role/exec",
+                "description": "nightly",
+                "timezone": "UTC",
+                "scheduleStartTime": 1000_i64,
+                "scheduleEndTime": 2000_i64,
+                "state": "ENABLED"
+            }),
+        );
+        let resp = svc.create_scheduled_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["state"].as_str().unwrap(), "ENABLED");
+        let arn = body["scheduledQueryArn"].as_str().unwrap().to_string();
+
+        let req = make_request("GetScheduledQuery", json!({ "identifier": arn.clone() }));
+        let resp = svc.get_scheduled_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["description"].as_str().unwrap(), "nightly");
+        assert_eq!(body["timezone"].as_str().unwrap(), "UTC");
+        assert_eq!(body["scheduleStartTime"].as_i64().unwrap(), 1000);
+        assert_eq!(body["scheduleEndTime"].as_i64().unwrap(), 2000);
+        assert_eq!(body["state"].as_str().unwrap(), "ENABLED");
+
+        // An update can disable the query.
+        let req = make_request(
+            "UpdateScheduledQuery",
+            json!({
+                "identifier": arn.clone(),
+                "queryString": "fields @message",
+                "queryLanguage": "CWLI",
+                "scheduleExpression": "rate(2 hours)",
+                "executionRoleArn": "arn:aws:iam::123456789012:role/exec",
+                "state": "DISABLED"
+            }),
+        );
+        svc.update_scheduled_query(&req).unwrap();
+        let req = make_request("GetScheduledQuery", json!({ "identifier": arn }));
+        let resp = svc.get_scheduled_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["state"].as_str().unwrap(), "DISABLED");
+    }
+
+    // A scheduled query created without an explicit state defaults to ENABLED.
+    #[test]
+    fn scheduled_query_defaults_state_enabled() {
+        let svc = make_service();
+        let req = make_request(
+            "CreateScheduledQuery",
+            json!({
+                "name": "sq2",
+                "queryString": "fields @timestamp",
+                "queryLanguage": "CWLI",
+                "scheduleExpression": "rate(1 hour)",
+                "executionRoleArn": "arn:aws:iam::123456789012:role/exec"
+            }),
+        );
+        let resp = svc.create_scheduled_query(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["state"].as_str().unwrap(), "ENABLED");
     }
 
     // -- Misc stubs --

--- a/crates/fakecloud-logs/src/service/queries.rs
+++ b/crates/fakecloud-logs/src/service/queries.rs
@@ -354,6 +354,9 @@ impl LogsService {
             &["CWLI", "SQL", "PPL"],
         )?;
 
+        // AWS defaults omitted queryLanguage to CWLI (Logs Insights QL).
+        let query_language = body["queryLanguage"].as_str().unwrap_or("CWLI").to_string();
+
         let now = Utc::now().timestamp_millis();
 
         let mut accounts = self.state.write();
@@ -366,6 +369,7 @@ impl LogsService {
                 query_string,
                 log_group_names,
                 last_modified: now,
+                query_language: Some(query_language),
             },
         );
 
@@ -406,13 +410,17 @@ impl LogsService {
             .values()
             .filter(|qd| name_prefix.is_empty() || qd.name.starts_with(name_prefix))
             .map(|qd| {
-                json!({
+                let mut obj = json!({
                     "queryDefinitionId": qd.query_definition_id,
                     "name": qd.name,
                     "queryString": qd.query_string,
                     "logGroupNames": qd.log_group_names,
                     "lastModified": qd.last_modified,
-                })
+                });
+                if let Some(ref ql) = qd.query_language {
+                    obj["queryLanguage"] = json!(ql);
+                }
+                obj
             })
             .collect();
 
@@ -616,6 +624,39 @@ mod tests {
         let resp = svc.describe_query_definitions(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["queryDefinitions"].as_array().unwrap().is_empty());
+    }
+
+    // PutQueryDefinition persists queryLanguage; describe echoes it, defaulting
+    // to CWLI when omitted (bug-hunt 2026-07-19).
+    #[test]
+    fn query_definition_persists_query_language() {
+        let svc = make_service();
+        // Explicit SQL.
+        svc.put_query_definition(&make_request(
+            "PutQueryDefinition",
+            json!({
+                "name": "sql-q",
+                "queryString": "SELECT * FROM logs",
+                "queryLanguage": "SQL",
+            }),
+        ))
+        .unwrap();
+        // Omitted -> defaults to CWLI.
+        svc.put_query_definition(&make_request(
+            "PutQueryDefinition",
+            json!({ "name": "default-q", "queryString": "fields @timestamp" }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .describe_query_definitions(&make_request("DescribeQueryDefinitions", json!({})))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let defs = body["queryDefinitions"].as_array().unwrap();
+        let sql = defs.iter().find(|d| d["name"] == "sql-q").unwrap();
+        assert_eq!(sql["queryLanguage"], "SQL");
+        let default = defs.iter().find(|d| d["name"] == "default-q").unwrap();
+        assert_eq!(default["queryLanguage"], "CWLI");
     }
 
     #[test]

--- a/crates/fakecloud-logs/src/state.rs
+++ b/crates/fakecloud-logs/src/state.rs
@@ -252,6 +252,10 @@ pub struct MetricTransformation {
     /// Terraform `aws_cloudwatch_log_metric_filter` resource asserts on it.
     #[serde(default)]
     pub unit: Option<String>,
+    /// Dimensions to publish with the metric (name -> value template). Echoed
+    /// on DescribeMetricFilters; the Terraform resource round-trips it.
+    #[serde(default)]
+    pub dimensions: Option<std::collections::BTreeMap<String, String>>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -358,6 +362,10 @@ pub struct QueryDefinition {
     pub query_string: String,
     pub log_group_names: Vec<String>,
     pub last_modified: i64,
+    /// Query language (CWLI / SQL / PPL). Echoed on DescribeQueryDefinitions;
+    /// defaults to CWLI when the caller omits it.
+    #[serde(default)]
+    pub query_language: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -432,6 +440,10 @@ pub struct LookupTable {
     pub table_body: String,
     pub creation_time: i64,
     pub last_modified_time: i64,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub kms_key_id: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -445,6 +457,18 @@ pub struct ScheduledQuery {
     pub status: String,
     pub creation_time: i64,
     pub last_modified_time: i64,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub timezone: Option<String>,
+    #[serde(default)]
+    pub schedule_start_time: Option<i64>,
+    #[serde(default)]
+    pub schedule_end_time: Option<i64>,
+    /// The desired ENABLED/DISABLED state (defaults to ENABLED). Distinct from
+    /// `status` (the server-derived lifecycle status).
+    #[serde(default)]
+    pub state: Option<String>,
 }
 
 /// On-disk snapshot envelope for CloudWatch Logs state. Versioned so

--- a/crates/fakecloud-route53resolver/src/service.rs
+++ b/crates/fakecloud-route53resolver/src/service.rs
@@ -594,6 +594,24 @@ impl Route53ResolverService {
                 .unwrap_or("IPV4")
                 .to_string(),
             protocols: string_list(body.get("Protocols")),
+            outpost_arn: body
+                .get("OutpostArn")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            preferred_instance_type: body
+                .get("PreferredInstanceType")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            dns64_enabled: body.get("Dns64Enabled").and_then(Value::as_bool),
+            ipv6_internet_access_enabled: body
+                .get("Ipv6InternetAccessEnabled")
+                .and_then(Value::as_bool),
+            rni_enhanced_metrics_enabled: body
+                .get("RniEnhancedMetricsEnabled")
+                .and_then(Value::as_bool),
+            target_name_server_metrics_enabled: body
+                .get("TargetNameServerMetricsEnabled")
+                .and_then(Value::as_bool),
         };
         let arn_str = endpoint.arn.clone();
         let tags = parse_tags(body.get("Tags"))?;
@@ -652,6 +670,27 @@ impl Route53ResolverService {
             let protocols = string_list(body.get("Protocols"));
             if !protocols.is_empty() {
                 rec.endpoint.protocols = protocols;
+            }
+            if let Some(v) = body.get("Dns64Enabled").and_then(Value::as_bool) {
+                rec.endpoint.dns64_enabled = Some(v);
+            }
+            if let Some(v) = body
+                .get("Ipv6InternetAccessEnabled")
+                .and_then(Value::as_bool)
+            {
+                rec.endpoint.ipv6_internet_access_enabled = Some(v);
+            }
+            if let Some(v) = body
+                .get("RniEnhancedMetricsEnabled")
+                .and_then(Value::as_bool)
+            {
+                rec.endpoint.rni_enhanced_metrics_enabled = Some(v);
+            }
+            if let Some(v) = body
+                .get("TargetNameServerMetricsEnabled")
+                .and_then(Value::as_bool)
+            {
+                rec.endpoint.target_name_server_metrics_enabled = Some(v);
             }
             rec.endpoint.status = "UPDATING".to_string();
             rec.endpoint.modification_time = now_rfc3339();
@@ -891,6 +930,10 @@ impl Route53ResolverService {
             share_status: "NOT_SHARED".to_string(),
             creation_time: now_rfc3339(),
             modification_time: now_rfc3339(),
+            delegation_record: body
+                .get("DelegationRecord")
+                .and_then(Value::as_str)
+                .map(str::to_string),
         };
         let arn_str = rule.arn.clone();
         let tags = parse_tags(body.get("Tags"))?;
@@ -1996,6 +2039,29 @@ impl Route53ResolverService {
                 .get("Qtype")
                 .and_then(Value::as_str)
                 .map(str::to_string),
+            dns_threat_protection: entry
+                .get("DnsThreatProtection")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            confidence_threshold: entry
+                .get("ConfidenceThreshold")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            firewall_rule_type: entry
+                .get("FirewallRuleType")
+                .filter(|v| !v.is_null())
+                .cloned(),
+            // AWS mints a threat-protection id for rules that carry a
+            // DnsThreatProtection detector or a structured FirewallRuleType.
+            firewall_threat_protection_id: if entry
+                .get("DnsThreatProtection")
+                .is_some_and(|v| !v.is_null())
+                || entry.get("FirewallRuleType").is_some_and(|v| !v.is_null())
+            {
+                Some(format!("rslvr-ftp-{}", hex17()))
+            } else {
+                None
+            },
         })
     }
 
@@ -2094,6 +2160,15 @@ impl Route53ResolverService {
             .and_then(Value::as_str)
         {
             rule.firewall_domain_redirection_action = Some(a.to_string());
+        }
+        if let Some(d) = body.get("DnsThreatProtection").and_then(Value::as_str) {
+            rule.dns_threat_protection = Some(d.to_string());
+        }
+        if let Some(c) = body.get("ConfidenceThreshold").and_then(Value::as_str) {
+            rule.confidence_threshold = Some(c.to_string());
+        }
+        if let Some(frt) = body.get("FirewallRuleType").filter(|v| !v.is_null()) {
+            rule.firewall_rule_type = Some(frt.clone());
         }
         rule.modification_time = now_rfc3339();
         let out = rule.clone();
@@ -3496,6 +3571,137 @@ mod tests {
             rule["FirewallDomainRedirectionAction"],
             "TRUST_REDIRECTION_DOMAIN"
         );
+    }
+
+    // bug-hunt 2026-07-19: CreateResolverEndpoint persists OutpostArn,
+    // PreferredInstanceType and the Dns64/Ipv6/metrics booleans; Get/List echo
+    // them, and UpdateResolverEndpoint round-trips the mutable booleans.
+    #[tokio::test]
+    async fn resolver_endpoint_optional_fields_round_trip() {
+        let svc = Route53ResolverService::default();
+        let (status, body) = call(
+            &svc,
+            "CreateResolverEndpoint",
+            json!({
+                "CreatorRequestId": "c1",
+                "Direction": "INBOUND",
+                "SecurityGroupIds": ["sg-1"],
+                "IpAddresses": [ { "SubnetId": "subnet-a" }, { "SubnetId": "subnet-b" } ],
+                "OutpostArn": "arn:aws:outposts:us-east-1:123456789012:outpost/op-abc",
+                "PreferredInstanceType": "m5.large",
+                "Dns64Enabled": true,
+                "Ipv6InternetAccessEnabled": false,
+                "RniEnhancedMetricsEnabled": true,
+                "TargetNameServerMetricsEnabled": true,
+            }),
+        )
+        .await;
+        assert_eq!(status, 200, "{body}");
+        let ep = &body["ResolverEndpoint"];
+        assert_eq!(
+            ep["OutpostArn"],
+            "arn:aws:outposts:us-east-1:123456789012:outpost/op-abc"
+        );
+        assert_eq!(ep["PreferredInstanceType"], "m5.large");
+        assert_eq!(ep["Dns64Enabled"], true);
+        assert_eq!(ep["Ipv6InternetAccessEnabled"], false);
+        assert_eq!(ep["RniEnhancedMetricsEnabled"], true);
+        assert_eq!(ep["TargetNameServerMetricsEnabled"], true);
+        let id = ep["Id"].as_str().unwrap().to_string();
+
+        let (_, got) = call(
+            &svc,
+            "GetResolverEndpoint",
+            json!({ "ResolverEndpointId": id }),
+        )
+        .await;
+        assert_eq!(got["ResolverEndpoint"]["OutpostArn"], ep["OutpostArn"]);
+        assert_eq!(got["ResolverEndpoint"]["Dns64Enabled"], true);
+
+        // Update flips Dns64Enabled.
+        let (s, upd) = call(
+            &svc,
+            "UpdateResolverEndpoint",
+            json!({ "ResolverEndpointId": id, "Dns64Enabled": false }),
+        )
+        .await;
+        assert_eq!(s, 200, "{upd}");
+        assert_eq!(upd["ResolverEndpoint"]["Dns64Enabled"], false);
+    }
+
+    // bug-hunt 2026-07-19: CreateResolverRule persists DelegationRecord and it
+    // round-trips on Get/List.
+    #[tokio::test]
+    async fn resolver_rule_delegation_record_round_trips() {
+        let svc = Route53ResolverService::default();
+        let (s, body) = call(
+            &svc,
+            "CreateResolverRule",
+            json!({
+                "CreatorRequestId": "c",
+                "RuleType": "RECURSIVE",
+                "DomainName": "example.com",
+                "DelegationRecord": "ns-1.example.com",
+            }),
+        )
+        .await;
+        assert_eq!(s, 200, "{body}");
+        assert_eq!(body["ResolverRule"]["DelegationRecord"], "ns-1.example.com");
+        let id = body["ResolverRule"]["Id"].as_str().unwrap().to_string();
+        let (_, got) = call(&svc, "GetResolverRule", json!({ "ResolverRuleId": id })).await;
+        assert_eq!(got["ResolverRule"]["DelegationRecord"], "ns-1.example.com");
+    }
+
+    // bug-hunt 2026-07-19: CreateFirewallRule persists DnsThreatProtection,
+    // ConfidenceThreshold and the structured FirewallRuleType; they round-trip
+    // on List and mint a FirewallThreatProtectionId.
+    #[tokio::test]
+    async fn firewall_rule_threat_protection_fields_round_trip() {
+        let svc = Route53ResolverService::default();
+        let (_, g) = call(
+            &svc,
+            "CreateFirewallRuleGroup",
+            json!({ "CreatorRequestId": "c", "Name": "g" }),
+        )
+        .await;
+        let group_id = g["FirewallRuleGroup"]["Id"].as_str().unwrap().to_string();
+        let (s, created) = call(
+            &svc,
+            "CreateFirewallRule",
+            json!({
+                "FirewallRuleGroupId": group_id,
+                "Name": "threat-rule",
+                "Priority": 5,
+                "Action": "BLOCK",
+                "BlockResponse": "NODATA",
+                "DnsThreatProtection": "DGA",
+                "ConfidenceThreshold": "HIGH",
+                "FirewallRuleType": { "DnsThreatProtection": { "Detector": "DGA" } },
+            }),
+        )
+        .await;
+        assert_eq!(s, 200, "{created}");
+        let rule = &created["FirewallRule"];
+        assert_eq!(rule["DnsThreatProtection"], "DGA");
+        assert_eq!(rule["ConfidenceThreshold"], "HIGH");
+        assert_eq!(
+            rule["FirewallRuleType"]["DnsThreatProtection"]["Detector"],
+            "DGA"
+        );
+        assert!(rule["FirewallThreatProtectionId"]
+            .as_str()
+            .unwrap()
+            .starts_with("rslvr-ftp-"));
+
+        let (_, listed) = call(
+            &svc,
+            "ListFirewallRules",
+            json!({ "FirewallRuleGroupId": group_id }),
+        )
+        .await;
+        let listed_rule = &listed["FirewallRules"][0];
+        assert_eq!(listed_rule["DnsThreatProtection"], "DGA");
+        assert_eq!(listed_rule["ConfidenceThreshold"], "HIGH");
     }
 
     // Finding 5: a NextToken that this service never minted is rejected with

--- a/crates/fakecloud-route53resolver/src/state.rs
+++ b/crates/fakecloud-route53resolver/src/state.rs
@@ -107,6 +107,18 @@ pub struct ResolverEndpoint {
     pub resolver_endpoint_type: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub protocols: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outpost_arn: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred_instance_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dns64_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ipv6_internet_access_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rni_enhanced_metrics_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_name_server_metrics_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,6 +157,8 @@ pub struct ResolverRule {
     pub share_status: String,
     pub creation_time: String,
     pub modification_time: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delegation_record: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -247,6 +261,17 @@ pub struct FirewallRule {
     pub firewall_domain_redirection_action: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub qtype: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dns_threat_protection: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence_threshold: Option<String>,
+    /// The (structured) rule-type configuration echoed back verbatim. Stored as
+    /// a JSON value because the `FirewallRuleType` union carries several
+    /// alternative nested configs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub firewall_rule_type: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub firewall_threat_protection_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-sagemaker/src/service/special.rs
+++ b/crates/fakecloud-sagemaker/src/service/special.rs
@@ -48,6 +48,16 @@ pub(super) fn dispatch(
         "RegisterDevices" => Ok(Some(register_devices(svc, ctx, meta, body))),
         "DeregisterDevices" => Ok(Some(deregister_devices(svc, ctx, meta, body))),
         "UpdateDevices" => Ok(Some(update_devices(svc, ctx, meta, body))),
+        "EnableSagemakerServicecatalogPortfolio" => {
+            Ok(Some(set_portfolio_status(svc, ctx, meta, body, "Enabled")))
+        }
+        "DisableSagemakerServicecatalogPortfolio" => {
+            Ok(Some(set_portfolio_status(svc, ctx, meta, body, "Disabled")))
+        }
+        "GetSagemakerServicecatalogPortfolioStatus" => {
+            Ok(Some(get_portfolio_status(svc, ctx, body)))
+        }
+        "RetryPipelineExecution" => Ok(Some(retry_pipeline_execution(svc, ctx, meta, body))),
         op if is_lifecycle_transition(op) => Ok(lifecycle_transition(svc, ctx, meta, body)),
         _ => Ok(None),
     }
@@ -115,6 +125,53 @@ fn delete_mpg_policy(
         data.singletons.remove(&mpg_policy_singleton(&name));
     }
     (engine::action(ctx, meta, body), true)
+}
+
+// ── Service Catalog portfolio status ─────────────────────────────────────
+//
+// `EnableSagemakerServicecatalogPortfolio` / `DisableSagemakerServicecatalogPortfolio`
+// / `GetSagemakerServicecatalogPortfolioStatus` are all Action verbs. The
+// generic Action arm discarded the Enable/Disable and returned an empty Get
+// (no `Status`), so the portfolio status never round-tripped and Terraform saw a
+// perpetual diff. Persist the account-scoped status singleton on Enable/Disable
+// and read it back in Get, defaulting to `Disabled` (the live-AWS default before
+// any Enable) (bug-hunt 2026-07-19).
+
+const PORTFOLIO_STATUS_SINGLETON: &str = "SagemakerServicecatalogPortfolioStatus";
+
+fn set_portfolio_status(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+    status: &str,
+) -> (AwsResponse, bool) {
+    {
+        let mut g = svc.state.write();
+        let data = g.get_or_create(&ctx.account);
+        data.singletons.insert(
+            PORTFOLIO_STATUS_SINGLETON.to_string(),
+            Value::String(status.to_string()),
+        );
+    }
+    (engine::action(ctx, meta, body), true)
+}
+
+fn get_portfolio_status(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    _body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let g = svc.state.read();
+    let status = g
+        .get(&ctx.account)
+        .and_then(|data| data.singletons.get(PORTFOLIO_STATUS_SINGLETON))
+        .and_then(Value::as_str)
+        .unwrap_or("Disabled")
+        .to_string();
+    let mut out = Map::new();
+    out.insert("Status".to_string(), Value::String(status));
+    (ok_json(Value::Object(out)), false)
 }
 
 // ── Edge devices ─────────────────────────────────────────────────────────
@@ -330,6 +387,35 @@ fn start_pipeline_execution(
         .or_insert_with(|| Value::String("Executing".to_string()));
     seed.insert("StartTime".to_string(), now_epoch());
     (engine::action_create(data, ctx, meta, &arn, &seed), true)
+}
+
+/// `RetryPipelineExecution` — re-run a stopped/failed pipeline execution by
+/// transitioning its stored `PipelineExecutionStatus` back to `Executing`, so a
+/// subsequent DescribePipelineExecution reflects the retry instead of the stale
+/// terminal status. The execution is keyed by its `PipelineExecutionArn` (as
+/// minted by `StartPipelineExecution`). If no such record exists the response
+/// still echoes the ARN (idempotent, matching the generic Action arm).
+fn retry_pipeline_execution(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let arn = str_member(body, "PipelineExecutionArn");
+    let mut g = svc.state.write();
+    let data = g.get_or_create(&ctx.account);
+    if let Some(key) = data.resolve_key("PipelineExecution", &arn) {
+        if let Some(rec) = data.get_resource_mut("PipelineExecution", &key) {
+            if let Some(obj) = rec.as_object_mut() {
+                obj.insert(
+                    "PipelineExecutionStatus".to_string(),
+                    Value::String("Executing".to_string()),
+                );
+                obj.insert("LastModifiedTime".to_string(), now_epoch());
+            }
+        }
+    }
+    (engine::action(ctx, meta, body), true)
 }
 
 /// `ImportHubContent` — persist a hub-content record so DescribeHubContent /

--- a/crates/fakecloud-sagemaker/src/service/tests.rs
+++ b/crates/fakecloud-sagemaker/src/service/tests.rs
@@ -658,3 +658,74 @@ fn register_devices_visible_to_read_siblings() {
     ));
     assert_eq!(err.code(), "ResourceNotFound");
 }
+
+// Enable/Disable persist the Service Catalog portfolio status; Get reads it back
+// (default Disabled before any Enable) (bug-hunt 2026-07-19).
+#[test]
+fn servicecatalog_portfolio_status_round_trips() {
+    let s = svc();
+    // Default before any Enable/Disable is Disabled.
+    let got = resp_json(&run(&s, "GetSagemakerServicecatalogPortfolioStatus", json!({})).unwrap());
+    assert_eq!(got["Status"], "Disabled");
+
+    run(&s, "EnableSagemakerServicecatalogPortfolio", json!({})).unwrap();
+    let got = resp_json(&run(&s, "GetSagemakerServicecatalogPortfolioStatus", json!({})).unwrap());
+    assert_eq!(got["Status"], "Enabled");
+
+    run(&s, "DisableSagemakerServicecatalogPortfolio", json!({})).unwrap();
+    let got = resp_json(&run(&s, "GetSagemakerServicecatalogPortfolioStatus", json!({})).unwrap());
+    assert_eq!(got["Status"], "Disabled");
+}
+
+// RetryPipelineExecution transitions a stopped execution's status back to
+// Executing, visible via DescribePipelineExecution (bug-hunt 2026-07-19).
+#[test]
+fn retry_pipeline_execution_transitions_status() {
+    let s = svc();
+    let started = resp_json(
+        &run(
+            &s,
+            "StartPipelineExecution",
+            json!({"PipelineName": "p1", "ClientRequestToken": "a".repeat(32)}),
+        )
+        .unwrap(),
+    );
+    let arn = started["PipelineExecutionArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Stop it so it leaves the Executing state.
+    run(
+        &s,
+        "StopPipelineExecution",
+        json!({"PipelineExecutionArn": arn, "ClientRequestToken": "b".repeat(32)}),
+    )
+    .unwrap();
+    let described = resp_json(
+        &run(
+            &s,
+            "DescribePipelineExecution",
+            json!({"PipelineExecutionArn": arn}),
+        )
+        .unwrap(),
+    );
+    assert_ne!(described["PipelineExecutionStatus"], "Executing");
+
+    // Retry brings it back to Executing.
+    run(
+        &s,
+        "RetryPipelineExecution",
+        json!({"PipelineExecutionArn": arn, "ClientRequestToken": "c".repeat(32)}),
+    )
+    .unwrap();
+    let described = resp_json(
+        &run(
+            &s,
+            "DescribePipelineExecution",
+            json!({"PipelineExecutionArn": arn}),
+        )
+        .unwrap(),
+    );
+    assert_eq!(described["PipelineExecutionStatus"], "Executing");
+}

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -441,6 +441,10 @@ fn state_machine_to_json(sm: &StateMachine) -> Value {
         });
     }
 
+    if let Some(ref enc) = sm.encryption_configuration {
+        resp["encryptionConfiguration"] = enc.clone();
+    }
+
     resp
 }
 
@@ -1143,6 +1147,110 @@ mod tests {
         let svc = StepFunctionsService::new(make_state());
         let arn = create_sm(&svc, "test-sm");
         assert!(arn.contains("test-sm"));
+    }
+
+    // bug-hunt 2026-07-19: CreateStateMachine with publish=true creates a real
+    // version that ListStateMachineVersions returns; without publish, no version
+    // ARN is returned and no version exists.
+    #[test]
+    fn create_state_machine_publish_creates_listable_version() {
+        let svc = StepFunctionsService::new(make_state());
+        let body = json!({
+            "name": "pub-sm",
+            "definition": VALID_DEF,
+            "roleArn": "arn:aws:iam::123456789012:role/r",
+            "publish": true,
+            "versionDescription": "first",
+        });
+        let req = make_request("CreateStateMachine", &body.to_string());
+        let resp = svc.create_state_machine(&req).unwrap();
+        let b = body_json(&resp);
+        let arn = b["stateMachineArn"].as_str().unwrap().to_string();
+        let version_arn = b["stateMachineVersionArn"].as_str().unwrap().to_string();
+        assert_eq!(version_arn, format!("{arn}:1"));
+
+        let list_req = make_request(
+            "ListStateMachineVersions",
+            &json!({ "stateMachineArn": arn }).to_string(),
+        );
+        let list = body_json(&svc.list_state_machine_versions(&list_req).unwrap());
+        let versions = list["stateMachineVersions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["stateMachineVersionArn"], version_arn);
+    }
+
+    #[test]
+    fn create_state_machine_no_publish_has_no_version() {
+        let svc = StepFunctionsService::new(make_state());
+        let arn = create_sm(&svc, "nopub-sm");
+        // No version ARN is returned when publish is absent.
+        let body = json!({
+            "name": "nopub-sm2",
+            "definition": VALID_DEF,
+            "roleArn": "arn:aws:iam::123456789012:role/r",
+        });
+        let req = make_request("CreateStateMachine", &body.to_string());
+        let b = body_json(&svc.create_state_machine(&req).unwrap());
+        assert!(b.get("stateMachineVersionArn").is_none());
+
+        let list_req = make_request(
+            "ListStateMachineVersions",
+            &json!({ "stateMachineArn": arn }).to_string(),
+        );
+        let list = body_json(&svc.list_state_machine_versions(&list_req).unwrap());
+        assert!(list["stateMachineVersions"].as_array().unwrap().is_empty());
+    }
+
+    // bug-hunt 2026-07-19: UpdateStateMachine with publish=true publishes the
+    // next version, and encryptionConfiguration persists + round-trips on
+    // Describe.
+    #[test]
+    fn update_state_machine_publish_and_encryption_round_trip() {
+        let svc = StepFunctionsService::new(make_state());
+        let create = json!({
+            "name": "enc-sm",
+            "definition": VALID_DEF,
+            "roleArn": "arn:aws:iam::123456789012:role/r",
+            "encryptionConfiguration": { "type": "CUSTOMER_MANAGED_KMS_KEY", "kmsKeyId": "key-123" },
+        });
+        let req = make_request("CreateStateMachine", &create.to_string());
+        let arn = body_json(&svc.create_state_machine(&req).unwrap())["stateMachineArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // encryptionConfiguration round-trips on Describe.
+        let desc_req = make_request(
+            "DescribeStateMachine",
+            &json!({ "stateMachineArn": arn }).to_string(),
+        );
+        let desc = body_json(&svc.describe_state_machine(&desc_req).unwrap());
+        assert_eq!(
+            desc["encryptionConfiguration"]["type"],
+            "CUSTOMER_MANAGED_KMS_KEY"
+        );
+        assert_eq!(desc["encryptionConfiguration"]["kmsKeyId"], "key-123");
+
+        // Update with publish creates version 1.
+        let upd = json!({
+            "stateMachineArn": arn,
+            "definition": VALID_DEF,
+            "publish": true,
+            "versionDescription": "v via update",
+        });
+        let upd_req = make_request("UpdateStateMachine", &upd.to_string());
+        let upd_body = body_json(&svc.update_state_machine(&upd_req).unwrap());
+        assert_eq!(
+            upd_body["stateMachineVersionArn"].as_str().unwrap(),
+            format!("{arn}:1")
+        );
+
+        let list_req = make_request(
+            "ListStateMachineVersions",
+            &json!({ "stateMachineArn": arn }).to_string(),
+        );
+        let list = body_json(&svc.list_state_machine_versions(&list_req).unwrap());
+        assert_eq!(list["stateMachineVersions"].as_array().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/fakecloud-stepfunctions/src/service/state_machines.rs
+++ b/crates/fakecloud-stepfunctions/src/service/state_machines.rs
@@ -83,15 +83,25 @@ impl StepFunctionsService {
             logging_configuration: body.get("loggingConfiguration").cloned(),
             tracing_configuration: body.get("tracingConfiguration").cloned(),
             description: body["description"].as_str().unwrap_or("").to_string(),
+            encryption_configuration: body.get("encryptionConfiguration").cloned(),
         };
 
         state.state_machines.insert(arn.clone(), sm);
 
-        Ok(AwsResponse::ok_json(json!({
+        let mut resp = json!({
             "stateMachineArn": arn,
             "creationDate": now.timestamp() as f64,
-            "stateMachineVersionArn": arn,
-        })))
+        });
+        // `publish: true` creates version 1 and returns its version-qualified ARN
+        // (which ListStateMachineVersions resolves). Without publish, no version
+        // exists and no `stateMachineVersionArn` is returned.
+        if body["publish"].as_bool() == Some(true) {
+            let version_description = body["versionDescription"].as_str().unwrap_or("");
+            let (version_arn, _) = publish_version(state, &arn, version_description);
+            resp["stateMachineVersionArn"] = json!(version_arn);
+        }
+
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_state_machine(
@@ -222,6 +232,10 @@ impl StepFunctionsService {
             sm.description = description.to_string();
         }
 
+        if let Some(enc) = body.get("encryptionConfiguration") {
+            sm.encryption_configuration = Some(enc.clone());
+        }
+
         let now = Utc::now();
         sm.update_date = now;
         sm.revision_id = uuid::Uuid::new_v4().to_string();
@@ -229,11 +243,20 @@ impl StepFunctionsService {
         let revision_id = sm.revision_id.clone();
         let sm_arn = sm.arn.clone();
 
-        Ok(AwsResponse::ok_json(json!({
+        let mut resp = json!({
             "updateDate": now.timestamp() as f64,
             "revisionId": revision_id,
-            "stateMachineVersionArn": sm_arn,
-        })))
+        });
+        // `publish: true` publishes a new version reflecting this update and
+        // returns its version-qualified ARN. Without publish, no version ARN is
+        // returned (a bare update does not create a version).
+        if body["publish"].as_bool() == Some(true) {
+            let version_description = body["versionDescription"].as_str().unwrap_or("");
+            let (version_arn, _) = publish_version(state, &sm_arn, version_description);
+            resp["stateMachineVersionArn"] = json!(version_arn);
+        }
+
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn describe_state_machine_for_execution(
@@ -273,34 +296,16 @@ impl StepFunctionsService {
             .as_str()
             .ok_or_else(|| missing("stateMachineArn"))?
             .to_string();
-        let description = body["description"].as_str().unwrap_or("").to_string();
+        let description = body["description"].as_str().unwrap_or("");
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
         if !state.state_machines.contains_key(&arn) {
             return Err(state_machine_not_found(&arn));
         }
-        let version = state
-            .state_machine_versions
-            .values()
-            .filter(|v| v.state_machine_arn == arn)
-            .map(|v| v.version)
-            .max()
-            .unwrap_or(0)
-            + 1;
-        let version_arn = format!("{arn}:{version}");
-        let v = crate::state::StateMachineVersion {
-            state_machine_arn: arn,
-            version,
-            revision_id: format!("rev-{version}"),
-            description,
-            creation_date: chrono::Utc::now(),
-        };
-        state
-            .state_machine_versions
-            .insert(version_arn.clone(), v.clone());
+        let (version_arn, creation_date) = publish_version(state, &arn, description);
         Ok(AwsResponse::ok_json(json!({
             "stateMachineVersionArn": version_arn,
-            "creationDate": v.creation_date.timestamp(),
+            "creationDate": creation_date.timestamp(),
         })))
     }
 
@@ -595,4 +600,34 @@ impl StepFunctionsService {
             }))),
         }
     }
+}
+
+/// Publish a new state-machine version and return its version-qualified ARN
+/// plus its creation timestamp. The version number is the current max for the
+/// state machine plus one (starting at 1). Callers must hold the state write
+/// lock and have verified the state machine exists.
+fn publish_version(
+    state: &mut crate::state::StepFunctionsState,
+    arn: &str,
+    description: &str,
+) -> (String, chrono::DateTime<chrono::Utc>) {
+    let version = state
+        .state_machine_versions
+        .values()
+        .filter(|v| v.state_machine_arn == arn)
+        .map(|v| v.version)
+        .max()
+        .unwrap_or(0)
+        + 1;
+    let version_arn = format!("{arn}:{version}");
+    let v = crate::state::StateMachineVersion {
+        state_machine_arn: arn.to_string(),
+        version,
+        revision_id: format!("rev-{version}"),
+        description: description.to_string(),
+        creation_date: chrono::Utc::now(),
+    };
+    let creation_date = v.creation_date;
+    state.state_machine_versions.insert(version_arn.clone(), v);
+    (version_arn, creation_date)
 }

--- a/crates/fakecloud-stepfunctions/src/state.rs
+++ b/crates/fakecloud-stepfunctions/src/state.rs
@@ -150,6 +150,8 @@ pub struct StateMachine {
     pub logging_configuration: Option<Value>,
     pub tracing_configuration: Option<Value>,
     pub description: String,
+    #[serde(default)]
+    pub encryption_configuration: Option<Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -373,6 +375,7 @@ mod tests {
                 logging_configuration: None,
                 tracing_configuration: None,
                 description: String::new(),
+                encryption_configuration: None,
             },
         );
         state.reset();


### PR DESCRIPTION
## Summary

Fixes a cluster of MED "stub / dropped-field" bugs across four services where a write succeeds but the read shows a default (Terraform perpetual-diff / lost config). Real persistence + read-back for each, no stubs.

### SageMaker (`fakecloud-sagemaker`)
Claims previously-unclaimed `Verb::Action` ops in `service/special.rs` (they fell through to the generic accept-and-discard arm):
- **Enable/Disable/GetSagemakerServicecatalogPortfolioStatus** — persists the account-scoped portfolio-status singleton on Enable/Disable and reads it back on Get (default `Disabled`). Previously Get returned an empty `{}` regardless.
- **RetryPipelineExecution** — transitions the stored `PipelineExecutionStatus` back to `Executing`, visible via DescribePipelineExecution.

(Start/Stop lifecycle transitions, MPG resource policy, and edge devices were already implemented by earlier bug-hunts.)

### CloudWatch Logs (`fakecloud-logs`)
Persist + echo fields the read path dropped:
- **CreateLookupTable** — `description`, `kmsKeyId` (new struct fields; echoed by GetLookupTable; UpdateLookupTable merges).
- **CreateScheduledQuery** — `description`, `timezone`, `scheduleStartTime`, `scheduleEndTime`, `state` (defaults ENABLED). Echoed by GetScheduledQuery; UpdateScheduledQuery can now disable a query; create/get return `state`.
- **DescribeDeliveries** — now echoes `recordFields` / `fieldDelimiter` / `s3DeliveryConfiguration` (shared `delivery_to_json` helper so Get/Describe agree).
- **PutMetricFilter** — `metricTransformation.dimensions` (new field; echoed by DescribeMetricFilters).
- **PutQueryDefinition** — `queryLanguage` (new field, defaults CWLI; echoed by DescribeQueryDefinitions).

### Route53Resolver (`fakecloud-route53resolver`)
New backing struct fields + persist + echo:
- **CreateResolverRule** — `DelegationRecord`.
- **Create/UpdateResolverEndpoint** — `OutpostArn`, `PreferredInstanceType`, `Dns64Enabled`, `Ipv6InternetAccessEnabled`, `RniEnhancedMetricsEnabled`, `TargetNameServerMetricsEnabled`.
- **Firewall rules** — `DnsThreatProtection`, `ConfidenceThreshold`, structured `FirewallRuleType` (+ minted `FirewallThreatProtectionId`).

### StepFunctions (`fakecloud-stepfunctions`)
- **Create/UpdateStateMachine** with `publish: true` now creates a real version-qualified ARN that `ListStateMachineVersions` returns (shared `publish_version` helper, also used by PublishStateMachineVersion). Without `publish`, no version ARN is returned (matching AWS). `versionDescription` is honored.
- **encryptionConfiguration** persisted on create/update and echoed by DescribeStateMachine.

CloudFormation provisioner constructors for all new struct fields were swept (whole-repo `--all-targets` build).

## Tests
- Round-trip regression test per fix (Create/Put/Update persists → Get/Describe/List reflects).
- `cargo nextest run -p fakecloud-conformance` for all four services: **51 passed, 0 failed**.
- `cargo clippy --all-targets` clean on all touched crates; `cargo fmt --all`.

## Notes / not done
- SageMaker **AssociateTrialComponent / DisassociateTrialComponent** left unimplemented: no wired read sibling (DescribeTrialComponent has no trial field; the ListTrialComponents `TrialName` filter is not implemented in the generic engine). Documented rather than faked.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes read-after-write gaps across `fakecloud-sagemaker`, `fakecloud-logs`, `fakecloud-route53resolver`, and `fakecloud-stepfunctions` so writes persist and reads echo the same fields. This removes Terraform perpetual-diffs and aligns behavior with AWS.

- **Bug Fixes**
  - `fakecloud-sagemaker`: Persist Service Catalog portfolio status for Enable/Disable/Get. `RetryPipelineExecution` now sets `PipelineExecutionStatus` back to `Executing`.
  - `fakecloud-logs`: Persist and echo dropped fields. Lookup tables: `description`, `kmsKeyId`. Scheduled queries: `description`, `timezone`, `scheduleStartTime`, `scheduleEndTime`, `state` (defaults to ENABLED; update can disable). Deliveries: `recordFields`, `fieldDelimiter`, `s3DeliveryConfiguration` (shared renderer). Metric filters: `metricTransformation.dimensions`. Query definitions: `queryLanguage` (defaults to CWLI).
  - `fakecloud-route53resolver`: Resolver endpoints persist `OutpostArn`, `PreferredInstanceType`, and booleans for `Dns64Enabled`, `Ipv6InternetAccessEnabled`, `RniEnhancedMetricsEnabled`, `TargetNameServerMetricsEnabled`. Resolver rules persist `DelegationRecord`. Firewall rules persist `DnsThreatProtection`, `ConfidenceThreshold`, structured `FirewallRuleType`, and mint `FirewallThreatProtectionId`.
  - `fakecloud-stepfunctions`: `Create/UpdateStateMachine` with `publish: true` now creates a real version ARN returned by `ListStateMachineVersions`. `encryptionConfiguration` is stored and returned by `DescribeStateMachine`. CloudFormation provisioners updated to set new fields across services.

<sup>Written for commit d68cd68de3bb74f001c8484875fc14d0124916ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

