### PR TITLE
fix(16 services): persist dropped create/update fields + evaluate queries (bug-hunt)

### DIFF
--- a/crates/fakecloud-amplify/src/service.rs
+++ b/crates/fakecloud-amplify/src/service.rs
@@ -325,6 +325,28 @@ fn ok(v: Value) -> Result<AwsResponse, AwsServiceError> {
     Ok(AwsResponse::json_value(StatusCode::OK, v))
 }
 
+/// Build the `certificate` object for a DomainAssociation from a request's
+/// `certificateSettings` input. Shared by create + update so both persist the
+/// requested cert type / customCertificateArn identically. Returns `None` when
+/// the request carries no `certificateSettings`.
+fn build_certificate(body: &Value, domain: &str) -> Option<Value> {
+    let cs = body.get("certificateSettings").and_then(Value::as_object)?;
+    let ctype = cs
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("AMPLIFY_MANAGED");
+    let mut cert = Map::new();
+    cert.insert("type".into(), json!(ctype));
+    if let Some(arn) = cs.get("customCertificateArn") {
+        cert.insert("customCertificateArn".into(), arn.clone());
+    }
+    cert.insert(
+        "certificateVerificationDNSRecord".into(),
+        json!(shared::certificate_verification_dns_record(domain)),
+    );
+    Some(Value::Object(cert))
+}
+
 fn parse_body(req: &AwsRequest) -> Result<Value, AwsServiceError> {
     if req.body.is_empty() {
         return Ok(json!({}));
@@ -890,21 +912,8 @@ impl AmplifyService {
             .collect();
         d.insert("subDomains".into(), json!(subdomains));
         // Certificate mirrors the requested certificate settings.
-        if let Some(cs) = body.get("certificateSettings").and_then(Value::as_object) {
-            let ctype = cs
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("AMPLIFY_MANAGED");
-            let mut cert = Map::new();
-            cert.insert("type".into(), json!(ctype));
-            if let Some(arn) = cs.get("customCertificateArn") {
-                cert.insert("customCertificateArn".into(), arn.clone());
-            }
-            cert.insert(
-                "certificateVerificationDNSRecord".into(),
-                json!(shared::certificate_verification_dns_record(domain)),
-            );
-            d.insert("certificate".into(), Value::Object(cert));
+        if let Some(cert) = build_certificate(body, domain) {
+            d.insert("certificate".into(), cert);
         }
         echo(
             &mut d,
@@ -1001,6 +1010,11 @@ impl AmplifyService {
                 })
                 .collect();
             a.insert("subDomains".into(), json!(subs));
+        }
+        // Persist updated certificateSettings so GetDomainAssociation echoes the
+        // new certificate (previously dropped, leaving a stale create-time cert).
+        if let Some(cert) = build_certificate(body, domain) {
+            a.insert("certificate".into(), cert);
         }
         // Re-enter verification so the update settles on the next read.
         a.insert("domainStatus".into(), json!("UPDATING"));
@@ -1846,6 +1860,42 @@ mod tests {
             .unwrap();
         let body = body_json(&created);
         body["app"]["appId"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn update_domain_persists_certificate_settings() {
+        // UpdateDomainAssociation dropped certificateSettings; the new cert must
+        // be echoed by GetDomainAssociation (bug-hunt).
+        let s = svc();
+        let c = ctx();
+        let app_id = make_app(&s, &c);
+        s.create_domain(
+            &c,
+            &app_id,
+            &json!({
+                "domainName": "example.com",
+                "subDomainSettings": [{ "prefix": "www", "branchName": "main" }],
+                "certificateSettings": { "type": "AMPLIFY_MANAGED" }
+            }),
+        )
+        .unwrap();
+
+        // Switch to a CUSTOM certificate.
+        let arn = "arn:aws:acm:us-east-1:000000000000:certificate/abc";
+        s.update_domain(
+            &c,
+            &app_id,
+            "example.com",
+            &json!({
+                "certificateSettings": { "type": "CUSTOM", "customCertificateArn": arn }
+            }),
+        )
+        .unwrap();
+
+        let dom = body_json(&s.get_domain(&c, &app_id, "example.com").unwrap());
+        let cert = &dom["domainAssociation"]["certificate"];
+        assert_eq!(cert["type"], "CUSTOM");
+        assert_eq!(cert["customCertificateArn"], arn);
     }
 
     #[test]

--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -1152,6 +1152,8 @@ mod tests {
             parameters: std::collections::BTreeMap::new(),
             created_at: Utc::now(),
             catalog_id: "123456789012".to_string(),
+            target_database: None,
+            federated_database: None,
             tables: std::collections::BTreeMap::new(),
         }
     }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
@@ -52,6 +52,14 @@ impl ResourceProvisioner {
                 parameters,
                 created_at: Utc::now(),
                 catalog_id: self.account_id.clone(),
+                target_database: input
+                    .get("TargetDatabase")
+                    .filter(|v| !v.is_null())
+                    .cloned(),
+                federated_database: input
+                    .get("FederatedDatabase")
+                    .filter(|v| !v.is_null())
+                    .cloned(),
                 tables: BTreeMap::new(),
             },
         );

--- a/crates/fakecloud-cloudfront/src/extras.rs
+++ b/crates/fakecloud-cloudfront/src/extras.rs
@@ -42,6 +42,8 @@ pub struct SslProtocolItems {
 #[serde(rename_all = "PascalCase")]
 pub struct CreateVpcOriginRequest {
     pub vpc_origin_endpoint_config: VpcOriginEndpointConfig,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub tags: Option<crate::model::Tags>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +68,8 @@ pub struct CreateAnycastIpListRequest {
     pub ip_address_type: Option<String>,
     #[serde(default, skip_serializing_if = "skip_if_none")]
     pub ipam_cidr_configs: Option<IpamCidrConfigList>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub tags: Option<crate::model::Tags>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -87,8 +91,12 @@ pub struct IpamCidrConfigList {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct IpamCidrConfig {
-    pub ipv4_pool_id: String,
-    pub allocation_size: i32,
+    pub cidr: String,
+    pub ipam_pool_arn: String,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub anycast_ip: Option<String>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub status: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,6 +110,11 @@ pub struct StoredAnycastIpList {
     pub anycast_ips: Vec<String>,
     pub last_modified_time: DateTime<Utc>,
     pub etag: String,
+    /// The create-time IPAM CIDR configuration, retained so GetAnycastIpList
+    /// echoes it back as `IpamConfig`. `None` when the list was created without
+    /// bring-your-own-IP IPAM configs.
+    #[serde(default)]
+    pub ipam_cidr_configs: Vec<IpamCidrConfig>,
 }
 
 // ─── Trust Store ──────────────────────────────────────────────────────
@@ -111,6 +124,14 @@ pub struct StoredAnycastIpList {
 pub struct CreateTrustStoreRequest {
     pub name: String,
     pub ca_certificates_bundle_source: CaCertificatesBundleSource,
+    #[serde(
+        rename = "UseClientCertificateOCSPEndpoint",
+        default,
+        skip_serializing_if = "skip_if_none"
+    )]
+    pub use_client_certificate_ocsp_endpoint: Option<bool>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub tags: Option<crate::model::Tags>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -138,6 +159,11 @@ pub struct StoredTrustStore {
     pub etag: String,
     pub last_modified_time: DateTime<Utc>,
     pub ca_certificates_bundle_source: CaCertificatesBundleSource,
+    /// Whether OCSP revocation checking of client certificates is enabled,
+    /// supplied at CreateTrustStore and echoed by GetTrustStore. Previously
+    /// dropped (bug-hunt).
+    #[serde(default)]
+    pub use_client_certificate_ocsp_endpoint: Option<bool>,
 }
 
 // ─── Resource Policy ──────────────────────────────────────────────────

--- a/crates/fakecloud-cloudfront/src/extras2.rs
+++ b/crates/fakecloud-cloudfront/src/extras2.rs
@@ -20,6 +20,8 @@ pub struct CreateConnectionGroupRequest {
     pub anycast_ip_list_id: Option<String>,
     #[serde(default, skip_serializing_if = "skip_if_none")]
     pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "skip_if_none")]
+    pub tags: Option<crate::model::Tags>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/fakecloud-cloudfront/src/extras2_service.rs
+++ b/crates/fakecloud-cloudfront/src/extras2_service.rs
@@ -35,6 +35,7 @@ impl CloudFrontService {
         if cfg.name.is_empty() {
             return Err(invalid_argument("Name is required"));
         }
+        let tags = crate::extras_service::tags_to_state(&cfg.tags);
         let mut state = self.state.write();
         let account = state
             .accounts
@@ -62,7 +63,7 @@ impl CloudFrontService {
         let stored = StoredConnectionGroup {
             id: id.clone(),
             name: cfg.name,
-            arn,
+            arn: arn.clone(),
             routing_endpoint,
             status: "InProgress".to_string(),
             etag: etag.clone(),
@@ -74,6 +75,9 @@ impl CloudFrontService {
             is_default: false,
         };
         account.connection_groups.insert(id.clone(), stored.clone());
+        if !tags.is_empty() {
+            account.tags.insert(arn, tags);
+        }
         drop(state);
         self.schedule_connection_group_deploy(id.clone());
         let body = render_connection_group(&stored);

--- a/crates/fakecloud-cloudfront/src/extras_service.rs
+++ b/crates/fakecloud-cloudfront/src/extras_service.rs
@@ -25,6 +25,24 @@ use crate::xml_io;
 const NS: &str = crate::NAMESPACE;
 const XML_DECL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>"#;
 
+/// Convert a parsed restXml `Tags` payload into the account-keyed tag list used
+/// by ListTagsForResource. Shared by the create ops that accept create-time
+/// Tags (VPC origins, anycast IP lists, trust stores, connection groups).
+pub(crate) fn tags_to_state(tags: &Option<crate::model::Tags>) -> Vec<crate::state::Tag> {
+    tags.as_ref()
+        .and_then(|t| t.items.as_ref())
+        .map(|list| {
+            list.tag
+                .iter()
+                .map(|t| crate::state::Tag {
+                    key: t.key.clone(),
+                    value: t.value.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 // ─── VPC Origin ───────────────────────────────────────────────────────
 
 impl CloudFrontService {
@@ -35,6 +53,7 @@ impl CloudFrontService {
         let parsed: CreateVpcOriginRequest = xml_io::from_xml_root(&req.body)
             .map_err(|e| invalid_argument(format!("invalid CreateVpcOriginRequest XML: {e}")))?;
         let cfg = parsed.vpc_origin_endpoint_config;
+        let tags = tags_to_state(&parsed.tags);
         if cfg.name.is_empty() {
             return Err(invalid_argument("Name is required"));
         }
@@ -64,7 +83,7 @@ impl CloudFrontService {
             Arn::global("cloudfront", DEFAULT_ACCOUNT, &format!("vpc-origin/{id}")).to_string();
         let stored = StoredVpcOrigin {
             id: id.clone(),
-            arn,
+            arn: arn.clone(),
             status: "Deployed".to_string(),
             etag: etag.clone(),
             created_time: now,
@@ -72,6 +91,9 @@ impl CloudFrontService {
             config: cfg,
         };
         account.vpc_origins.insert(id.clone(), stored.clone());
+        if !tags.is_empty() {
+            account.tags.insert(arn, tags);
+        }
         drop(state);
         let body = render_vpc_origin(&stored);
         Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
@@ -217,6 +239,14 @@ impl CloudFrontService {
         if cfg.ip_count != 3 && cfg.ip_count != 21 {
             return Err(invalid_argument("IpCount must be 3 or 21"));
         }
+        let tags = tags_to_state(&cfg.tags);
+        // Retain the bring-your-own-IP IPAM CIDR configs supplied at create time
+        // so GetAnycastIpList echoes them as IpamConfig (previously dropped).
+        let ipam_cidr_configs = cfg
+            .ipam_cidr_configs
+            .as_ref()
+            .map(|l| l.ipam_cidr_config.clone())
+            .unwrap_or_default();
         let mut state = self.state.write();
         let account = state
             .accounts
@@ -247,14 +277,18 @@ impl CloudFrontService {
             id: id.clone(),
             name: cfg.name,
             status: "Deployed".to_string(),
-            arn,
+            arn: arn.clone(),
             ip_count: cfg.ip_count,
             ip_address_type: cfg.ip_address_type,
             anycast_ips,
             last_modified_time: Utc::now(),
             etag: etag.clone(),
+            ipam_cidr_configs,
         };
         account.anycast_ip_lists.insert(id.clone(), stored.clone());
+        if !tags.is_empty() {
+            account.tags.insert(arn, tags);
+        }
         drop(state);
         let body = render_anycast_ip_list(&stored);
         Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
@@ -300,6 +334,9 @@ impl CloudFrontService {
         }
         if let Some(t) = cfg.ip_address_type {
             a.ip_address_type = Some(t);
+        }
+        if let Some(l) = cfg.ipam_cidr_configs {
+            a.ipam_cidr_configs = l.ipam_cidr_config;
         }
         a.last_modified_time = Utc::now();
         a.etag = generate_id_with_prefix("E");
@@ -404,15 +441,20 @@ impl CloudFrontService {
         let arn =
             Arn::global("cloudfront", DEFAULT_ACCOUNT, &format!("trust-store/{id}")).to_string();
         let etag = generate_id_with_prefix("E");
+        let tags = tags_to_state(&cfg.tags);
         let stored = StoredTrustStore {
             id: id.clone(),
-            arn,
+            arn: arn.clone(),
             name: cfg.name,
             etag: etag.clone(),
             last_modified_time: Utc::now(),
             ca_certificates_bundle_source: cfg.ca_certificates_bundle_source,
+            use_client_certificate_ocsp_endpoint: cfg.use_client_certificate_ocsp_endpoint,
         };
         account.trust_stores.insert(id.clone(), stored.clone());
+        if !tags.is_empty() {
+            account.tags.insert(arn, tags);
+        }
         drop(state);
         let body = render_trust_store(&stored);
         Ok(xml_with_etag(StatusCode::CREATED, body, &etag, Some(&id)))
@@ -677,6 +719,31 @@ fn render_anycast_ip_list(a: &StoredAnycastIpList) -> String {
     if let Some(t) = &a.ip_address_type {
         out.push_str(&format!("<IpAddressType>{}</IpAddressType>", esc(t)));
     }
+    if !a.ipam_cidr_configs.is_empty() {
+        out.push_str("<IpamConfig>");
+        out.push_str(&format!(
+            "<Quantity>{}</Quantity>",
+            a.ipam_cidr_configs.len()
+        ));
+        out.push_str("<IpamCidrConfigs>");
+        for c in &a.ipam_cidr_configs {
+            out.push_str("<IpamCidrConfig>");
+            out.push_str(&format!("<Cidr>{}</Cidr>", esc(&c.cidr)));
+            out.push_str(&format!(
+                "<IpamPoolArn>{}</IpamPoolArn>",
+                esc(&c.ipam_pool_arn)
+            ));
+            if let Some(ip) = &c.anycast_ip {
+                out.push_str(&format!("<AnycastIp>{}</AnycastIp>", esc(ip)));
+            }
+            if let Some(s) = &c.status {
+                out.push_str(&format!("<Status>{}</Status>", esc(s)));
+            }
+            out.push_str("</IpamCidrConfig>");
+        }
+        out.push_str("</IpamCidrConfigs>");
+        out.push_str("</IpamConfig>");
+    }
     out.push_str("<AnycastIps>");
     for ip in &a.anycast_ips {
         out.push_str(&format!("<AnycastIp>{}</AnycastIp>", esc(ip)));
@@ -718,6 +785,11 @@ fn render_trust_store(t: &StoredTrustStore) -> String {
         rfc3339(&t.last_modified_time)
     ));
     out.push_str(&render_bundle_source(&t.ca_certificates_bundle_source));
+    if let Some(ocsp) = t.use_client_certificate_ocsp_endpoint {
+        out.push_str(&format!(
+            "<UseClientCertificateOCSPEndpoint>{ocsp}</UseClientCertificateOCSPEndpoint>"
+        ));
+    }
     out.push_str("</TrustStore>");
     out
 }
@@ -737,4 +809,166 @@ fn render_bundle_source(s: &CaCertificatesBundleSource) -> String {
     }
     out.push_str("</CaCertificatesBundleSource>");
     out
+}
+
+#[cfg(test)]
+mod extras_create_tests {
+    use super::*;
+    use crate::state::CloudFrontAccounts;
+    use fakecloud_core::service::{AwsService, ResponseBody};
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn svc() -> CloudFrontService {
+        CloudFrontService::new(Arc::new(RwLock::new(CloudFrontAccounts::new())))
+    }
+
+    fn req(method: http::Method, path: &str, raw_query: &str, body: &str) -> AwsRequest {
+        AwsRequest {
+            service: "cloudfront".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: DEFAULT_ACCOUNT.into(),
+            request_id: "t".into(),
+            headers: HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            body: bytes::Bytes::from(body.to_string()),
+            path_segments: vec![],
+            raw_path: path.into(),
+            raw_query: raw_query.into(),
+            method,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body_str(resp: &AwsResponse) -> String {
+        match &resp.body {
+            ResponseBody::Bytes(b) => String::from_utf8(b.to_vec()).unwrap(),
+            _ => panic!("expected bytes body"),
+        }
+    }
+
+    fn between<'a>(xml: &'a str, tag: &str) -> Option<&'a str> {
+        xml.split(&format!("<{tag}>"))
+            .nth(1)
+            .and_then(|s| s.split(&format!("</{tag}>")).next())
+    }
+
+    #[tokio::test]
+    async fn create_trust_store_persists_ocsp_and_tags() {
+        let s = svc();
+        let body = format!(
+            r#"<?xml version="1.0"?>
+<CreateTrustStoreRequest xmlns="{NS}">
+  <Name>ts1</Name>
+  <CaCertificatesBundleSource>
+    <CaCertificatesBundleS3Location><Bucket>b</Bucket><Key>k</Key><Region>us-east-1</Region></CaCertificatesBundleS3Location>
+  </CaCertificatesBundleSource>
+  <UseClientCertificateOCSPEndpoint>true</UseClientCertificateOCSPEndpoint>
+  <Tags><Items><Tag><Key>team</Key><Value>edge</Value></Tag></Items></Tags>
+</CreateTrustStoreRequest>"#
+        );
+        let created = s
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/trust-store",
+                "",
+                &body,
+            ))
+            .await
+            .unwrap();
+        let xml = body_str(&created);
+        let id = between(&xml, "Id").unwrap().to_string();
+        let arn = between(&xml, "Arn").unwrap().to_string();
+
+        // GetTrustStore echoes the OCSP flag.
+        let got = s
+            .handle(req(
+                http::Method::GET,
+                &format!("/2020-05-31/trust-store/{id}"),
+                "",
+                "",
+            ))
+            .await
+            .unwrap();
+        let gxml = body_str(&got);
+        assert_eq!(
+            between(&gxml, "UseClientCertificateOCSPEndpoint"),
+            Some("true"),
+            "OCSP echoed: {gxml}"
+        );
+
+        // Create-time tags are visible via ListTagsForResource.
+        let tags = s
+            .handle(req(
+                http::Method::GET,
+                "/2020-05-31/tagging",
+                &format!("Resource={arn}"),
+                "",
+            ))
+            .await
+            .unwrap();
+        let txml = body_str(&tags);
+        assert!(txml.contains("<Key>team</Key>"), "tag listed: {txml}");
+        assert!(txml.contains("<Value>edge</Value>"));
+    }
+
+    #[tokio::test]
+    async fn create_anycast_ip_list_persists_ipam_and_tags() {
+        let s = svc();
+        let body = format!(
+            r#"<?xml version="1.0"?>
+<CreateAnycastIpListRequest xmlns="{NS}">
+  <Name>ail1</Name>
+  <IpCount>3</IpCount>
+  <IpamCidrConfigs>
+    <IpamCidrConfig>
+      <Cidr>10.0.0.0/24</Cidr>
+      <IpamPoolArn>arn:aws:ec2::123456789012:ipam-pool/ipam-pool-1</IpamPoolArn>
+    </IpamCidrConfig>
+  </IpamCidrConfigs>
+  <Tags><Items><Tag><Key>env</Key><Value>prod</Value></Tag></Items></Tags>
+</CreateAnycastIpListRequest>"#
+        );
+        let created = s
+            .handle(req(
+                http::Method::POST,
+                "/2020-05-31/anycast-ip-list",
+                "",
+                &body,
+            ))
+            .await
+            .unwrap();
+        let xml = body_str(&created);
+        let id = between(&xml, "Id").unwrap().to_string();
+        let arn = between(&xml, "Arn").unwrap().to_string();
+
+        let got = s
+            .handle(req(
+                http::Method::GET,
+                &format!("/2020-05-31/anycast-ip-list/{id}"),
+                "",
+                "",
+            ))
+            .await
+            .unwrap();
+        let gxml = body_str(&got);
+        assert!(gxml.contains("<IpamConfig>"), "IpamConfig echoed: {gxml}");
+        assert!(gxml.contains("<Cidr>10.0.0.0/24</Cidr>"));
+        assert!(gxml.contains("ipam-pool-1"));
+
+        let tags = s
+            .handle(req(
+                http::Method::GET,
+                "/2020-05-31/tagging",
+                &format!("Resource={arn}"),
+                "",
+            ))
+            .await
+            .unwrap();
+        assert!(body_str(&tags).contains("<Key>env</Key>"));
+    }
 }

--- a/crates/fakecloud-codeartifact/src/handlers.rs
+++ b/crates/fakecloud-codeartifact/src/handlers.rs
@@ -1506,30 +1506,76 @@ impl CodeArtifactService {
         let domain = req_q(req, "domain")?;
         let format = req_q(req, "format")?;
         validate_format(&format)?;
-        let _package = req_q(req, "package")?;
+        let package = req_q(req, "package")?;
+        let namespace = q(req, "namespace").unwrap_or_default();
         let region = req.region.clone();
         let owner = req.account_id.clone();
-        let mut guard = self.state.write();
-        let acct = guard.get_or_create(&req.account_id);
-        if !acct.domains.contains_key(&domain) {
+        let guard = self.state.read();
+        let acct = guard
+            .get(&req.account_id)
+            .filter(|a| a.domains.contains_key(&domain));
+        let Some(acct) = acct else {
             return Err(not_found(format!("Domain {domain} does not exist")));
-        }
-        // Absent a more specific match, the root package group `/*` is the
-        // strong association every package inherits.
-        let root = package_group_desc(&region, &owner, &domain, "/*", None, None);
-        ok(json!({ "packageGroup": root, "associationType": "STRONG" }))
+        };
+        // Resolve the MOST-SPECIFIC stored group whose pattern matches this
+        // package's coordinate path; every package inherits the root `/*` group
+        // when no explicit group is a better match.
+        let path = package_path(&format, &namespace, &package);
+        let patterns = domain_group_patterns(acct, &domain);
+        let pattern = best_group_pattern(&patterns, &path);
+        // Echo the stored group when it exists (preserving its contactInfo /
+        // description / origin config), else synthesize the implicit root group.
+        let gkey = format!("{domain}{SEP}{pattern}");
+        let group = acct
+            .package_groups
+            .get(&gkey)
+            .cloned()
+            .unwrap_or_else(|| package_group_desc(&region, &owner, &domain, &pattern, None, None));
+        ok(json!({ "packageGroup": group, "associationType": "STRONG" }))
     }
 
     fn list_associated_packages(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let domain = req_q(req, "domain")?;
-        let _pattern = req_q(req, "package-group")?;
-        let mut guard = self.state.write();
-        let acct = guard.get_or_create(&req.account_id);
-        if !acct.domains.contains_key(&domain) {
+        let pattern = req_q(req, "package-group")?;
+        let guard = self.state.read();
+        let acct = guard
+            .get(&req.account_id)
+            .filter(|a| a.domains.contains_key(&domain));
+        let Some(acct) = acct else {
             return Err(not_found(format!("Domain {domain} does not exist")));
+        };
+        // A package is associated with the requested group iff that group is its
+        // most-specific matching pattern. Enumerate the domain's packages and
+        // select the ones whose best match is `pattern`.
+        let patterns = domain_group_patterns(acct, &domain);
+        let dom_prefix = format!("{domain}{SEP}");
+        let mut packages = Vec::new();
+        for key in &acct.package_order {
+            if !key.starts_with(&dom_prefix) {
+                continue;
+            }
+            let Some(pkg) = acct.packages.get(key) else {
+                continue;
+            };
+            let format = pkg.get("format").and_then(Value::as_str).unwrap_or("");
+            let namespace = pkg.get("namespace").and_then(Value::as_str).unwrap_or("");
+            let name = pkg.get("package").and_then(Value::as_str).unwrap_or("");
+            let path = package_path(format, namespace, name);
+            if best_group_pattern(&patterns, &path) != pattern {
+                continue;
+            }
+            let mut item = Map::new();
+            item.insert("format".into(), json!(format));
+            item.insert(
+                "namespace".into(),
+                pkg.get("namespace").cloned().unwrap_or(Value::Null),
+            );
+            item.insert("package".into(), json!(name));
+            item.insert("associationType".into(), json!("STRONG"));
+            packages.push(Value::Object(item));
         }
         let mut out = Map::new();
-        out.insert("packages".into(), Value::Array(Vec::new()));
+        out.insert("packages".into(), Value::Array(packages));
         ok(Value::Object(out))
     }
 
@@ -1896,6 +1942,64 @@ fn validate_origin_restrictions(restrictions: &Value) -> Result<(), AwsServiceEr
         }
     }
     Ok(())
+}
+
+/// The CodeArtifact package-group path for a package's coordinates, e.g.
+/// `/npm/@types~/node` (scoped npm), `/npm/lodash`, `/maven/com.google~/guava`.
+/// Package groups match packages by this path.
+fn package_path(format: &str, namespace: &str, package: &str) -> String {
+    let mut p = format!("/{format}");
+    if !namespace.is_empty() {
+        // npm scopes are written `@scope~`; other formats use the namespace
+        // directly followed by `~` per CodeArtifact's path grammar.
+        if format == "npm" {
+            p.push_str(&format!("/@{namespace}~"));
+        } else {
+            p.push_str(&format!("/{namespace}~"));
+        }
+    }
+    p.push('/');
+    p.push_str(package);
+    p
+}
+
+/// Whether a package-group `pattern` matches a package `path`. Supports the
+/// prefix form (`/npm/*`, root `/*`), the exact form (`/npm/lodash$`), and a
+/// bare path prefix.
+fn pattern_matches(pattern: &str, path: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix("/*") {
+        // Root `/*` -> empty prefix -> matches everything.
+        return prefix.is_empty() || path == prefix || path.starts_with(&format!("{prefix}/"));
+    }
+    if let Some(exact) = pattern.strip_suffix('$') {
+        return path == exact;
+    }
+    path == pattern || path.starts_with(&format!("{pattern}/"))
+}
+
+/// Every stored package-group pattern for a domain, plus the implicit root.
+fn domain_group_patterns(acct: &crate::state::CodeArtifactState, domain: &str) -> Vec<String> {
+    let prefix = format!("{domain}{SEP}");
+    let mut patterns: Vec<String> = acct
+        .package_groups
+        .keys()
+        .filter_map(|k| k.strip_prefix(&prefix).map(str::to_string))
+        .collect();
+    if !patterns.iter().any(|p| p == "/*") {
+        patterns.push("/*".to_string());
+    }
+    patterns
+}
+
+/// The most-specific (longest) pattern that matches `path`, defaulting to the
+/// root `/*` group.
+fn best_group_pattern(patterns: &[String], path: &str) -> String {
+    patterns
+        .iter()
+        .filter(|p| pattern_matches(p, path))
+        .max_by_key(|p| p.len())
+        .cloned()
+        .unwrap_or_else(|| "/*".to_string())
 }
 
 /// Build a fresh `PackageGroupDescription` with default origin configuration.
@@ -2387,5 +2491,88 @@ mod handler_tests {
             .unwrap()
             .len();
         assert_eq!(conns, 1);
+    }
+
+    #[test]
+    fn associated_package_group_resolves_from_stored_groups() {
+        // GetAssociatedPackageGroup / ListAssociatedPackages returned a constant
+        // root group / empty list; they must derive real associations from the
+        // stored package groups and packages (bug-hunt).
+        let s = svc();
+        setup(&s, "d1", "r1");
+        publish(&s, "d1", "r1", "lodash", "1.0.0", "a1.tgz", b"one").unwrap();
+        publish(&s, "d1", "r1", "react", "1.0.0", "a2.tgz", b"two").unwrap();
+
+        // Create a format-wide group and an exact-package group.
+        for pattern in ["/npm/*", "/npm/lodash$"] {
+            s.create_package_group(&mkreq(
+                "CreatePackageGroup",
+                "domain=d1",
+                jbody(json!({ "packageGroup": pattern })),
+                HeaderMap::new(),
+            ))
+            .unwrap();
+        }
+
+        // lodash's most-specific group is the exact `/npm/lodash$`.
+        let g = body_json(
+            &s.get_associated_package_group(&mkreq(
+                "GetAssociatedPackageGroup",
+                "domain=d1&format=npm&package=lodash",
+                jbody(json!({})),
+                HeaderMap::new(),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(g["packageGroup"]["pattern"], "/npm/lodash$");
+        assert_eq!(g["associationType"], "STRONG");
+
+        // react falls under the format-wide `/npm/*`.
+        let g2 = body_json(
+            &s.get_associated_package_group(&mkreq(
+                "GetAssociatedPackageGroup",
+                "domain=d1&format=npm&package=react",
+                jbody(json!({})),
+                HeaderMap::new(),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(g2["packageGroup"]["pattern"], "/npm/*");
+
+        // ListAssociatedPackages for `/npm/*` returns react (lodash belongs to
+        // the more specific group), and `/npm/lodash$` returns lodash.
+        let list_wide = body_json(
+            &s.list_associated_packages(&mkreq(
+                "ListAssociatedPackages",
+                "domain=d1&package-group=%2Fnpm%2F*",
+                jbody(json!({})),
+                HeaderMap::new(),
+            ))
+            .unwrap(),
+        );
+        let wide_names: Vec<&str> = list_wide["packages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["package"].as_str().unwrap())
+            .collect();
+        assert_eq!(wide_names, vec!["react"], "wide group excludes lodash");
+
+        let list_exact = body_json(
+            &s.list_associated_packages(&mkreq(
+                "ListAssociatedPackages",
+                "domain=d1&package-group=%2Fnpm%2Flodash%24",
+                jbody(json!({})),
+                HeaderMap::new(),
+            ))
+            .unwrap(),
+        );
+        let exact_names: Vec<&str> = list_exact["packages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["package"].as_str().unwrap())
+            .collect();
+        assert_eq!(exact_names, vec!["lodash"]);
     }
 }

--- a/crates/fakecloud-codecommit/src/service.rs
+++ b/crates/fakecloud-codecommit/src/service.rs
@@ -1298,7 +1298,7 @@ impl CodeCommitService {
     fn list_file_commit_history(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let b = body(req);
         let name = require_repository_name(&b)?;
-        let _path = require(&b, "filePath", "PathRequiredException")?;
+        let path = require(&b, "filePath", "PathRequiredException")?.to_string();
         let account = self.account(req);
         let guard = self.state.read();
         let st = guard.get(&account);
@@ -1306,7 +1306,17 @@ impl CodeCommitService {
             .and_then(|s| s.repositories.get(&name))
             .ok_or_else(|| repo_not_found(&name))?;
         let commit_id = resolve_commit(repo, &b, "commitSpecifier")?;
-        // Walk the first-parent chain from the resolved commit.
+        // The blob id of `path` in a given commit's materialized tree, if present.
+        let blob_at = |cid: &str| -> Option<String> {
+            repo.trees
+                .get(cid)
+                .and_then(|t| t.get(&path))
+                .map(|e| e.blob_id.clone())
+        };
+        // Walk the first-parent chain, keeping only the commits that actually
+        // TOUCHED `filePath` (its blob differs from the first parent's, covering
+        // add/modify/delete). Previously every commit was returned regardless of
+        // the path (bug-hunt).
         let mut dag = Vec::new();
         let mut cur = Some(commit_id);
         while let Some(cid) = cur {
@@ -1318,11 +1328,22 @@ impl CodeCommitService {
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
-            dag.push(json!({
-                "commit": cid,
-                "parents": parents.iter().filter_map(|p| p.as_str()).collect::<Vec<_>>(),
-            }));
-            cur = parents.first().and_then(Value::as_str).map(str::to_string);
+            let first_parent = parents.first().and_then(Value::as_str);
+            let cur_blob = blob_at(&cid);
+            let parent_blob = first_parent.and_then(blob_at);
+            let touched = match first_parent {
+                // Root commit: touched iff the file exists in it.
+                None => cur_blob.is_some(),
+                // Otherwise the blob changed (add/modify/delete).
+                Some(_) => cur_blob != parent_blob,
+            };
+            if touched {
+                dag.push(json!({
+                    "commit": cid,
+                    "parents": parents.iter().filter_map(|p| p.as_str()).collect::<Vec<_>>(),
+                }));
+            }
+            cur = first_parent.map(str::to_string);
         }
         ok(json!({ "revisionDag": dag }))
     }
@@ -4399,5 +4420,57 @@ mod handler_tests {
             json!({ "approvalRuleTemplateName": "t" }),
         );
         assert_eq!(after["repositoryNames"], json!([]));
+    }
+
+    #[test]
+    fn list_file_commit_history_filters_by_file_path() {
+        // ListFileCommitHistory ignored filePath, returning every commit; it
+        // must return only commits that touched the given path (bug-hunt).
+        let s = svc();
+        make_repo(&s);
+        // c1 touches a.txt; c2 touches b.txt; c3 modifies a.txt again.
+        let c1 = put(&s, "main", "a.txt", "a1", None);
+        let c2 = put(&s, "main", "b.txt", "b1", Some(&c1));
+        let c3 = put(&s, "main", "a.txt", "a2", Some(&c2));
+
+        // History for a.txt: only c3 (modify) and c1 (add).
+        let hist = call(
+            &s,
+            "ListFileCommitHistory",
+            json!({
+                "repositoryName": "repo",
+                "commitSpecifier": "main",
+                "filePath": "a.txt"
+            }),
+        );
+        let commits: Vec<&str> = hist["revisionDag"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["commit"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            commits,
+            vec![c3.as_str(), c1.as_str()],
+            "only a.txt commits"
+        );
+
+        // History for b.txt: only c2.
+        let hist_b = call(
+            &s,
+            "ListFileCommitHistory",
+            json!({
+                "repositoryName": "repo",
+                "commitSpecifier": "main",
+                "filePath": "b.txt"
+            }),
+        );
+        let commits_b: Vec<&str> = hist_b["revisionDag"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["commit"].as_str().unwrap())
+            .collect();
+        assert_eq!(commits_b, vec![c2.as_str()], "only b.txt commit");
     }
 }

--- a/crates/fakecloud-comprehend/src/state.rs
+++ b/crates/fakecloud-comprehend/src/state.rs
@@ -152,18 +152,33 @@ impl ComprehendData {
             }
         }
 
-        // Endpoints -> IN_SERVICE, publishing the desired inference units.
+        // Endpoints -> IN_SERVICE, publishing the desired inference units and
+        // promoting the desired ModelArn / DataAccessRoleArn to their active
+        // fields. Without this promotion an UpdateEndpoint settles the status but
+        // DescribeEndpoint keeps returning the pre-update ModelArn/role forever
+        // (the new values sit unread under Desired*) (bug-hunt).
         for ep in self.endpoints.values_mut() {
             let desired = ep.get("DesiredInferenceUnits").cloned().unwrap_or(json!(1));
+            let mut stamp: Vec<(&str, Value)> = vec![
+                ("CurrentInferenceUnits", desired),
+                ("LastModifiedTime", json!(now)),
+            ];
+            if let Some(m) = ep.get("DesiredModelArn").filter(|v| !v.is_null()).cloned() {
+                stamp.push(("ModelArn", m));
+            }
+            if let Some(r) = ep
+                .get("DesiredDataAccessRoleArn")
+                .filter(|v| !v.is_null())
+                .cloned()
+            {
+                stamp.push(("DataAccessRoleArn", r));
+            }
             if settle_status(
                 ep,
                 "Status",
                 &["CREATING", "UPDATING"],
                 "IN_SERVICE",
-                &[
-                    ("CurrentInferenceUnits", desired),
-                    ("LastModifiedTime", json!(now)),
-                ],
+                &stamp,
             ) {
                 changed = true;
             }
@@ -293,6 +308,31 @@ mod tests {
         assert!(d.reconcile());
         assert_eq!(d.endpoints["arn"]["Status"], "IN_SERVICE");
         assert_eq!(d.endpoints["arn"]["CurrentInferenceUnits"], 2);
+    }
+
+    #[test]
+    fn updating_endpoint_promotes_desired_model_and_role() {
+        // An UpdateEndpoint sets Desired* fields and status UPDATING; settling
+        // must promote them to the active ModelArn / DataAccessRoleArn so a
+        // DescribeEndpoint returns the new values, not the pre-update ones.
+        let mut d = data();
+        d.endpoints.insert(
+            "arn".into(),
+            json!({
+                "Status": "UPDATING",
+                "ModelArn": "arn:old-model",
+                "DataAccessRoleArn": "arn:old-role",
+                "DesiredInferenceUnits": 3,
+                "DesiredModelArn": "arn:new-model",
+                "DesiredDataAccessRoleArn": "arn:new-role"
+            }),
+        );
+        assert!(d.reconcile());
+        let ep = &d.endpoints["arn"];
+        assert_eq!(ep["Status"], "IN_SERVICE");
+        assert_eq!(ep["CurrentInferenceUnits"], 3);
+        assert_eq!(ep["ModelArn"], "arn:new-model");
+        assert_eq!(ep["DataAccessRoleArn"], "arn:new-role");
     }
 
     #[test]

--- a/crates/fakecloud-config/src/e2e_tests.rs
+++ b/crates/fakecloud-config/src/e2e_tests.rs
@@ -503,3 +503,67 @@ async fn resource_config_history_honors_order_and_time_window() {
     .await;
     assert_eq!(none["configurationItems"].as_array().unwrap().len(), 0);
 }
+
+#[tokio::test]
+async fn put_config_rule_persists_create_time_tags() {
+    // Create-time Tags on Put* ops were dropped; ListTagsForResource must
+    // return them without a follow-up TagResource (bug-hunt).
+    let svc = service();
+    let acct = "111111111111";
+    let mut body = managed_rule_body("tagged-rule", "S3_BUCKET_VERSIONING_ENABLED");
+    body["Tags"] = json!([{"Key": "team", "Value": "sec"}, {"Key": "env", "Value": "prod"}]);
+    call(&svc, "PutConfigRule", acct, body).await;
+
+    // Resolve the rule ARN via DescribeConfigRules.
+    let desc = call(&svc, "DescribeConfigRules", acct, json!({})).await;
+    let arn = desc["ConfigRules"][0]["ConfigRuleArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let tags = call(
+        &svc,
+        "ListTagsForResource",
+        acct,
+        json!({ "ResourceArn": arn }),
+    )
+    .await;
+    let list = tags["Tags"].as_array().unwrap();
+    assert_eq!(list.len(), 2, "both create-time tags listed: {tags}");
+    assert!(list
+        .iter()
+        .any(|t| t["Key"] == "team" && t["Value"] == "sec"));
+    assert!(list
+        .iter()
+        .any(|t| t["Key"] == "env" && t["Value"] == "prod"));
+}
+
+#[tokio::test]
+async fn put_configuration_aggregator_persists_create_time_tags() {
+    let svc = service();
+    let acct = "111111111111";
+    let out = call(
+        &svc,
+        "PutConfigurationAggregator",
+        acct,
+        json!({
+            "ConfigurationAggregatorName": "agg",
+            "AccountAggregationSources": [{"AccountIds": ["111111111111"], "AllAwsRegions": true}],
+            "Tags": [{"Key": "owner", "Value": "data"}]
+        }),
+    )
+    .await;
+    let arn = out["ConfigurationAggregator"]["ConfigurationAggregatorArn"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let tags = call(
+        &svc,
+        "ListTagsForResource",
+        acct,
+        json!({ "ResourceArn": arn }),
+    )
+    .await;
+    assert_eq!(tags["Tags"][0]["Key"], "owner");
+    assert_eq!(tags["Tags"][0]["Value"], "data");
+}

--- a/crates/fakecloud-config/src/service.rs
+++ b/crates/fakecloud-config/src/service.rs
@@ -1536,7 +1536,15 @@ impl ConfigService {
             last_successful_invocation_time: existing
                 .and_then(|r| r.last_successful_invocation_time),
         };
-        acc.rules.insert(name, cfg_rule);
+        acc.rules.insert(name.clone(), cfg_rule);
+        let arn_for_tags = acc.rules[&name].arn.clone();
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(arn_for_tags).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -2677,6 +2685,13 @@ impl ConfigService {
         };
         let out_arn = pack.arn.clone();
         acc.conformance_packs.insert(name, pack);
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(out_arn.clone()).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         Ok(AwsResponse::ok_json(
             json!({ "ConformancePackArn": out_arn }),
         ))
@@ -2992,6 +3007,13 @@ impl ConfigService {
                 last_update_time: Utc::now(),
             },
         );
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(out_arn.clone()).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         Ok(AwsResponse::ok_json(
             json!({ "OrganizationConfigRuleArn": out_arn }),
         ))
@@ -3160,6 +3182,13 @@ impl ConfigService {
                 last_update_time: Utc::now(),
             },
         );
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(out_arn.clone()).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         Ok(AwsResponse::ok_json(
             json!({ "OrganizationConformancePackArn": out_arn }),
         ))
@@ -3292,7 +3321,15 @@ impl ConfigService {
             created_by: None,
         };
         let out = Self::aggregator_json(&agg);
+        let arn_for_tags = agg.arn.clone();
         acc.aggregators.insert(name, agg);
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(arn_for_tags).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         Ok(AwsResponse::ok_json(
             json!({ "ConfigurationAggregator": out }),
         ))
@@ -3427,9 +3464,15 @@ impl ConfigService {
         };
         let out = Self::auth_json(&auth);
         let mut st = self.state.write();
-        st.account_mut(account)
-            .aggregation_authorizations
-            .insert(key, auth);
+        let acc = st.account_mut(account);
+        acc.aggregation_authorizations.insert(key, auth);
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(arn.clone()).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         let _ = out;
         Ok(AwsResponse::ok_json(
             json!({ "AggregationAuthorization": Self::auth_json_by_arn(&arn) }),
@@ -3896,6 +3939,13 @@ impl ConfigService {
             },
         );
         let _ = id;
+        let tags = parse_create_tags(body);
+        if !tags.is_empty() {
+            let entry = acc.tags.entry(arn.clone()).or_default();
+            for (k, v) in tags {
+                entry.insert(k, v);
+            }
+        }
         Ok(AwsResponse::ok_json(json!({ "QueryArn": arn })))
     }
 
@@ -4174,6 +4224,26 @@ impl ConfigService {
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+/// Parse a Put* request's create-time `Tags` (a `TagsList` of `{Key, Value}`)
+/// into `(key, value)` pairs. Config Put ops accept Tags at create time but
+/// historically dropped them, so ListTagsForResource returned nothing until a
+/// follow-up TagResource (bug-hunt).
+fn parse_create_tags(body: &Value) -> Vec<(String, String)> {
+    body.get("Tags")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| {
+                    Some((
+                        t.get("Key").and_then(Value::as_str)?.to_string(),
+                        t.get("Value").and_then(Value::as_str)?.to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 fn account_id(req: &AwsRequest) -> String {
     if req.account_id.is_empty() {

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -496,6 +496,17 @@ impl FirehoseService {
         };
         let extra_destinations = extract_extra_destinations(&body, "Configuration");
 
+        // Create-time Tags must be returned by ListTagsForDeliveryStream without
+        // a follow-up TagDeliveryStream call (bug-hunt).
+        let mut create_tags = BTreeMap::new();
+        if let Some(arr) = body["Tags"].as_array() {
+            for t in arr {
+                if let (Some(k), Some(v)) = (t["Key"].as_str(), t["Value"].as_str()) {
+                    create_tags.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
         let now = Utc::now();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
@@ -517,7 +528,7 @@ impl FirehoseService {
             last_update: now,
             version_id: "1".to_string(),
             destination: s3_dest,
-            tags: BTreeMap::new(),
+            tags: create_tags,
             encryption: None,
             extra_destinations,
         };
@@ -1157,6 +1168,40 @@ mod tests {
             json!({ "DeliveryStreamName": name }),
         ))
         .unwrap();
+    }
+
+    #[test]
+    fn create_delivery_stream_persists_tags() {
+        // Create-time Tags must surface via ListTagsForDeliveryStream without a
+        // follow-up TagDeliveryStream (bug-hunt).
+        let svc = service();
+        svc.create_delivery_stream(&request(
+            "CreateDeliveryStream",
+            json!({
+                "DeliveryStreamName": "tagged-at-create",
+                "Tags": [
+                    {"Key": "team", "Value": "data"},
+                    {"Key": "env", "Value": "prod"}
+                ]
+            }),
+        ))
+        .unwrap();
+
+        let resp = svc
+            .list_tags_for_delivery_stream(&request(
+                "ListTagsForDeliveryStream",
+                json!({ "DeliveryStreamName": "tagged-at-create" }),
+            ))
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let tags = body["Tags"].as_array().unwrap();
+        assert_eq!(tags.len(), 2);
+        let mut pairs: Vec<(&str, &str)> = tags
+            .iter()
+            .map(|t| (t["Key"].as_str().unwrap(), t["Value"].as_str().unwrap()))
+            .collect();
+        pairs.sort();
+        assert_eq!(pairs, vec![("env", "prod"), ("team", "data")]);
     }
 
     fn describe_encryption(svc: &FirehoseService, name: &str) -> Value {

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -365,12 +365,30 @@ impl GlueService {
             .to_string();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
-        if !state.classifiers.contains_key(&name) {
-            return Err(entity_not_found(format!("Classifier {name} not found")));
-        }
+        // Preserve the original CreationTime and bump Version from the stored
+        // classifier -- the client `def` carries neither (both are output-only),
+        // so a naive wholesale replace previously dropped CreationTime and left
+        // Version un-bumped (bug-hunt). The stored kind may differ from the
+        // update kind, so read prior values from whichever sub-shape is stored.
+        let (prev_creation, prev_version) = state
+            .classifiers
+            .get(&name)
+            .and_then(Value::as_object)
+            .and_then(|wrapper| wrapper.values().next())
+            .map(|prev| {
+                (
+                    prev.get("CreationTime").cloned(),
+                    prev.get("Version").and_then(Value::as_i64).unwrap_or(1),
+                )
+            })
+            .ok_or_else(|| entity_not_found(format!("Classifier {name} not found")))?;
         let mut stored = def.clone();
         if let Some(obj) = stored.as_object_mut() {
+            if let Some(ct) = prev_creation {
+                obj.insert("CreationTime".into(), ct);
+            }
             obj.insert("LastUpdated".into(), json!(now_ts()));
+            obj.insert("Version".into(), json!(prev_version + 1));
         }
         state.classifiers.insert(name, json!({ kind: stored }));
         Ok(AwsResponse::ok_json(json!({})))

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -907,6 +907,12 @@ fn database_json(db: &Database) -> Value {
     if let Some(ref l) = db.location_uri {
         o["LocationUri"] = json!(l);
     }
+    if let Some(ref t) = db.target_database {
+        o["TargetDatabase"] = t.clone();
+    }
+    if let Some(ref f) = db.federated_database {
+        o["FederatedDatabase"] = f.clone();
+    }
     o
 }
 
@@ -1028,6 +1034,14 @@ impl GlueService {
                 parameters: parse_string_map(&input["Parameters"]),
                 created_at: Utc::now(),
                 catalog_id: req.account_id.clone(),
+                target_database: input
+                    .get("TargetDatabase")
+                    .filter(|v| !v.is_null())
+                    .cloned(),
+                federated_database: input
+                    .get("FederatedDatabase")
+                    .filter(|v| !v.is_null())
+                    .cloned(),
                 tables: BTreeMap::new(),
             },
         );
@@ -1087,6 +1101,16 @@ impl GlueService {
         if input["Parameters"].is_object() {
             db.parameters = parse_string_map(&input["Parameters"]);
         }
+        // UpdateDatabase replaces the DatabaseInput, so the link fields follow
+        // the input verbatim (present -> set, absent -> cleared).
+        db.target_database = input
+            .get("TargetDatabase")
+            .filter(|v| !v.is_null())
+            .cloned();
+        db.federated_database = input
+            .get("FederatedDatabase")
+            .filter(|v| !v.is_null())
+            .cloned();
         Ok(AwsResponse::ok_json(json!({})))
     }
 

--- a/crates/fakecloud-glue/src/state.rs
+++ b/crates/fakecloud-glue/src/state.rs
@@ -288,6 +288,14 @@ pub struct Database {
     pub parameters: BTreeMap<String, String>,
     pub created_at: DateTime<Utc>,
     pub catalog_id: String,
+    /// `DatabaseInput.TargetDatabase` for a resource-linked database, stored as
+    /// the raw wire object (`{CatalogId, DatabaseName, Region}`) and echoed back.
+    #[serde(default)]
+    pub target_database: Option<Value>,
+    /// `DatabaseInput.FederatedDatabase` (`{Identifier, ConnectionName,
+    /// ConnectionType}`) for a federated database, stored + echoed verbatim.
+    #[serde(default)]
+    pub federated_database: Option<Value>,
     /// Tables keyed by name.
     pub tables: BTreeMap<String, Table>,
 }

--- a/crates/fakecloud-glue/src/tests.rs
+++ b/crates/fakecloud-glue/src/tests.rs
@@ -803,3 +803,71 @@ fn get_tables_pagination_round_trips_next_token() {
         "last page has no token: {page2}"
     );
 }
+
+#[test]
+fn create_database_persists_target_and_federated() {
+    // CreateDatabase dropped TargetDatabase/FederatedDatabase; GetDatabase must
+    // echo them back (bug-hunt).
+    let svc = GlueService::default();
+    svc.create_database(&req(
+        "CreateDatabase",
+        json!({"DatabaseInput": {
+            "Name": "linked",
+            "TargetDatabase": {"CatalogId": "210987654321", "DatabaseName": "src", "Region": "us-west-2"},
+            "FederatedDatabase": {"Identifier": "fed-id", "ConnectionName": "conn"}
+        }}),
+    ))
+    .unwrap();
+
+    let got = body_of(
+        svc.get_database(&req("GetDatabase", json!({"Name": "linked"})))
+            .unwrap(),
+    );
+    let db = &got["Database"];
+    assert_eq!(db["TargetDatabase"]["DatabaseName"], "src");
+    assert_eq!(db["TargetDatabase"]["Region"], "us-west-2");
+    assert_eq!(db["FederatedDatabase"]["Identifier"], "fed-id");
+    assert_eq!(db["FederatedDatabase"]["ConnectionName"], "conn");
+}
+
+#[test]
+fn update_classifier_bumps_version_and_preserves_creation_time() {
+    // UpdateClassifier dropped CreationTime and never bumped Version (bug-hunt).
+    let svc = GlueService::default();
+    svc.create_classifier(&req(
+        "CreateClassifier",
+        json!({"CsvClassifier": {"Name": "c", "Delimiter": ","}}),
+    ))
+    .unwrap();
+
+    let got = body_of(
+        svc.get_classifier(&req("GetClassifier", json!({"Name": "c"})))
+            .unwrap(),
+    );
+    let created = &got["Classifier"]["CsvClassifier"];
+    assert_eq!(created["Version"], 1);
+    let creation_time = created["CreationTime"].clone();
+    assert!(
+        !creation_time.is_null(),
+        "CreationTime present after create"
+    );
+
+    svc.update_classifier(&req(
+        "UpdateClassifier",
+        json!({"CsvClassifier": {"Name": "c", "Delimiter": ";"}}),
+    ))
+    .unwrap();
+
+    let got = body_of(
+        svc.get_classifier(&req("GetClassifier", json!({"Name": "c"})))
+            .unwrap(),
+    );
+    let updated = &got["Classifier"]["CsvClassifier"];
+    assert_eq!(updated["Version"], 2, "version bumped: {got}");
+    assert_eq!(updated["Delimiter"], ";", "update applied");
+    assert_eq!(
+        updated["CreationTime"], creation_time,
+        "CreationTime preserved across update"
+    );
+    assert!(!updated["LastUpdated"].is_null());
+}

--- a/crates/fakecloud-lakeformation/src/service.rs
+++ b/crates/fakecloud-lakeformation/src/service.rs
@@ -969,6 +969,12 @@ impl LakeFormationService {
         if let Some(h) = body.get("HybridAccessEnabled").and_then(Value::as_bool) {
             r.hybrid_access_enabled = Some(h);
         }
+        if let Some(p) = body.get("WithPrivilegedAccess").and_then(Value::as_bool) {
+            r.with_privileged_access = Some(p);
+        }
+        if let Some(a) = str_field(body, "ExpectedResourceOwnerAccount") {
+            r.expected_resource_owner_account = Some(a);
+        }
         r.last_modified = Utc::now();
         Ok(ok(json!({})))
     }
@@ -2148,6 +2154,33 @@ mod tests {
             Ok(_) => panic!("expected an error, got Ok"),
             Err(e) => e,
         }
+    }
+
+    #[test]
+    fn update_resource_persists_expected_owner_and_privileged_access() {
+        let svc = svc();
+        let arn = "arn:aws:s3:::my-data-lake";
+        let reg = json!({
+            "ResourceArn": arn,
+            "RoleArn": "arn:aws:iam::123456789012:role/lf-role",
+        });
+        svc.register_resource(&req(reg.clone()), &reg).unwrap();
+
+        let upd = json!({
+            "ResourceArn": arn,
+            "RoleArn": "arn:aws:iam::123456789012:role/lf-role",
+            "ExpectedResourceOwnerAccount": "210987654321",
+            "WithPrivilegedAccess": true,
+        });
+        svc.update_resource(&req(upd.clone()), &upd).unwrap();
+
+        let desc = json!({ "ResourceArn": arn });
+        let out = body_of(svc.describe_resource(&req(desc.clone()), &desc).unwrap());
+        assert_eq!(
+            out["ResourceInfo"]["ExpectedResourceOwnerAccount"],
+            "210987654321"
+        );
+        assert_eq!(out["ResourceInfo"]["WithPrivilegedAccess"], true);
     }
 
     #[test]

--- a/crates/fakecloud-memorydb/src/service.rs
+++ b/crates/fakecloud-memorydb/src/service.rs
@@ -326,6 +326,47 @@ fn paginate(items: Vec<Value>, b: &Value, default_max: usize) -> (Vec<Value>, Op
     (items[start..end].to_vec(), next)
 }
 
+/// Build the shard/node topology for a cluster of `num_shards` shards, each with
+/// `replicas` read replicas (so `replicas + 1` nodes per shard). Shared by
+/// CreateCluster and UpdateCluster's scaling path so both produce identical
+/// node naming, endpoints and contiguous 16384-slot partitioning. New shards
+/// start `creating` and settle to `available` on the next DescribeClusters.
+fn build_shards(name: &str, num_shards: i32, replicas: i32, port: i32, region: &str) -> Vec<Shard> {
+    (0..num_shards)
+        .map(|i| {
+            let sname = format!("{:04}", i + 1);
+            let nodes = (0..=replicas)
+                .map(|j| Node {
+                    name: format!("{name}-{sname}-{:03}", j + 1),
+                    status: "creating".to_string(),
+                    availability_zone: format!("{region}a"),
+                    create_time: Utc::now(),
+                    endpoint: Endpoint {
+                        address: format!(
+                            "{name}-{sname}-{:03}.{name}.abc123.memorydb.{region}.amazonaws.com",
+                            j + 1
+                        ),
+                        port,
+                    },
+                })
+                .collect::<Vec<_>>();
+            // Partition the 16384 keyspace slots contiguously across shards,
+            // the way MemoryDB/Redis Cluster does (shard 1 `0-8191`,
+            // shard 2 `8192-16383`, ...), instead of giving every shard the
+            // full range.
+            let start = (i as i64 * 16384 / num_shards as i64) as i32;
+            let end = ((i as i64 + 1) * 16384 / num_shards as i64) as i32 - 1;
+            Shard {
+                name: sname,
+                status: "creating".to_string(),
+                slots: format!("{start}-{end}"),
+                number_of_nodes: nodes.len() as i32,
+                nodes,
+            }
+        })
+        .collect()
+}
+
 // ===== JSON builders (member names match the Smithy model) =====
 
 fn endpoint_json(e: &Endpoint) -> Value {
@@ -554,40 +595,7 @@ impl MemoryDbService {
             ),
             port,
         };
-        let shards = (0..num_shards)
-            .map(|i| {
-                let sname = format!("{:04}", i + 1);
-                let nodes = (0..=replicas)
-                    .map(|j| Node {
-                        name: format!("{name}-{sname}-{:03}", j + 1),
-                        status: "creating".to_string(),
-                        availability_zone: format!("{}a", req.region),
-                        create_time: Utc::now(),
-                        endpoint: Endpoint {
-                            address: format!(
-                                "{name}-{sname}-{:03}.{name}.abc123.memorydb.{}.amazonaws.com",
-                                j + 1,
-                                req.region
-                            ),
-                            port,
-                        },
-                    })
-                    .collect::<Vec<_>>();
-                // Partition the 16384 keyspace slots contiguously across shards,
-                // the way MemoryDB/Redis Cluster does (shard 1 `0-8191`,
-                // shard 2 `8192-16383`, ...), instead of giving every shard the
-                // full range.
-                let start = (i as i64 * 16384 / num_shards as i64) as i32;
-                let end = ((i as i64 + 1) * 16384 / num_shards as i64) as i32 - 1;
-                Shard {
-                    name: sname,
-                    status: "creating".to_string(),
-                    slots: format!("{start}-{end}"),
-                    number_of_nodes: nodes.len() as i32,
-                    nodes,
-                }
-            })
-            .collect();
+        let shards = build_shards(&name, num_shards, replicas, port, &req.region);
         let cluster = Cluster {
             name: name.clone(),
             description: opt_str(&b, "Description"),
@@ -744,6 +752,52 @@ impl MemoryDbService {
                 .iter()
                 .filter_map(|x| x.as_str().map(str::to_string))
                 .collect();
+        }
+        // Scaling: ShardConfiguration.ShardCount changes the number of shards and
+        // ReplicaConfiguration.ReplicaCount changes replicas-per-shard. Either can
+        // appear alone; the current replica count is recovered from an existing
+        // shard's node count (nodes = replicas + 1). Rebuilding the topology keeps
+        // node naming, endpoints and slot partitioning consistent with create.
+        let new_shard_count = b
+            .get("ShardConfiguration")
+            .and_then(|s| s.get("ShardCount"))
+            .and_then(Value::as_i64);
+        let new_replica_count = b
+            .get("ReplicaConfiguration")
+            .and_then(|s| s.get("ReplicaCount"))
+            .and_then(Value::as_i64);
+        if new_shard_count.is_some() || new_replica_count.is_some() {
+            let cur_replicas = c
+                .shards
+                .first()
+                .map(|sh| (sh.number_of_nodes - 1).max(0))
+                .unwrap_or(0) as i64;
+            let target_shards = new_shard_count.unwrap_or(c.number_of_shards as i64);
+            if !(1..=500).contains(&target_shards) {
+                return Err(fault(
+                    "InvalidParameterValueException",
+                    "NumShards must be between 1 and 500.",
+                ));
+            }
+            let target_replicas = new_replica_count.unwrap_or(cur_replicas);
+            if !(0..=5).contains(&target_replicas) {
+                return Err(fault(
+                    "InvalidParameterValueException",
+                    "NumReplicasPerShard must be between 0 and 5.",
+                ));
+            }
+            let target_shards = target_shards as i32;
+            let target_replicas = target_replicas as i32;
+            c.number_of_shards = target_shards;
+            c.shards = build_shards(&name, target_shards, target_replicas, c.port, &req.region);
+            c.availability_mode = if target_replicas > 0 {
+                "MultiAZ".to_string()
+            } else {
+                "SingleAZ".to_string()
+            };
+            // Freshly-built shards start `creating`; mark the cluster so the
+            // existing lazy DescribeClusters transition settles it to `available`.
+            c.status = "creating".to_string();
         }
         let out = cluster_json(c);
         // Apply any ACL reassignment to the ACL -> clusters back-references.
@@ -1854,6 +1908,51 @@ mod tests {
         assert_eq!(clusters.len(), 1);
         // Lazily transitions creating -> available on describe.
         assert_eq!(clusters[0]["Status"], "available");
+    }
+
+    #[test]
+    fn update_cluster_applies_shard_and_replica_scaling() {
+        let s = service();
+        call(
+            &s,
+            "CreateCluster",
+            json!({"ClusterName": "scale", "NodeType": "db.r6g.large", "ACLName": "open-access", "NumShards": 2, "NumReplicasPerShard": 1}),
+        )
+        .unwrap();
+
+        // Scale out to 4 shards and 2 replicas each (3 nodes per shard).
+        let upd = call(
+            &s,
+            "UpdateCluster",
+            json!({
+                "ClusterName": "scale",
+                "ShardConfiguration": {"ShardCount": 4},
+                "ReplicaConfiguration": {"ReplicaCount": 2}
+            }),
+        )
+        .unwrap();
+        assert_eq!(upd["Cluster"]["NumberOfShards"], 4);
+
+        let desc = call(&s, "DescribeClusters", json!({"ClusterName": "scale"})).unwrap();
+        let c = &desc["Clusters"][0];
+        assert_eq!(c["NumberOfShards"], 4);
+        let shards = c["Shards"].as_array().unwrap();
+        assert_eq!(shards.len(), 4, "shard vector rebuilt to new count");
+        assert_eq!(shards[0]["NumberOfNodes"], 3, "2 replicas + 1 primary");
+        assert_eq!(c["AvailabilityMode"], "MultiAZ");
+
+        // Scale replicas down to 0 alone (shard count unchanged).
+        call(
+            &s,
+            "UpdateCluster",
+            json!({"ClusterName": "scale", "ReplicaConfiguration": {"ReplicaCount": 0}}),
+        )
+        .unwrap();
+        let desc = call(&s, "DescribeClusters", json!({"ClusterName": "scale"})).unwrap();
+        let c = &desc["Clusters"][0];
+        assert_eq!(c["NumberOfShards"], 4, "shard count preserved");
+        assert_eq!(c["Shards"][0]["NumberOfNodes"], 1);
+        assert_eq!(c["AvailabilityMode"], "SingleAZ");
     }
 
     #[test]

--- a/crates/fakecloud-mq/src/service.rs
+++ b/crates/fakecloud-mq/src/service.rs
@@ -2101,6 +2101,39 @@ mod tests {
     }
 
     #[test]
+    fn create_broker_persists_ldap_metadata_and_describe_echoes_it_without_password() {
+        let s = svc();
+        let c = ctx("us-east-1");
+        let mut body = active_body("ldap");
+        body["ldapServerMetadata"] = json!({
+            "hosts": ["ldap.example.com"],
+            "roleBase": "ou=roles,dc=example,dc=com",
+            "roleSearchMatching": "(member=uid={0})",
+            "serviceAccountUsername": "cn=admin",
+            "serviceAccountPassword": "secret",
+            "userBase": "ou=users,dc=example,dc=com",
+            "userSearchMatching": "(uid={0})"
+        });
+        let created = json_of(s.create_broker(&c, &body).unwrap());
+        let id = created["brokerId"].as_str().unwrap().to_string();
+
+        let mut settled = false;
+        let described = json_of(s.describe_broker(&c, &id, &mut settled).unwrap());
+        let ldap = &described["ldapServerMetadata"];
+        assert_eq!(ldap["hosts"][0].as_str(), Some("ldap.example.com"));
+        assert_eq!(ldap["serviceAccountUsername"].as_str(), Some("cn=admin"));
+        assert_eq!(
+            ldap["userBase"].as_str(),
+            Some("ou=users,dc=example,dc=com")
+        );
+        // The write-only password is never echoed by DescribeBroker.
+        assert!(
+            ldap.get("serviceAccountPassword").is_none(),
+            "serviceAccountPassword must be stripped from DescribeBroker"
+        );
+    }
+
+    #[test]
     fn delete_configuration_in_use_by_broker_is_rejected() {
         let s = svc();
         let c = ctx("us-east-1");

--- a/crates/fakecloud-mq/src/shared.rs
+++ b/crates/fakecloud-mq/src/shared.rs
@@ -400,6 +400,14 @@ pub fn create_broker_record(
             .cloned()
             .unwrap_or(json!("NONE")),
     );
+    // LDAP integration supplied at create time is persisted so DescribeBroker
+    // echoes it. AWS's DescribeBroker returns LdapServerMetadataOutput, which
+    // omits the write-only serviceAccountPassword, so we strip it before storing.
+    if let Some(ldap) = b.get("ldapServerMetadata").and_then(Value::as_object) {
+        let mut ldap = ldap.clone();
+        ldap.remove("serviceAccountPassword");
+        broker.insert("ldapServerMetadata".into(), Value::Object(ldap));
+    }
 
     // Users supplied inline at create time become the broker's current users.
     let mut user_map = std::collections::BTreeMap::new();

--- a/crates/fakecloud-organizations/src/service/accounts.rs
+++ b/crates/fakecloud-organizations/src/service/accounts.rs
@@ -72,6 +72,16 @@ impl OrganizationsService {
         let org = guard.as_mut().expect("management gate proved Some");
         let status = org.begin_create_account(&email, &name, None);
         let request_id = status.id.clone();
+        // Apply create-time Tags to the reserved account id so
+        // ListTagsForResource reflects them without a follow-up TagResource.
+        // The id is reserved synchronously (before background enrollment), so
+        // the tags survive and are queryable immediately (bug-hunt).
+        let tags = parse_tags(body.get("Tags"));
+        if !tags.is_empty() {
+            if let Some(acct_id) = status.account_id.clone() {
+                org.set_resource_tags(&acct_id, &tags);
+            }
+        }
         drop(guard);
 
         self.spawn_create_account_completion(request_id);
@@ -98,6 +108,14 @@ impl OrganizationsService {
         let gov_id = org.next_account_id();
         let status = org.begin_create_account(&email, &name, Some(gov_id));
         let request_id = status.id.clone();
+        // Apply create-time Tags to the reserved (primary) account id, mirroring
+        // CreateAccount; the id is reserved synchronously (bug-hunt).
+        let tags = parse_tags(body.get("Tags"));
+        if !tags.is_empty() {
+            if let Some(acct_id) = status.account_id.clone() {
+                org.set_resource_tags(&acct_id, &tags);
+            }
+        }
         drop(guard);
 
         self.spawn_create_account_completion(request_id);

--- a/crates/fakecloud-organizations/src/service/tests.rs
+++ b/crates/fakecloud-organizations/src/service/tests.rs
@@ -1312,6 +1312,48 @@ async fn create_account_starts_in_progress_then_describes_succeeded() {
 }
 
 #[tokio::test]
+async fn create_account_applies_create_time_tags() {
+    // Create-time Tags were dropped; they must be visible via
+    // ListTagsForResource on the new account id without a follow-up
+    // TagResource (bug-hunt). Tags are set at reserve-time, queryable
+    // immediately even before the async enrollment completes.
+    let (svc, _state) = OrganizationsService::shared();
+    create_org_with_root(&svc).await;
+    let resp = svc
+        .handle(req_with(
+            "111111111111",
+            "CreateAccount",
+            json!({
+                "Email": "tagged@example.com",
+                "AccountName": "Tagged",
+                "Tags": [{"Key": "team", "Value": "platform"}]
+            }),
+        ))
+        .await
+        .unwrap();
+    let acct_id = body_value(resp)["CreateAccountStatus"]["AccountId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let listed = svc
+        .handle(req_with(
+            "111111111111",
+            "ListTagsForResource",
+            json!({"ResourceId": acct_id}),
+        ))
+        .await
+        .unwrap();
+    let v = body_value(listed);
+    let tags = v["Tags"].as_array().unwrap();
+    assert!(
+        tags.iter()
+            .any(|t| t["Key"] == "team" && t["Value"] == "platform"),
+        "create-time tag must be listed: {v}"
+    );
+}
+
+#[tokio::test]
 async fn create_account_only_management_account_can_call() {
     let (svc, _state) = OrganizationsService::shared();
     create_org_with_root(&svc).await;

--- a/crates/fakecloud-ram/src/service.rs
+++ b/crates/fakecloud-ram/src/service.rs
@@ -1357,32 +1357,50 @@ impl RamService {
         let from = req_str(body, "fromPermissionArn")?;
         let to = req_str(body, "toPermissionArn")?;
         let now = Utc::now();
+        let from_version = u32_field(body, "fromPermissionVersion").unwrap_or(1);
+        let id = gen_id();
+
+        // Validate, swap the association, and settle the work under a single
+        // write guard (a read-then-write split would race a concurrent op).
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
         // The source permission must exist (managed or customer-managed).
-        let known = find_managed(&from).is_some()
-            || self
-                .state
-                .read()
-                .get(&req.account_id)
-                .is_some_and(|st| st.permissions.contains_key(&from));
+        let known = find_managed(&from).is_some() || st.permissions.contains_key(&from);
         if !known {
             return Err(unknown_resource(format!(
                 "Permission {from} could not be found."
             )));
         }
-        let from_version = u32_field(body, "fromPermissionVersion").unwrap_or(1);
-        let id = gen_id();
+        // Actually replace the permission on every resource share that used the
+        // source permission, so ListPermissionAssociations reflects the swap.
+        // Without this the work would settle but the association never changed.
+        for share in st.resource_shares.values_mut() {
+            if share.permission_arns.iter().any(|p| p == &from) {
+                // Swap `from` -> `to`, dropping any duplicate if `to` was already
+                // associated (a share carries each permission at most once).
+                share.permission_arns.retain(|p| p != &to);
+                for p in share.permission_arns.iter_mut() {
+                    if p == &from {
+                        *p = to.clone();
+                    }
+                }
+                share.last_updated_time = now;
+            }
+        }
+        // RAM's ReplacePermissionAssociationsWork has no async backing here, so
+        // the swap completes synchronously and the work settles to COMPLETED
+        // (the model has only status/creationTime/lastUpdatedTime -- no
+        // statusCode/endTime -- so settling is status + lastUpdatedTime).
         let work = json!({
             "id": id,
             "fromPermissionArn": from,
             "fromPermissionVersion": from_version.to_string(),
             "toPermissionArn": to,
             "toPermissionVersion": "1",
-            "status": "IN_PROGRESS",
+            "status": "COMPLETED",
             "creationTime": ts(now),
             "lastUpdatedTime": ts(now),
         });
-        let mut accounts = self.state.write();
-        let st = accounts.get_or_create(&req.account_id);
         st.replace_works.insert(id, work.clone());
         Ok(ok(json!({
             "replacePermissionAssociationsWork": work,
@@ -1630,5 +1648,109 @@ impl RamService {
             )));
         }
         Ok(ok(json!({})))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    fn svc() -> RamService {
+        RamService::new(Arc::new(RwLock::new(MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "",
+        ))))
+    }
+
+    fn req(body: &Value) -> AwsRequest {
+        AwsRequest {
+            service: "ram".to_string(),
+            action: String::new(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".to_string(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn json_of(resp: AwsResponse) -> Value {
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    #[test]
+    fn replace_permission_associations_swaps_and_settles_completed() {
+        let s = svc();
+        let from = "arn:aws:ram::aws:permission/AWSRAMDefaultPermissionSubnet";
+        let to = "arn:aws:ram::aws:permission/AWSRAMDefaultPermissionTransitGateway";
+
+        // A share carrying the source permission.
+        let create_body = json!({
+            "name": "share-1",
+            "permissionArns": [from],
+        });
+        s.create_resource_share(&req(&create_body), &create_body)
+            .unwrap();
+
+        // Replace the permission.
+        let replace_body = json!({
+            "fromPermissionArn": from,
+            "toPermissionArn": to,
+        });
+        let out = json_of(
+            s.replace_permission_associations(&req(&replace_body), &replace_body)
+                .unwrap(),
+        );
+        // The work settles synchronously to COMPLETED, not stuck IN_PROGRESS.
+        assert_eq!(
+            out["replacePermissionAssociationsWork"]["status"], "COMPLETED",
+            "work must settle: {out}"
+        );
+        assert_eq!(
+            out["replacePermissionAssociationsWork"]["toPermissionArn"],
+            to
+        );
+
+        // ListReplacePermissionAssociationsWork reflects the settled work.
+        let works_body = json!({});
+        let works = json_of(s.list_replace_work(&req(&works_body), &works_body).unwrap());
+        assert_eq!(
+            works["replacePermissionAssociationsWorks"][0]["status"],
+            "COMPLETED"
+        );
+
+        // The association was actually swapped: `to` now appears, `from` is gone.
+        let assoc_body = json!({});
+        let assocs = json_of(
+            s.list_permission_associations(&req(&assoc_body), &assoc_body)
+                .unwrap(),
+        );
+        let arns: Vec<&str> = assocs["permissions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["arn"].as_str().unwrap())
+            .collect();
+        assert!(
+            arns.contains(&to),
+            "swapped-in permission present: {assocs}"
+        );
+        assert!(
+            !arns.contains(&from),
+            "swapped-out permission gone: {assocs}"
+        );
     }
 }

--- a/crates/fakecloud-resource-groups-tagging/src/lib.rs
+++ b/crates/fakecloud-resource-groups-tagging/src/lib.rs
@@ -4,7 +4,7 @@ pub mod persistence;
 pub mod service;
 pub mod state;
 
-pub use service::{ResourceGroupsTaggingService, RESOURCE_GROUPS_TAGGING_ACTIONS};
+pub use service::{ApiTagProvider, ResourceGroupsTaggingService, RESOURCE_GROUPS_TAGGING_ACTIONS};
 pub use state::{
     ResourceGroupsTaggingSnapshot, ResourceGroupsTaggingState, SharedResourceGroupsTaggingState,
     RESOURCE_GROUPS_TAGGING_SNAPSHOT_SCHEMA_VERSION,

--- a/crates/fakecloud-resource-groups-tagging/src/service.rs
+++ b/crates/fakecloud-resource-groups-tagging/src/service.rs
@@ -551,6 +551,41 @@ fn paginate_strings(all: Vec<String>, start: Option<usize>) -> (Vec<String>, Str
 
 /// `service:resourceType` from an ARN, per the tagging API's resource-type
 /// convention. Returns just the service when there's no meaningful sub-type.
+/// A [`TagProvider`] over the tagging API's own `api_tags` store, so that ARNs
+/// tagged via `TagResources` (which no modelled service owns) are visible
+/// through the shared [`TagProviderRegistry`] to every reader -- notably
+/// Resource Groups tag-query resolution. Register this once at startup.
+pub struct ApiTagProvider {
+    state: SharedResourceGroupsTaggingState,
+}
+
+impl ApiTagProvider {
+    pub fn new(state: SharedResourceGroupsTaggingState) -> Self {
+        Self { state }
+    }
+}
+
+impl fakecloud_core::tag_index::TagProvider for ApiTagProvider {
+    fn tagged_resources(&self, account_id: &str) -> Vec<fakecloud_core::tag_index::TaggedResource> {
+        let accounts = self.state.read();
+        accounts
+            .get(account_id)
+            .map(|st| {
+                st.api_tags
+                    .iter()
+                    .map(|(arn, tags)| {
+                        fakecloud_core::tag_index::TaggedResource::new(
+                            arn.clone(),
+                            resource_type_from_arn(arn),
+                            tags.clone(),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
 fn resource_type_from_arn(arn: &str) -> String {
     let parts: Vec<&str> = arn.split(':').collect();
     if parts.len() < 6 || parts[0] != "arn" {

--- a/crates/fakecloud-resource-groups/src/service.rs
+++ b/crates/fakecloud-resource-groups/src/service.rs
@@ -49,6 +49,10 @@ pub struct ResourceGroupsService {
     state: SharedResourceGroupsState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
+    /// Shared cross-service tag index, used to resolve TAG_FILTERS resource
+    /// queries (ListGroupResources / SearchResources) against live tagged
+    /// resources. `None` in unit tests that don't exercise query resolution.
+    tag_registry: Option<fakecloud_core::tag_index::TagProviderRegistry>,
 }
 
 /// A resolved route: the operation plus any path-derived argument.
@@ -104,11 +108,20 @@ impl ResourceGroupsService {
             state,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
+            tag_registry: None,
         }
     }
 
     pub fn with_snapshot_store(mut self, store: Arc<dyn SnapshotStore>) -> Self {
         self.snapshot_store = Some(store);
+        self
+    }
+
+    pub fn with_tag_registry(
+        mut self,
+        registry: fakecloud_core::tag_index::TagProviderRegistry,
+    ) -> Self {
+        self.tag_registry = Some(registry);
         self
     }
 
@@ -400,8 +413,17 @@ impl ResourceGroupsService {
         let group = st
             .and_then(|s| s.resolve_name(&key).and_then(|n| s.groups.get(n)))
             .ok_or_else(|| not_found(&key))?;
-        let items: Vec<Value> = group
-            .resources
+        // A group's members are the ARNs explicitly grouped via GroupResources
+        // PLUS everything its ResourceQuery matches in the cross-service tag
+        // index. Previously the query was never evaluated, so tag-based groups
+        // always reported zero members (bug-hunt).
+        let mut arns: BTreeSet<String> = group.resources.clone();
+        if let Some(rq) = &group.query {
+            for arn in self.evaluate_query(&req.account_id, &req.region, rq) {
+                arns.insert(arn);
+            }
+        }
+        let items: Vec<Value> = arns
             .iter()
             .map(|arn| {
                 json!({
@@ -410,8 +432,7 @@ impl ResourceGroupsService {
                 })
             })
             .collect();
-        let idents: Vec<Value> = group
-            .resources
+        let idents: Vec<Value> = arns
             .iter()
             .map(|arn| resource_identifier_json(arn))
             .collect();
@@ -432,15 +453,58 @@ impl ResourceGroupsService {
         let body = parse_json(&req.body)?;
         validate_max_results(&body)?;
         validate_next_token(&body)?;
-        // Evaluating a free-standing ResourceQuery against live resources needs
-        // the cross-service tag index (Resource Groups Tagging API batch). Until
-        // then SearchResources returns no matches rather than a fabricated set.
-        parse_resource_query(body.get("ResourceQuery"))?
+        let rq = parse_resource_query(body.get("ResourceQuery"))?
             .ok_or_else(|| bad_request("ResourceQuery is required."))?;
-        Ok(AwsResponse::json_value(
-            StatusCode::OK,
-            json!({ "ResourceIdentifiers": [], "QueryErrors": [] }),
-        ))
+        // Evaluate the free-standing ResourceQuery against the cross-service tag
+        // index (previously always empty -- bug-hunt).
+        let arns = self.evaluate_query(&req.account_id, &req.region, &rq);
+        let idents: Vec<Value> = arns
+            .iter()
+            .map(|arn| resource_identifier_json(arn))
+            .collect();
+        let (idents_page, next) = paginate(idents, &body);
+        let mut out = json!({ "ResourceIdentifiers": idents_page, "QueryErrors": [] });
+        if let Some(nt) = next {
+            out["NextToken"] = json!(nt);
+        }
+        Ok(AwsResponse::json_value(StatusCode::OK, out))
+    }
+
+    /// Resolve a TAG_FILTERS_1_0 resource query to matching ARNs by evaluating
+    /// its `ResourceTypeFilters` + `TagFilters` against the cross-service tag
+    /// index. Returns empty for CLOUDFORMATION_STACK_1_0 (no CFN-membership hook
+    /// is available here) or when no tag registry is wired.
+    fn evaluate_query(&self, account: &str, region: &str, rq: &ResourceQuery) -> Vec<String> {
+        if rq.type_ != "TAG_FILTERS_1_0" {
+            return Vec::new();
+        }
+        let Some(registry) = &self.tag_registry else {
+            return Vec::new();
+        };
+        let Ok(parsed) = serde_json::from_str::<Value>(&rq.query) else {
+            return Vec::new();
+        };
+        let type_filters = string_list(parsed.get("ResourceTypeFilters"));
+        let tag_filters: Vec<(String, Vec<String>)> = parsed
+            .get("TagFilters")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|f| {
+                        let key = f.get("Key").and_then(Value::as_str)?.to_string();
+                        let values = string_list(f.get("Values"));
+                        Some((key, values))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        registry
+            .resources(account, Some(region))
+            .into_iter()
+            .filter(|r| type_query_matches(&type_filters, &r.resource_type))
+            .filter(|r| tag_filters_match(&tag_filters, &r.tags))
+            .map(|r| r.arn)
+            .collect()
     }
 
     // --- configuration ----------------------------------------------------
@@ -868,6 +932,58 @@ fn parse_resource_query(v: Option<&Value>) -> Result<Option<ResourceQuery>, AwsS
     }))
 }
 
+/// Split a tagging resource type into `(service, Option<subtype>)`, e.g.
+/// `"ec2:instance"` -> `("ec2", Some("instance"))`, `"s3"` -> `("s3", None)`.
+fn split_service_type(t: &str) -> (String, Option<String>) {
+    let t = t.to_lowercase();
+    match t.split_once(':') {
+        Some((s, ty)) => (s.to_string(), Some(ty.to_string())),
+        None => (t, None),
+    }
+}
+
+/// Normalize a single `ResourceTypeFilters` entry (CloudFormation-style
+/// `AWS::EC2::Instance`, or already tagging-style `ec2:instance`) into a
+/// `(service, Option<subtype>)` pair.
+fn normalize_type_filter(filter: &str) -> (String, Option<String>) {
+    if filter.contains("::") {
+        let parts: Vec<&str> = filter.split("::").collect();
+        // ["AWS", "EC2", "Instance"] -> ("ec2", Some("instance"))
+        match parts.as_slice() {
+            [_, service, ty] => (service.to_lowercase(), Some(ty.to_lowercase())),
+            [_, service] => (service.to_lowercase(), None),
+            _ => split_service_type(filter),
+        }
+    } else {
+        split_service_type(filter)
+    }
+}
+
+/// Whether a resource's tagging type satisfies the query's `ResourceTypeFilters`.
+/// Empty filters or `AWS::AllSupported` match everything. A service-only filter
+/// matches every subtype of that service; a `service:type` filter matches a
+/// bare `service` resource (the tag index stores some services without a
+/// subtype).
+fn type_query_matches(filters: &[String], resource_type: &str) -> bool {
+    if filters.is_empty() || filters.iter().any(|f| f == "AWS::AllSupported") {
+        return true;
+    }
+    let (rs, rt) = split_service_type(resource_type);
+    filters.iter().any(|f| {
+        let (fs, ft) = normalize_type_filter(f);
+        fs == rs && (ft.is_none() || rt.is_none() || ft == rt)
+    })
+}
+
+/// Whether a resource's tags satisfy every `TagFilter` (ANDed). A filter with
+/// no values matches any value for the key; otherwise the value must be listed.
+fn tag_filters_match(filters: &[(String, Vec<String>)], tags: &BTreeMap<String, String>) -> bool {
+    filters.iter().all(|(key, values)| match tags.get(key) {
+        None => false,
+        Some(v) => values.is_empty() || values.iter().any(|x| x == v),
+    })
+}
+
 fn parse_tags(v: Option<&Value>) -> BTreeMap<String, String> {
     v.and_then(|t| t.as_object())
         .map(|o| {
@@ -1035,4 +1151,139 @@ fn not_found(what: &str) -> AwsServiceError {
         "NotFoundException",
         format!("The specified group or resource '{what}' was not found."),
     )
+}
+
+#[cfg(test)]
+mod query_tests {
+    use super::*;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::tag_index::{TagProvider, TagProviderRegistry, TaggedResource};
+    use parking_lot::RwLock;
+    use std::collections::BTreeMap;
+
+    /// A fixed set of tagged resources, standing in for real service providers.
+    struct FakeProvider(Vec<TaggedResource>);
+    impl TagProvider for FakeProvider {
+        fn tagged_resources(&self, _account_id: &str) -> Vec<TaggedResource> {
+            self.0.clone()
+        }
+    }
+
+    fn tagged(arn: &str, rtype: &str, tags: &[(&str, &str)]) -> TaggedResource {
+        let map: BTreeMap<String, String> = tags
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        TaggedResource::new(arn, rtype, map)
+    }
+
+    fn svc_with(resources: Vec<TaggedResource>) -> ResourceGroupsService {
+        let registry = TagProviderRegistry::new();
+        registry.register(Arc::new(FakeProvider(resources)));
+        let state: SharedResourceGroupsState = Arc::new(RwLock::new(MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "",
+        )));
+        ResourceGroupsService::new(state).with_tag_registry(registry)
+    }
+
+    fn req(path: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "resource-groups".into(),
+            action: String::new(),
+            region: "us-east-1".into(),
+            account_id: "123456789012".into(),
+            request_id: "test".into(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: serde_json::to_vec(&body).unwrap().into(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: path.into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    async fn body_of(s: &ResourceGroupsService, path: &str, body: Value) -> Value {
+        let resp = s.handle(req(path, body)).await.unwrap();
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    fn tag_query(type_filters: Value, tag_filters: Value) -> Value {
+        let q = json!({ "ResourceTypeFilters": type_filters, "TagFilters": tag_filters });
+        json!({ "Type": "TAG_FILTERS_1_0", "Query": q.to_string() })
+    }
+
+    #[tokio::test]
+    async fn search_resources_evaluates_tag_query() {
+        let s = svc_with(vec![
+            tagged(
+                "arn:aws:ec2:us-east-1:123456789012:instance/i-1",
+                "ec2:instance",
+                &[("stage", "test")],
+            ),
+            tagged(
+                "arn:aws:ec2:us-east-1:123456789012:instance/i-2",
+                "ec2:instance",
+                &[("stage", "prod")],
+            ),
+        ]);
+        let out = body_of(
+            &s,
+            "/resources/search",
+            json!({
+                "ResourceQuery": tag_query(
+                    json!(["AWS::AllSupported"]),
+                    json!([{ "Key": "stage", "Values": ["test"] }])
+                )
+            }),
+        )
+        .await;
+        let ids = out["ResourceIdentifiers"].as_array().unwrap();
+        assert_eq!(ids.len(), 1, "only the test-tagged instance: {out}");
+        assert_eq!(
+            ids[0]["ResourceArn"],
+            "arn:aws:ec2:us-east-1:123456789012:instance/i-1"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_group_resources_evaluates_group_query_and_type_filter() {
+        let s = svc_with(vec![
+            tagged(
+                "arn:aws:ec2:us-east-1:123456789012:instance/i-1",
+                "ec2:instance",
+                &[("team", "core")],
+            ),
+            tagged("arn:aws:s3:::my-bucket", "s3", &[("team", "core")]),
+        ]);
+        // Create a tag-query group scoped to EC2 instances tagged team=core.
+        s.handle(req(
+            "/groups",
+            json!({
+                "Name": "core-ec2",
+                "ResourceQuery": tag_query(
+                    json!(["AWS::EC2::Instance"]),
+                    json!([{ "Key": "team", "Values": ["core"] }])
+                )
+            }),
+        ))
+        .await
+        .unwrap();
+
+        let out = body_of(&s, "/list-group-resources", json!({ "Group": "core-ec2" })).await;
+        let ids = out["ResourceIdentifiers"].as_array().unwrap();
+        assert_eq!(ids.len(), 1, "only the EC2 instance matches: {out}");
+        assert_eq!(
+            ids[0]["ResourceArn"],
+            "arn:aws:ec2:us-east-1:123456789012:instance/i-1"
+        );
+        // Members are also surfaced under Resources with a status.
+        assert_eq!(out["Resources"][0]["Status"]["Name"], "ACTIVE");
+    }
 }

--- a/crates/fakecloud-s3tables/src/handlers.rs
+++ b/crates/fakecloud-s3tables/src/handlers.rs
@@ -503,6 +503,12 @@ impl S3TablesService {
             .cloned()
             .unwrap_or_else(|| json!({ "storageClass": "STANDARD" }));
         let tags = parse_tags(&body, "tags");
+        // The create-time Iceberg `metadata` union carries the initial schema.
+        // AWS writes an initial metadata document from it, so when it is
+        // supplied we retain it AND seed a metadataLocation pointer -- otherwise
+        // the schema was silently dropped and GetTableMetadataLocation returned
+        // nothing for a freshly created table (bug-hunt).
+        let iceberg_metadata = body.get("metadata").filter(|v| !v.is_null()).cloned();
         let now = Utc::now();
 
         let mut accounts = self.state.write();
@@ -543,9 +549,13 @@ impl S3TablesService {
             modified_by: String::new(),
             owner_account_id: req.account_id.clone(),
             version_token: token.clone(),
-            // No Iceberg metadata pointer until the client writes one (via
-            // CreateTable `metadata` or UpdateTableMetadataLocation).
-            metadata_location: None,
+            // Seed the metadata pointer from the create-time schema when given;
+            // otherwise none until the client writes one (via
+            // UpdateTableMetadataLocation).
+            metadata_location: iceberg_metadata
+                .as_ref()
+                .map(|_| format!("{warehouse}/metadata/00000-{}.metadata.json", gen_id())),
+            iceberg_metadata,
             warehouse_location: warehouse,
             managed_by_service: None,
             namespace_id,
@@ -1279,4 +1289,161 @@ fn table_to_get_value(t: &TableRecord, table_bucket_id: &str) -> Value {
     m.insert("format".into(), json!(t.format));
     m.insert("tableBucketId".into(), json!(table_bucket_id));
     Value::Object(m)
+}
+
+#[cfg(test)]
+mod create_table_metadata_tests {
+    use super::*;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use parking_lot::RwLock;
+
+    fn svc() -> S3TablesService {
+        S3TablesService::new(Arc::new(RwLock::new(MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "",
+        ))))
+    }
+
+    fn enc(s: &str) -> String {
+        percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).to_string()
+    }
+
+    fn request(method: Method, path: &str, body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "s3tables".to_string(),
+            action: String::new(),
+            region: "us-east-1".to_string(),
+            account_id: "123456789012".to_string(),
+            request_id: "test".to_string(),
+            headers: http::HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: bytes::Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: path.to_string(),
+            raw_query: String::new(),
+            method,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    async fn body_of(s: &S3TablesService, method: Method, path: &str, body: Value) -> Value {
+        let resp = s.handle(request(method, path, body)).await.unwrap();
+        serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_table_persists_iceberg_metadata_and_seeds_location() {
+        let s = svc();
+        // bucket -> namespace -> table
+        let created =
+            body_of(&s, Method::PUT, "/buckets", json!({ "name": "bkt" })).await;
+        let arn = created["arn"].as_str().unwrap().to_string();
+        let earn = enc(&arn);
+        body_of(
+            &s,
+            Method::PUT,
+            &format!("/namespaces/{earn}"),
+            json!({ "namespace": ["ns"] }),
+        )
+        .await;
+
+        // CreateTable WITH an Iceberg schema in `metadata`.
+        let metadata = json!({
+            "iceberg": {
+                "schema": {
+                    "fields": [
+                        {"name": "id", "type": "long", "required": true},
+                        {"name": "data", "type": "string"}
+                    ]
+                }
+            }
+        });
+        body_of(
+            &s,
+            Method::PUT,
+            &format!("/tables/{earn}/ns"),
+            json!({ "name": "t", "format": "ICEBERG", "metadata": metadata }),
+        )
+        .await;
+
+        // GetTableMetadataLocation now returns a seeded, non-empty pointer
+        // (previously empty because CreateTable dropped the metadata).
+        let loc = body_of(
+            &s,
+            Method::GET,
+            &format!("/tables/{earn}/ns/t/metadata-location"),
+            json!({}),
+        )
+        .await;
+        let ml = loc["metadataLocation"].as_str().unwrap_or_default();
+        assert!(
+            ml.ends_with(".metadata.json"),
+            "metadataLocation seeded from create-time schema: {loc}"
+        );
+
+        // GetTable also reflects the metadataLocation.
+        let got = body_of(
+            &s,
+            Method::GET,
+            &format!("/tables/{earn}/ns/t"),
+            json!({}),
+        )
+        .await;
+        assert_eq!(got["metadataLocation"], loc["metadataLocation"]);
+
+        // And the raw create-time schema is retained on the record.
+        let stored = s
+            .state
+            .read()
+            .get("123456789012")
+            .unwrap()
+            .table_buckets
+            .get(&arn)
+            .unwrap()
+            .tables
+            .values()
+            .next()
+            .unwrap()
+            .iceberg_metadata
+            .clone();
+        assert_eq!(stored, Some(metadata));
+    }
+
+    #[tokio::test]
+    async fn create_table_without_metadata_has_no_location() {
+        let s = svc();
+        let created =
+            body_of(&s, Method::PUT, "/buckets", json!({ "name": "bkt2" })).await;
+        let earn = enc(created["arn"].as_str().unwrap());
+        body_of(
+            &s,
+            Method::PUT,
+            &format!("/namespaces/{earn}"),
+            json!({ "namespace": ["ns"] }),
+        )
+        .await;
+        body_of(
+            &s,
+            Method::PUT,
+            &format!("/tables/{earn}/ns"),
+            json!({ "name": "t", "format": "ICEBERG" }),
+        )
+        .await;
+        let loc = body_of(
+            &s,
+            Method::GET,
+            &format!("/tables/{earn}/ns/t/metadata-location"),
+            json!({}),
+        )
+        .await;
+        assert!(
+            loc["metadataLocation"].as_str().unwrap_or_default().is_empty()
+                || loc.get("metadataLocation").is_none(),
+            "no metadata supplied -> no seeded location: {loc}"
+        );
+    }
 }

--- a/crates/fakecloud-s3tables/src/state.rs
+++ b/crates/fakecloud-s3tables/src/state.rs
@@ -60,6 +60,10 @@ pub struct TableRecord {
     pub version_token: String,
     /// Opaque S3 URI pointing at the table's Iceberg metadata document.
     pub metadata_location: Option<String>,
+    /// The create-time `metadata` union (Iceberg schema) supplied to
+    /// CreateTable, retained verbatim so the initial schema is not lost.
+    #[serde(default)]
+    pub iceberg_metadata: Option<Value>,
     pub warehouse_location: String,
     pub managed_by_service: Option<String>,
     pub namespace_id: String,

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -5196,8 +5196,15 @@ async fn main() {
         } else {
             None
         };
+    // Shared cross-service tag index. Resource Groups tag-query resolution and
+    // the Resource Groups Tagging API both read through it. Created here (before
+    // Resource Groups is built) and reused by the tagging service below; the
+    // ApiTagProvider over directly-tagged ARNs is registered alongside the
+    // tagging service.
+    let tag_provider_registry = fakecloud_core::tag_index::TagProviderRegistry::new();
     let mut resource_groups_service =
-        fakecloud_resource_groups::ResourceGroupsService::new(resource_groups_state.clone());
+        fakecloud_resource_groups::ResourceGroupsService::new(resource_groups_state.clone())
+            .with_tag_registry(tag_provider_registry.clone());
     if let Some(store) = resource_groups_snapshot_store {
         resource_groups_service = resource_groups_service.with_snapshot_store(store);
     }
@@ -6665,7 +6672,15 @@ async fn main() {
     // a given service is wired, its native tags simply don't appear here; tags
     // applied through this API always do. The registry starts empty and grows
     // as providers register at startup.
-    let tag_provider_registry = fakecloud_core::tag_index::TagProviderRegistry::new();
+    // Expose ARNs tagged directly via TagResources (which no modelled service
+    // owns) through the shared registry (created earlier, alongside Resource
+    // Groups), so Resource Groups tag-query resolution can match against them
+    // just as the tagging API does.
+    tag_provider_registry.register(std::sync::Arc::new(
+        fakecloud_resource_groups_tagging::ApiTagProvider::new(
+            resource_groups_tagging_state.clone(),
+        ),
+    ));
     let resource_groups_tagging_snapshot_store: Option<
         Arc<dyn fakecloud_persistence::SnapshotStore>,
     > = if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {

--- a/crates/fakecloud-swf/src/service.rs
+++ b/crates/fakecloud-swf/src/service.rs
@@ -920,6 +920,7 @@ impl SwfService {
                 .executions
                 .values()
                 .filter(|e| e.domain == domain && e.status == want)
+                .filter(|e| execution_matches_filters(e, body, open))
                 .map(wire_execution_info)
                 .collect();
             if reverse {
@@ -945,6 +946,7 @@ impl SwfService {
                 .executions
                 .values()
                 .filter(|e| e.domain == domain && e.status == want)
+                .filter(|e| execution_matches_filters(e, body, open))
                 .count();
             ok(json!({ "count": count, "truncated": false }))
         })
@@ -1176,13 +1178,124 @@ fn wire_open_counts(exec: &Execution) -> Value {
         .filter(|a| a.state != ActivityState::Closed)
         .count();
     let open_decisions = i64::from(exec.decision_scheduled || exec.decision_task_token.is_some());
+    // Timers / child workflows / lambdas are derived from the event history:
+    // each is opened by a *start* event and closed by a matching terminal one.
+    // The count is (started - closed), clamped at zero.
+    let count_events = |types: &[&str]| -> i64 {
+        exec.events
+            .iter()
+            .filter(|ev| {
+                ev.get("eventType")
+                    .and_then(Value::as_str)
+                    .is_some_and(|t| types.contains(&t))
+            })
+            .count() as i64
+    };
+    let open_timers =
+        (count_events(&["TimerStarted"]) - count_events(&["TimerFired", "TimerCanceled"])).max(0);
+    let open_children = (count_events(&["StartChildWorkflowExecutionInitiated"])
+        - count_events(&[
+            "ChildWorkflowExecutionCompleted",
+            "ChildWorkflowExecutionFailed",
+            "ChildWorkflowExecutionTimedOut",
+            "ChildWorkflowExecutionCanceled",
+            "ChildWorkflowExecutionTerminated",
+        ]))
+    .max(0);
+    let open_lambdas = (count_events(&["LambdaFunctionScheduled"])
+        - count_events(&[
+            "LambdaFunctionCompleted",
+            "LambdaFunctionFailed",
+            "LambdaFunctionTimedOut",
+        ]))
+    .max(0);
     json!({
         "openActivityTasks": open_activities,
         "openDecisionTasks": open_decisions,
-        "openTimers": 0,
-        "openChildWorkflowExecutions": 0,
-        "openLambdaFunctions": 0,
+        "openTimers": open_timers,
+        "openChildWorkflowExecutions": open_children,
+        "openLambdaFunctions": open_lambdas,
     })
+}
+
+/// Apply the List/Count*WorkflowExecutions filters to a single execution.
+/// `executionFilter`, `typeFilter` and `tagFilter` are mutually exclusive on
+/// AWS, but any that are present are ANDed with the time/close-status filters.
+/// `closeStatusFilter`/`closeTimeFilter` only apply to closed executions.
+fn execution_matches_filters(e: &Execution, body: &Value, open: bool) -> bool {
+    // executionFilter.workflowId
+    if let Some(wid) = body
+        .get("executionFilter")
+        .and_then(|f| f.get("workflowId"))
+        .and_then(Value::as_str)
+    {
+        if e.workflow_id != wid {
+            return false;
+        }
+    }
+    // typeFilter.name (+ optional version)
+    if let Some(tf) = body.get("typeFilter") {
+        if let Some(name) = tf.get("name").and_then(Value::as_str) {
+            if e.workflow_type_name != name {
+                return false;
+            }
+        }
+        if let Some(version) = tf.get("version").and_then(Value::as_str) {
+            if e.workflow_type_version != version {
+                return false;
+            }
+        }
+    }
+    // tagFilter.tag
+    if let Some(tag) = body
+        .get("tagFilter")
+        .and_then(|f| f.get("tag"))
+        .and_then(Value::as_str)
+    {
+        if !e.tag_list.iter().any(|t| t == tag) {
+            return false;
+        }
+    }
+    // startTimeFilter.oldestDate / latestDate (epoch seconds)
+    if let Some(stf) = body.get("startTimeFilter") {
+        if let Some(oldest) = stf.get("oldestDate").and_then(Value::as_f64) {
+            if e.start_timestamp < oldest {
+                return false;
+            }
+        }
+        if let Some(latest) = stf.get("latestDate").and_then(Value::as_f64) {
+            if e.start_timestamp > latest {
+                return false;
+            }
+        }
+    }
+    if !open {
+        // closeStatusFilter.status
+        if let Some(status) = body
+            .get("closeStatusFilter")
+            .and_then(|f| f.get("status"))
+            .and_then(Value::as_str)
+        {
+            if e.close_status.as_deref() != Some(status) {
+                return false;
+            }
+        }
+        // closeTimeFilter.oldestDate / latestDate
+        if let Some(ctf) = body.get("closeTimeFilter") {
+            let close = e.close_timestamp;
+            if let Some(oldest) = ctf.get("oldestDate").and_then(Value::as_f64) {
+                if close.is_none_or(|c| c < oldest) {
+                    return false;
+                }
+            }
+            if let Some(latest) = ctf.get("latestDate").and_then(Value::as_f64) {
+                if close.is_none_or(|c| c > latest) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
 }
 
 // ---- decider / worker loop ------------------------------------------------
@@ -2165,5 +2278,152 @@ mod tests {
         )
         .unwrap();
         assert_eq!(closed["count"], 1);
+    }
+
+    #[test]
+    fn list_and_count_open_executions_apply_filters() {
+        // List/Count*WorkflowExecutions previously ignored every filter; they
+        // must honor executionFilter / typeFilter / tagFilter (bug-hunt).
+        let svc = service();
+        call(
+            &svc,
+            "RegisterDomain",
+            json!({ "name": "d", "workflowExecutionRetentionPeriodInDays": "1" }),
+        )
+        .unwrap();
+        for (name, version) in [("wfA", "1"), ("wfB", "1")] {
+            call(
+                &svc,
+                "RegisterWorkflowType",
+                json!({
+                    "domain": "d", "name": name, "version": version,
+                    "defaultTaskList": { "name": "dtl" },
+                    "defaultChildPolicy": "TERMINATE",
+                    "defaultExecutionStartToCloseTimeout": "3600",
+                    "defaultTaskStartToCloseTimeout": "60"
+                }),
+            )
+            .unwrap();
+        }
+        // w1: type wfA, tag "red"; w2: type wfB, tag "blue".
+        call(
+            &svc,
+            "StartWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1", "workflowType": {"name": "wfA", "version": "1"}, "tagList": ["red"] }),
+        )
+        .unwrap();
+        call(
+            &svc,
+            "StartWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w2", "workflowType": {"name": "wfB", "version": "1"}, "tagList": ["blue"] }),
+        )
+        .unwrap();
+
+        // No filter -> both.
+        let all = call(
+            &svc,
+            "ListOpenWorkflowExecutions",
+            json!({ "domain": "d", "startTimeFilter": { "oldestDate": 0 } }),
+        )
+        .unwrap();
+        assert_eq!(all["executionInfos"].as_array().unwrap().len(), 2);
+
+        // executionFilter by workflowId.
+        let by_id = call(
+            &svc,
+            "ListOpenWorkflowExecutions",
+            json!({ "domain": "d", "startTimeFilter": { "oldestDate": 0 }, "executionFilter": { "workflowId": "w1" } }),
+        )
+        .unwrap();
+        let ids = by_id["executionInfos"].as_array().unwrap();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0]["execution"]["workflowId"], "w1");
+
+        // typeFilter by name.
+        let by_type = call(
+            &svc,
+            "CountOpenWorkflowExecutions",
+            json!({ "domain": "d", "startTimeFilter": { "oldestDate": 0 }, "typeFilter": { "name": "wfB" } }),
+        )
+        .unwrap();
+        assert_eq!(by_type["count"], 1);
+
+        // tagFilter.
+        let by_tag = call(
+            &svc,
+            "CountOpenWorkflowExecutions",
+            json!({ "domain": "d", "startTimeFilter": { "oldestDate": 0 }, "tagFilter": { "tag": "red" } }),
+        )
+        .unwrap();
+        assert_eq!(by_tag["count"], 1);
+
+        // A tag that matches nothing.
+        let none = call(
+            &svc,
+            "CountOpenWorkflowExecutions",
+            json!({ "domain": "d", "startTimeFilter": { "oldestDate": 0 }, "tagFilter": { "tag": "green" } }),
+        )
+        .unwrap();
+        assert_eq!(none["count"], 0);
+    }
+
+    #[test]
+    fn describe_execution_reports_real_open_counts() {
+        // openTimers / openChildWorkflowExecutions / openLambdaFunctions were
+        // hardcoded to 0; they must be derived from the event history (bug-hunt).
+        let svc = service();
+        call(
+            &svc,
+            "RegisterDomain",
+            json!({ "name": "d", "workflowExecutionRetentionPeriodInDays": "1" }),
+        )
+        .unwrap();
+        call(
+            &svc,
+            "RegisterWorkflowType",
+            json!({
+                "domain": "d", "name": "wf", "version": "1",
+                "defaultTaskList": { "name": "dtl" },
+                "defaultChildPolicy": "TERMINATE",
+                "defaultExecutionStartToCloseTimeout": "3600",
+                "defaultTaskStartToCloseTimeout": "60"
+            }),
+        )
+        .unwrap();
+        let start = call(
+            &svc,
+            "StartWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1", "workflowType": { "name": "wf", "version": "1" } }),
+        )
+        .unwrap();
+        let run_id = start["runId"].as_str().unwrap().to_string();
+
+        // Inject history: 2 timers started, 1 fired -> 1 open; 1 child started,
+        // none closed -> 1 open; 1 lambda scheduled -> 1 open.
+        {
+            let mut guard = svc.state.write();
+            let data = guard.get_or_create("000000000000");
+            let exec = data.executions.get_mut(&run_id).unwrap();
+            for t in [
+                "TimerStarted",
+                "TimerStarted",
+                "TimerFired",
+                "StartChildWorkflowExecutionInitiated",
+                "LambdaFunctionScheduled",
+            ] {
+                exec.events.push(json!({ "eventType": t }));
+            }
+        }
+
+        let desc = call(
+            &svc,
+            "DescribeWorkflowExecution",
+            json!({ "domain": "d", "execution": { "workflowId": "w1", "runId": run_id } }),
+        )
+        .unwrap();
+        let oc = &desc["openCounts"];
+        assert_eq!(oc["openTimers"], 1);
+        assert_eq!(oc["openChildWorkflowExecutions"], 1);
+        assert_eq!(oc["openLambdaFunctions"], 1);
     }
 }


### PR DESCRIPTION
Fixes a cluster of MED-severity dropped-field / no-op / constant-response bugs, one per service, all real user-facing (lost create-time config, stuck work, constant reads). Real persistence + read-back throughout — no stubs.

## Fixes

| Service | Bug | Fix |
|---|---|---|
| **mq** | CreateBroker dropped `ldapServerMetadata` | Persist + echo in DescribeBroker (write-only `serviceAccountPassword` stripped, matching `LdapServerMetadataOutput`) |
| **memorydb** | UpdateCluster dropped ShardConfiguration/ReplicaConfiguration (scale was a no-op) | Apply scaling (rebuild shard/node topology via a shared `build_shards`), reflected in DescribeClusters |
| **lakeformation** | UpdateResource dropped `ExpectedResourceOwnerAccount` (and `WithPrivilegedAccess`) | Persist + echo in DescribeResource/ListResources |
| **organizations** | CreateAccount/CreateGovCloudAccount dropped Tags | Persist create-time Tags on the reserved account id; returned by ListTagsForResource |
| **ram** | ReplacePermissionAssociations never swapped the permission (work stuck IN_PROGRESS) | Swap the permission on every resource share + settle the work to COMPLETED synchronously |
| **swf** | List/Count*Executions ignored all filters; DescribeWorkflowExecution hardcoded open counts | Apply execution/type/tag/close-status/time filters; derive real open timers/child-workflows/lambdas from event history |
| **resource-groups** | ListGroupResources/SearchResources never evaluated the query (tag groups always empty) | Evaluate TAG_FILTERS queries against the shared cross-service tag registry; new `ApiTagProvider` exposes directly-tagged ARNs |
| **s3tables** | CreateTable dropped the Iceberg `metadata`/schema | Retain create-time metadata + seed `metadataLocation` (echoed by GetTable/GetTableMetadataLocation) |
| **config** | 7 Put* ops dropped create-time Tags | Persist Tags per resource ARN; returned by ListTagsForResource |
| **cloudfront** | Create{VpcOrigin,AnycastIpList,TrustStore,ConnectionGroup} dropped IPAM/OCSP/Tags | Persist Tags for all 4; persist+echo anycast IPAM config and trust-store OCSP flag |
| **comprehend** | UpdateEndpoint never applied the new ModelArn/DataAccessRoleArn | Promote desired ModelArn/DataAccessRoleArn to their active fields on settle |
| **amplify** | UpdateDomainAssociation dropped certificateSettings | Persist + echo the resulting certificate in GetDomainAssociation |
| **glue** | CreateDatabase dropped TargetDatabase/FederatedDatabase; UpdateClassifier dropped CreationTime/Version | Persist+echo the DB link fields; preserve CreationTime + bump Version on classifier update |
| **firehose** | CreateDeliveryStream dropped Tags | Persist Tags; returned by ListTagsForDeliveryStream |
| **codeartifact** | GetAssociatedPackageGroup/ListAssociatedPackages returned constants | Resolve real associations from stored package-group patterns (most-specific match) |
| **codecommit** | ListFileCommitHistory ignored filePath | Filter to commits that actually touched the given path (add/modify/delete) |

## Testing
- Regression test per fix (round-trip): 20+ new tests, all passing locally.
- `cargo build --workspace --all-targets` green; `cargo clippy` on all touched crates clean (`-D warnings`); `cargo fmt` applied.
- Conformance (model-checksum probes, unaffected by these behavioral changes): `mq, memorydb, lakeformation, organizations, ram, s3tables, glue, firehose, codeartifact, codecommit` = 49/49 passed locally. The remaining touched-service probes were blocked locally by a concurrent agent's worktree sharing the target dir; CI runs the full suite.

## Notes
- No new struct field left an unswept constructor: the Glue `Database` field addition was propagated to the CloudFormation glue provisioner.
- New CloudFront struct fields are `#[serde(default)]` for snapshot back-compat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 16 service bugs that dropped create/update fields or returned constant/no‑op results. Inputs are now persisted and reflected in read APIs; Resource Groups tag queries now return real matches.

- New Features
  - Added a shared cross-service tag registry and wired it into Resource Groups.
  - Introduced `ApiTagProvider` so directly tagged ARNs are queryable by Resource Groups.

- Bug Fixes
  - mq: Persist `ldapServerMetadata`; `DescribeBroker` echoes it (without `serviceAccountPassword`).
  - memorydb: `UpdateCluster` applies shard/replica scaling; `DescribeClusters` shows the new topology.
  - lakeformation: `UpdateResource` persists `ExpectedResourceOwnerAccount` and `WithPrivilegedAccess`.
  - organizations: `CreateAccount`/`CreateGovCloudAccount` persist create-time Tags; `ListTagsForResource` returns them.
  - ram: `ReplacePermissionAssociations` actually swaps the permission and completes work synchronously.
  - swf: All list/count filters respected; open counts derived from event history (timers/children/lambdas).
  - resource-groups: `ListGroupResources`/`SearchResources` evaluate `TAG_FILTERS` via the shared tag registry.
  - s3tables: `CreateTable` retains Iceberg `metadata` and seeds `metadataLocation`; reads echo both.
  - config: Persist Tags for `Put*` resources; `ListTagsForResource` returns them.
  - cloudfront: Persist Tags for VPC Origins, Anycast IP Lists, Trust Stores, and Connection Groups; persist anycast IPAM config and trust-store OCSP flag.
  - comprehend: `UpdateEndpoint` promotes `DesiredModelArn` and `DesiredDataAccessRoleArn` to active on settle.
  - amplify: Create/`UpdateDomainAssociation` persist `certificateSettings`; `GetDomainAssociation` echoes the cert.
  - glue: `CreateDatabase` keeps `TargetDatabase`/`FederatedDatabase`; `UpdateClassifier` preserves `CreationTime` and bumps `Version`.
  - firehose: `CreateDeliveryStream` stores Tags; `ListTagsForDeliveryStream` returns them.
  - codeartifact: `GetAssociatedPackageGroup`/`ListAssociatedPackages` resolve real associations (most-specific match).
  - codecommit: `ListFileCommitHistory` filters by `filePath` (add/modify/delete only).

<sup>Written for commit b8a17605864ff9bf7eb0be5da1d7f1ce28647c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

