### PR TITLE
fix(acmpca): stamp IssueCertificate ApiPassthrough into the issued certificate (bug-hunt)

### DIFF
--- a/crates/fakecloud-acmpca/src/service.rs
+++ b/crates/fakecloud-acmpca/src/service.rs
@@ -809,6 +809,15 @@ impl AcmPcaService {
             .get("TemplateArn")
             .and_then(Value::as_str)
             .map(str::to_string);
+        // ApiPassthrough (Subject + Extensions) is stamped into the issued
+        // certificate so a caller that requests SANs / a subject / key-usage
+        // actually gets them back from GetCertificate. Rejected outright if it
+        // is present but not an object.
+        let api_passthrough = match body.get("ApiPassthrough") {
+            Some(v) if v.is_object() => Some(v.clone()),
+            Some(Value::Null) | None => None,
+            Some(_) => return Err(invalid_args("ApiPassthrough must be an object")),
+        };
         let idempotency_token = body
             .get("IdempotencyToken")
             .and_then(Value::as_str)
@@ -910,6 +919,7 @@ impl AcmPcaService {
             not_before,
             not_after,
             is_ca_template,
+            api_passthrough.as_ref(),
         )
         .map_err(malformed_csr)?;
 
@@ -2283,6 +2293,133 @@ mod tests {
             }),
         )));
         assert_eq!(err.code(), "InvalidArgsException");
+    }
+
+    /// Bug-hunt regression: `IssueCertificate` `ApiPassthrough` (Subject +
+    /// Extensions) is stamped into the issued certificate, so a caller that asks
+    /// for subject-alternative-names, a subject override, key-usage and
+    /// extended-key-usage actually gets them back from `GetCertificate` — rather
+    /// than the field being silently accepted and dropped.
+    #[tokio::test]
+    async fn issue_certificate_applies_api_passthrough() {
+        use x509_parser::extensions::GeneralName;
+
+        let svc = AcmPcaService::default();
+        let arn = create_active_root(&svc, "EC_prime256v1", "SHA256WITHECDSA").await;
+
+        let issued = svc
+            .issue_certificate(&req(
+                "IssueCertificate",
+                json!({
+                    "CertificateAuthorityArn": arn,
+                    "Csr": leaf_csr(),
+                    "SigningAlgorithm": "SHA256WITHECDSA",
+                    "Validity": { "Value": 365, "Type": "DAYS" },
+                    "ApiPassthrough": {
+                        "Subject": { "CommonName": "passthrough.example.com" },
+                        "Extensions": {
+                            "SubjectAlternativeNames": [
+                                { "DnsName": "alt.example.com" },
+                                { "IpAddress": "10.0.0.1" }
+                            ],
+                            "KeyUsage": { "DigitalSignature": true, "KeyEncipherment": true },
+                            "ExtendedKeyUsage": [
+                                { "ExtendedKeyUsageType": "SERVER_AUTH" }
+                            ]
+                        }
+                    }
+                }),
+            ))
+            .unwrap();
+        let cert_arn = body_json(&issued)["CertificateArn"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let leaf_pem = body_json(
+            &svc.get_certificate(&req(
+                "GetCertificate",
+                json!({ "CertificateAuthorityArn": arn, "CertificateArn": cert_arn }),
+            ))
+            .unwrap(),
+        )["Certificate"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let (_, pem) = x509_parser::pem::parse_x509_pem(leaf_pem.as_bytes()).unwrap();
+        let cert = pem.parse_x509().unwrap();
+
+        // Subject override applied.
+        assert!(
+            cert.subject()
+                .to_string()
+                .contains("passthrough.example.com"),
+            "ApiPassthrough Subject must override the certificate subject, got: {}",
+            cert.subject()
+        );
+
+        // Both SANs present.
+        let san = cert
+            .subject_alternative_name()
+            .unwrap()
+            .expect("issued cert must carry a SubjectAlternativeName extension");
+        let has_dns = san
+            .value
+            .general_names
+            .iter()
+            .any(|g| matches!(g, GeneralName::DNSName("alt.example.com")));
+        let has_ip = san
+            .value
+            .general_names
+            .iter()
+            .any(|g| matches!(g, GeneralName::IPAddress(&[10, 0, 0, 1])));
+        assert!(
+            has_dns,
+            "ApiPassthrough DnsName SAN must appear in the cert"
+        );
+        assert!(
+            has_ip,
+            "ApiPassthrough IpAddress SAN must appear in the cert"
+        );
+
+        // KeyUsage applied.
+        let ku = cert
+            .key_usage()
+            .unwrap()
+            .expect("issued cert must carry a KeyUsage extension");
+        assert!(ku.value.digital_signature());
+        assert!(ku.value.key_encipherment());
+
+        // ExtendedKeyUsage applied.
+        let eku = cert
+            .extended_key_usage()
+            .unwrap()
+            .expect("issued cert must carry an ExtendedKeyUsage extension");
+        assert!(eku.value.server_auth, "SERVER_AUTH EKU must be present");
+    }
+
+    /// Bug-hunt regression: an unsupported `ApiPassthrough` extension
+    /// (`CertificatePolicies`, which cannot be faithfully encoded) is rejected
+    /// with an error rather than silently accepted and dropped.
+    #[tokio::test]
+    async fn issue_certificate_rejects_unsupported_passthrough() {
+        let svc = AcmPcaService::default();
+        let arn = create_active_root(&svc, "EC_prime256v1", "SHA256WITHECDSA").await;
+        let err = expect_err(svc.issue_certificate(&req(
+            "IssueCertificate",
+            json!({
+                "CertificateAuthorityArn": arn,
+                "Csr": leaf_csr(),
+                "SigningAlgorithm": "SHA256WITHECDSA",
+                "Validity": { "Value": 365, "Type": "DAYS" },
+                "ApiPassthrough": {
+                    "Extensions": {
+                        "CertificatePolicies": [ { "CertPolicyId": "1.2.3.4" } ]
+                    }
+                }
+            }),
+        )));
+        assert_eq!(err.code(), "MalformedCSRException");
     }
 
     /// UpdateCertificateAuthority(Status): a PENDING_CERTIFICATE CA can be moved

--- a/crates/fakecloud-acmpca/src/validate.rs
+++ b/crates/fakecloud-acmpca/src/validate.rs
@@ -1,11 +1,12 @@
 //! Input validation + real X.509 crypto for ACM Private CA.
 
+use base64::Engine;
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, CertificateSigningRequestParams,
-    DistinguishedName, DnType, IsCa, KeyPair, KeyUsagePurpose, SignatureAlgorithm,
-    PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_RSA_SHA256, PKCS_RSA_SHA384,
-    PKCS_RSA_SHA512,
+    CustomExtension, DistinguishedName, DnType, ExtendedKeyUsagePurpose, Ia5String, IsCa, KeyPair,
+    KeyUsagePurpose, SanType, SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384,
+    PKCS_RSA_SHA256, PKCS_RSA_SHA384, PKCS_RSA_SHA512,
 };
 use rsa::pkcs8::{EncodePrivateKey, LineEnding};
 use serde_json::Value;
@@ -172,6 +173,12 @@ pub fn self_issuer(subject: &Value, ca_key: &KeyPair) -> Result<Certificate, Str
 
 /// Sign an end-entity (or subordinate-CA) certificate from a client CSR using
 /// the given issuer + CA key. Returns `(certificate_pem, serial_hex)`.
+///
+/// `api_passthrough` carries the caller's `IssueCertificate` `ApiPassthrough`
+/// (Subject override + Extensions). ACM PCA stamps those values into the signed
+/// certificate, so — unlike a naive re-sign of the CSR — the SANs, subject,
+/// key-usage, extended-key-usage and custom extensions the caller asked for
+/// actually appear in the certificate returned by `GetCertificate`.
 pub fn issue_certificate(
     issuer_cert: &Certificate,
     ca_key: &KeyPair,
@@ -179,6 +186,7 @@ pub fn issue_certificate(
     not_before: DateTime<Utc>,
     not_after: DateTime<Utc>,
     is_ca: bool,
+    api_passthrough: Option<&Value>,
 ) -> Result<(String, String), String> {
     let mut csr = CertificateSigningRequestParams::from_pem(csr_pem)
         .map_err(|_| "the certificate signing request (CSR) is invalid".to_string())?;
@@ -192,10 +200,209 @@ pub fn issue_certificate(
     } else {
         csr.params.is_ca = IsCa::NoCa;
     }
+    if let Some(passthrough) = api_passthrough {
+        apply_api_passthrough(&mut csr.params, passthrough, is_ca)?;
+    }
     let cert = csr
         .signed_by(issuer_cert, ca_key)
         .map_err(|e| format!("certificate issuance failed: {e}"))?;
     Ok((cert.pem(), hex::encode(serial)))
+}
+
+/// Stamp an `ApiPassthrough` (Subject + Extensions) onto the certificate params
+/// before signing, so the issued certificate really carries what the caller
+/// requested. A `Subject` overrides the CSR's distinguished name; `Extensions`
+/// (SANs, KeyUsage, ExtendedKeyUsage, CustomExtensions) override the
+/// corresponding CSR extensions.
+///
+/// `CertificatePolicies` is the one `Extensions` sub-field left unapplied: it
+/// requires hand-encoding the RFC 5280 certificatePolicies extension (policy
+/// OIDs plus qualifier `IA5String`/`UserNotice` structures), for which rcgen
+/// 0.13 exposes no first-class API. Rather than silently accept-and-drop it,
+/// an explicit `CertificatePolicies` is rejected below so the caller is never
+/// misled into thinking a policy was embedded.
+fn apply_api_passthrough(
+    params: &mut CertificateParams,
+    passthrough: &Value,
+    is_ca: bool,
+) -> Result<(), String> {
+    if let Some(subject) = passthrough.get("Subject").filter(|v| v.is_object()) {
+        params.distinguished_name = build_dn(subject);
+    }
+    let Some(ext) = passthrough.get("Extensions").filter(|v| v.is_object()) else {
+        return Ok(());
+    };
+
+    if let Some(sans) = ext.get("SubjectAlternativeNames").and_then(Value::as_array) {
+        let mut mapped = Vec::with_capacity(sans.len());
+        for san in sans {
+            mapped.push(general_name_to_san(san)?);
+        }
+        params.subject_alt_names = mapped;
+    }
+
+    // KeyUsage passthrough applies to end-entity certificates. For a CA
+    // certificate the KeyCertSign/CrlSign usages set above are mandatory, so a
+    // passthrough KeyUsage is not allowed to weaken them.
+    if !is_ca {
+        if let Some(ku) = ext.get("KeyUsage").filter(|v| v.is_object()) {
+            params.key_usages = key_usage_to_purposes(ku);
+        }
+    }
+
+    if let Some(ekus) = ext.get("ExtendedKeyUsage").and_then(Value::as_array) {
+        let mut mapped = Vec::with_capacity(ekus.len());
+        for eku in ekus {
+            mapped.push(extended_key_usage_to_purpose(eku)?);
+        }
+        params.extended_key_usages = mapped;
+    }
+
+    if let Some(customs) = ext.get("CustomExtensions").and_then(Value::as_array) {
+        for custom in customs {
+            params.custom_extensions.push(custom_extension(custom)?);
+        }
+    }
+
+    if ext
+        .get("CertificatePolicies")
+        .and_then(Value::as_array)
+        .is_some_and(|p| !p.is_empty())
+    {
+        return Err("ApiPassthrough Extensions.CertificatePolicies is not supported".to_string());
+    }
+    Ok(())
+}
+
+/// Map an ACM PCA `GeneralName` to an rcgen `SanType`. The four IA5String-based
+/// name forms (DNS, RFC822/email, URI, IP) cover the SANs clients actually put
+/// in a certificate; the ASN.1-structured forms (`DirectoryName`, `OtherName`,
+/// `EdiPartyName`, `RegisteredId`) are rejected rather than dropped.
+fn general_name_to_san(name: &Value) -> Result<SanType, String> {
+    let ia5 = |field: &str| -> Result<Ia5String, String> {
+        let s = name.get(field).and_then(Value::as_str).unwrap_or_default();
+        Ia5String::try_from(s.to_string())
+            .map_err(|_| format!("invalid IA5String in GeneralName.{field}: {s}"))
+    };
+    if name.get("DnsName").is_some() {
+        Ok(SanType::DnsName(ia5("DnsName")?))
+    } else if name.get("Rfc822Name").is_some() {
+        Ok(SanType::Rfc822Name(ia5("Rfc822Name")?))
+    } else if name.get("UniformResourceIdentifier").is_some() {
+        Ok(SanType::URI(ia5("UniformResourceIdentifier")?))
+    } else if let Some(ip) = name.get("IpAddress").and_then(Value::as_str) {
+        let addr = ip
+            .parse::<std::net::IpAddr>()
+            .map_err(|_| format!("invalid IpAddress in SubjectAlternativeNames: {ip}"))?;
+        Ok(SanType::IpAddress(addr))
+    } else {
+        Err("unsupported SubjectAlternativeNames GeneralName type".to_string())
+    }
+}
+
+/// Map an ACM PCA `KeyUsage` (a struct of booleans) to rcgen key-usage purposes.
+fn key_usage_to_purposes(ku: &Value) -> Vec<KeyUsagePurpose> {
+    let on = |field: &str| ku.get(field).and_then(Value::as_bool).unwrap_or(false);
+    let mut out = Vec::new();
+    if on("DigitalSignature") {
+        out.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if on("NonRepudiation") {
+        out.push(KeyUsagePurpose::ContentCommitment);
+    }
+    if on("KeyEncipherment") {
+        out.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    if on("DataEncipherment") {
+        out.push(KeyUsagePurpose::DataEncipherment);
+    }
+    if on("KeyAgreement") {
+        out.push(KeyUsagePurpose::KeyAgreement);
+    }
+    if on("KeyCertSign") {
+        out.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if on("CRLSign") {
+        out.push(KeyUsagePurpose::CrlSign);
+    }
+    if on("EncipherOnly") {
+        out.push(KeyUsagePurpose::EncipherOnly);
+    }
+    if on("DecipherOnly") {
+        out.push(KeyUsagePurpose::DecipherOnly);
+    }
+    out
+}
+
+/// Map an ACM PCA `ExtendedKeyUsage` entry to an rcgen extended-key-usage
+/// purpose. Either a named `ExtendedKeyUsageType` or an arbitrary dotted
+/// `ExtendedKeyUsageObjectIdentifier` is accepted.
+fn extended_key_usage_to_purpose(eku: &Value) -> Result<ExtendedKeyUsagePurpose, String> {
+    if let Some(ty) = eku.get("ExtendedKeyUsageType").and_then(Value::as_str) {
+        return match ty {
+            "SERVER_AUTH" => Ok(ExtendedKeyUsagePurpose::ServerAuth),
+            "CLIENT_AUTH" => Ok(ExtendedKeyUsagePurpose::ClientAuth),
+            "CODE_SIGNING" => Ok(ExtendedKeyUsagePurpose::CodeSigning),
+            "EMAIL_PROTECTION" => Ok(ExtendedKeyUsagePurpose::EmailProtection),
+            "TIME_STAMPING" => Ok(ExtendedKeyUsagePurpose::TimeStamping),
+            "OCSP_SIGNING" => Ok(ExtendedKeyUsagePurpose::OcspSigning),
+            // Named ACM PCA purposes without a first-class rcgen variant map to
+            // their well-known OIDs (RFC 5280 / Microsoft) via `Other`.
+            "SMART_CARD_LOGIN" => Ok(ExtendedKeyUsagePurpose::Other(vec![
+                1, 3, 6, 1, 4, 1, 311, 20, 2, 2,
+            ])),
+            "DOCUMENT_SIGNING" => Ok(ExtendedKeyUsagePurpose::Other(vec![
+                1, 3, 6, 1, 4, 1, 311, 10, 3, 12,
+            ])),
+            "CERTIFICATE_TRANSPARENCY" => Ok(ExtendedKeyUsagePurpose::Other(vec![
+                1, 3, 6, 1, 4, 1, 11129, 2, 4, 4,
+            ])),
+            other => Err(format!("Invalid ExtendedKeyUsageType: {other}")),
+        };
+    }
+    if let Some(oid) = eku
+        .get("ExtendedKeyUsageObjectIdentifier")
+        .and_then(Value::as_str)
+    {
+        return Ok(ExtendedKeyUsagePurpose::Other(parse_oid(oid)?));
+    }
+    Err(
+        "ExtendedKeyUsage requires ExtendedKeyUsageType or ExtendedKeyUsageObjectIdentifier"
+            .to_string(),
+    )
+}
+
+/// Build an rcgen `CustomExtension` from an ACM PCA `CustomExtension`
+/// (dotted OID + base64 DER value + optional Critical flag).
+fn custom_extension(custom: &Value) -> Result<CustomExtension, String> {
+    let oid = custom
+        .get("ObjectIdentifier")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "CustomExtension.ObjectIdentifier is required".to_string())?;
+    let value_b64 = custom
+        .get("Value")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "CustomExtension.Value is required".to_string())?;
+    let content = base64::engine::general_purpose::STANDARD
+        .decode(value_b64)
+        .map_err(|_| "CustomExtension.Value must be base64".to_string())?;
+    let mut ext = CustomExtension::from_oid_content(&parse_oid(oid)?, content);
+    if custom
+        .get("Critical")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        ext.set_criticality(true);
+    }
+    Ok(ext)
+}
+
+/// Parse a dotted OID string (`1.3.6.1.5.5.7.3.1`) into its arc components.
+fn parse_oid(oid: &str) -> Result<Vec<u64>, String> {
+    oid.split('.')
+        .map(|arc| arc.parse::<u64>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| format!("invalid object identifier: {oid}"))
 }
 
 /// Outcome of verifying an imported CA certificate against the CA key pair.

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/acmpca.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/acmpca.rs
@@ -135,6 +135,13 @@ impl ResourceProvisioner {
             .get("TemplateArn")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // AWS::ACMPCA::Certificate carries the same ApiPassthrough (Subject +
+        // Extensions) as the API, so stamp it into the issued certificate here
+        // too rather than dropping it.
+        let api_passthrough = props
+            .get("ApiPassthrough")
+            .filter(|v| v.is_object())
+            .cloned();
         let (validity_value, validity_type) = props
             .get("Validity")
             .map(|v| {
@@ -184,9 +191,16 @@ impl ResourceProvisioner {
                 .map_err(|e| format!("failed to build issuer: {e}"))?;
             (issuer, Some(ca_cert_pem))
         };
-        let (cert_pem, serial) =
-            fakecloud_acmpca::issue_certificate(&issuer, &ca_key, &csr_pem, now, not_after, is_ca)
-                .map_err(|e| format!("ACM PCA certificate issuance failed: {e}"))?;
+        let (cert_pem, serial) = fakecloud_acmpca::issue_certificate(
+            &issuer,
+            &ca_key,
+            &csr_pem,
+            now,
+            not_after,
+            is_ca,
+            api_passthrough.as_ref(),
+        )
+        .map_err(|e| format!("ACM PCA certificate issuance failed: {e}"))?;
 
         let cert_arn = format!("{ca_arn}/certificate/{serial}");
         let chain = chain_base.map(|mut c| {


### PR DESCRIPTION
## Bug-hunt: ACM PCA stub / dropped-field audit

Focused stub/dropped-field/write-read-asymmetry audit of \`crates/fakecloud-acmpca\` (the sub-agent for this crate was killed by a rate-limit in the 2026-07-19 bug-hunt before it could report, so this closes that gap).

### Confirmed bug (fixed)

**\`IssueCertificate\` silently dropped the entire \`ApiPassthrough\` field.** The handler read \`Csr\`, \`SigningAlgorithm\`, \`Validity\`, \`ValidityNotBefore\`, \`TemplateArn\` and \`IdempotencyToken\`, but never touched \`ApiPassthrough\` (grep for \`ApiPassthrough\` in the crate returned nothing). Since this crate does *real* X.509 issuance via \`rcgen\`, dropping \`ApiPassthrough\` meant a caller who requested subject-alternative-names, a subject override, key-usage or extended-key-usage got a certificate back from \`GetCertificate\` that did **not** contain any of them — a genuine write-read asymmetry that makes the issued cert unusable for the requested hostnames.

### Fix

\`ApiPassthrough\` (Subject + Extensions) is now stamped into the signed certificate on **both** issuance paths (the awsJson API handler and the CloudFormation \`AWS::ACMPCA::Certificate\` provisioner, which carries the same property):

- \`Subject\` -> overrides the certificate distinguished name
- \`Extensions.SubjectAlternativeNames\` -> DNS / IP / RFC822 / URI general names
- \`Extensions.KeyUsage\` -> the nine RFC 5280 key-usage bits (end-entity only; a CA cert's mandatory KeyCertSign/CrlSign are not weakened)
- \`Extensions.ExtendedKeyUsage\` -> named EKU types + arbitrary dotted OIDs
- \`Extensions.CustomExtensions\` -> arbitrary OID + base64 DER value + Critical flag

**Deliberately not applied:** \`Extensions.CertificatePolicies\`. It requires hand-encoding the RFC 5280 certificatePolicies extension (policy OIDs plus qualifier IA5String/UserNotice structures) and rcgen 0.13 exposes no first-class API for it. Rather than accept-and-drop it (the exact bug class this PR fixes), an explicit \`CertificatePolicies\` is **rejected** so the caller is never misled into thinking a policy was embedded.

### Round-trips verified (both sides read in code)

Create/Update/Issue/Revoke/Delete/Tag/Permission/Policy/AuditReport were all cross-checked against their Describe/Get/List read paths and the Smithy model (\`aws-models/acm-pca.json\`). The rest of the crate already persists and echoes its accepted fields correctly (CA configuration, revocation config, usage mode, key-storage standard, tags, lifecycle transitions, idempotency) — \`ApiPassthrough\` was the one dropped field.

### Tests

- New \`issue_certificate_applies_api_passthrough\`: issue a leaf with Subject + SANs (DNS + IP) + KeyUsage + ExtendedKeyUsage, then \`GetCertificate\` and parse the X.509 to assert every field is present.
- New \`issue_certificate_rejects_unsupported_passthrough\`: \`CertificatePolicies\` is rejected, not dropped.

### Validation

- \`cargo build -p fakecloud -p fakecloud-acmpca -p fakecloud-cloudformation --all-targets\` — clean
- \`cargo nextest run -p fakecloud-conformance --test acmpca\` — **23/23 pass**
- \`cargo clippy -p fakecloud-acmpca -p fakecloud-cloudformation --all-targets -- -D warnings\` — clean
- \`cargo fmt --all\` — clean
- \`cargo test -p fakecloud-acmpca\` — 12/12 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ACM PCA `IssueCertificate` dropping `ApiPassthrough` so issued certificates include the requested Subject, SANs, KeyUsage, ExtendedKeyUsage, and CustomExtensions. Applies to both the API and `AWS::ACMPCA::Certificate` CloudFormation path; `CertificatePolicies` is rejected instead of silently dropped.

- **Bug Fixes**
  - Stamp `ApiPassthrough` (Subject + Extensions) into the signed cert in `fakecloud-acmpca` and `fakecloud-cloudformation`.
  - Apply Subject override, SANs (DNS/IP/RFC822/URI), KeyUsage (end-entity only), ExtendedKeyUsage, and CustomExtensions.
  - Reject `Extensions.CertificatePolicies` with a clear error to avoid accept-and-drop behavior.
  - Validate `ApiPassthrough` type; return errors for malformed input.
  - Add tests to confirm passthrough fields appear in `GetCertificate` and unsupported policies are rejected.

<sup>Written for commit dac31b8e6fb0b163a3d76c9d65d97a5a490c1fbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

