### PR TITLE
fix: persist dropped modify/create fields + settle statuses across 12 services (bug-hunt)

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -588,8 +588,10 @@ impl AcmService {
         // sends a confirmation email; tests drive the approval via
         // `POST /_fakecloud/acm/certificates/{arn}/approve`.
         // ImportCertificate stays ISSUED-on-arrival (its own code path
-        // never enters this branch).
-        if validation_method == "DNS" {
+        // never enters this branch). HTTP-validated certs also auto-issue
+        // (real ACM completes them once the redirect resolves); only EMAIL
+        // waits for explicit approval.
+        if validation_method == "DNS" || validation_method == "HTTP" {
             self.spawn_auto_issue_tick(req.account_id.clone(), arn.clone());
         }
 
@@ -1603,8 +1605,8 @@ fn effective_sans(domain: &str, extras: &[String]) -> Vec<String> {
 fn synth_domain_validation(domain: &str, sans: &[String], method: &str) -> Vec<DomainValidation> {
     effective_sans(domain, sans)
         .iter()
-        .map(|d| {
-            if method == "DNS" {
+        .map(|d| match method {
+            "DNS" => {
                 let token = synth_dns_token(d);
                 DomainValidation {
                     domain_name: d.clone(),
@@ -1613,17 +1615,39 @@ fn synth_domain_validation(domain: &str, sans: &[String], method: &str) -> Vec<D
                     resource_record_name: Some(format!("_{token}.{d}.")),
                     resource_record_type: Some("CNAME".to_string()),
                     resource_record_value: Some(format!("_{token}.acm-validations.aws.")),
+                    http_redirect_from: None,
+                    http_redirect_to: None,
                 }
-            } else {
+            }
+            "HTTP" => {
+                // For HTTP validation ACM publishes a well-known token path that
+                // must redirect to an acm-validations.aws target.
+                let token = synth_dns_token(d);
                 DomainValidation {
                     domain_name: d.clone(),
                     validation_status: "PENDING_VALIDATION".to_string(),
-                    validation_method: "EMAIL".to_string(),
+                    validation_method: "HTTP".to_string(),
                     resource_record_name: None,
                     resource_record_type: None,
                     resource_record_value: None,
+                    http_redirect_from: Some(format!(
+                        "http://{d}/.well-known/pki-validation/{token}.txt"
+                    )),
+                    http_redirect_to: Some(format!(
+                        "https://{token}.acm-validations.aws/.well-known/pki-validation/{token}.txt"
+                    )),
                 }
             }
+            _ => DomainValidation {
+                domain_name: d.clone(),
+                validation_status: "PENDING_VALIDATION".to_string(),
+                validation_method: "EMAIL".to_string(),
+                resource_record_name: None,
+                resource_record_type: None,
+                resource_record_value: None,
+                http_redirect_from: None,
+                http_redirect_to: None,
+            },
         })
         .collect()
 }
@@ -1898,6 +1922,15 @@ fn domain_validation_json(v: &DomainValidation) -> Value {
                 "Name": name,
                 "Type": rtype,
                 "Value": value,
+            }),
+        );
+    }
+    if let (Some(from), Some(to)) = (&v.http_redirect_from, &v.http_redirect_to) {
+        out.as_object_mut().unwrap().insert(
+            "HttpRedirect".to_string(),
+            json!({
+                "RedirectFrom": from,
+                "RedirectTo": to,
             }),
         );
     }
@@ -2286,6 +2319,80 @@ mod tests {
         let rs = &last["Certificate"]["RenewalSummary"];
         assert_eq!(rs["RenewalStatus"], "PENDING_AUTO_RENEWAL");
         assert!(rs["UpdatedAt"].as_f64().unwrap() > 0.0);
+    }
+
+    #[tokio::test]
+    async fn http_validation_labeled_http_with_redirect_and_issues() {
+        let svc = AcmService::default()
+            .with_pending_validation_delay(std::time::Duration::from_millis(50));
+        let resp = svc
+            .handle(make_req(
+                "RequestCertificate",
+                json!({"DomainName": "http.example.com", "ValidationMethod": "HTTP"}),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let arn = body["CertificateArn"].as_str().unwrap().to_string();
+
+        // DescribeCertificate reports HTTP (not the old mislabeled EMAIL) with
+        // an HttpRedirect (not a DNS ResourceRecord).
+        let desc = svc
+            .handle(make_req(
+                "DescribeCertificate",
+                json!({"CertificateArn": arn}),
+            ))
+            .await
+            .unwrap();
+        let desc: Value = serde_json::from_slice(desc.body.expect_bytes()).unwrap();
+        let dvo = &desc["Certificate"]["DomainValidationOptions"][0];
+        assert_eq!(dvo["ValidationMethod"], "HTTP");
+        assert!(dvo.get("ResourceRecord").is_none());
+        assert!(dvo["HttpRedirect"]["RedirectFrom"]
+            .as_str()
+            .unwrap()
+            .contains("/.well-known/pki-validation/"));
+        assert!(dvo["HttpRedirect"]["RedirectTo"]
+            .as_str()
+            .unwrap()
+            .contains("acm-validations.aws"));
+
+        // SearchCertificates agrees with Describe on the method (previously
+        // Describe said EMAIL while Search said HTTP).
+        let search = svc
+            .handle(make_req("SearchCertificates", json!({"Filters": {}})))
+            .await
+            .unwrap();
+        let search: Value = serde_json::from_slice(search.body.expect_bytes()).unwrap();
+        let summary = search["Results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["CertificateArn"] == json!(arn))
+            .expect("cert in search results");
+        assert_eq!(
+            summary["CertificateMetadata"]["AcmCertificateMetadata"]["ValidationMethod"],
+            "HTTP"
+        );
+
+        // HTTP-validated certs auto-issue (only EMAIL waits for approval).
+        let mut issued = false;
+        for _ in 0..40 {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let resp = svc
+                .handle(make_req(
+                    "DescribeCertificate",
+                    json!({"CertificateArn": arn}),
+                ))
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            if body["Certificate"]["Status"] == "ISSUED" {
+                issued = true;
+                break;
+            }
+        }
+        assert!(issued, "HTTP-validated cert should auto-issue");
     }
 
     #[tokio::test]

--- a/crates/fakecloud-acm/src/state.rs
+++ b/crates/fakecloud-acm/src/state.rs
@@ -112,6 +112,13 @@ pub struct DomainValidation {
     pub resource_record_name: Option<String>,
     pub resource_record_type: Option<String>,
     pub resource_record_value: Option<String>,
+    /// HTTP validation redirect (`HttpRedirect.RedirectFrom`) — set for
+    /// ValidationMethod=HTTP certificates.
+    #[serde(default)]
+    pub http_redirect_from: Option<String>,
+    /// HTTP validation redirect target (`HttpRedirect.RedirectTo`).
+    #[serde(default)]
+    pub http_redirect_to: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/fakecloud-autoscaling/src/service.rs
+++ b/crates/fakecloud-autoscaling/src/service.rs
@@ -686,26 +686,44 @@ impl AutoScalingService {
         Ok(self.ok("SetDesiredCapacity", String::new(), req))
     }
 
-    fn delete_auto_scaling_group(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+    async fn delete_auto_scaling_group(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let name = required_query_param(req, "AutoScalingGroupName")?;
         let force = optional_query_param(req, "ForceDelete")
             .map(|v| v == "true")
             .unwrap_or(false);
-        let mut accounts = self.state.write();
-        let st = accounts.get_or_create(&req.account_id);
-        if let Some(g) = st.groups.get(&name) {
-            if !g.instances.is_empty() && !force {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "ResourceInUse",
-                    format!(
-                        "You cannot delete an AutoScalingGroup while there are instances or \
-                         pending Spot instance requests still in the group. ({name})"
-                    ),
-                ));
+        // Collect the backing instance ids under the lock, then drop the group.
+        // ForceDelete must terminate them; without force a non-empty group is an
+        // error. The EC2 termination happens off the lock below.
+        let backing_ids = {
+            let mut accounts = self.state.write();
+            let st = accounts.get_or_create(&req.account_id);
+            if let Some(g) = st.groups.get(&name) {
+                if !g.instances.is_empty() && !force {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ResourceInUse",
+                        format!(
+                            "You cannot delete an AutoScalingGroup while there are instances or \
+                             pending Spot instance requests still in the group. ({name})"
+                        ),
+                    ));
+                }
             }
-        }
-        st.groups.remove(&name);
+            st.groups
+                .remove(&name)
+                .map(|g| {
+                    g.instances
+                        .into_iter()
+                        .map(|i| i.instance_id)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        };
+        // ForceDelete reaps the backing EC2 instances instead of leaking them.
+        self.terminate_ec2_instances(&backing_ids, req).await;
         Ok(self.ok("DeleteAutoScalingGroup", String::new(), req))
     }
 
@@ -1273,7 +1291,7 @@ impl AwsService for AutoScalingService {
             "CreateAutoScalingGroup" => self.create_auto_scaling_group(&req).await,
             "DescribeAutoScalingGroups" => self.describe_auto_scaling_groups(&req),
             "UpdateAutoScalingGroup" => self.update_auto_scaling_group(&req).await,
-            "DeleteAutoScalingGroup" => self.delete_auto_scaling_group(&req),
+            "DeleteAutoScalingGroup" => self.delete_auto_scaling_group(&req).await,
             "SetDesiredCapacity" => self.set_desired_capacity(&req).await,
             "DescribeAutoScalingInstances" => self.describe_auto_scaling_instances(&req),
             "DescribeScalingActivities" => self.describe_scaling_activities(&req),
@@ -1423,6 +1441,69 @@ mod tests {
         ))) {
             Err(e) => assert!(format!("{e:?}").contains("ValidationError")),
             Ok(_) => panic!("desired capacity above MaxSize must be rejected"),
+        }
+    }
+
+    #[tokio::test]
+    async fn force_delete_terminates_backing_ec2_instances() {
+        let account = "123456789012";
+        let ec2_state: fakecloud_ec2::SharedEc2State = Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(account, "us-east-1", ""),
+        ));
+        let s = AutoScalingService::new(Arc::new(parking_lot::RwLock::new(
+            AutoScalingAccounts::new(),
+        )))
+        .with_ec2(ec2_state.clone(), None);
+
+        s.handle(req(
+            "CreateLaunchConfiguration",
+            &[
+                ("LaunchConfigurationName", "lc1"),
+                ("ImageId", "ami-1"),
+                ("InstanceType", "t3.micro"),
+            ],
+        ))
+        .await
+        .unwrap();
+        s.handle(req(
+            "CreateAutoScalingGroup",
+            &[
+                ("AutoScalingGroupName", "asg1"),
+                ("LaunchConfigurationName", "lc1"),
+                ("MinSize", "2"),
+                ("MaxSize", "5"),
+                ("DesiredCapacity", "2"),
+                ("AvailabilityZones.member.1", "us-east-1a"),
+            ],
+        ))
+        .await
+        .unwrap();
+
+        // Two real EC2 instances were launched and are running.
+        let running: Vec<String> = ec2_state
+            .read()
+            .default_ref()
+            .instances
+            .iter()
+            .filter(|(_, i)| i.state_name != "terminated")
+            .map(|(id, _)| id.clone())
+            .collect();
+        assert_eq!(running.len(), 2, "ASG must launch 2 real EC2 instances");
+
+        // Force-delete the non-empty group -> the backing instances terminate.
+        s.handle(req(
+            "DeleteAutoScalingGroup",
+            &[("AutoScalingGroupName", "asg1"), ("ForceDelete", "true")],
+        ))
+        .await
+        .unwrap();
+        let ec2 = ec2_state.read();
+        for id in &running {
+            assert_eq!(
+                ec2.default_ref().instances.get(id).unwrap().state_name,
+                "terminated",
+                "instance {id} must be terminated by ForceDelete"
+            );
         }
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -3194,6 +3194,8 @@ fn synth_acm_domain_validation(
             resource_record_name: Some(format!("_amzn-validations.{name}.")),
             resource_record_type: Some("CNAME".to_string()),
             resource_record_value: Some(format!("{}.acm-validations.aws.", Uuid::new_v4())),
+            http_redirect_from: None,
+            http_redirect_to: None,
         })
         .collect()
 }

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -1815,14 +1815,20 @@ async fn ec2_describe_addresses_attribute() {
 async fn ec2_modify_address_attribute() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    // The reverse-DNS attribute is set on a real Elastic IP, so allocate one.
+    let alloc = c.allocate_address().send().await.unwrap();
+    let id = alloc.allocation_id().unwrap();
     let r = c
         .modify_address_attribute()
-        .allocation_id("eipalloc-1")
+        .allocation_id(id)
         .domain_name("x.com")
         .send()
         .await
         .unwrap();
-    assert!(r.address().is_some());
+    assert_eq!(
+        r.address().and_then(|a| a.ptr_record()),
+        Some("x.com")
+    );
 }
 
 #[test_action("ec2", "ResetAddressAttribute", checksum = "6d8e2e96")]
@@ -1830,9 +1836,11 @@ async fn ec2_modify_address_attribute() {
 async fn ec2_reset_address_attribute() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let alloc = c.allocate_address().send().await.unwrap();
+    let id = alloc.allocation_id().unwrap();
     let r = c
         .reset_address_attribute()
-        .allocation_id("eipalloc-1")
+        .allocation_id(id)
         .attribute(aws_sdk_ec2::types::AddressAttributeName::DomainName)
         .send()
         .await
@@ -4423,9 +4431,19 @@ async fn ec2_delete_vpc_endpoint_service_configurations() {
 async fn ec2_modify_vpc_endpoint_service_configuration() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let id = c
+        .create_vpc_endpoint_service_configuration()
+        .send()
+        .await
+        .unwrap()
+        .service_configuration()
+        .unwrap()
+        .service_id()
+        .unwrap()
+        .to_string();
     let r = c
         .modify_vpc_endpoint_service_configuration()
-        .service_id("vpce-svc-1")
+        .service_id(&id)
         .send()
         .await
         .unwrap();
@@ -4437,9 +4455,19 @@ async fn ec2_modify_vpc_endpoint_service_configuration() {
 async fn ec2_describe_vpc_endpoint_service_permissions() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let id = c
+        .create_vpc_endpoint_service_configuration()
+        .send()
+        .await
+        .unwrap()
+        .service_configuration()
+        .unwrap()
+        .service_id()
+        .unwrap()
+        .to_string();
     let r = c
         .describe_vpc_endpoint_service_permissions()
-        .service_id("vpce-svc-1")
+        .service_id(&id)
         .send()
         .await
         .unwrap();
@@ -4451,8 +4479,18 @@ async fn ec2_describe_vpc_endpoint_service_permissions() {
 async fn ec2_modify_vpc_endpoint_service_permissions() {
     let s = TestServer::start().await;
     let c = s.ec2_client().await;
+    let id = c
+        .create_vpc_endpoint_service_configuration()
+        .send()
+        .await
+        .unwrap()
+        .service_configuration()
+        .unwrap()
+        .service_id()
+        .unwrap()
+        .to_string();
     c.modify_vpc_endpoint_service_permissions()
-        .service_id("vpce-svc-1")
+        .service_id(&id)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-conformance/tests/ec2.rs
+++ b/crates/fakecloud-conformance/tests/ec2.rs
@@ -1825,10 +1825,7 @@ async fn ec2_modify_address_attribute() {
         .send()
         .await
         .unwrap();
-    assert_eq!(
-        r.address().and_then(|a| a.ptr_record()),
-        Some("x.com")
-    );
+    assert_eq!(r.address().and_then(|a| a.ptr_record()), Some("x.com"));
 }
 
 #[test_action("ec2", "ResetAddressAttribute", checksum = "6d8e2e96")]

--- a/crates/fakecloud-conformance/tests/ecs.rs
+++ b/crates/fakecloud-conformance/tests/ecs.rs
@@ -515,11 +515,23 @@ async fn ecs_start_task() {
         .await
         .unwrap();
     register_conformance_task_def(&client, "confo-start-td").await;
+    // StartTask places the task on a real registered container instance.
+    let ci = client
+        .register_container_instance()
+        .cluster("confo-start")
+        .send()
+        .await
+        .unwrap();
+    let ci_arn = ci
+        .container_instance()
+        .and_then(|c| c.container_instance_arn())
+        .unwrap()
+        .to_string();
     let resp = client
         .start_task()
         .cluster("confo-start")
         .task_definition("confo-start-td")
-        .container_instances("ci-placeholder")
+        .container_instances(ci_arn)
         .send()
         .await
         .unwrap();

--- a/crates/fakecloud-conformance/tests/ssm.rs
+++ b/crates/fakecloud-conformance/tests/ssm.rs
@@ -1118,12 +1118,28 @@ async fn ssm_get_connection_status() {
 async fn ssm_get_calendar_state() {
     let server = TestServer::start().await;
     let client = server.ssm_client().await;
+    // GetCalendarState evaluates a real Change Calendar document, so create one
+    // first (as on real AWS — querying a nonexistent calendar is InvalidDocument).
     client
+        .create_document()
+        .name("cal")
+        .document_type(aws_sdk_ssm::types::DocumentType::ChangeCalendar)
+        .document_format(aws_sdk_ssm::types::DocumentFormat::Text)
+        .content(
+            "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\n\
+             X-CALENDAR-TYPE:DEFAULT_OPEN\r\nEND:VCALENDAR\r\n",
+        )
+        .send()
+        .await
+        .unwrap();
+    let out = client
         .get_calendar_state()
         .calendar_names("arn:aws:ssm:us-east-1:123456789012:document/cal")
         .send()
         .await
         .unwrap();
+    // An empty DEFAULT_OPEN calendar is OPEN.
+    assert_eq!(out.state(), Some(&aws_sdk_ssm::types::CalendarState::Open));
 }
 
 #[test_action("ssm", "DescribePatchGroupState", checksum = "6ff4c75a")]

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -1088,7 +1088,10 @@ async fn ssm_get_calendar_state() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.state(), Some(&aws_sdk_ssm::types::CalendarState::Closed));
+    assert_eq!(
+        resp.state(),
+        Some(&aws_sdk_ssm::types::CalendarState::Closed)
+    );
 }
 
 #[tokio::test]

--- a/crates/fakecloud-e2e/tests/ssm.rs
+++ b/crates/fakecloud-e2e/tests/ssm.rs
@@ -1051,13 +1051,44 @@ async fn ssm_get_calendar_state() {
     let server = TestServer::start().await;
     let client = server.ssm_client().await;
 
+    // GetCalendarState evaluates a real Change Calendar document, so one must
+    // exist first (querying a nonexistent calendar is InvalidDocument on AWS).
+    // A DEFAULT_OPEN calendar with a single CLOSED window lets us assert both
+    // states from one document.
+    client
+        .create_document()
+        .name("cal")
+        .document_type(aws_sdk_ssm::types::DocumentType::ChangeCalendar)
+        .document_format(aws_sdk_ssm::types::DocumentFormat::Text)
+        .content(
+            "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\n\
+             X-CALENDAR-TYPE:DEFAULT_OPEN\r\nBEGIN:VEVENT\r\n\
+             DTSTART:20221130T230000Z\r\nDTEND:20221201T010000Z\r\nUID:e1\r\n\
+             SUMMARY:freeze\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Outside the freeze window -> OPEN (the calendar default).
     let resp = client
         .get_calendar_state()
         .calendar_names("arn:aws:ssm:us-east-1:123456789012:document/cal")
+        .at_time("2022-11-30T12:00:00Z")
         .send()
         .await
         .unwrap();
     assert_eq!(resp.state(), Some(&aws_sdk_ssm::types::CalendarState::Open));
+
+    // Inside the freeze window -> CLOSED.
+    let resp = client
+        .get_calendar_state()
+        .calendar_names("arn:aws:ssm:us-east-1:123456789012:document/cal")
+        .at_time("2022-11-30T23:30:00Z")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.state(), Some(&aws_sdk_ssm::types::CalendarState::Closed));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-ec2/src/service/eip.rs
+++ b/crates/fakecloud-ec2/src/service/eip.rs
@@ -93,6 +93,7 @@ pub(crate) fn allocate_address(
         private_ip_address: None,
         public_ipv4_pool: public_ipv4_pool.clone(),
         network_border_group: network_border_group.clone(),
+        domain_name: None,
     };
     {
         let mut accounts = svc.state.write();
@@ -290,54 +291,86 @@ pub(crate) fn disassociate_address(
 }
 
 pub(crate) fn describe_addresses_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     validate_max_results(&req.query_params, 1, 1000)?;
     validate_enum(&req.query_params, "Attribute", &["domain-name"])?;
+    let wanted = indexed_list(&req.query_params, "AllocationId");
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    // AWS only returns addresses that have a domain-name attribute set.
+    let mut items: Vec<String> = state
+        .elastic_ips
+        .values()
+        .filter(|e| wanted.is_empty() || wanted.contains(&e.allocation_id))
+        .filter(|e| e.domain_name.is_some())
+        .map(address_attribute_xml)
+        .collect();
+    items.sort();
     Ok(Ec2Service::respond(
         "DescribeAddressesAttribute",
         &req.request_id,
-        &ec2_list("addressSet", &[]),
+        &ec2_list("addressSet", &items),
     ))
 }
 
-fn address_attribute_body(req: &AwsRequest) -> String {
-    let alloc = req
-        .query_params
-        .get("AllocationId")
-        .cloned()
-        .unwrap_or_default();
+fn address_attribute_xml(eip: &ElasticIp) -> String {
+    let ptr = match &eip.domain_name {
+        Some(name) => ec2_elem("ptrRecord", name),
+        None => String::new(),
+    };
     format!(
-        "<address>{}{}</address>",
-        ec2_elem("publicIp", "52.0.0.1"),
-        ec2_elem("allocationId", &alloc),
+        "{}{}{}",
+        ec2_elem("publicIp", &eip.public_ip),
+        ec2_elem("allocationId", &eip.allocation_id),
+        ptr,
     )
 }
 
 pub(crate) fn modify_address_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "AllocationId")?;
+    let alloc = require(&req.query_params, "AllocationId")?;
+    let domain_name = req.query_params.get("DomainName").cloned();
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let eip = state
+        .elastic_ips
+        .get_mut(&alloc)
+        .ok_or_else(|| not_found("InvalidAllocationID.NotFound", &alloc))?;
+    if let Some(name) = domain_name {
+        eip.domain_name = Some(name);
+    }
+    let body = format!("<address>{}</address>", address_attribute_xml(eip));
     Ok(Ec2Service::respond(
         "ModifyAddressAttribute",
         &req.request_id,
-        &address_attribute_body(req),
+        &body,
     ))
 }
 
 pub(crate) fn reset_address_attribute(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "AllocationId")?;
+    let alloc = require(&req.query_params, "AllocationId")?;
     require(&req.query_params, "Attribute")?;
     validate_enum(&req.query_params, "Attribute", &["domain-name"])?;
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let eip = state
+        .elastic_ips
+        .get_mut(&alloc)
+        .ok_or_else(|| not_found("InvalidAllocationID.NotFound", &alloc))?;
+    eip.domain_name = None;
+    let body = format!("<address>{}</address>", address_attribute_xml(eip));
     Ok(Ec2Service::respond(
         "ResetAddressAttribute",
         &req.request_id,
-        &address_attribute_body(req),
+        &body,
     ))
 }
 
@@ -757,6 +790,93 @@ mod eip_tests {
 
     fn body(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn modify_address_attribute_persists_ptr_record() {
+        let svc = Ec2Service::new();
+        let alloc = {
+            let out = body(
+                allocate_address(&svc, &req("AllocateAddress", &[("Domain", "vpc")])).unwrap(),
+            );
+            out.split("<allocationId>")
+                .nth(1)
+                .and_then(|s| s.split("</allocationId>").next())
+                .unwrap()
+                .to_string()
+        };
+
+        // Before any modify, the address has no domain-name attribute so it is
+        // omitted from DescribeAddressesAttribute.
+        let empty = body(
+            describe_addresses_attribute(
+                &svc,
+                &req(
+                    "DescribeAddressesAttribute",
+                    &[("Attribute", "domain-name")],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(
+            !empty.contains("ptrRecord"),
+            "no PTR before modify: {empty}"
+        );
+
+        let modified = body(
+            modify_address_attribute(
+                &svc,
+                &req(
+                    "ModifyAddressAttribute",
+                    &[("AllocationId", &alloc), ("DomainName", "host.example.com")],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(
+            modified.contains("<ptrRecord>host.example.com</ptrRecord>"),
+            "{modified}"
+        );
+
+        // DescribeAddressesAttribute now reflects it.
+        let desc = body(
+            describe_addresses_attribute(
+                &svc,
+                &req(
+                    "DescribeAddressesAttribute",
+                    &[("Attribute", "domain-name"), ("AllocationId.1", &alloc)],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(
+            desc.contains("<ptrRecord>host.example.com</ptrRecord>"),
+            "{desc}"
+        );
+
+        // ResetAddressAttribute clears it.
+        reset_address_attribute(
+            &svc,
+            &req(
+                "ResetAddressAttribute",
+                &[("AllocationId", &alloc), ("Attribute", "domain-name")],
+            ),
+        )
+        .unwrap();
+        let after = body(
+            describe_addresses_attribute(
+                &svc,
+                &req(
+                    "DescribeAddressesAttribute",
+                    &[("Attribute", "domain-name")],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(
+            !after.contains("ptrRecord"),
+            "PTR cleared after reset: {after}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/endpoint.rs
+++ b/crates/fakecloud-ec2/src/service/endpoint.rs
@@ -336,14 +336,21 @@ pub(crate) fn reject_vpc_endpoint_connections(
 // ---- endpoint service configurations ----
 
 fn service_config_xml(s: &EndpointService, tags: &[Tag]) -> String {
+    let private_dns = match &s.private_dns_name {
+        Some(name) => ec2_elem("privateDnsName", name),
+        None => String::new(),
+    };
     format!(
-        "{}{}{}<acceptanceRequired>{}</acceptanceRequired><managesVpcEndpoints>false</managesVpcEndpoints>{}{}{}",
+        "{}{}{}<acceptanceRequired>{}</acceptanceRequired><managesVpcEndpoints>false</managesVpcEndpoints>{}{}{}{}{}{}",
         ec2_elem("serviceId", &s.service_id),
         ec2_elem("serviceName", &s.service_name),
         ec2_elem("serviceState", &s.state),
         s.acceptance_required,
         ec2_elem("payerResponsibility", &s.payer_responsibility),
         ec2_list("networkLoadBalancerArnSet", &s.nlb_arns),
+        ec2_list("gatewayLoadBalancerArnSet", &s.gwlb_arns),
+        ec2_list("supportedIpAddressTypes", &s.supported_ip_address_types),
+        private_dns,
         super::tags::tag_set_xml(tags),
     )
 }
@@ -371,6 +378,10 @@ pub(crate) fn create_vpc_endpoint_service_configuration(
             .unwrap_or(true),
         payer_responsibility: "ServiceOwner".to_string(),
         nlb_arns: indexed_list(&req.query_params, "NetworkLoadBalancerArn"),
+        gwlb_arns: indexed_list(&req.query_params, "GatewayLoadBalancerArn"),
+        supported_ip_address_types: indexed_list(&req.query_params, "SupportedIpAddressType"),
+        private_dns_name: req.query_params.get("PrivateDnsName").cloned(),
+        allowed_principals: Vec::new(),
     };
     let tags = {
         let mut accounts = svc.state.write();
@@ -440,10 +451,48 @@ pub(crate) fn describe_vpc_endpoint_service_configurations(
 }
 
 pub(crate) fn modify_vpc_endpoint_service_configuration(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "ServiceId")?;
+    let id = require(&req.query_params, "ServiceId")?;
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let s = state
+        .endpoint_services
+        .get_mut(&id)
+        .ok_or_else(|| invalid_service_id(&id))?;
+
+    if let Some(v) = req.query_params.get("AcceptanceRequired") {
+        s.acceptance_required = v == "true";
+    }
+    // Add/remove NLB + GWLB ARN sets.
+    apply_set_edit(
+        &mut s.nlb_arns,
+        &indexed_list(&req.query_params, "AddNetworkLoadBalancerArn"),
+        &indexed_list(&req.query_params, "RemoveNetworkLoadBalancerArn"),
+    );
+    apply_set_edit(
+        &mut s.gwlb_arns,
+        &indexed_list(&req.query_params, "AddGatewayLoadBalancerArn"),
+        &indexed_list(&req.query_params, "RemoveGatewayLoadBalancerArn"),
+    );
+    apply_set_edit(
+        &mut s.supported_ip_address_types,
+        &indexed_list(&req.query_params, "AddSupportedIpAddressType"),
+        &indexed_list(&req.query_params, "RemoveSupportedIpAddressType"),
+    );
+    // PrivateDnsName: set or (via RemovePrivateDnsName) clear.
+    if req
+        .query_params
+        .get("RemovePrivateDnsName")
+        .map(|v| v == "true")
+        == Some(true)
+    {
+        s.private_dns_name = None;
+    } else if let Some(name) = req.query_params.get("PrivateDnsName") {
+        s.private_dns_name = Some(name.clone());
+    }
+
     Ok(Ec2Service::respond(
         "ModifyVpcEndpointServiceConfiguration",
         &req.request_id,
@@ -452,28 +501,90 @@ pub(crate) fn modify_vpc_endpoint_service_configuration(
 }
 
 pub(crate) fn describe_vpc_endpoint_service_permissions(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "ServiceId")?;
+    let id = require(&req.query_params, "ServiceId")?;
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    let s = state
+        .endpoint_services
+        .get(&id)
+        .ok_or_else(|| invalid_service_id(&id))?;
+    let principals: Vec<String> = s
+        .allowed_principals
+        .iter()
+        .map(|p| allowed_principal_xml(p))
+        .collect();
     Ok(Ec2Service::respond(
         "DescribeVpcEndpointServicePermissions",
         &req.request_id,
-        &ec2_list("allowedPrincipals", &[]),
+        &ec2_list("allowedPrincipals", &principals),
     ))
 }
 
 pub(crate) fn modify_vpc_endpoint_service_permissions(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
-    require(&req.query_params, "ServiceId")?;
-    let body = format!("{}{}", ec2_list("addedPrincipalSet", &[]), ec2_return(true));
+    let id = require(&req.query_params, "ServiceId")?;
+    let add = indexed_list(&req.query_params, "AddAllowedPrincipal");
+    let remove = indexed_list(&req.query_params, "RemoveAllowedPrincipal");
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let s = state
+        .endpoint_services
+        .get_mut(&id)
+        .ok_or_else(|| invalid_service_id(&id))?;
+    apply_set_edit(&mut s.allowed_principals, &add, &remove);
+    let added: Vec<String> = add.iter().map(|p| allowed_principal_xml(p)).collect();
+    let body = format!(
+        "{}{}",
+        ec2_list("addedPrincipalSet", &added),
+        ec2_return(true)
+    );
     Ok(Ec2Service::respond(
         "ModifyVpcEndpointServicePermissions",
         &req.request_id,
         &body,
     ))
+}
+
+/// Serialize one allowed principal into the `AllowedPrincipal` member shape.
+fn allowed_principal_xml(principal: &str) -> String {
+    let principal_type = if principal.contains(":root") || principal.ends_with(":root") {
+        "Account"
+    } else if principal.contains(":user/") {
+        "User"
+    } else if principal.contains(":role/") {
+        "Role"
+    } else {
+        "Account"
+    };
+    format!(
+        "{}{}",
+        ec2_elem("principalType", principal_type),
+        ec2_elem("principal", principal),
+    )
+}
+
+/// Apply an add/remove edit to a de-duplicated ordered set of strings.
+fn apply_set_edit(set: &mut Vec<String>, add: &[String], remove: &[String]) {
+    set.retain(|x| !remove.contains(x));
+    for a in add {
+        if !set.contains(a) {
+            set.push(a.clone());
+        }
+    }
+}
+
+fn invalid_service_id(id: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        http::StatusCode::BAD_REQUEST,
+        "InvalidVpcEndpointServiceId.NotFound",
+        format!("The VpcEndpointServiceId '{id}' does not exist"),
+    )
 }
 
 pub(crate) fn modify_vpc_endpoint_service_payer_responsibility(
@@ -899,5 +1010,127 @@ mod tests {
             Ok(_) => panic!("expected NotFound error"),
         };
         assert!(format!("{err:?}").contains("InvalidVpcEndpointId.NotFound"));
+    }
+
+    fn body_str(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn modify_endpoint_service_config_persists_and_describes() {
+        let svc = Ec2Service::new();
+        let created = create_vpc_endpoint_service_configuration(
+            &svc,
+            &req(
+                "CreateVpcEndpointServiceConfiguration",
+                &[("NetworkLoadBalancerArn.1", "arn:nlb:a")],
+            ),
+        )
+        .unwrap();
+        let created_body = body_str(created);
+        let id = created_body
+            .split("<serviceId>")
+            .nth(1)
+            .and_then(|s| s.split("</serviceId>").next())
+            .unwrap()
+            .to_string();
+
+        modify_vpc_endpoint_service_configuration(
+            &svc,
+            &req(
+                "ModifyVpcEndpointServiceConfiguration",
+                &[
+                    ("ServiceId", &id),
+                    ("AddNetworkLoadBalancerArn.1", "arn:nlb:b"),
+                    ("RemoveNetworkLoadBalancerArn.1", "arn:nlb:a"),
+                    ("AcceptanceRequired", "false"),
+                    ("PrivateDnsName", "svc.example.com"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let desc = body_str(
+            describe_vpc_endpoint_service_configurations(
+                &svc,
+                &req(
+                    "DescribeVpcEndpointServiceConfigurations",
+                    &[("ServiceId.1", &id)],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(desc.contains("arn:nlb:b"), "new NLB persisted: {desc}");
+        assert!(!desc.contains("arn:nlb:a"), "old NLB removed: {desc}");
+        assert!(desc.contains("<acceptanceRequired>false</acceptanceRequired>"));
+        assert!(desc.contains("<privateDnsName>svc.example.com</privateDnsName>"));
+    }
+
+    #[test]
+    fn modify_endpoint_service_permissions_persists_and_describes() {
+        let svc = Ec2Service::new();
+        let created = body_str(
+            create_vpc_endpoint_service_configuration(
+                &svc,
+                &req("CreateVpcEndpointServiceConfiguration", &[]),
+            )
+            .unwrap(),
+        );
+        let id = created
+            .split("<serviceId>")
+            .nth(1)
+            .and_then(|s| s.split("</serviceId>").next())
+            .unwrap()
+            .to_string();
+
+        modify_vpc_endpoint_service_permissions(
+            &svc,
+            &req(
+                "ModifyVpcEndpointServicePermissions",
+                &[
+                    ("ServiceId", &id),
+                    ("AddAllowedPrincipal.1", "arn:aws:iam::111122223333:root"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc = body_str(
+            describe_vpc_endpoint_service_permissions(
+                &svc,
+                &req(
+                    "DescribeVpcEndpointServicePermissions",
+                    &[("ServiceId", &id)],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(
+            desc.contains("arn:aws:iam::111122223333:root"),
+            "principal added: {desc}"
+        );
+
+        // Removing it clears the Describe view.
+        modify_vpc_endpoint_service_permissions(
+            &svc,
+            &req(
+                "ModifyVpcEndpointServicePermissions",
+                &[
+                    ("ServiceId", &id),
+                    ("RemoveAllowedPrincipal.1", "arn:aws:iam::111122223333:root"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc = body_str(
+            describe_vpc_endpoint_service_permissions(
+                &svc,
+                &req(
+                    "DescribeVpcEndpointServicePermissions",
+                    &[("ServiceId", &id)],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(!desc.contains("111122223333"), "principal removed: {desc}");
     }
 }

--- a/crates/fakecloud-ec2/src/service/va.rs
+++ b/crates/fakecloud-ec2/src/service/va.rs
@@ -5,10 +5,10 @@ use fakecloud_aws::ec2query::{ec2_elem, ec2_list};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
-use crate::service_helpers::{gen_id, require, validate_enum, validate_max_results};
+use crate::service_helpers::{gen_id, indexed_list, require, validate_enum, validate_max_results};
 use crate::state::{
     Ec2State, Tag, VerifiedAccessEndpoint, VerifiedAccessGroup, VerifiedAccessInstance,
-    VerifiedAccessTrustProvider,
+    VerifiedAccessLoggingConfig, VerifiedAccessTrustProvider,
 };
 
 const FIXED_TIME: &str = "2024-01-01T00:00:00.000Z";
@@ -582,13 +582,19 @@ pub(crate) fn modify_verified_access_group_policy(
 // ---- endpoints ----
 
 fn endpoint_xml(e: &VerifiedAccessEndpoint, tags: &[Tag]) -> String {
+    let description = if e.description.is_empty() {
+        String::new()
+    } else {
+        ec2_elem("description", &e.description)
+    };
     format!(
-        "{}{}{}<endpointType>{}</endpointType><attachmentType>{}</attachmentType><status><code>active</code></status><creationTime>{}</creationTime>{}",
+        "{}{}{}<endpointType>{}</endpointType><attachmentType>{}</attachmentType>{}<status><code>active</code></status><creationTime>{}</creationTime>{}",
         ec2_elem("verifiedAccessEndpointId", &e.id),
         ec2_elem("verifiedAccessGroupId", &e.group_id),
         ec2_elem("verifiedAccessInstanceId", &e.instance_id),
         e.endpoint_type,
         e.attachment_type,
+        description,
         FIXED_TIME,
         super::tags::tag_set_xml(tags),
     )
@@ -621,6 +627,11 @@ pub(crate) fn create_verified_access_endpoint(
         instance_id,
         endpoint_type: et,
         attachment_type: at,
+        description: req
+            .query_params
+            .get("Description")
+            .cloned()
+            .unwrap_or_default(),
     };
     let tags = {
         let mut accounts = svc.state.write();
@@ -664,6 +675,7 @@ pub(crate) fn delete_verified_access_endpoint(
             instance_id: "vai-0".to_string(),
             endpoint_type: "load-balancer".to_string(),
             attachment_type: "vpc".to_string(),
+            description: String::new(),
         });
     let tags = state.tags_for(&id).to_vec();
     state.tags.remove(&id);
@@ -704,30 +716,30 @@ pub(crate) fn modify_verified_access_endpoint(
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let id = require(&req.query_params, "VerifiedAccessEndpointId")?;
-    let (e, tags) = {
-        let accounts = svc.state.read();
-        let e = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.va_endpoints.get(&id).cloned())
-            .unwrap_or(VerifiedAccessEndpoint {
-                id: id.clone(),
-                group_id: "vagr-0".to_string(),
-                instance_id: "vai-0".to_string(),
-                endpoint_type: "load-balancer".to_string(),
-                attachment_type: "vpc".to_string(),
-            });
-        let tags = accounts
-            .get(&req.account_id)
-            .map(|s| s.tags_for(&id).to_vec())
-            .unwrap_or_default();
-        (e, tags)
-    };
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create(&req.account_id);
+    let e = state.va_endpoints.get_mut(&id).ok_or_else(|| {
+        AwsServiceError::aws_error(
+            http::StatusCode::BAD_REQUEST,
+            "InvalidVerifiedAccessEndpointId.NotFound",
+            format!("The VerifiedAccessEndpointId '{id}' does not exist"),
+        )
+    })?;
+    if let Some(desc) = req.query_params.get("Description") {
+        e.description = desc.clone();
+    }
+    // An endpoint can be reassigned to a different group.
+    if let Some(group) = req.query_params.get("VerifiedAccessGroupId") {
+        e.group_id = group.clone();
+    }
+    let snapshot = e.clone();
+    let tags = state.tags_for(&id).to_vec();
     Ok(Ec2Service::respond(
         "ModifyVerifiedAccessEndpoint",
         &req.request_id,
         &format!(
             "<verifiedAccessEndpoint>{}</verifiedAccessEndpoint>",
-            endpoint_xml(&e, &tags)
+            endpoint_xml(&snapshot, &tags)
         ),
     ))
 }
@@ -788,26 +800,90 @@ pub(crate) fn get_verified_access_endpoint_targets(
 
 // ---- logging + export ----
 
+fn logging_configuration_xml(inst: &str, cfg: &VerifiedAccessLoggingConfig) -> String {
+    let opt = |tag: &str, v: &Option<String>| match v {
+        Some(s) => ec2_elem(tag, s),
+        None => String::new(),
+    };
+    let log_version = cfg.log_version.as_deref().unwrap_or("ocsf-1.0.0-rc.2");
+    format!(
+        "{}<accessLogs>\
+         <cloudWatchLogs><enabled>{}</enabled>{}</cloudWatchLogs>\
+         <kinesisDataFirehose><enabled>{}</enabled>{}</kinesisDataFirehose>\
+         <s3><enabled>{}</enabled>{}{}{}</s3>\
+         <logVersion>{}</logVersion><includeTrustContext>{}</includeTrustContext>\
+         </accessLogs>",
+        ec2_elem("verifiedAccessInstanceId", inst),
+        cfg.cloudwatch_logs_enabled,
+        opt("logGroup", &cfg.cloudwatch_logs_group),
+        cfg.kinesis_firehose_enabled,
+        opt("deliveryStream", &cfg.kinesis_firehose_stream),
+        cfg.s3_enabled,
+        opt("bucketName", &cfg.s3_bucket_name),
+        opt("prefix", &cfg.s3_prefix),
+        opt("bucketOwner", &cfg.s3_bucket_owner),
+        log_version,
+        cfg.include_trust_context,
+    )
+}
+
 pub(crate) fn describe_verified_access_instance_logging_configurations(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     validate_max_results(&req.query_params, 1, 10)?;
+    let wanted = indexed_list(&req.query_params, "VerifiedAccessInstanceId");
+    let accounts = svc.state.read();
+    let empty = Ec2State::new(&req.account_id, &req.region);
+    let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    let mut items: Vec<String> = state
+        .va_logging
+        .iter()
+        .filter(|(inst, _)| wanted.is_empty() || wanted.contains(inst))
+        .map(|(inst, cfg)| {
+            format!(
+                "<loggingConfiguration>{}</loggingConfiguration>",
+                logging_configuration_xml(inst, cfg)
+            )
+        })
+        .collect();
+    items.sort();
     Ok(Ec2Service::respond(
         "DescribeVerifiedAccessInstanceLoggingConfigurations",
         &req.request_id,
-        &ec2_list("loggingConfigurationSet", &[]),
+        &ec2_list("loggingConfigurationSet", &items),
     ))
 }
 
 pub(crate) fn modify_verified_access_instance_logging_configuration(
-    _svc: &Ec2Service,
+    svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
     let inst = require(&req.query_params, "VerifiedAccessInstanceId")?;
+    let qp = &req.query_params;
+    let bool_qp = |k: &str| qp.get(k).map(|v| v == "true").unwrap_or(false);
+    let cfg = VerifiedAccessLoggingConfig {
+        log_version: qp.get("AccessLogs.LogVersion").cloned(),
+        include_trust_context: bool_qp("AccessLogs.IncludeTrustContext"),
+        cloudwatch_logs_enabled: bool_qp("AccessLogs.CloudWatchLogs.Enabled"),
+        cloudwatch_logs_group: qp.get("AccessLogs.CloudWatchLogs.LogGroup").cloned(),
+        kinesis_firehose_enabled: bool_qp("AccessLogs.KinesisDataFirehose.Enabled"),
+        kinesis_firehose_stream: qp
+            .get("AccessLogs.KinesisDataFirehose.DeliveryStream")
+            .cloned(),
+        s3_enabled: bool_qp("AccessLogs.S3.Enabled"),
+        s3_bucket_name: qp.get("AccessLogs.S3.BucketName").cloned(),
+        s3_prefix: qp.get("AccessLogs.S3.Prefix").cloned(),
+        s3_bucket_owner: qp.get("AccessLogs.S3.BucketOwner").cloned(),
+    };
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        state.va_logging.insert(inst.clone(), cfg.clone());
+    }
     let body = format!(
-        "<loggingConfiguration>{}<accessLogs><logVersion>ocsf-1.0.0-rc.2</logVersion></accessLogs></loggingConfiguration>",
-        ec2_elem("verifiedAccessInstanceId", &inst),
+        "<loggingConfiguration>{}</loggingConfiguration>",
+        logging_configuration_xml(&inst, &cfg)
     );
     Ok(Ec2Service::respond(
         "ModifyVerifiedAccessInstanceLoggingConfiguration",
@@ -831,4 +907,104 @@ pub(crate) fn export_verified_access_instance_client_configuration(
         &req.request_id,
         &body,
     ))
+}
+
+#[cfg(test)]
+mod va_tests {
+    use super::*;
+    use crate::test_support::ec2_request as req;
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn modify_endpoint_persists_description_and_group() {
+        let svc = Ec2Service::new();
+        let created = body(
+            create_verified_access_endpoint(
+                &svc,
+                &req(
+                    "CreateVerifiedAccessEndpoint",
+                    &[
+                        ("VerifiedAccessGroupId", "vagr-1"),
+                        ("EndpointType", "load-balancer"),
+                        ("AttachmentType", "vpc"),
+                        ("Description", "orig"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        let id = created
+            .split("<verifiedAccessEndpointId>")
+            .nth(1)
+            .and_then(|s| s.split("</verifiedAccessEndpointId>").next())
+            .unwrap()
+            .to_string();
+        assert!(created.contains("<description>orig</description>"));
+
+        modify_verified_access_endpoint(
+            &svc,
+            &req(
+                "ModifyVerifiedAccessEndpoint",
+                &[
+                    ("VerifiedAccessEndpointId", &id),
+                    ("Description", "updated"),
+                    ("VerifiedAccessGroupId", "vagr-2"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let desc = body(
+            describe_verified_access_endpoints(&svc, &req("DescribeVerifiedAccessEndpoints", &[]))
+                .unwrap(),
+        );
+        assert!(
+            desc.contains("<description>updated</description>"),
+            "{desc}"
+        );
+        assert!(
+            desc.contains("<verifiedAccessGroupId>vagr-2</verifiedAccessGroupId>"),
+            "{desc}"
+        );
+    }
+
+    #[test]
+    fn logging_configuration_persists_and_describes() {
+        let svc = Ec2Service::new();
+        modify_verified_access_instance_logging_configuration(
+            &svc,
+            &req(
+                "ModifyVerifiedAccessInstanceLoggingConfiguration",
+                &[
+                    ("VerifiedAccessInstanceId", "vai-1"),
+                    ("AccessLogs.CloudWatchLogs.Enabled", "true"),
+                    ("AccessLogs.CloudWatchLogs.LogGroup", "/aws/va/logs"),
+                    ("AccessLogs.IncludeTrustContext", "true"),
+                    ("AccessLogs.LogVersion", "ocsf-1.0.0-rc.2"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let desc = body(
+            describe_verified_access_instance_logging_configurations(
+                &svc,
+                &req("DescribeVerifiedAccessInstanceLoggingConfigurations", &[]),
+            )
+            .unwrap(),
+        );
+        assert!(
+            desc.contains("<verifiedAccessInstanceId>vai-1</verifiedAccessInstanceId>"),
+            "{desc}"
+        );
+        assert!(desc.contains("<logGroup>/aws/va/logs</logGroup>"), "{desc}");
+        assert!(desc.contains("<enabled>true</enabled>"), "{desc}");
+        assert!(
+            desc.contains("<includeTrustContext>true</includeTrustContext>"),
+            "{desc}"
+        );
+    }
 }

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -247,6 +247,9 @@ pub struct ElasticIp {
     pub public_ipv4_pool: String,
     #[serde(default = "default_eip_network_border_group")]
     pub network_border_group: String,
+    /// Reverse-DNS (PTR) record configured via ModifyAddressAttribute.
+    #[serde(default)]
+    pub domain_name: Option<String>,
 }
 
 fn default_eip_public_ipv4_pool() -> String {
@@ -696,6 +699,15 @@ pub struct EndpointService {
     pub payer_responsibility: String,
     #[serde(default)]
     pub nlb_arns: Vec<String>,
+    #[serde(default)]
+    pub gwlb_arns: Vec<String>,
+    #[serde(default)]
+    pub supported_ip_address_types: Vec<String>,
+    #[serde(default)]
+    pub private_dns_name: Option<String>,
+    /// Principal ARNs granted access via ModifyVpcEndpointServicePermissions.
+    #[serde(default)]
+    pub allowed_principals: Vec<String>,
 }
 
 /// A VPC endpoint connection notification.
@@ -1032,6 +1044,34 @@ pub struct VerifiedAccessEndpoint {
     pub instance_id: String,
     pub endpoint_type: String,
     pub attachment_type: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+/// Access-logging configuration for a Verified Access instance, set by
+/// ModifyVerifiedAccessInstanceLoggingConfiguration.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct VerifiedAccessLoggingConfig {
+    #[serde(default)]
+    pub log_version: Option<String>,
+    #[serde(default)]
+    pub include_trust_context: bool,
+    #[serde(default)]
+    pub cloudwatch_logs_enabled: bool,
+    #[serde(default)]
+    pub cloudwatch_logs_group: Option<String>,
+    #[serde(default)]
+    pub kinesis_firehose_enabled: bool,
+    #[serde(default)]
+    pub kinesis_firehose_stream: Option<String>,
+    #[serde(default)]
+    pub s3_enabled: bool,
+    #[serde(default)]
+    pub s3_bucket_name: Option<String>,
+    #[serde(default)]
+    pub s3_prefix: Option<String>,
+    #[serde(default)]
+    pub s3_bucket_owner: Option<String>,
 }
 
 /// A Network Insights reachability path.
@@ -1662,6 +1702,9 @@ pub struct Ec2State {
     /// endpoint-id -> policy document.
     #[serde(default)]
     pub va_endpoint_policies: BTreeMap<String, String>,
+    /// instance-id -> access-logging configuration.
+    #[serde(default)]
+    pub va_logging: BTreeMap<String, VerifiedAccessLoggingConfig>,
     #[serde(default)]
     pub ni_paths: BTreeMap<String, NetworkInsightsPath>,
     #[serde(default)]

--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -317,6 +317,29 @@ impl EcsService {
                 value: value.clone(),
             };
             state.attributes.insert(key, attr);
+            // Container-instance attributes must also surface in
+            // DescribeContainerInstances, which reads ContainerInstance.attributes.
+            if target_type == "container-instance" {
+                let ci_key = format!(
+                    "{}/{}",
+                    cluster_name,
+                    container_instance_id_from_ref(&target_id)
+                );
+                if let Some(ci) = state.container_instances.get_mut(&ci_key) {
+                    if let Some(existing) = ci.attributes.iter_mut().find(|r| r.name == name) {
+                        existing.value = value.clone();
+                        existing.target_type = Some(target_type.clone());
+                        existing.target_id = Some(target_id.clone());
+                    } else {
+                        ci.attributes.push(AttributeRef {
+                            name: name.to_string(),
+                            value: value.clone(),
+                            target_type: Some(target_type.clone()),
+                            target_id: Some(target_id.clone()),
+                        });
+                    }
+                }
+            }
             stored.push(json!({
                 "name": name,
                 "value": value,
@@ -345,6 +368,16 @@ impl EcsService {
             let target_id = a.get("targetId").and_then(|v| v.as_str()).unwrap_or("");
             let key = format!("{}/{}/{}", cluster_name, target_id, name);
             if let Some(attr) = state.attributes.remove(&key) {
+                if attr.target_type == "container-instance" {
+                    let ci_key = format!(
+                        "{}/{}",
+                        cluster_name,
+                        container_instance_id_from_ref(target_id)
+                    );
+                    if let Some(ci) = state.container_instances.get_mut(&ci_key) {
+                        ci.attributes.retain(|r| r.name != name);
+                    }
+                }
                 deleted.push(json!({
                     "name": attr.name,
                     "value": attr.value,

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -78,12 +78,26 @@ impl EcsService {
     }
 
     pub fn run_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        self.run_task_impl(request, Vec::new())
+    }
+
+    /// Shared RunTask/StartTask core. `explicit_instances` is empty for RunTask
+    /// (placement is chosen by strategy) and holds the caller-specified
+    /// container-instance references for StartTask (one task placed per entry).
+    fn run_task_impl(
+        &self,
+        request: &AwsRequest,
+        explicit_instances: Vec<String>,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let body = request.json_body();
+        let start_task = !explicit_instances.is_empty();
         let td_ref = req_str(&body, "taskDefinition")?;
         let cluster_ref = opt_str(&body, "cluster");
         let cluster_name = EcsState::resolve_cluster_name(cluster_ref);
+        // StartTask places tasks on registered EC2/EXTERNAL container instances,
+        // so it is never FARGATE; RunTask defaults to FARGATE.
         let launch_type = opt_str(&body, "launchType")
-            .unwrap_or("FARGATE")
+            .unwrap_or(if start_task { "EC2" } else { "FARGATE" })
             .to_string();
         let placement_constraints: Vec<Value> = body
             .get("placementConstraints")
@@ -97,14 +111,20 @@ impl EcsService {
             .unwrap_or_default();
         // AWS caps RunTask at 1..=10 tasks per call and rejects anything else
         // with InvalidParameterException — it does NOT silently clamp to 1.
-        let count = match body.get("count").and_then(|v| v.as_i64()) {
-            Some(n) if (1..=10).contains(&n) => n as usize,
-            Some(n) => {
-                return Err(invalid_parameter(format!(
-                    "count should be between 1 and 10, inclusive. count={n}"
-                )))
+        // StartTask instead launches exactly one task per specified container
+        // instance.
+        let count = if start_task {
+            explicit_instances.len()
+        } else {
+            match body.get("count").and_then(|v| v.as_i64()) {
+                Some(n) if (1..=10).contains(&n) => n as usize,
+                Some(n) => {
+                    return Err(invalid_parameter(format!(
+                        "count should be between 1 and 10, inclusive. count={n}"
+                    )))
+                }
+                None => 1,
             }
-            None => 1,
         };
         // Defaulted to `family:<taskDefinitionFamily>` below once the task
         // definition is resolved, mirroring how real AWS labels a bare RunTask.
@@ -200,7 +220,11 @@ impl EcsService {
 
         let mut spawned_tasks: Vec<String> = Vec::new();
         let mut task_jsons: Vec<Value> = Vec::new();
-        for _ in 0..count {
+        // `task_index` maps a StartTask task to its explicit container instance;
+        // for RunTask (count from `count`) it is unused, so a plain range loop
+        // is clearer than restructuring around the two shapes.
+        #[allow(clippy::needless_range_loop)]
+        for task_index in 0..count {
             let task_id = uuid::Uuid::new_v4().to_string().replace('-', "");
             let task_arn = state.task_arn(&cluster_name, &task_id);
             let containers: Vec<Container> = td_containers
@@ -332,9 +356,28 @@ impl EcsService {
                 volume_configurations: volume_configurations.clone(),
                 task_set_arn: None,
             };
-            // Best-effort placement for EC2 / EXTERNAL launch types.
-            if launch_type != "FARGATE" {
-                if let Some(arn) = crate::placement::select_container_instance(
+            // Placement. StartTask targets the caller's explicit container
+            // instances (one per task); RunTask picks by strategy. Either way we
+            // resolve to a real registered instance and bump its pending count.
+            let placement_arn = if start_task {
+                let reference = &explicit_instances[task_index];
+                let tail = reference
+                    .rsplit_once("container-instance/")
+                    .map(|(_, t)| t)
+                    .unwrap_or(reference);
+                match super::helpers::resolve_container_instance_key(state, tail) {
+                    Some(key) => state
+                        .container_instances
+                        .get(&key)
+                        .map(|ci| ci.container_instance_arn.clone()),
+                    None => {
+                        return Err(invalid_parameter(format!(
+                            "Container instance {reference} is not registered in cluster {cluster_name}"
+                        )));
+                    }
+                }
+            } else if launch_type != "FARGATE" {
+                crate::placement::select_container_instance(
                     state,
                     &cluster_name,
                     &placement_constraints,
@@ -342,15 +385,18 @@ impl EcsService {
                     task.group.as_deref(),
                     &td_arn,
                     &launch_type,
-                ) {
-                    task.container_instance_arn = Some(arn.clone());
-                    if let Some(ci) = state
-                        .container_instances
-                        .values_mut()
-                        .find(|ci| ci.container_instance_arn == arn)
-                    {
-                        ci.pending_tasks_count += 1;
-                    }
+                )
+            } else {
+                None
+            };
+            if let Some(arn) = placement_arn {
+                task.container_instance_arn = Some(arn.clone());
+                if let Some(ci) = state
+                    .container_instances
+                    .values_mut()
+                    .find(|ci| ci.container_instance_arn == arn)
+                {
+                    ci.pending_tasks_count += 1;
                 }
             }
             state.tasks.insert(task_id.clone(), task.clone());
@@ -434,11 +480,24 @@ impl EcsService {
     }
 
     pub(super) fn start_task(&self, request: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
-        // StartTask targets explicit container instances. Our ECS emulator
-        // has no concept of registered container instances yet (Batch 4);
-        // fall through to the same semantics as RunTask so the API is
-        // usable while the container-instance surface is pending.
-        self.run_task(request)
+        // StartTask places one task on each caller-specified container instance
+        // (as opposed to RunTask, which picks placement by strategy).
+        let body = request.json_body();
+        let instances: Vec<String> = body
+            .get("containerInstances")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if instances.is_empty() {
+            return Err(invalid_parameter(
+                "containerInstances is required and must not be empty for StartTask",
+            ));
+        }
+        self.run_task_impl(request, instances)
     }
 
     pub(super) async fn stop_task(

--- a/crates/fakecloud-ecs/src/service_tests.rs
+++ b/crates/fakecloud-ecs/src/service_tests.rs
@@ -445,6 +445,139 @@ mod scheduler_reconcile {
     }
 
     #[tokio::test]
+    async fn start_task_places_on_specified_container_instance() {
+        let svc = EcsService::new(empty_state());
+        svc.create_cluster(&ecs_request("CreateCluster", json!({"clusterName": "c1"})))
+            .unwrap();
+        svc.register_task_definition(&ecs_request(
+            "RegisterTaskDefinition",
+            json!({
+                "family": "web",
+                "containerDefinitions": [{"name": "app", "image": "nginx", "essential": true}]
+            }),
+        ))
+        .unwrap();
+        // Register two container instances.
+        let mut ci_ids = Vec::new();
+        for _ in 0..2 {
+            let resp = svc
+                .register_container_instance(&ecs_request(
+                    "RegisterContainerInstance",
+                    json!({"cluster": "c1"}),
+                ))
+                .unwrap();
+            let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            ci_ids.push(
+                v["containerInstance"]["containerInstanceArn"]
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
+            );
+        }
+
+        // StartTask on the SECOND instance -> the task lands there, not on a
+        // synthetic i-fakecloud-1.
+        let resp = svc
+            .start_task(&ecs_request(
+                "StartTask",
+                json!({
+                    "cluster": "c1",
+                    "taskDefinition": "web",
+                    "containerInstances": [ci_ids[1].clone()]
+                }),
+            ))
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(v["tasks"].as_array().unwrap().len(), 1);
+        assert_eq!(v["tasks"][0]["containerInstanceArn"], json!(ci_ids[1]));
+        assert!(
+            !v["tasks"][0]["containerInstanceArn"]
+                .as_str()
+                .unwrap()
+                .contains("i-fakecloud-1"),
+            "must not use the synthetic placeholder instance"
+        );
+
+        // StartTask with no containerInstances is rejected.
+        assert!(svc
+            .start_task(&ecs_request(
+                "StartTask",
+                json!({"cluster": "c1", "taskDefinition": "web"}),
+            ))
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn put_attributes_reflected_in_describe_container_instances() {
+        let svc = EcsService::new(empty_state());
+        svc.create_cluster(&ecs_request("CreateCluster", json!({"clusterName": "c1"})))
+            .unwrap();
+        let resp = svc
+            .register_container_instance(&ecs_request(
+                "RegisterContainerInstance",
+                json!({"cluster": "c1"}),
+            ))
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let ci_arn = v["containerInstance"]["containerInstanceArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        svc.put_attributes(&ecs_request(
+            "PutAttributes",
+            json!({
+                "cluster": "c1",
+                "attributes": [{
+                    "name": "stack",
+                    "value": "prod",
+                    "targetType": "container-instance",
+                    "targetId": ci_arn.clone()
+                }]
+            }),
+        ))
+        .unwrap();
+
+        // DescribeContainerInstances must now include the attribute set via PutAttributes.
+        let resp = svc
+            .describe_container_instances(&ecs_request(
+                "DescribeContainerInstances",
+                json!({"cluster": "c1", "containerInstances": [ci_arn.clone()]}),
+            ))
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let attrs = v["containerInstances"][0]["attributes"].as_array().unwrap();
+        let found = attrs
+            .iter()
+            .find(|a| a["name"] == json!("stack"))
+            .expect("PutAttributes attribute must appear in DescribeContainerInstances");
+        assert_eq!(found["value"], json!("prod"));
+
+        // DeleteAttributes removes it from the Describe view too.
+        svc.delete_attributes(&ecs_request(
+            "DeleteAttributes",
+            json!({
+                "cluster": "c1",
+                "attributes": [{
+                    "name": "stack",
+                    "targetType": "container-instance",
+                    "targetId": ci_arn.clone()
+                }]
+            }),
+        ))
+        .unwrap();
+        let resp = svc
+            .describe_container_instances(&ecs_request(
+                "DescribeContainerInstances",
+                json!({"cluster": "c1", "containerInstances": [ci_arn]}),
+            ))
+            .unwrap();
+        let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let attrs = v["containerInstances"][0]["attributes"].as_array().unwrap();
+        assert!(attrs.iter().all(|a| a["name"] != json!("stack")));
+    }
+
+    #[tokio::test]
     async fn update_service_applies_extended_fields() {
         // UpdateService previously read only desiredCount/taskDefinition/
         // lifecycleHooks and dropped everything else (bug-audit 2026-06-20, 1.15).

--- a/crates/fakecloud-elasticache/src/service/users.rs
+++ b/crates/fakecloud-elasticache/src/service/users.rs
@@ -416,7 +416,12 @@ impl ElastiCacheService {
             if let Some(a) = access_string {
                 user.access_string = a;
             }
-            user.status = "modifying".to_string();
+            // The change is applied synchronously, so the user settles straight
+            // back to `active`. Leaving it `modifying` (as before) would hang the
+            // provider's update waiter (Pending: modifying, Target: active)
+            // forever, since fakecloud has no async tick to flip it. Mirrors
+            // `modify_user_group`.
+            user.status = "active".to_string();
             let rg_ids: Vec<String> = state
                 .replication_groups
                 .values()

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -3920,6 +3920,38 @@ async fn reboot_cache_cluster_marks_rebooting_when_no_runtime() {
 }
 
 #[tokio::test]
+async fn modify_user_settles_active() {
+    let svc = fresh_service();
+    svc.create_user(&request(
+        "CreateUser",
+        &[
+            ("UserId", "u1"),
+            ("UserName", "u1"),
+            ("Engine", "redis"),
+            ("AccessString", "on ~* +@all"),
+        ],
+    ))
+    .unwrap();
+
+    let resp = svc
+        .modify_user(&request(
+            "ModifyUser",
+            &[("UserId", "u1"), ("AccessString", "on ~app:* +@read")],
+        ))
+        .await
+        .unwrap();
+    let body_str = body(resp);
+    // Response reports the settled status, not a stuck "modifying".
+    assert!(body_str.contains("<Status>active</Status>"), "{body_str}");
+
+    // And a subsequent read confirms persistence of both status and change.
+    let state = svc.state.read();
+    let user = state.get("123456789012").unwrap().users.get("u1").unwrap();
+    assert_eq!(user.status, "active");
+    assert_eq!(user.access_string, "on ~app:* +@read");
+}
+
+#[tokio::test]
 async fn modify_unknown_user_errors() {
     let svc = fresh_service();
     let req = request("ModifyUser", &[("UserId", "ghost")]);

--- a/crates/fakecloud-elasticbeanstalk/src/service.rs
+++ b/crates/fakecloud-elasticbeanstalk/src/service.rs
@@ -15,9 +15,9 @@ use fakecloud_persistence::{SnapshotHook, SnapshotStore};
 
 use crate::state::{
     environment_status as est, AccountState, Application, ApplicationVersion,
-    ConfigurationTemplate, ElasticBeanstalkSnapshot, Environment, Event, MaxAgeRule, MaxCountRule,
-    OptionSetting, ResourceLifecycleConfig, ResourceTag, SharedEbState, SourceBuildInformation,
-    ELASTICBEANSTALK_SNAPSHOT_SCHEMA_VERSION,
+    ConfigurationTemplate, CustomPlatform, ElasticBeanstalkSnapshot, Environment, Event,
+    MaxAgeRule, MaxCountRule, OptionSetting, ResourceLifecycleConfig, ResourceTag, SharedEbState,
+    SourceBuildInformation, ELASTICBEANSTALK_SNAPSHOT_SCHEMA_VERSION,
 };
 
 const NS: &str = "http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/";
@@ -1887,10 +1887,18 @@ impl ElasticBeanstalkService {
     fn list_platform_versions(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         // Each member is already fully wrapped (`<member>...</member>`), so
         // paginate the raw fragments and join without re-wrapping.
-        let all: Vec<String> = SOLUTION_STACKS
+        let mut all: Vec<String> = SOLUTION_STACKS
             .iter()
             .map(|s| render_platform_summary(s, &req.region))
             .collect();
+        // Include the account's custom platforms alongside the managed stacks.
+        {
+            let mut guard = self.state.write();
+            let acct = guard.get_or_create(&req.account_id);
+            for p in acct.platforms.values() {
+                all.push(render_custom_platform_summary(p));
+            }
+        }
         let (page, next_token) = paginate_members(all, "MaxRecords", req);
         let inner = format!(
             "<PlatformSummaryList>{}</PlatformSummaryList>{}",
@@ -1921,15 +1929,43 @@ impl ElasticBeanstalkService {
 
     fn describe_platform_version(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let arn = required_query_param(req, "PlatformArn")?;
-        let inner = format!(
-            "<PlatformDescription>{}{}{}{}{}</PlatformDescription>",
-            el("PlatformArn", &arn),
-            el("PlatformOwner", "AWSElasticBeanstalk"),
-            el("PlatformStatus", "Ready"),
-            el("PlatformCategory", "generic"),
-            el("PlatformLifecycleState", "Supported"),
-        );
-        Ok(self.ok("DescribePlatformVersion", inner, req))
+        // A custom platform created in this account is described from the store.
+        {
+            let mut guard = self.state.write();
+            let acct = guard.get_or_create(&req.account_id);
+            if let Some(p) = acct.platforms.get(&arn) {
+                let inner = format!(
+                    "<PlatformDescription>{}{}{}{}{}{}{}{}</PlatformDescription>",
+                    el("PlatformArn", &p.arn),
+                    el("PlatformOwner", &p.owner),
+                    el("PlatformName", &p.name),
+                    el("PlatformVersion", &p.version),
+                    el("PlatformStatus", &p.status),
+                    el("PlatformCategory", &p.category),
+                    el("PlatformLifecycleState", "Supported"),
+                    el("DateCreated", &iso(p.date_created)),
+                );
+                return Ok(self.ok("DescribePlatformVersion", inner, req));
+            }
+        }
+        // Otherwise it must be one of the AWS-managed solution stacks; anything
+        // else is genuinely unknown (real ACM returns the service exception).
+        if is_managed_platform_arn(&arn) {
+            let inner = format!(
+                "<PlatformDescription>{}{}{}{}{}</PlatformDescription>",
+                el("PlatformArn", &arn),
+                el("PlatformOwner", "AWSElasticBeanstalk"),
+                el("PlatformStatus", "Ready"),
+                el("PlatformCategory", "generic"),
+                el("PlatformLifecycleState", "Supported"),
+            );
+            return Ok(self.ok("DescribePlatformVersion", inner, req));
+        }
+        Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ElasticBeanstalkServiceException",
+            format!("No Platform named '{arn}' found."),
+        ))
     }
 
     fn create_platform_version(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -1942,11 +1978,29 @@ impl ElasticBeanstalkService {
             "arn:aws:elasticbeanstalk:{}:{}:platform/{name}/{version}",
             req.region, req.account_id
         );
+        let now = Utc::now();
+        let platform = CustomPlatform {
+            arn: arn.clone(),
+            name,
+            version,
+            owner: req.account_id.clone(),
+            status: "Ready".to_string(),
+            category: "custom".to_string(),
+            date_created: now,
+            date_updated: now,
+        };
+        {
+            let mut guard = self.state.write();
+            let acct = guard.get_or_create(&req.account_id);
+            acct.platforms.insert(arn.clone(), platform.clone());
+        }
         let inner = format!(
-            "<PlatformSummary>{}{}{}</PlatformSummary>{}",
-            el("PlatformArn", &arn),
-            el("PlatformOwner", &req.account_id),
-            el("PlatformStatus", "Creating"),
+            "<PlatformSummary>{}{}{}{}{}</PlatformSummary>{}",
+            el("PlatformArn", &platform.arn),
+            el("PlatformOwner", &platform.owner),
+            el("PlatformStatus", &platform.status),
+            el("PlatformCategory", &platform.category),
+            el("PlatformVersion", &platform.version),
             "<Builder/>",
         );
         Ok(self.ok("CreatePlatformVersion", inner, req))
@@ -1954,10 +2008,20 @@ impl ElasticBeanstalkService {
 
     fn delete_platform_version(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let arn = required_query_param(req, "PlatformArn")?;
+        let removed = {
+            let mut guard = self.state.write();
+            let acct = guard.get_or_create(&req.account_id);
+            acct.platforms.remove(&arn)
+        };
+        let status = if removed.is_some() {
+            "Deleting"
+        } else {
+            "Deleted"
+        };
         let inner = format!(
             "<PlatformSummary>{}{}</PlatformSummary>",
             el("PlatformArn", &arn),
-            el("PlatformStatus", "Deleting"),
+            el("PlatformStatus", status),
         );
         Ok(self.ok("DeletePlatformVersion", inner, req))
     }
@@ -2358,6 +2422,24 @@ fn render_platform_summary(stack: &str, region: &str) -> String {
     )
 }
 
+fn render_custom_platform_summary(p: &CustomPlatform) -> String {
+    format!(
+        "<member>{}{}{}{}{}</member>",
+        el("PlatformArn", &p.arn),
+        el("PlatformOwner", &p.owner),
+        el("PlatformStatus", &p.status),
+        el("PlatformCategory", &p.category),
+        el("PlatformVersion", &p.version),
+    )
+}
+
+/// An AWS-managed solution-stack platform ARN carries an empty account segment
+/// (`...:elasticbeanstalk:<region>::platform/...`); custom platforms carry the
+/// owning account id.
+fn is_managed_platform_arn(arn: &str) -> bool {
+    arn.contains(":elasticbeanstalk:") && arn.contains("::platform/")
+}
+
 fn platform_family(stack: &str) -> &'static str {
     let lower = stack.to_ascii_lowercase();
     if lower.contains("node.js") {
@@ -2589,6 +2671,8 @@ impl AwsService for ElasticBeanstalkService {
                 | "AssociateEnvironmentOperationsRole"
                 | "DisassociateEnvironmentOperationsRole"
                 | "SwapEnvironmentCNAMEs"
+                | "CreatePlatformVersion"
+                | "DeletePlatformVersion"
         );
         let result = match req.action.as_str() {
             // Applications

--- a/crates/fakecloud-elasticbeanstalk/src/service/tests.rs
+++ b/crates/fakecloud-elasticbeanstalk/src/service/tests.rs
@@ -664,3 +664,59 @@ fn worker_tier_environment_has_no_endpoint() {
     );
     assert!(!out.contains("<CNAME>"), "worker has no CNAME; out={out}");
 }
+
+#[test]
+fn platform_version_create_describe_list_delete_roundtrip() {
+    let svc = svc();
+    // Unknown platform describes as a service exception, not a fake "Ready".
+    assert_eq!(
+        err_code(
+            &svc,
+            "DescribePlatformVersion",
+            &[(
+                "PlatformArn",
+                "arn:aws:elasticbeanstalk:us-east-1:123456789012:platform/ghost/1.0.0",
+            )],
+        ),
+        "ElasticBeanstalkServiceException"
+    );
+
+    // Create persists a custom platform.
+    let created = body(
+        &svc,
+        "CreatePlatformVersion",
+        &[
+            ("PlatformName", "custom-node"),
+            ("PlatformVersion", "1.0.0"),
+            ("PlatformDefinitionBundle.S3Bucket", "b"),
+            ("PlatformDefinitionBundle.S3Key", "k"),
+        ],
+    );
+    assert!(
+        created.contains("<PlatformStatus>Ready</PlatformStatus>"),
+        "{created}"
+    );
+    let arn = "arn:aws:elasticbeanstalk:us-east-1:123456789012:platform/custom-node/1.0.0";
+
+    // Describe returns the created platform.
+    let described = body(&svc, "DescribePlatformVersion", &[("PlatformArn", arn)]);
+    assert!(
+        described.contains("<PlatformName>custom-node</PlatformName>"),
+        "{described}"
+    );
+    assert!(
+        described.contains("<PlatformCategory>custom</PlatformCategory>"),
+        "{described}"
+    );
+
+    // List includes it alongside the managed stacks.
+    let listed = body(&svc, "ListPlatformVersions", &[]);
+    assert!(listed.contains(arn), "custom platform in list: {listed}");
+
+    // Delete removes it; a subsequent describe is a service exception again.
+    body(&svc, "DeletePlatformVersion", &[("PlatformArn", arn)]);
+    assert_eq!(
+        err_code(&svc, "DescribePlatformVersion", &[("PlatformArn", arn)]),
+        "ElasticBeanstalkServiceException"
+    );
+}

--- a/crates/fakecloud-elasticbeanstalk/src/state.rs
+++ b/crates/fakecloud-elasticbeanstalk/src/state.rs
@@ -91,6 +91,21 @@ pub struct AccountState {
     /// Resource tags keyed by resource ARN (applications and environments).
     #[serde(default)]
     pub tags: BTreeMap<String, Vec<ResourceTag>>,
+    /// Custom platform versions keyed by platform ARN (CreatePlatformVersion).
+    #[serde(default)]
+    pub platforms: BTreeMap<String, CustomPlatform>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomPlatform {
+    pub arn: String,
+    pub name: String,
+    pub version: String,
+    pub owner: String,
+    pub status: String,
+    pub category: String,
+    pub date_created: DateTime<Utc>,
+    pub date_updated: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/fakecloud-emr/src/handlers.rs
+++ b/crates/fakecloud-emr/src/handlers.rs
@@ -93,12 +93,23 @@ impl EmrService {
                 cluster.insert(out_key.into(), json!(v));
             }
         }
-        for key in ["Applications", "Tags", "Configurations", "PlacementGroups"] {
+        for key in ["Applications", "Tags", "Configurations"] {
             if let Some(arr) = body.get(key).filter(|v| v.is_array()) {
                 cluster.insert(key.into(), arr.clone());
             }
         }
+        // The RunJobFlow input field is `PlacementGroupConfigs`, but the Cluster
+        // output field (read back by DescribeCluster) is `PlacementGroups`.
+        if let Some(arr) = body.get("PlacementGroupConfigs").filter(|v| v.is_array()) {
+            cluster.insert("PlacementGroups".into(), arr.clone());
+        }
         let cluster = Value::Object(cluster);
+
+        // Inline ManagedScalingPolicy / AutoTerminationPolicy passed to
+        // RunJobFlow must be stored where Get{ManagedScaling,AutoTermination}Policy
+        // read them, otherwise they are silently dropped.
+        let managed_scaling_policy = body.get("ManagedScalingPolicy").cloned();
+        let auto_termination_policy = body.get("AutoTerminationPolicy").cloned();
 
         // Sub-resources derived from the RunJobFlow request.
         let groups = self.build_instance_groups(&instances, created);
@@ -131,6 +142,12 @@ impl EmrService {
                 if !tags.is_empty() {
                     acct.tags.insert(id.clone(), tags.clone());
                 }
+            }
+            if let Some(p) = managed_scaling_policy {
+                acct.managed_scaling_policies.insert(id.clone(), p);
+            }
+            if let Some(p) = auto_termination_policy {
+                acct.auto_termination_policies.insert(id.clone(), p);
             }
         });
 
@@ -1596,4 +1613,102 @@ fn release_labels() -> Vec<String> {
         "emr-6.14.0".into(),
         "emr-5.36.1".into(),
     ]
+}
+
+#[cfg(test)]
+mod run_job_flow_tests {
+    use super::*;
+    use crate::state::SharedEmrState;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn svc() -> EmrService {
+        let state: SharedEmrState = Arc::new(RwLock::new(MultiAccountState::new(
+            "000000000000",
+            "us-east-1",
+            "",
+        )));
+        EmrService::new(state)
+    }
+
+    fn req(action: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "emr".into(),
+            action: action.into(),
+            region: "us-east-1".into(),
+            account_id: "000000000000".into(),
+            request_id: "test".into(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn json_of(resp: AwsResponse) -> Value {
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    #[test]
+    fn run_job_flow_persists_placement_groups_and_inline_policies() {
+        let s = svc();
+        let resp = s
+            .run_job_flow(&req(
+                "RunJobFlow",
+                json!({
+                    "Name": "c",
+                    "Instances": {"KeepJobFlowAliveWhenNoSteps": true},
+                    "PlacementGroupConfigs": [
+                        {"InstanceRole": "MASTER", "PlacementStrategy": "SPREAD"}
+                    ],
+                    "ManagedScalingPolicy": {
+                        "ComputeLimits": {
+                            "UnitType": "Instances",
+                            "MinimumCapacityUnits": 1,
+                            "MaximumCapacityUnits": 5
+                        }
+                    },
+                    "AutoTerminationPolicy": {"IdleTimeout": 60}
+                }),
+            ))
+            .unwrap();
+        let id = json_of(resp)["JobFlowId"].as_str().unwrap().to_string();
+
+        // DescribeCluster echoes the placement groups (read from the correct
+        // input key PlacementGroupConfigs, stored under output key PlacementGroups).
+        let desc = json_of(
+            s.describe_cluster(&req("DescribeCluster", json!({"ClusterId": id})))
+                .unwrap(),
+        );
+        let pgs = desc["Cluster"]["PlacementGroups"].as_array().unwrap();
+        assert_eq!(pgs.len(), 1);
+        assert_eq!(pgs[0]["InstanceRole"], "MASTER");
+        assert_eq!(pgs[0]["PlacementStrategy"], "SPREAD");
+
+        // Inline policies are retrievable via their Get ops.
+        let msp = json_of(
+            s.get_managed_scaling_policy(&req("GetManagedScalingPolicy", json!({"ClusterId": id})))
+                .unwrap(),
+        );
+        assert_eq!(
+            msp["ManagedScalingPolicy"]["ComputeLimits"]["MaximumCapacityUnits"],
+            5
+        );
+        let atp = json_of(
+            s.get_auto_termination_policy(&req(
+                "GetAutoTerminationPolicy",
+                json!({"ClusterId": id}),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(atp["AutoTerminationPolicy"]["IdleTimeout"], 60);
+    }
 }

--- a/crates/fakecloud-iot/src/service/engine.rs
+++ b/crates/fakecloud-iot/src/service/engine.rs
@@ -92,6 +92,27 @@ fn build_record(
 /// `attributes`; otherwise they replace it wholesale. In both modes an
 /// empty-string value removes that attribute, matching AWS IoT semantics. A
 /// record without an `attributePayload` is left untouched.
+/// Honour the request-only boolean removal toggles carried by several
+/// `Update*` operations. Each toggle, when true, clears its associated stored
+/// field; the toggle itself is never part of the persisted resource, so it is
+/// always stripped from the record.
+fn apply_removal_toggles(record: &mut Map<String, Value>) {
+    for (toggle, field) in [
+        ("removeThingType", "thingTypeName"),           // UpdateThing
+        ("deleteBehaviors", "behaviors"),               // UpdateSecurityProfile
+        ("deleteAlertTargets", "alertTargets"),         // UpdateSecurityProfile
+        ("removeAuthorizerConfig", "authorizerConfig"), // UpdateDomainConfiguration
+    ] {
+        let set = record
+            .remove(toggle)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if set {
+            record.remove(field);
+        }
+    }
+}
+
 fn apply_attribute_payload(record: &mut Map<String, Value>) {
     let Some(payload) = record.remove("attributePayload") else {
         return;
@@ -173,6 +194,10 @@ pub(super) fn update(
         for (k, v) in body {
             obj.insert(k.clone(), v.clone());
         }
+        // Honour the request-only removal toggles that the blind overlay would
+        // otherwise store as spurious fields while leaving the associated data in
+        // place (e.g. UpdateThing removeThingType).
+        apply_removal_toggles(obj);
         // Fold any `attributePayload` (honouring its `merge` flag against the
         // existing attributes) into the top-level `attributes` map before it is
         // stored, so the update is visible to DescribeThing / ListThings.

--- a/crates/fakecloud-iot/src/service/tests.rs
+++ b/crates/fakecloud-iot/src/service/tests.rs
@@ -165,6 +165,60 @@ fn update_thing_merges_attributes() {
     assert_eq!(got["thingTypeName"], "b");
 }
 
+#[test]
+fn update_thing_remove_thing_type_clears_association() {
+    let s = svc();
+    run(&s, "POST", "/things/t1", &[], json!({"thingTypeName": "a"})).unwrap();
+    // removeThingType must drop thingTypeName rather than persisting the toggle.
+    run(
+        &s,
+        "PATCH",
+        "/things/t1",
+        &[],
+        json!({"removeThingType": true}),
+    )
+    .unwrap();
+    let got = body_of(&run(&s, "GET", "/things/t1", &[], Value::Null).unwrap());
+    assert!(
+        got.get("thingTypeName").is_none() || got["thingTypeName"].is_null(),
+        "thingTypeName should be cleared: {got}"
+    );
+    // The request-only toggle must not leak into the stored/returned resource.
+    assert!(got.get("removeThingType").is_none());
+}
+
+#[test]
+fn update_security_profile_delete_behaviors_and_alert_targets() {
+    let s = svc();
+    run(
+        &s,
+        "POST",
+        "/security-profiles/sp1",
+        &[],
+        json!({
+            "behaviors": [{"name": "b1", "metric": "aws:num-messages-received"}],
+            "alertTargets": {"SNS": {"alertTargetArn": "arn:aws:sns:us-east-1:000000000000:t", "roleArn": "arn:aws:iam::000000000000:role/r"}}
+        }),
+    )
+    .unwrap();
+    run(
+        &s,
+        "PATCH",
+        "/security-profiles/sp1",
+        &[],
+        json!({"deleteBehaviors": true, "deleteAlertTargets": true}),
+    )
+    .unwrap();
+    let got = body_of(&run(&s, "GET", "/security-profiles/sp1", &[], Value::Null).unwrap());
+    assert!(got.get("behaviors").is_none(), "behaviors cleared: {got}");
+    assert!(
+        got.get("alertTargets").is_none(),
+        "alertTargets cleared: {got}"
+    );
+    assert!(got.get("deleteBehaviors").is_none());
+    assert!(got.get("deleteAlertTargets").is_none());
+}
+
 // ---------- thing types / groups / billing groups ----------
 
 #[test]

--- a/crates/fakecloud-lambda/src/extras/account.rs
+++ b/crates/fakecloud-lambda/src/extras/account.rs
@@ -89,9 +89,8 @@ impl LambdaService {
             "ListFunctionsByCodeSigningConfig" => self.list_functions_by_code_signing(res, aid),
 
             // Event invoke
-            "PutFunctionEventInvokeConfig" | "UpdateFunctionEventInvokeConfig" => {
-                self.put_function_event_invoke(res, req)
-            }
+            "PutFunctionEventInvokeConfig" => self.put_function_event_invoke(res, req),
+            "UpdateFunctionEventInvokeConfig" => self.update_function_event_invoke(res, req),
             "GetFunctionEventInvokeConfig" => self.get_function_event_invoke(res, req),
             "DeleteFunctionEventInvokeConfig" => self.delete_function_event_invoke(res, req),
             "ListFunctionEventInvokeConfigs" => self.list_function_event_invoke(res, aid),

--- a/crates/fakecloud-lambda/src/extras/event_invoke.rs
+++ b/crates/fakecloud-lambda/src/extras/event_invoke.rs
@@ -63,6 +63,60 @@ impl LambdaService {
         ok(event_invoke_json(&cfg))
     }
 
+    /// `UpdateFunctionEventInvokeConfig` merges: only the fields present in the
+    /// request are overwritten; anything omitted (notably `DestinationConfig`)
+    /// keeps its stored value. This is the difference from Put, which replaces
+    /// the whole config. Updating a non-existent config is a not-found error.
+    pub(super) fn update_function_event_invoke(
+        &self,
+        function_name: &str,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = body(req);
+        let qualifier = parse_qualifier(req);
+        let key = Self::ev_key(function_name, &qualifier);
+
+        // Validate provided ranges before touching state.
+        if let Some(event_age) = body.get("MaximumEventAgeInSeconds").and_then(Value::as_i64) {
+            if !(60..=21600).contains(&event_age) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!("MaximumEventAgeInSeconds must be 60..21600 (got {event_age})"),
+                ));
+            }
+        }
+        if let Some(retries) = body.get("MaximumRetryAttempts").and_then(Value::as_i64) {
+            if !(0..=2).contains(&retries) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterValueException",
+                    format!("MaximumRetryAttempts must be 0..2 (got {retries})"),
+                ));
+            }
+        }
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
+        let cfg = state
+            .event_invoke_configs
+            .get_mut(&key)
+            .ok_or_else(|| not_found("EventInvokeConfig", function_name))?;
+
+        if let Some(event_age) = body.get("MaximumEventAgeInSeconds").and_then(Value::as_i64) {
+            cfg.maximum_event_age = event_age;
+        }
+        if let Some(retries) = body.get("MaximumRetryAttempts").and_then(Value::as_i64) {
+            cfg.maximum_retry_attempts = retries;
+        }
+        if body.get("DestinationConfig").is_some() {
+            cfg.destination_config = body.get("DestinationConfig").cloned();
+        }
+        cfg.last_modified = Utc::now();
+        let snapshot = cfg.clone();
+        ok(event_invoke_json(&snapshot))
+    }
+
     pub(super) fn get_function_event_invoke(
         &self,
         function_name: &str,

--- a/crates/fakecloud-lambda/src/service/init.rs
+++ b/crates/fakecloud-lambda/src/service/init.rs
@@ -103,9 +103,10 @@ impl LambdaService {
             && segs.get(3).map(|s| s.as_str()) == Some("event-invoke-config")
         {
             let res = segs.get(2).map(|s| s.to_string());
+            // Per the Lambda API: PUT = Put (full replace), POST = Update (merge).
             return match req.method {
-                Method::POST => Some(("PutFunctionEventInvokeConfig", res)),
-                Method::PUT => Some(("UpdateFunctionEventInvokeConfig", res)),
+                Method::PUT => Some(("PutFunctionEventInvokeConfig", res)),
+                Method::POST => Some(("UpdateFunctionEventInvokeConfig", res)),
                 Method::GET => Some(("GetFunctionEventInvokeConfig", res)),
                 Method::DELETE => Some(("DeleteFunctionEventInvokeConfig", res)),
                 _ => None,

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -3304,6 +3304,82 @@ async fn put_function_event_invoke_destination_config_echo_variants() {
     );
 }
 
+// UpdateFunctionEventInvokeConfig (HTTP POST) merges: updating only
+// MaximumRetryAttempts must NOT drop a previously-stored DestinationConfig.
+// Put (HTTP PUT) replaces the whole config.
+#[tokio::test]
+async fn update_function_event_invoke_merges_and_put_replaces() {
+    let svc = LambdaService::new(make_state());
+    seed_function(&svc, "ei-fn").await;
+
+    // Put (PUT) a full config with a DestinationConfig.
+    let put = make_request(
+        Method::PUT,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        &json!({
+            "MaximumRetryAttempts": 2,
+            "MaximumEventAgeInSeconds": 3600,
+            "DestinationConfig": {
+                "OnFailure": {"Destination": "arn:aws:sqs:us-east-1:123456789012:dlq"}
+            }
+        })
+        .to_string(),
+    );
+    svc.handle(put).await.unwrap();
+
+    // Update (POST) only MaximumRetryAttempts -> DestinationConfig must survive.
+    let upd = make_request(
+        Method::POST,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        &json!({"MaximumRetryAttempts": 0}).to_string(),
+    );
+    let v: Value =
+        serde_json::from_slice(svc.handle(upd).await.unwrap().body.expect_bytes()).unwrap();
+    assert_eq!(v["MaximumRetryAttempts"], json!(0));
+    assert_eq!(v["MaximumEventAgeInSeconds"], json!(3600), "age preserved");
+    assert_eq!(
+        v["DestinationConfig"]["OnFailure"]["Destination"],
+        "arn:aws:sqs:us-east-1:123456789012:dlq",
+        "Update must not drop the existing DestinationConfig"
+    );
+
+    // Get confirms the merged state persisted.
+    let get = make_request(
+        Method::GET,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        "",
+    );
+    let g: Value =
+        serde_json::from_slice(svc.handle(get).await.unwrap().body.expect_bytes()).unwrap();
+    assert_eq!(g["MaximumRetryAttempts"], json!(0));
+    assert_eq!(
+        g["DestinationConfig"]["OnFailure"]["Destination"],
+        "arn:aws:sqs:us-east-1:123456789012:dlq"
+    );
+
+    // Put (PUT) again without DestinationConfig -> full replace clears it.
+    let put2 = make_request(
+        Method::PUT,
+        "/2019-09-25/functions/ei-fn/event-invoke-config",
+        &json!({"MaximumRetryAttempts": 1}).to_string(),
+    );
+    let r: Value =
+        serde_json::from_slice(svc.handle(put2).await.unwrap().body.expect_bytes()).unwrap();
+    // Put synthesizes empty halves when DestinationConfig omitted.
+    assert_eq!(
+        r["DestinationConfig"],
+        json!({"OnSuccess": {}, "OnFailure": {}})
+    );
+
+    // Update on a non-existent function's config is a not-found error.
+    let upd_missing = make_request(
+        Method::POST,
+        "/2019-09-25/functions/ghost-fn/event-invoke-config",
+        &json!({"MaximumRetryAttempts": 1}).to_string(),
+    );
+    assert!(svc.handle(upd_missing).await.is_err());
+}
+
 /// In-memory `LambdaBackend` used by the pre-pull regression test below.
 /// Records every `prepull_image` call so the test can assert that
 /// CreateFunction kicked one off, without spinning up a real container.

--- a/crates/fakecloud-neptune/src/service.rs
+++ b/crates/fakecloud-neptune/src/service.rs
@@ -676,16 +676,44 @@ impl NeptuneService {
     fn failover_db_cluster(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let id = optional_query_param(req, "DBClusterIdentifier")
             .ok_or_else(|| db_cluster_not_found("<unspecified>"))?;
-        let accounts = self.state.read();
-        let empty = NeptuneState::new(&req.account_id, &req.region);
-        let st = accounts.get(&req.account_id).unwrap_or(&empty);
+        // Optional: promote a specific instance to writer, else the first
+        // non-writer member is promoted.
+        let target = optional_query_param(req, "TargetDBInstanceIdentifier");
+
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
         let cluster = st
             .clusters
-            .get(&id)
+            .get_mut(&id)
             .ok_or_else(|| db_cluster_not_found(&id))?;
+
+        // Pick the new writer: the requested target if valid, otherwise the
+        // first member that isn't already the writer.
+        let new_writer = target
+            .as_deref()
+            .filter(|t| {
+                cluster
+                    .members
+                    .iter()
+                    .any(|m| m.db_instance_identifier == *t)
+            })
+            .map(String::from)
+            .or_else(|| {
+                cluster
+                    .members
+                    .iter()
+                    .find(|m| !m.is_writer)
+                    .map(|m| m.db_instance_identifier.clone())
+            });
+        if let Some(writer) = new_writer {
+            for m in &mut cluster.members {
+                m.is_writer = m.db_instance_identifier == writer;
+            }
+        }
+        let cluster = cluster.clone();
         Ok(ok_xml(
             "FailoverDBCluster",
-            format!("<DBCluster>{}</DBCluster>", xml::db_cluster(cluster)),
+            format!("<DBCluster>{}</DBCluster>", xml::db_cluster(&cluster)),
             &req.request_id,
         ))
     }
@@ -922,6 +950,10 @@ impl NeptuneService {
         let cluster_pmw = cluster.preferred_maintenance_window.clone();
         let cluster_subnet = cluster.db_subnet_group.clone();
         let cluster_engine_version = cluster.engine_version.clone();
+        // A Neptune instance inherits its cluster's storage encryption; it is a
+        // cluster-level property (there is no per-instance StorageEncrypted knob).
+        let cluster_storage_encrypted = cluster.storage_encrypted;
+        let cluster_kms_key_id = cluster.kms_key_id.clone();
         let az = cluster
             .availability_zones
             .first()
@@ -954,8 +986,8 @@ impl NeptuneService {
             preferred_maintenance_window: optional_query_param(req, "PreferredMaintenanceWindow")
                 .unwrap_or(cluster_pmw),
             backup_retention_period: 1,
-            storage_encrypted: false,
-            kms_key_id: None,
+            storage_encrypted: cluster_storage_encrypted,
+            kms_key_id: cluster_kms_key_id,
             db_subnet_group: cluster_subnet,
             enabled_cloudwatch_logs_exports: Vec::new(),
             instance_create_time: Utc::now(),
@@ -1014,6 +1046,12 @@ impl NeptuneService {
         }
         if let Some(v) = optional_query_param(req, "AutoMinorVersionUpgrade") {
             inst.auto_minor_version_upgrade = v == "true";
+        }
+        if let Some(v) = optional_query_param(req, "PubliclyAccessible") {
+            inst.publicly_accessible = v == "true";
+        }
+        if let Some(v) = optional_query_param(req, "EngineVersion") {
+            inst.engine_version = v;
         }
         let mut inst = inst.clone();
         if let Some(new_id) =

--- a/crates/fakecloud-neptune/src/tests.rs
+++ b/crates/fakecloud-neptune/src/tests.rs
@@ -181,6 +181,148 @@ async fn instance_attaches_to_cluster() {
 }
 
 #[tokio::test]
+async fn failover_flips_cluster_writer() {
+    let svc = service();
+    call(
+        &svc,
+        "CreateDBCluster",
+        &[("DBClusterIdentifier", "c1"), ("Engine", "neptune")],
+    )
+    .await;
+    for id in ["writer", "reader"] {
+        call(
+            &svc,
+            "CreateDBInstance",
+            &[
+                ("DBInstanceIdentifier", id),
+                ("DBInstanceClass", "db.r5.large"),
+                ("Engine", "neptune"),
+                ("DBClusterIdentifier", "c1"),
+            ],
+        )
+        .await;
+    }
+    // The first instance is the writer.
+    {
+        let st = svc.state.read();
+        let members = &st
+            .get("123456789012")
+            .unwrap()
+            .clusters
+            .get("c1")
+            .unwrap()
+            .members;
+        assert!(
+            members
+                .iter()
+                .find(|m| m.db_instance_identifier == "writer")
+                .unwrap()
+                .is_writer
+        );
+        assert!(
+            !members
+                .iter()
+                .find(|m| m.db_instance_identifier == "reader")
+                .unwrap()
+                .is_writer
+        );
+    }
+
+    // Failover with an explicit target promotes it.
+    call(
+        &svc,
+        "FailoverDBCluster",
+        &[
+            ("DBClusterIdentifier", "c1"),
+            ("TargetDBInstanceIdentifier", "reader"),
+        ],
+    )
+    .await;
+    let st = svc.state.read();
+    let members = &st
+        .get("123456789012")
+        .unwrap()
+        .clusters
+        .get("c1")
+        .unwrap()
+        .members;
+    assert!(
+        members
+            .iter()
+            .find(|m| m.db_instance_identifier == "reader")
+            .unwrap()
+            .is_writer
+    );
+    assert!(
+        !members
+            .iter()
+            .find(|m| m.db_instance_identifier == "writer")
+            .unwrap()
+            .is_writer
+    );
+}
+
+#[tokio::test]
+async fn instance_inherits_cluster_encryption_and_modify_persists_fields() {
+    let svc = service();
+    call(
+        &svc,
+        "CreateDBCluster",
+        &[
+            ("DBClusterIdentifier", "enc"),
+            ("Engine", "neptune"),
+            ("StorageEncrypted", "true"),
+        ],
+    )
+    .await;
+    let resp = call(
+        &svc,
+        "CreateDBInstance",
+        &[
+            ("DBInstanceIdentifier", "i1"),
+            ("DBInstanceClass", "db.r5.large"),
+            ("Engine", "neptune"),
+            ("DBClusterIdentifier", "enc"),
+        ],
+    )
+    .await;
+    // The instance inherits the cluster's encryption rather than hardcoding false.
+    assert!(body(&resp).contains("<StorageEncrypted>true</StorageEncrypted>"));
+
+    // ModifyDBInstance persists PubliclyAccessible + EngineVersion.
+    let resp = call(
+        &svc,
+        "ModifyDBInstance",
+        &[
+            ("DBInstanceIdentifier", "i1"),
+            ("PubliclyAccessible", "true"),
+            ("EngineVersion", "1.3.0.0"),
+        ],
+    )
+    .await;
+    let xml = body(&resp);
+    assert!(
+        xml.contains("<PubliclyAccessible>true</PubliclyAccessible>"),
+        "{xml}"
+    );
+    assert!(
+        xml.contains("<EngineVersion>1.3.0.0</EngineVersion>"),
+        "{xml}"
+    );
+
+    // And they survive a subsequent Describe.
+    let resp = call(
+        &svc,
+        "DescribeDBInstances",
+        &[("DBInstanceIdentifier", "i1")],
+    )
+    .await;
+    let xml = body(&resp);
+    assert!(xml.contains("<PubliclyAccessible>true</PubliclyAccessible>"));
+    assert!(xml.contains("<EngineVersion>1.3.0.0</EngineVersion>"));
+}
+
+#[tokio::test]
 async fn cluster_endpoint_lifecycle() {
     let svc = service();
     call(

--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -1035,14 +1035,9 @@ impl OpenSearchService {
             "AttachDataSource" => self.attach_data_source(l, req),
             "DetachDataSource" => self.detach_data_source(l, req),
             "DescribeDataSourceAttachment" => self.describe_data_source_attachment(l, req),
-            "ListDataSourceAttachments" => self.list_data_source_attachments(l),
-            "GetDefaultApplicationSetting" | "PutDefaultApplicationSetting" => {
-                let arn = format!(
-                    "arn:aws:es:{}:{}:application/default",
-                    req.region, req.account_id
-                );
-                Ok(ok(json!({ "applicationArn": arn })))
-            }
+            "ListDataSourceAttachments" => self.list_data_source_attachments(l, req),
+            "PutDefaultApplicationSetting" => self.put_default_application_setting(l, req),
+            "GetDefaultApplicationSetting" => self.get_default_application_setting(req),
             // ---- Data sources (per domain) ----
             "AddDataSource" => self.add_data_source(l, req),
             "GetDataSource" => self.get_data_source(l, req),
@@ -2124,6 +2119,8 @@ impl OpenSearchService {
             app_configs: b.get("appConfigs").cloned().unwrap_or(json!([])),
             tags: parse_tag_list(b.get("tagList")),
             capabilities: Default::default(),
+            attachments: Default::default(),
+            is_default_setting: false,
         };
         // CreateApplicationResponse is a distinct (smaller) shape than
         // GetApplication: no endpoint/status/lastUpdatedAt.
@@ -2226,13 +2223,16 @@ impl OpenSearchService {
             .applications
             .get_mut(&id)
             .ok_or_else(|| not_found_generic(&format!("Application {id} not found.")))?;
-        app.capabilities
-            .insert(name.clone(), json!({"capabilityName": name}));
+        let config = b.get("capabilityConfig").cloned().unwrap_or(json!({}));
+        app.capabilities.insert(
+            name.clone(),
+            json!({"capabilityName": name, "capabilityConfig": config}),
+        );
         Ok(ok(json!({
             "capabilityName": name,
             "applicationId": id,
             "status": "ACTIVE",
-            "capabilityConfig": {},
+            "capabilityConfig": config,
         })))
     }
 
@@ -2244,12 +2244,17 @@ impl OpenSearchService {
             .get(&req.account_id)
             .and_then(|st| st.applications.get(&id))
             .ok_or_else(|| not_found_generic(&format!("Application {id} not found.")))?;
-        let _ = &app.capabilities;
+        // Return the stored capability config rather than a hardcoded empty one.
+        let stored = app
+            .capabilities
+            .get(&cap)
+            .ok_or_else(|| not_found_generic(&format!("Capability {cap} not found.")))?;
+        let config = stored.get("capabilityConfig").cloned().unwrap_or(json!({}));
         Ok(ok(json!({
             "capabilityName": cap,
             "applicationId": id,
             "status": "ACTIVE",
-            "capabilityConfig": {},
+            "capabilityConfig": config,
         })))
     }
 
@@ -2275,13 +2280,24 @@ impl OpenSearchService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let app_id = label(l.id.as_deref())?;
         let b = body(req);
-        Ok(ok(json!({
-            "attachmentId": short_id(),
+        let attachment_id = short_id();
+        let ds_arn = b.get("dataSourceArn").cloned().unwrap_or(json!(""));
+        let record = json!({
+            "attachmentId": attachment_id,
             "id": app_id,
-            "arn": b.get("dataSourceArn").cloned().unwrap_or(json!("")),
-            "dataSourceArn": b.get("dataSourceArn").cloned().unwrap_or(json!("")),
+            "arn": ds_arn,
+            "dataSourceArn": ds_arn,
             "status": "ATTACHED",
-        })))
+        });
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        let app = st
+            .applications
+            .get_mut(&app_id)
+            .ok_or_else(|| not_found_generic(&format!("Application {app_id} not found.")))?;
+        app.attachments
+            .insert(attachment_id.clone(), record.clone());
+        Ok(ok(record))
     }
 
     fn detach_data_source(
@@ -2291,10 +2307,18 @@ impl OpenSearchService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let app_id = label(l.id.as_deref())?;
         let b = body(req);
+        let ds_arn = b.get("dataSourceArn").cloned().unwrap_or(json!(""));
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        if let Some(app) = st.applications.get_mut(&app_id) {
+            // Drop any attachment(s) for this data-source ARN.
+            app.attachments
+                .retain(|_, v| v.get("dataSourceArn") != Some(&ds_arn));
+        }
         Ok(ok(json!({
             "id": app_id,
-            "arn": b.get("dataSourceArn").cloned().unwrap_or(json!("")),
-            "dataSourceArn": b.get("dataSourceArn").cloned().unwrap_or(json!("")),
+            "arn": ds_arn,
+            "dataSourceArn": ds_arn,
         })))
     }
 
@@ -2305,18 +2329,79 @@ impl OpenSearchService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let app_id = label(l.id.as_deref())?;
         let b = body(req);
-        Ok(ok(json!({
-            "attachmentId": b.get("attachmentId").cloned().unwrap_or(json!(short_id())),
-            "id": app_id,
-            "arn": "",
-            "dataSourceArn": "",
-            "status": "ATTACHED",
-        })))
+        let attachment_id = b
+            .get("attachmentId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let accounts = self.state.read();
+        let app = accounts
+            .get(&req.account_id)
+            .and_then(|st| st.applications.get(&app_id))
+            .ok_or_else(|| not_found_generic(&format!("Application {app_id} not found.")))?;
+        let record = app
+            .attachments
+            .get(&attachment_id)
+            .cloned()
+            .ok_or_else(|| not_found_generic(&format!("Attachment {attachment_id} not found.")))?;
+        Ok(ok(record))
     }
 
-    fn list_data_source_attachments(&self, l: &Labels) -> Result<AwsResponse, AwsServiceError> {
-        let _ = label(l.id.as_deref())?;
-        Ok(ok(json!({ "attachments": [] })))
+    fn list_data_source_attachments(
+        &self,
+        l: &Labels,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let app_id = label(l.id.as_deref())?;
+        let accounts = self.state.read();
+        let attachments: Vec<Value> = accounts
+            .get(&req.account_id)
+            .and_then(|st| st.applications.get(&app_id))
+            .map(|app| app.attachments.values().cloned().collect())
+            .unwrap_or_default();
+        Ok(ok(json!({ "attachments": attachments })))
+    }
+
+    fn put_default_application_setting(
+        &self,
+        l: &Labels,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let b = body(req);
+        let arn = b
+            .get("applicationArn")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| l.id.clone())
+            .ok_or_else(|| not_found_generic("applicationArn is required."))?;
+        let set_as_default = b
+            .get("setAsDefault")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        // Exactly one application is the account default; clear the others.
+        for app in st.applications.values_mut() {
+            app.is_default_setting = set_as_default && (app.arn == arn || app.id == arn);
+        }
+        Ok(ok(json!({ "applicationArn": arn })))
+    }
+
+    fn get_default_application_setting(
+        &self,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let arn = accounts
+            .get(&req.account_id)
+            .and_then(|st| {
+                st.applications
+                    .values()
+                    .find(|a| a.is_default_setting)
+                    .map(|a| a.arn.clone())
+            })
+            .unwrap_or_default();
+        Ok(ok(json!({ "applicationArn": arn })))
     }
 
     // ===================================================================
@@ -2552,7 +2637,13 @@ impl OpenSearchService {
         match op {
             "CreateIndex" => {
                 let name = req_str(&b, "IndexName")?;
-                d.indices.insert(name.clone(), json!({"IndexName": name}));
+                // Persist the submitted IndexSchema so GetIndex returns it
+                // rather than a stub.
+                let schema = b.get("IndexSchema").cloned().unwrap_or(json!({}));
+                d.indices.insert(
+                    name.clone(),
+                    json!({"IndexName": name, "IndexSchema": schema}),
+                );
                 Ok(ok(json!({ "Status": "CREATED" })))
             }
             "DeleteIndex" => {
@@ -2562,9 +2653,15 @@ impl OpenSearchService {
             }
             "UpdateIndex" => {
                 let ix = label(l.index.as_deref())?;
-                d.indices
+                let entry = d
+                    .indices
                     .entry(ix.clone())
-                    .or_insert_with(|| json!({"IndexName": ix}));
+                    .or_insert_with(|| json!({"IndexName": ix, "IndexSchema": {}}));
+                if let Some(schema) = b.get("IndexSchema") {
+                    if let Some(obj) = entry.as_object_mut() {
+                        obj.insert("IndexSchema".to_string(), schema.clone());
+                    }
+                }
                 Ok(ok(json!({ "Status": "UPDATED" })))
             }
             "GetIndex" => {
@@ -2572,8 +2669,8 @@ impl OpenSearchService {
                 let schema = d
                     .indices
                     .get(&ix)
-                    .cloned()
-                    .unwrap_or_else(|| json!({"IndexName": ix}));
+                    .and_then(|entry| entry.get("IndexSchema").cloned())
+                    .unwrap_or(json!({}));
                 Ok(ok(json!({ "IndexSchema": schema })))
             }
             _ => Ok(ok(json!({}))),

--- a/crates/fakecloud-opensearch/src/state.rs
+++ b/crates/fakecloud-opensearch/src/state.rs
@@ -130,6 +130,13 @@ pub struct Application {
     /// Capabilities registered on this application keyed by capability name.
     #[serde(default)]
     pub capabilities: BTreeMap<String, Value>,
+    /// Data-source attachments keyed by attachmentId (AttachDataSource).
+    #[serde(default)]
+    pub attachments: BTreeMap<String, Value>,
+    /// Whether this application is registered as the account default
+    /// (PutDefaultApplicationSetting).
+    #[serde(default)]
+    pub is_default_setting: bool,
 }
 
 /// An application migration (2021 API only), account-scoped.

--- a/crates/fakecloud-opensearch/tests/service_tests.rs
+++ b/crates/fakecloud-opensearch/tests/service_tests.rs
@@ -1488,3 +1488,161 @@ async fn update_direct_query_data_source_persists_type() {
     let v = json_of(&resp);
     assert_eq!(v["DataSourceType"], new_type);
 }
+
+async fn create_app(svc: &OpenSearchService, name: &str) -> (String, String) {
+    let created = json_of(
+        &call(
+            svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/application"),
+                json!({"name": name}),
+            ),
+        )
+        .await,
+    );
+    (
+        created["id"].as_str().unwrap().to_string(),
+        created["arn"].as_str().unwrap().to_string(),
+    )
+}
+
+#[tokio::test]
+async fn register_capability_roundtrips_config() {
+    let svc = service();
+    let (id, _) = create_app(&svc, "cap-app").await;
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/application/{id}/capability/register"),
+            json!({"capabilityName": "SQL", "capabilityConfig": {"enabled": "true"}}),
+        ),
+    )
+    .await;
+    let got = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{OS}/opensearch/application/{id}/capability/SQL"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(got["capabilityName"], "SQL");
+    assert_eq!(got["capabilityConfig"]["enabled"], "true");
+}
+
+#[tokio::test]
+async fn attach_data_source_roundtrips_on_application() {
+    let svc = service();
+    let (id, _) = create_app(&svc, "attach-app").await;
+    let attached = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/application/{id}/attachDataSource"),
+                json!({"dataSourceArn": "arn:aws:s3:::my-data-source-bucket-name-example"}),
+            ),
+        )
+        .await,
+    );
+    let attachment_id = attached["attachmentId"].as_str().unwrap().to_string();
+
+    let listed = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/application/{id}/listDataSourceAttachments"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(listed["attachments"].as_array().unwrap().len(), 1);
+
+    let described = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/application/{id}/describeDataSourceAttachment"),
+                json!({"attachmentId": attachment_id, "dataSourceArn": "arn:aws:s3:::my-data-source-bucket-name-example"}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(
+        described["dataSourceArn"],
+        "arn:aws:s3:::my-data-source-bucket-name-example"
+    );
+}
+
+#[tokio::test]
+async fn default_application_setting_roundtrips() {
+    let svc = service();
+    let (_, arn) = create_app(&svc, "default-app").await;
+    call(
+        &svc,
+        req(
+            Method::PUT,
+            &format!("{OS}/opensearch/defaultApplicationSetting"),
+            json!({"applicationArn": arn, "setAsDefault": true}),
+        ),
+    )
+    .await;
+    let got = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{OS}/opensearch/defaultApplicationSetting"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(got["applicationArn"], arn);
+}
+
+#[tokio::test]
+async fn create_index_persists_schema() {
+    let svc = service();
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain"),
+            json!({"DomainName": "ixdomain"}),
+        ),
+    )
+    .await;
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain/ixdomain/index"),
+            json!({"IndexName": "logs", "IndexSchema": {"mappings": {"properties": {"ts": {"type": "date"}}}}}),
+        ),
+    )
+    .await;
+    let got = json_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("{OS}/opensearch/domain/ixdomain/index/logs"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(
+        got["IndexSchema"]["mappings"]["properties"]["ts"]["type"],
+        "date"
+    );
+}

--- a/crates/fakecloud-ssm/src/service/misc.rs
+++ b/crates/fakecloud-ssm/src/service/misc.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use serde_json::json;
 
 use fakecloud_aws::arn::Arn;
@@ -7,6 +7,8 @@ use fakecloud_core::validation::*;
 
 use crate::state::{SsmServiceSetting, SsmState};
 
+use super::documents::doc_not_found;
+use super::helpers::aws_400;
 use super::{missing, SsmService};
 
 impl SsmService {
@@ -23,18 +25,83 @@ impl SsmService {
         })))
     }
 
+    /// Evaluate one or more Change Calendar documents at a point in time.
+    ///
+    /// A Change Calendar document holds an iCalendar (RFC 5545) body whose
+    /// `X-CALENDAR-TYPE` property sets the default state (`DEFAULT_OPEN` or
+    /// `DEFAULT_CLOSED`); each `VEVENT` marks a window during which the state is
+    /// the opposite of the default. When several calendars are supplied the
+    /// aggregate is `CLOSED` if any one of them is `CLOSED` at `AtTime`.
     pub(super) fn get_calendar_state(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let _calendar_names = body["CalendarNames"]
+        let calendar_names = body["CalendarNames"]
             .as_array()
             .ok_or_else(|| missing("CalendarNames"))?;
-        Ok(AwsResponse::ok_json(json!({
-            "State": "OPEN",
-            "AtTime": Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-        })))
+        if calendar_names.is_empty() {
+            return Err(missing("CalendarNames"));
+        }
+
+        // Requested evaluation instant; echoed back verbatim in the response.
+        let at_time = match body["AtTime"].as_str() {
+            Some(s) => parse_iso8601(s).ok_or_else(|| {
+                aws_400(
+                    "ValidationException",
+                    "AtTime is not a valid ISO 8601 timestamp",
+                )
+            })?,
+            None => Utc::now(),
+        };
+        let at_time_str = at_time.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        let accounts = self.state.read();
+        let empty = SsmState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+        let mut aggregate_closed = false;
+        let mut next_transition: Option<DateTime<Utc>> = None;
+
+        for entry in calendar_names {
+            let raw = entry.as_str().ok_or_else(|| {
+                aws_400(
+                    "ValidationException",
+                    "CalendarNames entries must be strings",
+                )
+            })?;
+            let name = calendar_document_key(raw);
+            let doc = state
+                .documents
+                .get(&name)
+                .ok_or_else(|| doc_not_found(&name))?;
+            if doc.document_type != "ChangeCalendar" {
+                return Err(aws_400(
+                    "InvalidDocumentType",
+                    format!("Document {name} is not a Change Calendar"),
+                ));
+            }
+
+            let calendar = parse_change_calendar(&doc.content);
+            if calendar.is_closed_at(at_time) {
+                aggregate_closed = true;
+            }
+            if let Some(t) = calendar.next_transition_after(at_time) {
+                next_transition = Some(match next_transition {
+                    Some(cur) => cur.min(t),
+                    None => t,
+                });
+            }
+        }
+
+        let mut resp = json!({
+            "State": if aggregate_closed { "CLOSED" } else { "OPEN" },
+            "AtTime": at_time_str,
+        });
+        if let Some(t) = next_transition {
+            resp["NextTransitionTime"] = json!(t.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+        }
+        Ok(AwsResponse::ok_json(resp))
     }
 
     pub(super) fn get_service_setting(
@@ -138,6 +205,122 @@ impl SsmService {
     }
 
     // ── Inventory ─────────────────────────────────────────────────
+}
+
+/// Resolve a `CalendarNames` entry (either a bare document name or a
+/// `arn:aws:ssm:...:document/<name>` ARN) to the key used in `state.documents`.
+fn calendar_document_key(raw: &str) -> String {
+    if raw.starts_with("arn:") {
+        if let Ok(arn) = raw.parse::<Arn>() {
+            // resource looks like `document/my-cal`
+            if let Some(name) = arn.resource.strip_prefix("document/") {
+                return name.to_string();
+            }
+            return arn.resource;
+        }
+    }
+    raw.to_string()
+}
+
+/// Parse an ISO 8601 timestamp. Accepts RFC 3339 (`2022-11-30T23:00:00Z`,
+/// with optional fractional seconds/offset) and the compact iCalendar form
+/// (`20221130T230000Z`).
+fn parse_iso8601(s: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    parse_ical_datetime(s)
+}
+
+/// A parsed Change Calendar: its default state plus the event windows during
+/// which the state is the opposite of the default.
+struct ChangeCalendar {
+    /// `true` when `X-CALENDAR-TYPE` is `DEFAULT_OPEN` (the AWS default).
+    default_open: bool,
+    /// `(start, end)` windows; state is flipped from the default while inside.
+    windows: Vec<(DateTime<Utc>, DateTime<Utc>)>,
+}
+
+impl ChangeCalendar {
+    fn is_closed_at(&self, at: DateTime<Utc>) -> bool {
+        let inside = self.windows.iter().any(|(s, e)| at >= *s && at < *e);
+        // Inside a window the state is the inverse of the default.
+        if inside {
+            self.default_open
+        } else {
+            !self.default_open
+        }
+    }
+
+    /// The earliest window boundary strictly after `at`, i.e. the next instant
+    /// the calendar flips state.
+    fn next_transition_after(&self, at: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        self.windows
+            .iter()
+            .flat_map(|(s, e)| [*s, *e])
+            .filter(|t| *t > at)
+            .min()
+    }
+}
+
+/// Parse a Change Calendar iCalendar (RFC 5545) body into its default state and
+/// event windows. Unparseable bodies degrade to an all-OPEN calendar.
+fn parse_change_calendar(content: &str) -> ChangeCalendar {
+    let mut default_open = true;
+    let mut windows = Vec::new();
+    let mut cur_start: Option<DateTime<Utc>> = None;
+    let mut cur_end: Option<DateTime<Utc>> = None;
+    let mut in_event = false;
+
+    for line in content.lines() {
+        let line = line.trim();
+        // Split off any property parameters: `NAME;PARAM=x:VALUE`.
+        let (prop, value) = match line.split_once(':') {
+            Some((p, v)) => (p, v.trim()),
+            None => continue,
+        };
+        let key = prop.split(';').next().unwrap_or(prop).to_ascii_uppercase();
+        match key.as_str() {
+            "X-CALENDAR-TYPE" => {
+                default_open = !value.eq_ignore_ascii_case("DEFAULT_CLOSED");
+            }
+            "BEGIN" if value.eq_ignore_ascii_case("VEVENT") => {
+                in_event = true;
+                cur_start = None;
+                cur_end = None;
+            }
+            "END" if value.eq_ignore_ascii_case("VEVENT") => {
+                if let (Some(s), Some(e)) = (cur_start, cur_end) {
+                    windows.push((s, e));
+                }
+                in_event = false;
+            }
+            "DTSTART" if in_event => cur_start = parse_ical_datetime(value),
+            "DTEND" if in_event => cur_end = parse_ical_datetime(value),
+            _ => {}
+        }
+    }
+
+    ChangeCalendar {
+        default_open,
+        windows,
+    }
+}
+
+/// Parse an iCalendar DATE-TIME (`20221130T230000Z`) or DATE (`20221130`)
+/// value into a UTC instant. Any zone qualifier is treated as UTC.
+fn parse_ical_datetime(value: &str) -> Option<DateTime<Utc>> {
+    let v = value.trim().trim_end_matches('Z');
+    if let Some((date, time)) = v.split_once('T') {
+        let d = NaiveDate::parse_from_str(date, "%Y%m%d").ok()?;
+        let t = NaiveDateTime::parse_from_str(&format!("{date}T{time}"), "%Y%m%dT%H%M%S")
+            .ok()
+            .map(|dt| dt.time())
+            .unwrap_or_else(|| d.and_hms_opt(0, 0, 0).unwrap().time());
+        return Some(Utc.from_utc_datetime(&d.and_time(t)));
+    }
+    let d = NaiveDate::parse_from_str(v, "%Y%m%d").ok()?;
+    Some(Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0).unwrap()))
 }
 
 pub(super) fn get_default_service_setting(setting_id: &str) -> String {

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -472,15 +472,86 @@ fn get_connection_status_returns_connected() {
 }
 
 #[test]
-fn get_calendar_state_returns_open() {
+fn get_calendar_state_unknown_calendar_errors() {
     let svc = make_service();
     let req = make_request(
         "GetCalendarState",
-        json!({ "CalendarNames": ["arn:aws:ssm:us-east-1:123456789012:document/cal"] }),
+        json!({ "CalendarNames": ["arn:aws:ssm:us-east-1:123456789012:document/nope"] }),
     );
-    let resp = svc.get_calendar_state(&req).unwrap();
+    let err = svc.get_calendar_state(&req).err().expect("expected error");
+    assert_eq!(err.code(), "InvalidDocument");
+}
+
+#[test]
+fn get_calendar_state_evaluates_closed_window() {
+    let svc = make_service();
+    // A DEFAULT_OPEN change calendar with a single CLOSED window on 2022-11-30
+    // from 23:00Z to 2022-12-01 01:00Z.
+    let ical = "BEGIN:VCALENDAR\r\n\
+        PRODID:-//AWS//Change Calendar 1.0//EN\r\n\
+        VERSION:2.0\r\n\
+        X-CALENDAR-TYPE:DEFAULT_OPEN\r\n\
+        BEGIN:VEVENT\r\n\
+        DTSTART:20221130T230000Z\r\n\
+        DTEND:20221201T010000Z\r\n\
+        UID:evt-1\r\n\
+        SUMMARY:freeze\r\n\
+        END:VEVENT\r\n\
+        END:VCALENDAR\r\n";
+    svc.create_document(&make_request(
+        "CreateDocument",
+        json!({
+            "Name": "prod-cal",
+            "Content": ical,
+            "DocumentType": "ChangeCalendar",
+            "DocumentFormat": "TEXT",
+        }),
+    ))
+    .unwrap();
+
+    // Inside the CLOSED window -> CLOSED, with the window end as next transition.
+    let resp = svc
+        .get_calendar_state(&make_request(
+            "GetCalendarState",
+            json!({ "CalendarNames": ["prod-cal"], "AtTime": "2022-11-30T23:30:00Z" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["State"].as_str().unwrap(), "CLOSED");
+    assert_eq!(body["AtTime"].as_str().unwrap(), "2022-11-30T23:30:00Z");
+    assert_eq!(
+        body["NextTransitionTime"].as_str().unwrap(),
+        "2022-12-01T01:00:00Z"
+    );
+
+    // Before the window -> OPEN (default), next transition is the window start.
+    let resp = svc
+        .get_calendar_state(&make_request(
+            "GetCalendarState",
+            json!({ "CalendarNames": ["prod-cal"], "AtTime": "2022-11-30T12:00:00Z" }),
+        ))
+        .unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
     assert_eq!(body["State"].as_str().unwrap(), "OPEN");
+    assert_eq!(
+        body["NextTransitionTime"].as_str().unwrap(),
+        "2022-11-30T23:00:00Z"
+    );
+
+    // A non-calendar document is rejected.
+    svc.create_document(&make_request(
+        "CreateDocument",
+        json!({ "Name": "plain", "Content": "{\"schemaVersion\":\"2.2\"}", "DocumentType": "Command" }),
+    ))
+    .unwrap();
+    let err = svc
+        .get_calendar_state(&make_request(
+            "GetCalendarState",
+            json!({ "CalendarNames": ["plain"] }),
+        ))
+        .err()
+        .expect("expected error");
+    assert_eq!(err.code(), "InvalidDocumentType");
 }
 
 #[test]


### PR DESCRIPTION
Fixes a cluster of MED-severity stub / dropped-field / no-op-modify bugs across 12 services. Each was a real user-facing bug where an operation validated its input, returned success, but persisted nothing (or settled a status incorrectly). No stubs: every fix does real persistence + read-back or returns a real error, with a regression test.

## Fixes

1. **SSM** `GetCalendarState` — hardcoded `OPEN`. Now parses the stored Change Calendar iCalendar body (`X-CALENDAR-TYPE` default + `VEVENT` windows), evaluates OPEN/CLOSED at `AtTime`, returns `NextTransitionTime`, and errors `InvalidDocument`/`InvalidDocumentType` like AWS.
2. **EC2** — `ModifyVpcEndpointServiceConfiguration` (NLB/GWLB/IP-type/PrivateDNS/acceptance), `ModifyVpcEndpointServicePermissions` (+`Describe`), `Modify`/`ResetAddressAttribute` (EIP reverse-DNS PTR, +`DescribeAddressesAttribute`), `ModifyVerifiedAccessEndpoint` (description/group) and the VerifiedAccess instance logging config were accept-and-discard. Now persist + reflect in their Describe siblings.
3. **Lambda** `UpdateFunctionEventInvokeConfig` — routed to Put (full replace), dropping an existing `DestinationConfig` when updating only `MaximumRetryAttempts`. Now merges; Put still replaces. Also fixed inverted PUT/POST routing (`PUT`=Put, `POST`=Update per the API).
4. **ElastiCache** `ModifyUser` — left status `modifying` forever. Now settles to `active` (mirrors `ModifyUserGroup`).
5. **Autoscaling** `DeleteAutoScalingGroup(ForceDelete)` — leaked backing EC2 instances. Now terminates them.
6. **EMR** `RunJobFlow` — read the wrong input key (`PlacementGroups` vs `PlacementGroupConfigs`) and dropped inline `ManagedScalingPolicy`/`AutoTerminationPolicy`. Now reads the right key and persists both policies so their `Get*` ops return them.
7. **ECS** — `StartTask` ignored `containerInstances` (fake `i-fakecloud-1`); now places on the specified registered instances. `PutAttributes`/`DeleteAttributes` are now reflected in `DescribeContainerInstances`.
8. **ElasticBeanstalk** — no platform store: `CreatePlatformVersion` persisted nothing and `DescribePlatformVersion` returned a fake `Ready` for any ARN. Added a platform store; Create persists, Describe returns the created platform or `ElasticBeanstalkServiceException` for unknown, List includes custom platforms, Delete removes.
9. **IoT** — generic update ignored removal toggles. Now honors `removeThingType`, `deleteBehaviors`, `deleteAlertTargets`, `removeAuthorizerConfig` (and strips the request-only toggle from the stored record).
10. **OpenSearch** — `AttachDataSource`, `RegisterCapability` (read side), `PutDefaultApplicationSetting`, `CreateIndex` (schema) were accept-and-discard. Now persist + reflect in their reads.
11. **Neptune** — `FailoverDBCluster` no-op (now flips the writer); `ModifyDBInstance` dropped `PubliclyAccessible`/`EngineVersion` (now persisted); `CreateDBInstance` hardcoded `storage_encrypted=false` in an encrypted cluster (now inherits cluster encryption + KMS key).
12. **ACM** — `RequestCertificate` with `ValidationMethod=HTTP` was mislabeled `EMAIL`, never issued, and Describe/Search disagreed. HTTP is now labeled HTTP with a real `HttpRedirect`, auto-issues, and Describe/Search agree. (Verified against `aws-models/acm.json`: `ValidationMethod` enum is `[EMAIL, DNS, HTTP]` — HTTP is real, not a false positive.)

## Testing
- Per-fix regression tests (round-trip / status-transition), all green.
- Conformance (source of truth) green for every touched service; where an op became AWS-correct in rejecting nonexistent resources, the conformance + e2e tests were updated to establish the precondition (create the calendar / allocate the EIP / register the container instance / create the endpoint service) rather than relaxing the implementation. Conformance checksums are model-derived and unchanged.
- `cargo build --workspace --all-targets`, `cargo clippy` on touched crates (`-D warnings`), `cargo fmt --all` all clean.

No false positives skipped — all 12 implemented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped persistence and incorrect status handling across 12 services so operations now write state, read back correctly, or return proper errors. Brings behavior in line with AWS and removes accept-and-discard stubs.

- **Bug Fixes**
  - SSM GetCalendarState parses Change Calendar iCalendar, evaluates OPEN/CLOSED at `AtTime`, returns `NextTransitionTime`, and errors `InvalidDocument`/`InvalidDocumentType`.
  - EC2: persist endpoint service config (NLB/GWLB/IP types, PrivateDNS, acceptance) and permissions; EIP PTR via `Modify`/`ResetAddressAttribute` + `DescribeAddressesAttribute`; VerifiedAccess endpoint description/group and instance logging config; reads reflect changes.
  - Lambda: correct PUT/POST routing; `UpdateFunctionEventInvokeConfig` merges without dropping `DestinationConfig`; `PutFunctionEventInvokeConfig` still replaces.
  - ElastiCache `ModifyUser` settles to `active` (no stuck `modifying`).
  - Auto Scaling `DeleteAutoScalingGroup(ForceDelete)` terminates backing instances.
  - EMR `RunJobFlow` uses `PlacementGroupConfigs` and persists inline `ManagedScalingPolicy`/`AutoTerminationPolicy`.
  - ECS `StartTask` places on specified registered container instances; `PutAttributes`/`DeleteAttributes` reflected in `DescribeContainerInstances`.
  - Elastic Beanstalk: add platform store; `CreatePlatformVersion` persists; `Describe/List/Delete` work and unknown ARNs error.
  - IoT: honor `removeThingType`, `deleteBehaviors`, `deleteAlertTargets`, `removeAuthorizerConfig`; toggles are stripped from stored records.
  - OpenSearch: persist `AttachDataSource`, `RegisterCapability`, `PutDefaultApplicationSetting`, and `CreateIndex` schema; reads reflect changes.
  - Neptune: `FailoverDBCluster` flips writer; `ModifyDBInstance` persists `PubliclyAccessible`/`EngineVersion`; `CreateDBInstance` inherits cluster encryption/KMS key.
  - ACM: HTTP-validated `RequestCertificate` is labeled `HTTP` with real `HttpRedirect`, auto-issues, and `Describe`/Search agree.

<sup>Written for commit dcc04e3d922e49ac59e96a1418b907cae14688b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

