### PR TITLE
fix(eventbridge): anything-but on array-valued event field no longer always-matches (bug-hunt)

### DIFF
--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -480,17 +480,45 @@ pub(crate) fn matches_value(pattern: &Value, event_value: &Value) -> bool {
             true
         }
         // A content-filter list matches if ANY of its elements matches the
-        // event value. When the event value is itself an array, AWS matches
-        // if ANY element of the event array satisfies the filter element
-        // (the whole array is still passed first so presence-style matchers
-        // like `exists` see it), so array-valued event fields are matchable.
-        Value::Array(arr) => arr.iter().any(|elem| {
-            matches_single(elem, event_value)
-                || matches!(event_value, Value::Array(items)
-                    if items.iter().any(|item| matches_single(elem, item)))
-        }),
+        // event value.
+        Value::Array(arr) => arr
+            .iter()
+            .any(|elem| matches_content_filter(elem, event_value)),
         _ => false,
     }
+}
+
+/// Evaluate a single content-filter element against an event value, applying
+/// the correct array-vs-matcher semantics.
+///
+/// Positive matchers (`prefix`, `suffix`, `exists`, plain equality, ...) match
+/// if the whole value matches (so presence matchers like `exists` see the
+/// array) or, for an array-valued field, if ANY element matches.
+///
+/// Negation matchers (`anything-but`) invert this: the filter matches only when
+/// NONE of the event values are excluded. Against an array field that means
+/// EVERY element must individually satisfy the negation. Feeding the whole array
+/// to the scalar matcher (as positive matchers do) would always pass -- a
+/// scalar forbidden value never equals the whole array -- silently bypassing
+/// the filter and over-delivering to targets.
+fn matches_content_filter(elem: &Value, event_value: &Value) -> bool {
+    if is_negation_matcher(elem) {
+        match event_value {
+            Value::Array(items) => items.iter().all(|item| matches_single(elem, item)),
+            other => matches_single(elem, other),
+        }
+    } else {
+        matches_single(elem, event_value)
+            || matches!(event_value, Value::Array(items)
+                if items.iter().any(|item| matches_single(elem, item)))
+    }
+}
+
+/// A content-filter element is a negation matcher when it is an object carrying
+/// an `anything-but` key (in any of its sub-forms: string, list, number, or a
+/// nested inner matcher).
+fn is_negation_matcher(elem: &Value) -> bool {
+    matches!(elem, Value::Object(obj) if obj.contains_key("anything-but"))
 }
 
 pub(crate) fn matches_single(pattern_elem: &Value, event_value: &Value) -> bool {

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -368,6 +368,112 @@ fn array_valued_field_matches_prefix_filter() {
     ));
 }
 
+// ---- anything-but against array-valued event fields (filter bypass) ----
+
+#[test]
+fn anything_but_array_field_excludes_when_element_forbidden() {
+    let pattern = r#"{"detail":{"category":[{"anything-but":["blocked"]}]}}"#;
+    // Array contains only the forbidden value -> must NOT match.
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"category":["blocked"]}"#
+    ));
+    // Array contains an allowed value only -> match.
+    assert!(test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"category":["allowed"]}"#
+    ));
+    // Array contains one allowed and one forbidden -> one element is excluded,
+    // so the whole array must NOT match.
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"category":["allowed","blocked"]}"#
+    ));
+}
+
+#[test]
+fn anything_but_string_array_field_excludes() {
+    let pattern = r#"{"detail":{"category":[{"anything-but":"blocked"}]}}"#;
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"category":["blocked"]}"#
+    ));
+    assert!(test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"category":["allowed"]}"#
+    ));
+}
+
+#[test]
+fn anything_but_number_array_field_excludes() {
+    let pattern = r#"{"detail":{"code":[{"anything-but":404}]}}"#;
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"code":[404]}"#
+    ));
+    assert!(test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"code":[200]}"#
+    ));
+    // Mixed array with one forbidden value -> NO match.
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"code":[200,404]}"#
+    ));
+}
+
+#[test]
+fn anything_but_nested_prefix_array_field_excludes() {
+    let pattern = r#"{"detail":{"name":[{"anything-but":{"prefix":"tmp-"}}]}}"#;
+    // Every element must avoid the forbidden prefix.
+    assert!(test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"name":["prod-a","prod-b"]}"#
+    ));
+    // One element hits the forbidden prefix -> NO match.
+    assert!(!test_matches(
+        Some(pattern),
+        "app",
+        "Event",
+        r#"{"name":["prod-a","tmp-b"]}"#
+    ));
+}
+
+#[test]
+fn positive_matcher_array_field_still_matches_any_element() {
+    // Regression guard: positive matchers keep ANY-element semantics.
+    assert!(test_matches(
+        Some(r#"{"detail":{"tags":["b"]}}"#),
+        "app",
+        "Event",
+        r#"{"tags":["a","b"]}"#
+    ));
+    assert!(test_matches(
+        Some(r#"{"detail":{"tags":[{"prefix":"pre"}]}}"#),
+        "app",
+        "Event",
+        r#"{"tags":["nope","prefixed"]}"#
+    ));
+}
+
 // ---- anything-but nested matchers (L1) ----
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity event-pattern filter bypass in the EventBridge matching engine.

The content-filter array branch in `matches_value` passed the **whole** event array to `matches_single` first (`matches_single(elem, event_value) || per-element any`). For the negation matcher `anything-but`, the whole-array test `!arr.iter().any(|v| values_equal(v, whole_array))` is **always true** (a scalar forbidden value never equals the whole array), short-circuiting before per-element evaluation.

Result: a pattern like `{"detail":{"category":[{"anything-but":["blocked"]}]}}` **incorrectly matched** an event with `category:["blocked"]` (AWS: must NOT match) — silent over-delivery to targets. This affected every `anything-but` sub-form (string / list / number / nested matcher) against array-valued event fields.

## Fix

Split content-filter evaluation into `matches_content_filter`, which classifies each pattern element:

- **Negation matchers** (`anything-but`, any sub-form): against an array field the filter matches only if **NONE** of the elements are excluded, i.e. **every** element must individually satisfy the negation. The whole array is never fed to the scalar matcher.
- **Positive matchers** (`prefix`, `suffix`, `exists`, equality, ...): unchanged — match if the whole value matches (so `exists` sees the array) or **any** element matches.

## Tests

Added regression tests in `service_tests.rs` covering `anything-but` (list, string, number, nested-prefix) against array fields, plus a positive-matcher any-element guard:

- `category:[{anything-but:[blocked]}]` vs `["blocked"]` -> NO match; vs `["allowed"]` -> match; vs `["allowed","blocked"]` -> NO match
- positive matchers still match when any element matches

## Validation

- `cargo build -p fakecloud-eventbridge` clean
- `cargo test -p fakecloud-eventbridge --lib`: 249 passed
- `cargo nextest run -p fakecloud-conformance -E 'binary(eventbridge)'`: **57 passed, 0 failed**
- `cargo clippy -p fakecloud-eventbridge --all-targets -- -D warnings` clean, `cargo fmt --all` applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a high-severity EventBridge filter bypass where `anything-but` on array-valued fields always matched, causing over-delivery. Negation matchers now require that no array elements are excluded; positive matchers keep whole-value or any-element semantics.

- Bug Fixes
  - Implemented `matches_content_filter` to apply correct array handling for negation vs. positive matchers.
  - Added `is_negation_matcher` and removed whole-array pass-through for `anything-but`.
  - Added regression tests for list, string, number, and nested-prefix cases; confirmed positive matchers still match when any element matches.

<sup>Written for commit 3ed7317c0f5dbced428e3a895e77835b7ca17154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

