### PR TITLE
fix(s3,rds,kms,route53): non-blocking multipart assembly + reboot recovery + DNS SOA/ANY + wire-fidelity (bug-hunt); docs(ghcr)

### DIFF
--- a/crates/fakecloud-cloudfront/src/functions_service.rs
+++ b/crates/fakecloud-cloudfront/src/functions_service.rs
@@ -114,7 +114,12 @@ impl CloudFrontService {
         drop(state);
         let view = stage_view(&f, &stage);
         let mut headers = HeaderMap::new();
-        headers.insert(ETAG, view.etag.parse().unwrap());
+        headers.insert(
+            ETAG,
+            view.etag
+                .parse()
+                .unwrap_or_else(|_| http::HeaderValue::from_static("")),
+        );
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(view.function_code.as_bytes())
             .unwrap_or_default();

--- a/crates/fakecloud-e2e/tests/s3.rs
+++ b/crates/fakecloud-e2e/tests/s3.rs
@@ -1159,6 +1159,94 @@ async fn s3_multipart_upload_basic() {
     assert_eq!(body.as_ref(), expected.as_slice());
 }
 
+/// Regression for the non-blocking multipart assembly change (bug-hunt
+/// 2026-07-19): CompleteMultipartUpload with several parts still assembles the
+/// object in order, returns a well-formed multipart ETag (`<md5>-<N>`), and the
+/// downloaded bytes match the concatenation of the uploaded parts.
+#[tokio::test]
+async fn s3_multipart_upload_three_parts_etag_and_order() {
+    let server = TestServer::start().await;
+    let client = server.s3_client().await;
+
+    client
+        .create_bucket()
+        .bucket("mp3-bucket")
+        .send()
+        .await
+        .unwrap();
+
+    let create = client
+        .create_multipart_upload()
+        .bucket("mp3-bucket")
+        .key("three.bin")
+        .send()
+        .await
+        .unwrap();
+    let upload_id = create.upload_id().unwrap().to_string();
+
+    use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+    // Three parts; non-last parts must be >= 5 MiB. Distinct fill bytes so an
+    // out-of-order assembly would be detectable in the downloaded object.
+    let part_bytes: [Vec<u8>; 3] = [
+        vec![b'x'; 5 * 1024 * 1024],
+        vec![b'y'; 5 * 1024 * 1024],
+        b"tail-part-three".to_vec(),
+    ];
+    let mut completed = CompletedMultipartUpload::builder();
+    for (i, data) in part_bytes.iter().enumerate() {
+        let pn = (i + 1) as i32;
+        let up = client
+            .upload_part()
+            .bucket("mp3-bucket")
+            .key("three.bin")
+            .upload_id(&upload_id)
+            .part_number(pn)
+            .body(ByteStream::from(data.clone()))
+            .send()
+            .await
+            .unwrap();
+        completed = completed.parts(
+            CompletedPart::builder()
+                .part_number(pn)
+                .e_tag(up.e_tag().unwrap())
+                .build(),
+        );
+    }
+
+    let complete = client
+        .complete_multipart_upload()
+        .bucket("mp3-bucket")
+        .key("three.bin")
+        .upload_id(&upload_id)
+        .multipart_upload(completed.build())
+        .send()
+        .await
+        .unwrap();
+
+    // Multipart ETag carries the "-<part count>" suffix.
+    let etag = complete.e_tag().unwrap().trim_matches('"').to_string();
+    assert!(
+        etag.ends_with("-3"),
+        "multipart ETag should end with -3, got {etag}"
+    );
+
+    let get = client
+        .get_object()
+        .bucket("mp3-bucket")
+        .key("three.bin")
+        .send()
+        .await
+        .unwrap();
+    // GetObject echoes the same multipart ETag.
+    assert_eq!(get.e_tag().unwrap().trim_matches('"'), etag);
+    let body = get.body.collect().await.unwrap().into_bytes();
+    let mut expected = Vec::new();
+    for data in &part_bytes {
+        expected.extend_from_slice(data);
+    }
+    assert_eq!(body.as_ref(), expected.as_slice());
+}
+
 #[tokio::test]
 async fn s3_multipart_abort() {
     let server = TestServer::start().await;

--- a/crates/fakecloud-kms/src/state.rs
+++ b/crates/fakecloud-kms/src/state.rs
@@ -24,7 +24,7 @@ pub struct KmsState {
     /// lazily on first encrypt and persisted alongside the rest of the
     /// state so that ciphertexts produced before a server restart still
     /// decrypt afterwards.
-    #[serde(default = "default_master_key_bytes")]
+    #[serde(default = "default_master_key_bytes_on_load")]
     pub master_key_bytes: Vec<u8>,
     /// In-flight RSA wrapping keypairs handed out by GetParametersForImport
     /// and consumed by ImportKeyMaterial to RSA-OAEP-unwrap the encrypted
@@ -52,6 +52,24 @@ fn default_master_key_bytes() -> Vec<u8> {
     let mut bytes = vec![0u8; 32];
     OsRng.fill_bytes(&mut bytes);
     bytes
+}
+
+/// serde `default` for [`KmsState::master_key_bytes`], invoked ONLY when a
+/// persisted snapshot is deserialized WITHOUT the field — e.g. a state file
+/// written by a fakecloud build predating per-account master keys. Silently
+/// regenerating the key would make every ciphertext blob produced by that
+/// older build undecryptable (`Decrypt` -> `InvalidCiphertextException`) with
+/// no indication why, so we log a loud warning to surface the data-integrity
+/// break. Fresh accounts go through [`KmsState::new`], which calls
+/// [`default_master_key_bytes`] directly and stays quiet — only the on-load
+/// default path warns.
+fn default_master_key_bytes_on_load() -> Vec<u8> {
+    tracing::warn!(
+        "KMS state snapshot was missing the per-account master key; generating \
+         a fresh one. Ciphertext produced before this upgrade can NO LONGER be \
+         decrypted (Decrypt will fail with InvalidCiphertextException)."
+    );
+    default_master_key_bytes()
 }
 
 impl KmsState {
@@ -207,5 +225,35 @@ mod tests {
         assert!(!state.aliases.is_empty());
         state.reset();
         assert!(state.aliases.is_empty());
+    }
+
+    #[test]
+    fn snapshot_with_master_key_preserves_it() {
+        // A snapshot that carries the master key must round-trip it byte-for-byte
+        // so ciphertext produced before a restart still decrypts.
+        let mut original = KmsState::new("123456789012", "us-east-1");
+        original.master_key_bytes = vec![7u8; 32];
+        let json = serde_json::to_string(&original).unwrap();
+        let loaded: KmsState = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.master_key_bytes, vec![7u8; 32]);
+    }
+
+    #[test]
+    fn snapshot_missing_master_key_is_defaulted_on_load() {
+        // An older snapshot with no `master_key_bytes` (predating per-account
+        // master keys) must still deserialize, with a freshly generated 32-byte
+        // key via the on-load default (which also logs a loud warning that the
+        // prior ciphertext is now undecryptable).
+        let json = r#"{
+            "account_id": "123456789012",
+            "region": "us-east-1",
+            "keys": {},
+            "aliases": {},
+            "grants": [],
+            "custom_key_stores": {}
+        }"#;
+        let loaded: KmsState = serde_json::from_str(json).unwrap();
+        assert_eq!(loaded.master_key_bytes.len(), 32);
+        assert!(loaded.import_wrapping_keys.is_empty());
     }
 }

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -1107,7 +1107,7 @@ impl RdsService {
                     .db_name
                     .clone()
                     .unwrap_or_else(|| default_db_name(&inst.engine).to_string());
-                let Ok(running) = runtime
+                let running = match runtime
                     .restart_container(
                         &id,
                         &inst.engine,
@@ -1116,8 +1116,42 @@ impl RdsService {
                         &logical_db,
                     )
                     .await
-                else {
-                    return;
+                {
+                    Ok(running) => running,
+                    Err(error) => {
+                        // The container restart failed. Without resetting the
+                        // status here the instance is stuck reporting
+                        // "rebooting" forever (DescribeDBInstances never clears
+                        // it), so flip it back to "available" — the previous
+                        // container is still running, the reboot just didn't
+                        // land — then persist and emit a failure event so the
+                        // stuck state is both cleared and observable. Mirrors the
+                        // CreateDBInstance background task's Err handling.
+                        tracing::error!(%error, db_instance_identifier=%id, "reboot_db_instance restart failed");
+                        let arn = {
+                            let mut accounts = state_handle.write();
+                            let state = accounts.get_or_create(&account_id);
+                            let Some(instance) = state.instances.get_mut(&id) else {
+                                return;
+                            };
+                            instance.db_instance_status = "available".to_string();
+                            instance.db_instance_arn.clone()
+                        };
+                        save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock)
+                            .await;
+                        emit_event_static_with_state(
+                            delivery_bus.as_ref(),
+                            Some(&state_handle),
+                            Some(&account_id),
+                            RdsSourceType::DbInstance,
+                            &id,
+                            &arn,
+                            "RDS-EVENT-0006",
+                            &["availability"],
+                            "DB instance reboot failed; instance returned to available",
+                        );
+                        return;
+                    }
                 };
                 let arn = {
                     let mut accounts = state_handle.write();

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2374,6 +2374,44 @@ async fn reboot_db_instance_missing_id_errors() {
     assert_code(svc.reboot_db_instance(&req).await, "MissingParameter");
 }
 
+#[tokio::test]
+async fn reboot_db_instance_restart_failure_resets_status() {
+    // Regression (bug-hunt 2026-07-19): a failed container restart must not
+    // leave the instance stuck reporting "rebooting" forever. The stub runtime
+    // has no registered container, so `restart_container` returns Err
+    // immediately; the background task must flip the status back to "available".
+    let svc = make_service().with_runtime(Arc::new(crate::runtime::RdsRuntime::new_stub()));
+    seed_instance(&svc, "db1");
+
+    let req = request("RebootDBInstance", &[("DBInstanceIdentifier", "db1")]);
+    // The synchronous response reports "rebooting".
+    svc.reboot_db_instance(&req).await.expect("reboot accepted");
+
+    // The background restart fails, then resets the status. Poll until it clears
+    // (the reset is a fast Err path, but the task is spawned asynchronously).
+    let mut status = String::new();
+    for _ in 0..200 {
+        {
+            let accounts = svc.state.read();
+            status = accounts
+                .default_ref()
+                .instances
+                .get("db1")
+                .expect("instance present")
+                .db_instance_status
+                .clone();
+        }
+        if status != "rebooting" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        status, "available",
+        "failed reboot must reset status to available, not stay stuck at rebooting"
+    );
+}
+
 // ── create_db_instance validation ──
 
 #[tokio::test]

--- a/crates/fakecloud-route53/src/resolver.rs
+++ b/crates/fakecloud-route53/src/resolver.rs
@@ -245,6 +245,45 @@ pub fn resolve(accounts: &Route53Accounts, qname: &str, qtype: &str) -> Resoluti
         }
     };
 
+    // ANY (`*`, qtype 255): return every record type held at the exact name
+    // (RFC 8482 permits a minimal answer; a full one is also valid and more
+    // useful for a local service-discovery resolver). Wildcard synthesis and
+    // CNAME chasing don't apply — ANY reports what actually lives at the node.
+    if qtype_uc == "ANY" || qtype_uc == "*" {
+        let mut answers = Vec::new();
+        for rr in &records {
+            if normalize(&rr.name) != qname_norm {
+                continue;
+            }
+            let ttl = rr
+                .ttl
+                .and_then(|t| u32::try_from(t).ok())
+                .unwrap_or(DEFAULT_TTL);
+            if let Some(values) = &rr.resource_records {
+                for v in &values.resource_record {
+                    answers.push(AnswerRecord {
+                        name: qname_norm.clone(),
+                        rtype: rr.record_type.to_ascii_uppercase(),
+                        ttl,
+                        value: v.value.clone(),
+                    });
+                }
+            }
+        }
+        let status = if !answers.is_empty() {
+            ResolveStatus::Answered
+        } else if name_exists(&records, &qname_norm) {
+            ResolveStatus::NoData
+        } else {
+            ResolveStatus::NxDomain
+        };
+        return Resolution {
+            answers,
+            status,
+            external_cname: None,
+        };
+    }
+
     // Direct hits for the requested type.
     let direct = records_of_type(&records, &qname_norm, &qtype_uc);
     if !direct.is_empty() {
@@ -319,6 +358,28 @@ pub fn resolve(accounts: &Route53Accounts, qname: &str, qtype: &str) -> Resoluti
         status,
         external_cname: None,
     }
+}
+
+/// The apex `SOA` record of the most-specific local zone authoritative for
+/// `qname`, used to fill the authority section of a negative (NXDOMAIN/NODATA)
+/// response so clients can cache the negative answer (RFC 2308). `None` when no
+/// local zone is authoritative or the zone has no SOA record.
+pub fn zone_soa(accounts: &Route53Accounts, qname: &str) -> Option<AnswerRecord> {
+    let qname_norm = normalize(qname);
+    // Find the apex of the most-specific zone authoritative for the name (same
+    // best-match rule `authoritative_records` uses to scope the record set).
+    let mut apex: Option<String> = None;
+    for account in accounts.accounts.values() {
+        for zone in account.hosted_zones.values() {
+            let zn = normalize(&zone.name);
+            if name_in_zone(&qname_norm, &zn) && apex.as_ref().is_none_or(|a| zn.len() > a.len()) {
+                apex = Some(zn);
+            }
+        }
+    }
+    let apex = apex?;
+    let records = authoritative_records(accounts, &qname_norm)?;
+    collect(&records, &apex, &apex, "SOA").into_iter().next()
 }
 
 #[cfg(test)]
@@ -764,5 +825,90 @@ mod tests {
             resolve(&acc, "y.b.example", "A").answers[0].value,
             "2.2.2.2"
         );
+    }
+
+    #[test]
+    fn any_returns_all_record_types_at_name() {
+        let acc = accounts_with(
+            "000000000000",
+            vec![zone(
+                "example.com.",
+                vec![
+                    rrset("app.example.com.", "A", 60, &["10.0.0.5", "10.0.0.6"]),
+                    rrset("app.example.com.", "TXT", 300, &["\"hello\""]),
+                    rrset("other.example.com.", "A", 60, &["10.0.0.9"]),
+                ],
+            )],
+        );
+        let r = resolve(&acc, "app.example.com", "ANY");
+        assert_eq!(r.status, ResolveStatus::Answered);
+        // Both A values plus the TXT, and nothing from the unrelated owner.
+        assert_eq!(r.answers.len(), 3);
+        assert!(r
+            .answers
+            .iter()
+            .any(|a| a.rtype == "A" && a.value == "10.0.0.5"));
+        assert!(r
+            .answers
+            .iter()
+            .any(|a| a.rtype == "A" && a.value == "10.0.0.6"));
+        assert!(r.answers.iter().any(|a| a.rtype == "TXT"));
+        assert!(r.answers.iter().all(|a| a.name == "app.example.com."));
+    }
+
+    #[test]
+    fn any_on_absent_name_is_nxdomain() {
+        let acc = accounts_with(
+            "000000000000",
+            vec![zone(
+                "example.com.",
+                vec![rrset("app.example.com.", "A", 60, &["10.0.0.5"])],
+            )],
+        );
+        assert_eq!(
+            resolve(&acc, "missing.example.com", "ANY").status,
+            ResolveStatus::NxDomain
+        );
+    }
+
+    #[test]
+    fn zone_soa_returns_apex_soa_for_subdomain() {
+        let acc = accounts_with(
+            "000000000000",
+            vec![zone(
+                "example.com.",
+                vec![
+                    rrset(
+                        "example.com.",
+                        "SOA",
+                        900,
+                        &["ns.example.com. hostmaster.example.com. 1 7200 900 1209600 86400"],
+                    ),
+                    rrset("app.example.com.", "A", 60, &["10.0.0.5"]),
+                ],
+            )],
+        );
+        // A negative lookup deep in the zone still resolves the apex SOA.
+        let soa = zone_soa(&acc, "missing.example.com").expect("apex SOA");
+        assert_eq!(soa.rtype, "SOA");
+        assert_eq!(soa.name, "example.com.");
+        assert!(soa.value.starts_with("ns.example.com."));
+    }
+
+    #[test]
+    fn zone_soa_none_when_not_authoritative() {
+        let acc = accounts_with(
+            "000000000000",
+            vec![zone(
+                "example.com.",
+                vec![rrset(
+                    "example.com.",
+                    "SOA",
+                    900,
+                    &["ns.example.com. hostmaster.example.com. 1 7200 900 1209600 86400"],
+                )],
+            )],
+        );
+        assert!(zone_soa(&acc, "elsewhere.org").is_none());
     }
 }

--- a/crates/fakecloud-s3/src/service/multipart.rs
+++ b/crates/fakecloud-s3/src/service/multipart.rs
@@ -627,56 +627,75 @@ impl S3Service {
         // Assemble the object from its parts OFF-LOCK. Bodies are read via the
         // state-free `read_body_uncached`, so no S3 lock is held during the
         // (potentially large) concatenation, hashing, and disk persist below.
-        let mut combined_data = Vec::new();
-        let mut md5_digests = Vec::new();
-        let mut part_sizes = Vec::new();
-        // Per-part raw additional-checksum digests, collected in
-        // part-number order so we can build the COMPOSITE checksum
-        // (hash-of-part-hashes) AWS returns for multipart objects.
-        let mut part_checksum_digests: Vec<Vec<u8>> = Vec::new();
+        //
+        // The read+concat+hash of every part is synchronous, blocking disk IO
+        // (`std::fs::read`) that can process multi-GB objects, so run it inside
+        // `run_blocking_io`: on the multi-threaded runtime this hands the tokio
+        // worker's other tasks to a sibling thread for the duration instead of
+        // stalling them (and risking the client timeout) — the same helper
+        // GetObject uses (bug-hunt 2026-07-19). Behavior/response are
+        // unchanged; only where the CPU/IO runs differs.
+        let checksum_algorithm = upload.checksum_algorithm.clone();
+        let (combined_data, md5_digests, part_sizes, part_checksum_digests) =
+            super::objects::run_blocking_io(|| {
+                let mut combined_data = Vec::new();
+                let mut md5_digests = Vec::new();
+                let mut part_sizes = Vec::new();
+                // Per-part raw additional-checksum digests, collected in
+                // part-number order so we can build the COMPOSITE checksum
+                // (hash-of-part-hashes) AWS returns for multipart objects.
+                let mut part_checksum_digests: Vec<Vec<u8>> = Vec::new();
 
-        for (part_num, submitted_etag) in &sorted_parts {
-            let part = upload.parts.get(part_num).ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidPart",
-                    "One or more of the specified parts could not be found.",
-                )
+                for (part_num, submitted_etag) in &sorted_parts {
+                    let part = upload.parts.get(part_num).ok_or_else(|| {
+                        AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidPart",
+                            "One or more of the specified parts could not be found.",
+                        )
+                    })?;
+                    if submitted_etag != &part.etag {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidPart",
+                            "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's entity tag.",
+                        ));
+                    }
+                    let part_bytes = crate::state::S3State::read_body_uncached(&part.body)
+                        .map_err(super::io_to_aws)?;
+                    let part_md5 = Md5::digest(&part_bytes);
+                    // Fail closed if the bytes just read no longer hash to the
+                    // part's recorded etag. We snapshot (clone) the upload —
+                    // including each part's fixed disk path and etag — then read
+                    // bodies off-lock. In disk mode a concurrent UploadPart of
+                    // the same part number rewrites part-NNNNN.bin after the
+                    // snapshot, so without this check Complete would assemble the
+                    // *new* bytes while validating them against the *old* cloned
+                    // etag, producing an object whose content doesn't match the
+                    // parts the client committed (bug-hunt 2026-06-13, finding
+                    // 4.1). Memory-mode parts are immutable, so this never trips
+                    // for them.
+                    if format!("{:x}", part_md5) != part.etag {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidPart",
+                            "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's etag.",
+                        ));
+                    }
+                    if let Some(algo) = checksum_algorithm.as_deref() {
+                        part_checksum_digests.push(super::compute_checksum_raw(algo, &part_bytes));
+                    }
+                    combined_data.extend_from_slice(&part_bytes);
+                    md5_digests.extend_from_slice(&part_md5);
+                    part_sizes.push((*part_num, part_bytes.len() as u64));
+                }
+                Ok::<_, AwsServiceError>((
+                    combined_data,
+                    md5_digests,
+                    part_sizes,
+                    part_checksum_digests,
+                ))
             })?;
-            if submitted_etag != &part.etag {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidPart",
-                    "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's entity tag.",
-                ));
-            }
-            let part_bytes =
-                crate::state::S3State::read_body_uncached(&part.body).map_err(super::io_to_aws)?;
-            let part_md5 = Md5::digest(&part_bytes);
-            // Fail closed if the bytes just read no longer hash to the part's
-            // recorded etag. We snapshot (clone) the upload — including each
-            // part's fixed disk path and etag — then read bodies off-lock. In
-            // disk mode a concurrent UploadPart of the same part number
-            // rewrites part-NNNNN.bin after the snapshot, so without this
-            // check Complete would assemble the *new* bytes while validating
-            // them against the *old* cloned etag, producing an object whose
-            // content doesn't match the parts the client committed (bug-hunt
-            // 2026-06-13, finding 4.1). Memory-mode parts are immutable, so
-            // this never trips for them.
-            if format!("{:x}", part_md5) != part.etag {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "InvalidPart",
-                    "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not have matched the part's etag.",
-                ));
-            }
-            if let Some(algo) = upload.checksum_algorithm.as_deref() {
-                part_checksum_digests.push(super::compute_checksum_raw(algo, &part_bytes));
-            }
-            combined_data.extend_from_slice(&part_bytes);
-            md5_digests.extend_from_slice(&part_md5);
-            part_sizes.push((*part_num, part_bytes.len() as u64));
-        }
 
         // Multipart ETag: MD5(concat(part_md5_digests))-N
         let combined_md5 = Md5::digest(&md5_digests);
@@ -771,10 +790,16 @@ impl S3Service {
             // completes (bug-hunt 2026-06-24, 4.1). In memory mode
             // `mpu_complete` returns an empty placeholder, so the in-memory
             // body set at construction is kept.
-            let assembled_body = self
-                .store
-                .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta)
-                .map_err(super::persistence_error)?;
+            // `mpu_complete` streams every part into the object file in disk
+            // mode — more blocking disk IO — so run it under `run_blocking_io`
+            // too. `block_in_place` keeps running on this thread (holding the
+            // write lock), it just lets the runtime spin up a replacement worker
+            // for other tasks; no await happens here, so the lock is safe.
+            let assembled_body = super::objects::run_blocking_io(|| {
+                self.store
+                    .mpu_complete(bucket, upload_id, key, meta.version_id.as_deref(), &meta)
+            })
+            .map_err(super::persistence_error)?;
             if !matches!(assembled_body, BodyRef::Memory(_)) {
                 obj.body = assembled_body;
             }

--- a/crates/fakecloud-server/src/dns.rs
+++ b/crates/fakecloud-server/src/dns.rs
@@ -195,9 +195,18 @@ async fn handle_query(cfg: &DnsConfig, raw: &[u8], udp: bool) -> Option<Vec<u8>>
     let ra = cfg.upstream.is_some();
 
     let qtype_str = qtype_to_str(query.qtype);
-    let resolution = {
+    let (resolution, soa) = {
         let accounts = cfg.route53.read();
-        resolver::resolve(&accounts, &query.qname, qtype_str)
+        let resolution = resolver::resolve(&accounts, &query.qname, qtype_str);
+        // Fetch the zone SOA for the negative-response authority section while
+        // we still hold the read guard (RFC 2308 negative caching).
+        let soa = match resolution.status {
+            ResolveStatus::NxDomain | ResolveStatus::NoData => {
+                resolver::zone_soa(&accounts, &query.qname)
+            }
+            _ => None,
+        };
+        (resolution, soa)
     };
 
     match resolution.status {
@@ -213,6 +222,7 @@ async fn handle_query(cfg: &DnsConfig, raw: &[u8], udp: bool) -> Option<Vec<u8>>
                 ra,
                 udp_limit,
                 edns,
+                None,
             )),
         },
         ResolveStatus::NxDomain => Some(build_response(
@@ -223,8 +233,18 @@ async fn handle_query(cfg: &DnsConfig, raw: &[u8], udp: bool) -> Option<Vec<u8>>
             ra,
             udp_limit,
             edns,
+            soa.as_ref(),
         )),
-        ResolveStatus::NoData => Some(build_response(&query, &[], 0, true, ra, udp_limit, edns)),
+        ResolveStatus::NoData => Some(build_response(
+            &query,
+            &[],
+            0,
+            true,
+            ra,
+            udp_limit,
+            edns,
+            soa.as_ref(),
+        )),
         ResolveStatus::Answered => {
             let mut answers = resolution.answers;
             // The CNAME chain left all local zones: forward-resolve the external
@@ -249,6 +269,7 @@ async fn handle_query(cfg: &DnsConfig, raw: &[u8], udp: bool) -> Option<Vec<u8>>
                 ra,
                 udp_limit,
                 edns,
+                None,
             ))
         }
     }
@@ -612,6 +633,9 @@ fn wire_encodable(rtype: &str) -> bool {
 /// client retries over TCP (which passes `None`, never truncating). `edns` is the
 /// client's advertised UDP size when its query carried EDNS0, so a truncated (or
 /// any) reply can echo an OPT record.
+// Orthogonal wire-encoding inputs (flags, size limits, sections); bundling them
+// into a struct would obscure more than it clarifies for a single hot builder.
+#[allow(clippy::too_many_arguments)]
 fn build_response(
     query: &Query,
     answers: &[resolver::AnswerRecord],
@@ -620,6 +644,7 @@ fn build_response(
     ra: bool,
     udp_limit: Option<usize>,
     edns: Option<u16>,
+    authority: Option<&resolver::AnswerRecord>,
 ) -> Vec<u8> {
     // Deduplicate (a merged cross-account zone or a CNAME chase can surface the
     // same record twice), preserving order, then keep only records we can
@@ -655,39 +680,60 @@ fn build_response(
     });
     let opt_len = opt.map_or(0, |o| o.len());
 
+    let write_rr = |out: &mut Vec<u8>, rr: &resolver::AnswerRecord, tc: u16| {
+        write_name(out, &rr.name);
+        out.extend_from_slice(&tc.to_be_bytes());
+        out.extend_from_slice(&CLASS_IN.to_be_bytes());
+        out.extend_from_slice(&rr.ttl.to_be_bytes());
+        let rdata = encode_rdata(&rr.rtype, &rr.value);
+        out.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+        out.extend_from_slice(&rdata);
+    };
+
     let header_and_question = 12 + query.question.len();
     let mut body = Vec::with_capacity(encodable.len() * 32);
     for (ans, tc) in &encodable {
-        write_name(&mut body, &ans.name);
-        body.extend_from_slice(&tc.to_be_bytes());
-        body.extend_from_slice(&CLASS_IN.to_be_bytes());
-        body.extend_from_slice(&ans.ttl.to_be_bytes());
-        let rdata = encode_rdata(&ans.rtype, &ans.value);
-        body.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
-        body.extend_from_slice(&rdata);
+        write_rr(&mut body, ans, *tc);
     }
 
-    // UDP over the client's advertised size: truncate (TC set, no answers) so it
-    // retries over TCP rather than getting a datagram its buffer would drop. The
-    // OPT record (if any) is retained so an EDNS client still sees a valid reply.
-    let (ancount, body) = match udp_limit {
-        Some(limit) if header_and_question + body.len() + opt_len > limit => {
-            flags |= FLAG_TC;
-            (0u16, Vec::new())
+    // Authority section: the zone SOA for a negative (NXDOMAIN/NODATA) response,
+    // so clients can cache the negative answer (RFC 2308). Only wire-encodable
+    // (it always is for SOA) records are placed here.
+    let mut auth_body = Vec::new();
+    let mut nscount: u16 = 0;
+    if let Some(soa) = authority {
+        if wire_encodable(&soa.rtype) {
+            if let Some(tc) = type_code(&soa.rtype) {
+                write_rr(&mut auth_body, soa, tc);
+                nscount = 1;
+            }
         }
-        _ => (encodable.len() as u16, body),
+    }
+
+    // UDP over the client's advertised size: truncate (TC set, no answer or
+    // authority records) so it retries over TCP rather than getting a datagram
+    // its buffer would drop. The OPT record (if any) is retained so an EDNS
+    // client still sees a valid reply.
+    let (ancount, nscount, body, auth_body) = match udp_limit {
+        Some(limit) if header_and_question + body.len() + auth_body.len() + opt_len > limit => {
+            flags |= FLAG_TC;
+            (0u16, 0u16, Vec::new(), Vec::new())
+        }
+        _ => (encodable.len() as u16, nscount, body, auth_body),
     };
     let arcount: u16 = if opt.is_some() { 1 } else { 0 };
 
-    let mut out = Vec::with_capacity(header_and_question + body.len() + opt_len);
+    let mut out = Vec::with_capacity(header_and_question + body.len() + auth_body.len() + opt_len);
     out.extend_from_slice(&query.id.to_be_bytes());
     out.extend_from_slice(&flags.to_be_bytes());
     out.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT
     out.extend_from_slice(&ancount.to_be_bytes()); // ANCOUNT
-    out.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+    out.extend_from_slice(&nscount.to_be_bytes()); // NSCOUNT
     out.extend_from_slice(&arcount.to_be_bytes()); // ARCOUNT
     out.extend_from_slice(&query.question);
     out.extend_from_slice(&body);
+    // Authority section follows the answer section, before the additional (OPT).
+    out.extend_from_slice(&auth_body);
     if let Some(opt) = opt {
         out.extend_from_slice(&opt);
     }
@@ -727,6 +773,7 @@ fn qtype_to_str(qtype: u16) -> &'static str {
         28 => "AAAA",
         33 => "SRV",
         99 => "SPF",
+        255 => "ANY",
         257 => "CAA",
         _ => "",
     }
@@ -779,7 +826,7 @@ mod tests {
             ttl: 60,
             value: "10.0.0.5".to_string(),
         }];
-        let resp = build_response(&query, &answers, 0, true, true, None, None);
+        let resp = build_response(&query, &answers, 0, true, true, None, None, None);
         // Header: same id, QR+AA+RA set, ANCOUNT = 1.
         assert_eq!(u16::from_be_bytes([resp[0], resp[1]]), 0xABCD);
         let flags = u16::from_be_bytes([resp[2], resp[3]]);
@@ -793,7 +840,7 @@ mod tests {
     #[test]
     fn nxdomain_sets_rcode_and_no_answers() {
         let query = parse_query(&a_query(1, "nope.example.com")).unwrap();
-        let resp = build_response(&query, &[], RCODE_NXDOMAIN, true, true, None, None);
+        let resp = build_response(&query, &[], RCODE_NXDOMAIN, true, true, None, None, None);
         assert_eq!(
             u16::from_be_bytes([resp[2], resp[3]]) & 0x000f,
             RCODE_NXDOMAIN
@@ -802,10 +849,41 @@ mod tests {
     }
 
     #[test]
+    fn negative_response_carries_authority_soa() {
+        // An NXDOMAIN with a zone SOA passed as authority must set NSCOUNT=1 and
+        // append the SOA record after the (empty) answer section (RFC 2308).
+        let query = parse_query(&a_query(7, "nope.example.com")).unwrap();
+        let soa = AnswerRecord {
+            name: "example.com.".to_string(),
+            rtype: "SOA".to_string(),
+            ttl: 900,
+            value: "ns.example.com. hostmaster.example.com. 1 7200 900 1209600 86400".to_string(),
+        };
+        let resp = build_response(
+            &query,
+            &[],
+            RCODE_NXDOMAIN,
+            true,
+            false,
+            None,
+            None,
+            Some(&soa),
+        );
+        assert_eq!(u16::from_be_bytes([resp[6], resp[7]]), 0); // ANCOUNT
+        assert_eq!(u16::from_be_bytes([resp[8], resp[9]]), 1); // NSCOUNT
+                                                               // Authority SOA present: the owner "example.com" appears in the body.
+        assert!(
+            resp.windows(7).any(|w| w == b"example"),
+            "authority SOA owner must be encoded"
+        );
+    }
+
+    #[test]
     fn qtype_mapping() {
         assert_eq!(qtype_to_str(1), "A");
         assert_eq!(qtype_to_str(28), "AAAA");
         assert_eq!(qtype_to_str(15), "MX");
+        assert_eq!(qtype_to_str(255), "ANY");
         assert_eq!(qtype_to_str(9999), "");
     }
 
@@ -821,7 +899,7 @@ mod tests {
                 value: format!("\"chunk number {i} with some padding text\""),
             })
             .collect();
-        let resp = build_response(&query, &answers, 0, true, true, Some(512), None);
+        let resp = build_response(&query, &answers, 0, true, true, Some(512), None, None);
         let flags = u16::from_be_bytes([resp[2], resp[3]]);
         assert_eq!(flags & FLAG_TC, FLAG_TC, "TC must be set when truncated");
         assert_eq!(
@@ -831,7 +909,7 @@ mod tests {
         );
         assert!(resp.len() <= 512);
         // Over TCP (no limit) the same answer is emitted in full.
-        let tcp = build_response(&query, &answers, 0, true, true, None, None);
+        let tcp = build_response(&query, &answers, 0, true, true, None, None, None);
         assert_eq!(u16::from_be_bytes([tcp[2], tcp[3]]) & FLAG_TC, 0);
         assert_eq!(u16::from_be_bytes([tcp[6], tcp[7]]), 50);
     }
@@ -863,7 +941,16 @@ mod tests {
             value: "10.0.0.5".to_string(),
         }];
         // Client advertised EDNS (Some size), plenty of room -> full answer + OPT.
-        let resp = build_response(&query, &answers, 0, true, true, Some(4096), Some(1232));
+        let resp = build_response(
+            &query,
+            &answers,
+            0,
+            true,
+            true,
+            Some(4096),
+            Some(1232),
+            None,
+        );
         assert_eq!(u16::from_be_bytes([resp[6], resp[7]]), 1); // ANCOUNT
         assert_eq!(u16::from_be_bytes([resp[10], resp[11]]), 1); // ARCOUNT (OPT)
                                                                  // The OPT is the trailing 11 bytes: root name (0), TYPE=41, then class/ttl/rdlen.

--- a/website/content/docs/guides/dns.md
+++ b/website/content/docs/guides/dns.md
@@ -50,7 +50,7 @@ Run fakecloud where containers can reach it (here on a fixed address in the comp
 ```yaml
 services:
   fakecloud:
-    image: faiscadev/fakecloud
+    image: ghcr.io/faiscadev/fakecloud
     command: ["--dns", "--dns-addr", "0.0.0.0:53"]
     networks:
       appnet:

--- a/website/content/docs/guides/instance-credentials.md
+++ b/website/content/docs/guides/instance-credentials.md
@@ -52,7 +52,7 @@ services:
       AWS_CONTAINER_CREDENTIALS_FULL_URI: http://fakecloud:4566/_fakecloud/credentials
       AWS_ENDPOINT_URL: http://fakecloud:4566
   fakecloud:
-    image: fakecloud/fakecloud
+    image: ghcr.io/faiscadev/fakecloud
 ```
 
 The AWS SDKs only fetch container credentials over plain HTTP from loopback hosts (`127.0.0.1`, `localhost`) or when the host resolves to a loopback/link-local address; a compose service name backed by a private-network address is treated the same way real ECS treats `169.254.170.2`.


### PR DESCRIPTION
Fixes a mixed tail of confirmed bugs across disjoint crates in one PR (bug-hunt 2026-07-19). Each fix ships with a regression test.

## 1. S3 -- non-blocking multipart assembly (MED)
`CompleteMultipartUpload` assembled the whole object via blocking `std::fs::read` inline in the async handler, stalling a tokio worker (and risking the client timeout) on large multipart objects. The part read/hash/concat **and** the disk persist (`mpu_complete`) now run under `run_blocking_io` -- the same `block_in_place`/inline helper GetObject uses. Behavior and the response (object bytes + multipart ETag) are unchanged.
- Test: `s3_multipart_upload_three_parts_etag_and_order` (e2e) -- 3 parts, verifies in-order assembly, `<md5>-3` ETag, and GetObject echoes it.

## 2. RDS -- RebootDBInstance stuck "rebooting" (MED)
On a container-restart failure the background task early-returned without clearing the persisted `rebooting` status, so `DescribeDBInstances` reported it forever. The Err path now resets status to `available`, persists, and emits an event (mirrors the CreateDBInstance task's Err handling).
- Test: `reboot_db_instance_restart_failure_resets_status` (unit, stub runtime forces the Err path).

## 3. KMS -- silent master-key regeneration (LOW)
A snapshot deserialized without `master_key_bytes` silently regenerated the key via `#[serde(default)]`, making prior ciphertext undecryptable with no signal. The on-load default now logs a loud warning (serialize path unchanged; fresh accounts stay quiet). Verified `GenerateDataKey` `NumberOfBytes` bounds (1..=1024) are already enforced.
- Tests: master key round-trips; a snapshot missing the field defaults on load.

## 4. Route53/DNS -- wire fidelity (LOW)
- Negative responses (NXDOMAIN/NODATA) now carry the zone apex **SOA** in the authority section (RFC 2308 negative caching); NSCOUNT is set and the SOA is dropped alongside answers under UDP truncation.
- **ANY** (qtype 255) now returns all record types held at the name instead of NODATA.
- Tests: resolver ANY + `zone_soa` unit tests; `negative_response_carries_authority_soa` wire test; `qtype_mapping` covers 255.

## 5. Distribution docs (MED)
`dns.md` and `instance-credentials.md` used bare Docker Hub image refs; the image is published only to GHCR. Both now use `ghcr.io/faiscadev/fakecloud`. Swept `website/` -- these were the only two bare `image:` refs (remaining `faiscadev/fakecloud` hits are repo names in prose, correct as-is).

## 6. CloudFront -- panic robustness (LOW)
`GetFunction` built its ETag header with `parse().unwrap()`; replaced with `unwrap_or_else(|_| HeaderValue::from_static(""))` so a malformed etag can't panic the request task. No cloudfront conflict encountered on fresh main.

## Testing
- `cargo clippy --all-targets -- -D warnings` clean on all touched crates.
- `cargo fmt --all --check` clean.
- Conformance (source of truth): route53, kms, s3/s3tables (109 passed), rds (38 passed, incl. `rds_reboot_db_instance`).
- e2e: all 12 s3 multipart tests pass.
- Unit: route53 resolver, kms state, server dns, rds reboot suites pass.

### DNS notes (deliberate scope)
- DS/DNSKEY/RRSIG remain mapped to "" in `qtype_to_str`: proper wire RDATA encoders for those DNSSEC types don't exist yet, and mapping them without encoders would emit garbage RDATA (violating no-stub). The required fix (ANY) is implemented fully.
- The `/_fakecloud/dns/resolve` introspection endpoint still allowlists its types and rejects ANY with a 400; no SDK surface change here (this PR is the socket wire layer).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blocking S3 multipart completion, un-sticks RDS reboots, and improves DNS wire fidelity; also hardens KMS/CloudFront and updates docs to GHCR. This reduces timeouts, fixes stale states, and makes negative DNS caching correct without changing public APIs.

- **Bug Fixes**
  - S3: Move multipart assembly and final persist to `run_blocking_io` to avoid blocking async workers; behavior and ETag `<md5>-N` unchanged. Added e2e test for 3-part assembly.
  - RDS: On reboot failure, reset status to "available", persist, and emit an event to avoid being stuck at "rebooting". Added unit test.
  - DNS/Route53: NXDOMAIN/NODATA now include the zone apex `SOA` in the authority section (dropped if UDP-truncated). `ANY` returns all record types at the name. Added resolver and wire tests, plus qtype 255 mapping.
  - KMS: When loading a snapshot missing `master_key_bytes`, log a clear warning before generating a new key (no silent key rotation). Added round‑trip and defaulting tests.
  - CloudFront: Guard ETag header parsing to prevent panics on malformed values.

- **Docs**
  - Switch Docker image references to `ghcr.io/faiscadev/fakecloud` in `dns.md` and `instance-credentials.md`.

<sup>Written for commit cca4a015b53ad96bc8a26096ef00635766e30ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

