### PR TITLE
fix(apigateway,pinpoint): string-typed PatchOperation values + persist template/segment/campaign content

### DIFF
--- a/crates/fakecloud-apigateway/src/helpers.rs
+++ b/crates/fakecloud-apigateway/src/helpers.rs
@@ -12,6 +12,27 @@ pub(crate) fn conflict(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::CONFLICT, "ConflictException", msg.into())
 }
 
+/// PatchOperation.value is modeled as a STRING in the API Gateway API, so
+/// clients (CLI/SDK/Terraform) send booleans as `"true"`/`"false"`. Accept both
+/// the native JSON boolean and its string form so e.g. disabling an API key
+/// (`{"op":"replace","path":"/enabled","value":"false"}`) is not silently
+/// dropped.
+pub(crate) fn patch_bool(value: &Value) -> Option<bool> {
+    value
+        .as_bool()
+        .or_else(|| value.as_str().map(|s| s == "true"))
+}
+
+/// Like [`patch_bool`] but for integer-valued patch fields (e.g.
+/// `/timeoutInMillis`, `/authorizerResultTtlInSeconds`) that arrive as a quoted
+/// string per the STRING-typed PatchOperation.value model.
+pub(crate) fn patch_i32(value: &Value) -> Option<i32> {
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|s| s.parse::<i64>().ok()))
+        .map(|v| v as i32)
+}
+
 pub(crate) fn ok(value: Value) -> Result<AwsResponse, AwsServiceError> {
     Ok(AwsResponse::ok_json(strip_nulls_deep(value)))
 }
@@ -420,7 +441,7 @@ pub(crate) fn apply_rest_api_patch(api: &mut RestApi, op: &str, path: &str, valu
         "/version" => api.version = value.as_str().map(String::from),
         "/policy" => api.policy = value.as_str().map(String::from),
         "/disableExecuteApiEndpoint" => {
-            if let Some(b) = value.as_bool() {
+            if let Some(b) = patch_bool(value) {
                 api.disable_execute_api_endpoint = b;
             }
         }
@@ -535,7 +556,7 @@ pub(crate) fn apply_method_patch(m: &mut ApiMethod, op: &str, path: &str, value:
         }
         "/authorizerId" => m.authorizer_id = value.as_str().map(String::from),
         "/apiKeyRequired" => {
-            if let Some(b) = value.as_bool() {
+            if let Some(b) = patch_bool(value) {
                 m.api_key_required = b;
             }
         }

--- a/crates/fakecloud-apigateway/src/service_api_keys.rs
+++ b/crates/fakecloud-apigateway/src/service_api_keys.rs
@@ -135,7 +135,9 @@ impl ApiGatewayService {
                 }
                 "/description" => k.description = value.as_str().map(String::from),
                 "/enabled" => {
-                    if let Some(b) = value.as_bool() {
+                    // PatchOperation.value is a STRING, so clients send
+                    // `"false"` to disable a key; accept both forms.
+                    if let Some(b) = patch_bool(value) {
                         k.enabled = b;
                     }
                 }
@@ -157,5 +159,70 @@ impl ApiGatewayService {
         });
         k.last_updated_date = chrono::Utc::now();
         ok(api_key_to_json(k, false))
+    }
+}
+
+#[cfg(test)]
+mod patch_value_tests {
+    use super::*;
+    use crate::ApiGatewayService;
+
+    fn svc() -> ApiGatewayService {
+        let state =
+            std::sync::Arc::new(
+                parking_lot::RwLock::new(fakecloud_core::multi_account::MultiAccountState::<
+                    crate::state::ApiGatewayState,
+                >::new("123456789012", "us-east-1", "")),
+            );
+        ApiGatewayService::new(state)
+    }
+
+    fn req(body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "apigateway".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body_of(resp: &AwsResponse) -> Value {
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    #[test]
+    fn update_api_key_disable_via_string_value() {
+        // PatchOperation.value is a STRING, so the CLI/SDK/Terraform send
+        // `"false"` to disable a key. Previously read via as_bool() and dropped,
+        // leaving the key enabled and still usable.
+        let svc = svc();
+        let created = body_of(
+            &svc.create_api_key(&req(json!({ "name": "k", "enabled": true })))
+                .unwrap(),
+        );
+        let id = created["id"].as_str().unwrap().to_string();
+        assert_eq!(created["enabled"], json!(true));
+        let params: BTreeMap<String, String> = [("apiKeyId".to_string(), id)].into_iter().collect();
+        svc.update_api_key(
+            &req(json!({ "patchOperations": [
+                { "op": "replace", "path": "/enabled", "value": "false" }
+            ] })),
+            &params,
+        )
+        .unwrap();
+        let got = body_of(&svc.get_api_key(&req(json!({})), &params).unwrap());
+        assert_eq!(got["enabled"], json!(false));
     }
 }

--- a/crates/fakecloud-apigateway/src/service_authorizers.rs
+++ b/crates/fakecloud-apigateway/src/service_authorizers.rs
@@ -154,7 +154,9 @@ impl ApiGatewayService {
                 "/authorizerUri" => a.authorizer_uri = value.as_str().map(String::from),
                 "/identitySource" => a.identity_source = value.as_str().map(String::from),
                 "/authorizerResultTtlInSeconds" => {
-                    a.authorizer_result_ttl_in_seconds = value.as_i64().map(|v| v as i32);
+                    // STRING-typed PatchOperation.value arrives quoted; `remove`
+                    // clears the field (Null -> None), matching prior behavior.
+                    a.authorizer_result_ttl_in_seconds = patch_i32(value);
                 }
                 // Previously dropped: rotating Cognito provider ARNs or updating
                 // the authorizer's IAM credentials / identity validation

--- a/crates/fakecloud-apigateway/src/service_integrations.rs
+++ b/crates/fakecloud-apigateway/src/service_integrations.rs
@@ -153,7 +153,9 @@ impl ApiGatewayService {
                     }
                 }
                 "/timeoutInMillis" => {
-                    integration.timeout_in_millis = value.as_i64().map(|v| v as i32);
+                    // STRING-typed PatchOperation.value arrives quoted; `remove`
+                    // clears the field (Null -> None), matching prior behavior.
+                    integration.timeout_in_millis = patch_i32(value);
                 }
                 // Previously dropped (bug-audit 2026-06-20, 1.21).
                 "/credentials" => integration.credentials = value.as_str().map(String::from),
@@ -456,5 +458,80 @@ impl ApiGatewayService {
         )
         .await?;
         ok(result)
+    }
+}
+
+#[cfg(test)]
+mod patch_value_tests {
+    use super::*;
+    use crate::ApiGatewayService;
+
+    fn svc() -> ApiGatewayService {
+        let state =
+            std::sync::Arc::new(
+                parking_lot::RwLock::new(fakecloud_core::multi_account::MultiAccountState::<
+                    crate::state::ApiGatewayState,
+                >::new("123456789012", "us-east-1", "")),
+            );
+        ApiGatewayService::new(state)
+    }
+
+    fn req(body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "apigateway".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "rid".into(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: Vec::new(),
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn params() -> BTreeMap<String, String> {
+        [
+            ("restApiId".to_string(), "api1".to_string()),
+            ("resourceId".to_string(), "res1".to_string()),
+            ("httpMethod".to_string(), "GET".to_string()),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    #[test]
+    fn update_integration_timeout_via_string_value() {
+        // PatchOperation.value is a STRING, so `/timeoutInMillis` arrives quoted
+        // (e.g. "29000"). Previously read via as_i64() and silently dropped.
+        let svc = svc();
+        let p = params();
+        svc.put_integration(
+            &req(json!({ "type": "HTTP_PROXY", "uri": "https://example.com" })),
+            &p,
+        )
+        .unwrap();
+        svc.update_integration(
+            &req(json!({ "patchOperations": [
+                { "op": "replace", "path": "/timeoutInMillis", "value": "29000" }
+            ] })),
+            &p,
+        )
+        .unwrap();
+        let got: Value = serde_json::from_slice(
+            svc.get_integration(&req(json!({})), &p)
+                .unwrap()
+                .body
+                .expect_bytes(),
+        )
+        .unwrap();
+        assert_eq!(got["timeoutInMillis"], json!(29000));
     }
 }

--- a/crates/fakecloud-apigateway/src/service_stages.rs
+++ b/crates/fakecloud-apigateway/src/service_stages.rs
@@ -161,16 +161,14 @@ impl ApiGatewayService {
                 }
                 "/description" => s.description = value.as_str().map(String::from),
                 "/tracingEnabled" => {
-                    if let Some(b) = value.as_bool() {
+                    if let Some(b) = patch_bool(value) {
                         s.tracing_enabled = b;
                     }
                 }
                 // Previously dropped (bug-audit 2026-06-20, 1.21).
                 "/cacheClusterEnabled" => {
-                    if let Some(b) = value.as_bool() {
+                    if let Some(b) = patch_bool(value) {
                         s.cache_cluster_enabled = b;
-                    } else if let Some(v) = value.as_str() {
-                        s.cache_cluster_enabled = v == "true";
                     }
                 }
                 "/cacheClusterSize" => s.cache_cluster_size = value.as_str().map(String::from),
@@ -407,6 +405,9 @@ mod patch_tests {
                 { "op": "replace", "path": "/cacheClusterSize", "value": "0.5" },
                 { "op": "replace", "path": "/webAclArn", "value": "arn:aws:wafv2:::webacl/x" },
                 { "op": "replace", "path": "/~1pets/GET/throttling/rateLimit", "value": "10" },
+                // PatchOperation.value is a STRING; `/tracingEnabled` arrives as
+                // "true" and was previously dropped by an as_bool()-only read.
+                { "op": "replace", "path": "/tracingEnabled", "value": "true" },
             ])),
             &params,
         )
@@ -415,6 +416,7 @@ mod patch_tests {
         let accounts = state.read();
         let s = &accounts.get("123456789012").unwrap().stages["api1"]["prod"];
         assert!(s.cache_cluster_enabled);
+        assert!(s.tracing_enabled);
         assert_eq!(s.cache_cluster_size.as_deref(), Some("0.5"));
         assert_eq!(s.web_acl_arn.as_deref(), Some("arn:aws:wafv2:::webacl/x"));
         // Method settings are keyed by "{resourcePath}/{httpMethod}" with a

--- a/crates/fakecloud-pinpoint/src/service.rs
+++ b/crates/fakecloud-pinpoint/src/service.rs
@@ -812,6 +812,22 @@ pub(crate) fn copy_many(out: &mut Map<String, Value>, src: &Value, keys: &[&str]
     }
 }
 
+/// Merge every non-null member of a request body into `out`. Used to persist the
+/// full write-request definition (e.g. a segment's `Dimensions`, a campaign's
+/// `MessageConfiguration`, an email template's `Subject`/`HtmlPart`) so nothing
+/// is silently dropped on round-trip. Callers insert server-authoritative
+/// members (`Id`, `Arn`, `Version`, timestamps, ...) AFTER this so they win over
+/// anything the client echoed for a read-only member.
+pub(crate) fn merge_body(out: &mut Map<String, Value>, src: &Value) {
+    if let Some(obj) = src.as_object() {
+        for (k, v) in obj {
+            if !v.is_null() {
+                out.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
 pub(crate) fn parse_query(raw: &str) -> Vec<(String, String)> {
     raw.split('&')
         .filter(|p| !p.is_empty())

--- a/crates/fakecloud-pinpoint/src/service/campaigns.rs
+++ b/crates/fakecloud-pinpoint/src/service/campaigns.rs
@@ -5,22 +5,9 @@ use serde_json::{json, Map, Value};
 
 use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
-use super::{copy_many, created, not_found, ok, paginate, Ctx, PinpointService};
+use super::{created, merge_body, not_found, ok, paginate, Ctx, PinpointService};
 use crate::shared;
 use crate::state::Versioned;
-
-/// Scalar `CampaignResponse` members that are safe to echo from the write
-/// request (no nested structures, so response shape validation can't trip).
-const CAMPAIGN_SCALARS: &[&str] = &[
-    "Name",
-    "Description",
-    "HoldoutPercent",
-    "IsPaused",
-    "TreatmentName",
-    "TreatmentDescription",
-    "Priority",
-    "tags",
-];
 
 impl PinpointService {
     pub(super) fn create_campaign(
@@ -216,6 +203,10 @@ fn campaigns_page(
 fn build_campaign(ctx: &Ctx, app_id: &str, id: &str, version: i64, body: &Value) -> Value {
     let now = shared::now_iso();
     let mut out = Map::new();
+    // Persist the full WriteCampaignRequest definition (MessageConfiguration /
+    // Schedule / TemplateConfiguration / AdditionalTreatments / Limits / Hook /
+    // ...) so GetCampaign round-trips it, then overlay server members.
+    merge_body(&mut out, body);
     out.insert("Id".into(), json!(id));
     out.insert("ApplicationId".into(), json!(app_id));
     out.insert(
@@ -242,6 +233,5 @@ fn build_campaign(ctx: &Ctx, app_id: &str, id: &str, version: i64, body: &Value)
             .unwrap_or(0)),
     );
     out.insert("Version".into(), json!(version));
-    copy_many(&mut out, body, CAMPAIGN_SCALARS);
     Value::Object(out)
 }

--- a/crates/fakecloud-pinpoint/src/service/channels.rs
+++ b/crates/fakecloud-pinpoint/src/service/channels.rs
@@ -11,7 +11,7 @@ use serde_json::{json, Map, Value};
 
 use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
-use super::{not_found, ok, Ctx, PinpointService};
+use super::{copy_many, not_found, ok, Ctx, PinpointService};
 use crate::shared;
 
 impl PinpointService {
@@ -114,6 +114,23 @@ fn not_found_channel(channel: &str) -> AwsServiceError {
     ))
 }
 
+/// Non-secret config members shared between a `*ChannelRequest` and its
+/// `*ChannelResponse`. Secrets (ApiKey / Certificate / PrivateKey / SecretKey /
+/// ClientSecret / ServiceJson / ...) are deliberately NOT echoed — a channel
+/// response summarizes credentials via `HasCredential` / `Credential`, so
+/// blanket-copying the request would leak secrets and add members absent from
+/// the response shape.
+const CHANNEL_CONFIG: &[&str] = &[
+    "ConfigurationSet",
+    "FromAddress",
+    "Identity",
+    "RoleArn",
+    "OrchestrationSendingRoleArn",
+    "SenderId",
+    "ShortCode",
+    "DefaultAuthenticationMethod",
+];
+
 fn build_channel(app_id: &str, channel: &str, body: &Value) -> Value {
     let now = shared::now_iso();
     let enabled = body.get("Enabled").and_then(Value::as_bool).unwrap_or(true);
@@ -127,8 +144,12 @@ fn build_channel(app_id: &str, channel: &str, body: &Value) -> Value {
     out.insert("HasCredential".into(), json!(true));
     out.insert("IsArchived".into(), json!(false));
     out.insert("Version".into(), json!(1));
-    if channel == "baidu" {
-        // `Credential` is a required member of `BaiduChannelResponse`.
+    // Echo the non-secret channel config the client wrote. Previously dropped:
+    // Get*Channel returned only Enabled, losing FromAddress / SenderId / etc.
+    copy_many(&mut out, body, CHANNEL_CONFIG);
+    // `Credential` is a response member for channels whose request supplies an
+    // `ApiKey` (Baidu/GCM); it is required by `BaiduChannelResponse`.
+    if matches!(channel, "baidu" | "gcm") {
         let cred = body.get("ApiKey").and_then(Value::as_str).unwrap_or("");
         out.insert("Credential".into(), json!(cred));
     }

--- a/crates/fakecloud-pinpoint/src/service/journeys.rs
+++ b/crates/fakecloud-pinpoint/src/service/journeys.rs
@@ -6,20 +6,9 @@ use serde_json::{json, Map, Value};
 use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
 use super::{
-    copy_many, created, not_found, not_found_app, ok, paginate, str_field, Ctx, PinpointService,
+    created, merge_body, not_found, not_found_app, ok, paginate, str_field, Ctx, PinpointService,
 };
 use crate::shared;
-
-/// Scalar `JourneyResponse` members safe to echo from the write request.
-const JOURNEY_SCALARS: &[&str] = &[
-    "RefreshFrequency",
-    "StartActivity",
-    "LocalTime",
-    "WaitForQuietTime",
-    "RefreshOnSegmentUpdate",
-    "SendingSchedule",
-    "tags",
-];
 
 impl PinpointService {
     pub(super) fn create_journey(
@@ -261,12 +250,15 @@ fn not_found_journey(jid: &str) -> AwsServiceError {
 fn build_journey(app_id: &str, id: &str, state: &str, body: &Value) -> Value {
     let now = shared::now_iso();
     let mut out = Map::new();
+    // Persist the full WriteJourneyRequest definition (Activities /
+    // StartCondition / StartActivity / Schedule / Limits / ...) so GetJourney
+    // round-trips it, then overlay server-authoritative members.
+    merge_body(&mut out, body);
     out.insert("Id".into(), json!(id));
     out.insert("ApplicationId".into(), json!(app_id));
     out.insert("Name".into(), json!(str_field(body, "Name")));
     out.insert("State".into(), json!(state));
     out.insert("CreationDate".into(), json!(now));
     out.insert("LastModifiedDate".into(), json!(now));
-    copy_many(&mut out, body, JOURNEY_SCALARS);
     Value::Object(out)
 }

--- a/crates/fakecloud-pinpoint/src/service/segments.rs
+++ b/crates/fakecloud-pinpoint/src/service/segments.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Map, Value};
 
 use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
-use super::{copy_many, created, not_found, not_found_app, ok, paginate, Ctx, PinpointService};
+use super::{created, merge_body, not_found, not_found_app, ok, paginate, Ctx, PinpointService};
 use crate::shared;
 use crate::state::Versioned;
 
@@ -209,6 +209,10 @@ fn build_segment(ctx: &Ctx, app_id: &str, id: &str, version: i64, body: &Value) 
         "DIMENSIONAL"
     };
     let mut out = Map::new();
+    // Persist the full write-request definition (Dimensions / SegmentGroups /
+    // Name / tags / ImportDefinition, ...) so GetSegment round-trips it, then
+    // overlay server-authoritative members.
+    merge_body(&mut out, body);
     out.insert("Id".into(), json!(id));
     out.insert("ApplicationId".into(), json!(app_id));
     out.insert(
@@ -225,6 +229,5 @@ fn build_segment(ctx: &Ctx, app_id: &str, id: &str, version: i64, body: &Value) 
     out.insert("LastModifiedDate".into(), json!(now));
     out.insert("SegmentType".into(), json!(segment_type));
     out.insert("Version".into(), json!(version));
-    copy_many(&mut out, body, &["Name", "tags"]);
     Value::Object(out)
 }

--- a/crates/fakecloud-pinpoint/src/service/templates.rs
+++ b/crates/fakecloud-pinpoint/src/service/templates.rs
@@ -10,14 +10,11 @@ use serde_json::{json, Map, Value};
 use fakecloud_core::service::{AwsResponse, AwsServiceError};
 
 use super::{
-    accepted, bad_request, copy_many, created, not_found, ok, paginate, query_one, Ctx,
+    accepted, bad_request, copy_many, created, merge_body, not_found, ok, paginate, query_one, Ctx,
     PinpointService,
 };
 use crate::shared;
 use crate::state::Template;
-
-/// Members common to every `*TemplateResponse` shape.
-const TEMPLATE_SCALARS: &[&str] = &["TemplateDescription", "tags"];
 
 /// The valid `TemplateType` enum values.
 const TEMPLATE_TYPES: &[&str] = &["EMAIL", "SMS", "VOICE", "PUSH", "INAPP"];
@@ -221,17 +218,20 @@ fn select_version(tmpl: &Template, version: Option<&str>) -> Result<Value, AwsSe
     }
 }
 
-/// Build a template response record from the common `*TemplateResponse` members.
+/// Build a template response record. Persists the full `*TemplateRequest`
+/// definition (Subject / HtmlPart / TextPart / Body / voice + push + in-app
+/// content, DefaultSubstitutions, ...) so a `Get*Template` round-trips the
+/// content the client wrote, then overlays the server-authoritative members.
 fn build_template(name: &str, ttype: &str, version: &str, arn: &str, body: &Value) -> Value {
     let now = shared::now_iso();
     let mut out = Map::new();
+    merge_body(&mut out, body);
     out.insert("TemplateName".into(), json!(name));
     out.insert("TemplateType".into(), json!(ttype));
     out.insert("Arn".into(), json!(arn));
     out.insert("Version".into(), json!(version));
     out.insert("CreationDate".into(), json!(now));
     out.insert("LastModifiedDate".into(), json!(now));
-    copy_many(&mut out, body, TEMPLATE_SCALARS);
     Value::Object(out)
 }
 

--- a/crates/fakecloud-pinpoint/src/service/tests.rs
+++ b/crates/fakecloud-pinpoint/src/service/tests.rs
@@ -382,6 +382,175 @@ fn resolve_action_routes_key_paths() {
     }
 }
 
+#[test]
+fn email_template_round_trips_content() {
+    // Regression: build_template previously copied only TemplateDescription/tags,
+    // dropping Subject/HtmlPart/TextPart so Get*Template returned no content.
+    let svc = service();
+    let ctx = ctx();
+    svc.create_template(
+        &ctx,
+        "welcome",
+        "EMAIL",
+        &json!({
+            "Subject": "Hi {{name}}",
+            "HtmlPart": "<h1>Hello</h1>",
+            "TextPart": "Hello",
+            "TemplateDescription": "greeting",
+            "DefaultSubstitutions": "{\"name\":\"there\"}"
+        }),
+    )
+    .unwrap();
+    let got = body_of(&svc.get_template(&ctx, "welcome", "EMAIL", &[]).unwrap());
+    assert_eq!(got["Subject"], "Hi {{name}}");
+    assert_eq!(got["HtmlPart"], "<h1>Hello</h1>");
+    assert_eq!(got["TextPart"], "Hello");
+    assert_eq!(got["TemplateDescription"], "greeting");
+    assert_eq!(got["DefaultSubstitutions"], "{\"name\":\"there\"}");
+    // Server-authoritative members still win.
+    assert_eq!(got["TemplateName"], "welcome");
+    assert_eq!(got["TemplateType"], "EMAIL");
+}
+
+#[test]
+fn segment_round_trips_dimensions_and_groups() {
+    // Regression: build_segment previously copied only Name/tags, dropping
+    // Dimensions/SegmentGroups so GetSegment returned an empty definition.
+    let svc = service();
+    let ctx = ctx();
+    let app = new_app(&svc, &ctx, "seg");
+    let dims =
+        json!({ "Attributes": { "Plan": { "Values": ["pro"], "AttributeType": "INCLUSIVE" } } });
+    let groups = json!({ "Include": "ALL", "Groups": [] });
+    let create = body_of(
+        &svc.create_segment(
+            &ctx,
+            &app,
+            &json!({ "Name": "s", "Dimensions": dims, "SegmentGroups": groups }),
+        )
+        .unwrap(),
+    );
+    let sid = create["Id"].as_str().unwrap().to_string();
+    let got = body_of(&svc.get_segment(&ctx, &app, &sid).unwrap());
+    assert_eq!(got["Dimensions"], dims);
+    assert_eq!(got["SegmentGroups"], groups);
+    assert_eq!(got["Name"], "s");
+}
+
+#[test]
+fn campaign_round_trips_message_configuration() {
+    // Regression: build_campaign previously dropped MessageConfiguration /
+    // Schedule / TemplateConfiguration.
+    let svc = service();
+    let ctx = ctx();
+    let app = new_app(&svc, &ctx, "c");
+    let msg_cfg = json!({ "EmailMessage": { "Title": "Sale", "Body": "Buy now" } });
+    let schedule = json!({ "StartTime": "2026-01-01T00:00:00Z", "Frequency": "ONCE" });
+    let tmpl_cfg = json!({ "EmailTemplate": { "Name": "welcome" } });
+    let create = body_of(
+        &svc.create_campaign(
+            &ctx,
+            &app,
+            &json!({
+                "Name": "c1",
+                "SegmentId": "seg",
+                "MessageConfiguration": msg_cfg,
+                "Schedule": schedule,
+                "TemplateConfiguration": tmpl_cfg
+            }),
+        )
+        .unwrap(),
+    );
+    let cid = create["Id"].as_str().unwrap().to_string();
+    let got = body_of(&svc.get_campaign(&ctx, &app, &cid).unwrap());
+    assert_eq!(got["MessageConfiguration"], msg_cfg);
+    assert_eq!(got["Schedule"], schedule);
+    assert_eq!(got["TemplateConfiguration"], tmpl_cfg);
+    assert_eq!(got["SegmentId"], "seg");
+}
+
+#[test]
+fn journey_round_trips_activities_and_start_condition() {
+    // Regression: build_journey previously dropped Activities/StartCondition.
+    let svc = service();
+    let ctx = ctx();
+    let app = new_app(&svc, &ctx, "j");
+    let activities = json!({ "a1": { "Wait": { "WaitTime": { "WaitFor": "P1D" } } } });
+    let start = json!({ "SegmentStartCondition": { "SegmentId": "seg" } });
+    let create = body_of(
+        &svc.create_journey(
+            &ctx,
+            &app,
+            &json!({ "Name": "j1", "Activities": activities, "StartCondition": start }),
+        )
+        .unwrap(),
+    );
+    let jid = create["Id"].as_str().unwrap().to_string();
+    let got = body_of(&svc.get_journey(&ctx, &app, &jid).unwrap());
+    assert_eq!(got["Activities"], activities);
+    assert_eq!(got["StartCondition"], start);
+    assert_eq!(got["Name"], "j1");
+}
+
+#[test]
+fn email_channel_round_trips_config_but_not_secrets() {
+    // Regression: build_channel previously returned only Enabled, dropping
+    // FromAddress/Identity/RoleArn. Secrets must NOT be echoed.
+    let svc = service();
+    let ctx = ctx();
+    let app = new_app(&svc, &ctx, "ch");
+    svc.update_channel(
+        &ctx,
+        &app,
+        "email",
+        &json!({
+            "Enabled": true,
+            "FromAddress": "no-reply@example.com",
+            "Identity": "arn:aws:ses:us-east-1:000000000000:identity/example.com",
+            "RoleArn": "arn:aws:iam::000000000000:role/pinpoint"
+        }),
+    )
+    .unwrap();
+    let got = body_of(&svc.get_channel(&ctx, &app, "email").unwrap());
+    assert_eq!(got["FromAddress"], "no-reply@example.com");
+    assert_eq!(
+        got["Identity"],
+        "arn:aws:ses:us-east-1:000000000000:identity/example.com"
+    );
+    assert_eq!(got["RoleArn"], "arn:aws:iam::000000000000:role/pinpoint");
+    assert_eq!(got["Platform"], "EMAIL");
+}
+
+#[test]
+fn apns_channel_does_not_leak_secrets() {
+    // APNSChannelRequest carries secrets (Certificate/PrivateKey/TokenKey/...)
+    // absent from APNSChannelResponse; they must never be echoed back.
+    let svc = service();
+    let ctx = ctx();
+    let app = new_app(&svc, &ctx, "ch2");
+    svc.update_channel(
+        &ctx,
+        &app,
+        "apns",
+        &json!({
+            "Enabled": true,
+            "DefaultAuthenticationMethod": "TOKEN",
+            "Certificate": "SECRET-CERT",
+            "PrivateKey": "SECRET-KEY",
+            "TokenKey": "SECRET-TOKEN",
+            "TeamId": "TEAM123"
+        }),
+    )
+    .unwrap();
+    let got = body_of(&svc.get_channel(&ctx, &app, "apns").unwrap());
+    assert_eq!(got["DefaultAuthenticationMethod"], "TOKEN");
+    assert!(got.get("Certificate").is_none(), "secret leaked");
+    assert!(got.get("PrivateKey").is_none(), "secret leaked");
+    assert!(got.get("TokenKey").is_none(), "secret leaked");
+    assert!(got.get("TeamId").is_none(), "non-response member leaked");
+    assert_eq!(got["HasCredential"], json!(true));
+}
+
 fn test_request() -> AwsRequest {
     AwsRequest {
         service: "pinpoint".to_string(),


### PR DESCRIPTION
Fixes two HIGH bug clusters found during bug-hunt, in two disjoint crates.

## Cluster 1 — API Gateway string-typed PatchOperation values

`PatchOperation.value` is modeled as a **string** in the API Gateway API, so the CLI/SDK/Terraform send booleans as `"false"` and numbers as quoted strings. Six `Update*` handlers read these via `as_bool()` / `as_i64()` only, silently dropping the patch:

- `UpdateApiKey /enabled` — a key could not be disabled (returned 200 with `enabled:true`, key kept working)
- `UpdateStage /tracingEnabled`
- `UpdateIntegration /timeoutInMillis`
- `UpdateAuthorizer /authorizerResultTtlInSeconds`
- `UpdateMethod /apiKeyRequired`
- `UpdateRestApi /disableExecuteApiEndpoint`

Fix: two shared coercion helpers (`patch_bool`, `patch_i32`) in `helpers.rs` that accept both the native JSON type and its string form, applied at all six sites. `/cacheClusterEnabled` (which already had an ad-hoc string parse) now routes through the shared helper. Integer fields keep clear-on-`remove` semantics.

## Cluster 2 — Pinpoint content-drop

Several `Create`/`Update` builders copied only a hand-picked scalar subset of the request body, discarding the substantive definition so the matching `Get` returned empty content:

- Email/SMS/Voice/Push/InApp **templates** — dropped Subject/HtmlPart/TextPart/Body/etc.
- **Segments** — dropped Dimensions/SegmentGroups
- **Campaigns** — dropped MessageConfiguration/Schedule/TemplateConfiguration
- **Journeys** — dropped Activities/StartCondition
- **Channels** — dropped FromAddress/SenderId/etc.

Fix: a `merge_body` helper persists the full write-request definition for templates/segments/campaigns/journeys (request members are a subset of the response shapes), overlaying server-authoritative members afterward.

Channels are handled with a curated non-secret allowlist instead of a blanket merge: `*ChannelRequest` shapes carry secrets (ApiKey/Certificate/PrivateKey/SecretKey/ClientSecret/ServiceJson) that are **absent** from the `*ChannelResponse` shapes, so blanket-copying would leak credentials and add out-of-model members. GCM now also maps `ApiKey -> Credential` (a real response member previously dropped).

## Tests
- API Gateway: `UpdateApiKey /enabled="false"` actually disables (GetApiKey shows `enabled:false`); `/timeoutInMillis="29000"` round-trips; `/tracingEnabled="true"` applies.
- Pinpoint: email-template content round-trip; segment Dimensions/SegmentGroups; campaign MessageConfiguration/Schedule; journey Activities/StartCondition; email-channel config round-trip; APNS channel does not leak secrets.

## Validation
- `cargo nextest run -p fakecloud-conformance -E 'test(apigateway)'`: 31/31 passed (apigateway v1 + v2)
- Pinpoint crate unit tests: 34/34 passed (Pinpoint is not in the conformance audit list; covered by crate tests)
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all` clean

## False positives
None — all listed sub-items were real and fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two high-impact bugs: API Gateway patch updates were ignored when values arrived as strings, and Pinpoint write APIs dropped content, causing empty reads and potential secret leaks.

- **Bug Fixes**
  - `fakecloud-apigateway`: Handle string-typed `PatchOperation.value` for booleans and integers via shared helpers, so updates apply for `/enabled`, `/tracingEnabled`, `/timeoutInMillis`, `/authorizerResultTtlInSeconds`, `/apiKeyRequired`, `/disableExecuteApiEndpoint` (and `/cacheClusterEnabled` now uses the helper). Integer fields still clear on `remove`.
  - `fakecloud-pinpoint`: Persist full request bodies for templates, segments, campaigns, and journeys so `Get*` APIs round-trip all content. For channels, echo only non-secret config (e.g., FromAddress/SenderId/RoleArn), avoid leaking secrets, and map GCM `ApiKey` to response `Credential`.

<sup>Written for commit aebb8e9abeedf5b80db9726754481475d1a3b6a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

