### PR TITLE
fix(core,dynamodb,cloudwatch,iam,kinesis,route53): correctness-tail (pagination/number-precision/alarm-state/id-length/iterator/ordering)

### DIFF
--- a/crates/fakecloud-application-autoscaling/src/service.rs
+++ b/crates/fakecloud-application-autoscaling/src/service.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use tokio::sync::Mutex as AsyncMutex;
 
 use fakecloud_aws::arn::{partition_for, Arn};
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::{SnapshotHook, SnapshotStore};
 
@@ -346,7 +346,8 @@ impl ApplicationAutoScalingService {
             .unwrap_or_default();
         drop(state);
         all.sort_by(|a, b| a.arn.cmp(&b.arn));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_next_token())?;
         let mut response = json!({
             "ScalableTargets": page.iter().map(scalable_target_json).collect::<Vec<_>>(),
         });
@@ -514,7 +515,8 @@ impl ApplicationAutoScalingService {
             .unwrap_or_default();
         drop(state);
         all.sort_by(|a, b| a.arn.cmp(&b.arn));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_next_token())?;
         let mut response = json!({
             "ScalingPolicies": page.iter().map(scaling_policy_json).collect::<Vec<_>>(),
         });
@@ -684,7 +686,8 @@ impl ApplicationAutoScalingService {
             .unwrap_or_default();
         drop(state);
         all.sort_by(|a, b| a.arn.cmp(&b.arn));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_next_token())?;
         let mut response = json!({
             "ScheduledActions": page.iter().map(scheduled_action_json).collect::<Vec<_>>(),
         });
@@ -771,7 +774,8 @@ impl ApplicationAutoScalingService {
             .unwrap_or_default();
         drop(state);
         all.sort_by_key(|a| std::cmp::Reverse(a.start_time));
-        let (page, next) = paginate(&all, next_token.as_deref(), max_results);
+        let (page, next) = paginate_checked(&all, next_token.as_deref(), max_results)
+            .map_err(|_| invalid_next_token())?;
         let mut response = json!({
             "ScalingActivities": page.iter().map(scaling_activity_json).collect::<Vec<_>>(),
         });
@@ -930,6 +934,18 @@ fn require_str(body: &Value, field: &str) -> Result<String, AwsServiceError> {
 
 fn invalid_param(msg: impl Into<String>) -> AwsServiceError {
     AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", msg)
+}
+
+/// A malformed pagination token. AWS Application Auto Scaling declares
+/// `InvalidNextTokenException` on its Describe* ops for this case; returning it
+/// (rather than silently restarting at page 0) stops a client that feeds back a
+/// garbage token from looping forever.
+fn invalid_next_token() -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::BAD_REQUEST,
+        "InvalidNextTokenException",
+        "The specified next token is not valid.",
+    )
 }
 
 // Smithy: com.amazonaws.applicationautoscaling#ServiceNamespace
@@ -1553,15 +1569,28 @@ mod tests {
     }
 
     // bug-audit 2026-05-28, 1.7: list ops reject a malformed NextToken
-    // (paginate_checked -> ValidationException) instead of silently restarting
-    // at page 0. The rejection primitive is exercised here; the wiring lives in
-    // the Describe* paginated handlers above.
+    // (paginate_checked -> InvalidNextTokenException) instead of silently
+    // restarting at page 0.
     #[test]
     fn paginate_checked_rejects_invalid_token() {
-        use fakecloud_core::pagination::paginate_checked;
         let items: Vec<i32> = (0..5).collect();
         assert!(paginate_checked(&items, Some("not-a-valid-token"), 3).is_err());
         assert!(paginate_checked(&items, Some("2"), 3).is_ok());
         assert!(paginate_checked(&items, None, 3).is_ok());
+    }
+
+    // The rejection is wired into the Describe* handlers: a garbage NextToken
+    // returns InvalidNextTokenException, not page 0.
+    #[test]
+    fn describe_scalable_targets_rejects_garbage_next_token() {
+        let svc = ApplicationAutoScalingService::default();
+        let err = match svc.describe_scalable_targets(&make_req(
+            "DescribeScalableTargets",
+            json!({ "ServiceNamespace": "ecs", "NextToken": "not-a-number" }),
+        )) {
+            Ok(_) => panic!("expected InvalidNextTokenException"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), "InvalidNextTokenException");
     }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudwatch.rs
@@ -192,6 +192,7 @@ impl ResourceProvisioner {
             configuration_updated_timestamp: now,
             alarm_configuration_updated_timestamp: now,
             metrics: parse_cfn_alarm_metrics(props),
+            state_manually_set: false,
         };
         let region_alarms = state.alarms_in_mut(&self.region);
         if region_alarms.contains_key(&alarm_name) {

--- a/crates/fakecloud-cloudwatch/src/alarm_eval.rs
+++ b/crates/fakecloud-cloudwatch/src/alarm_eval.rs
@@ -16,10 +16,12 @@
 //! transitions in the alarm history. It is invoked from `DescribeAlarms` so a
 //! `PutMetricData` -> `DescribeAlarms` sequence reflects the alarm firing.
 //!
-//! Evaluation never clobbers an alarm whose watched metric has no datapoints in
-//! the window when `treat_missing_data` is the default `missing` (or `ignore`):
-//! such an alarm keeps whatever state it already holds — including one set
-//! explicitly via `SetAlarmState`.
+//! Missing-data handling follows `treat_missing_data`: `breaching` /
+//! `notBreaching` force ALARM / OK, `ignore` keeps the current state, and the
+//! default `missing` transitions an alarm with no datapoints to
+//! INSUFFICIENT_DATA. A state forced via `SetAlarmState` is kept sticky (so it
+//! can drive composite alarms) until real datapoints arrive, at which point
+//! data governs the state.
 
 use std::collections::HashMap;
 
@@ -43,7 +45,15 @@ pub(crate) fn evaluate_alarms(state: &mut CloudWatchState, region: &str, now: Da
                     .as_ref()
                     .and_then(|ns| data_map.and_then(|m| m.get(ns)))
                     .map(|v| v.as_slice());
-                if let Some((new_state, reason)) = evaluate_metric_alarm(alarm, data, now) {
+                let manually_set = alarm.state_manually_set;
+                if let Some((new_state, reason, had_data)) =
+                    evaluate_metric_alarm(alarm, data, now, manually_set)
+                {
+                    // Once real datapoints govern the alarm, a prior manual
+                    // override no longer applies.
+                    if had_data {
+                        alarm.state_manually_set = false;
+                    }
                     if new_state != alarm.state_value {
                         let old = alarm.state_value.as_str().to_string();
                         alarm.state_value = new_state;
@@ -147,11 +157,18 @@ fn evaluate_composite_alarms(state: &mut CloudWatchState, region: &str, now: Dat
 /// Compute the state a single-metric alarm should hold, or `None` to leave the
 /// current state unchanged (metric-math / anomaly alarms, or a metric with no
 /// datapoints under the default missing-data treatment).
+/// Returns `Some((state, reason, had_data))` where `had_data` is whether the
+/// evaluation window held any real datapoints, or `None` to leave the current
+/// state unchanged. `manually_set` is whether the current state came from
+/// `SetAlarmState`; when true, a metric with no data under the default
+/// missing-data treatment keeps its manual state instead of resetting to
+/// INSUFFICIENT_DATA.
 pub(crate) fn evaluate_metric_alarm(
     alarm: &MetricAlarm,
     data: Option<&[MetricDatum]>,
     now: DateTime<Utc>,
-) -> Option<(AlarmState, String)> {
+    manually_set: bool,
+) -> Option<(AlarmState, String, bool)> {
     // Only plain single-metric alarms with a static threshold are evaluated.
     // Metric-math (`Metrics`) and anomaly-detection (`ThresholdMetricId`)
     // alarms are left untouched.
@@ -223,19 +240,35 @@ pub(crate) fn evaluate_metric_alarm(
     }
     let missing = eval_periods - present;
 
-    // No real datapoints: don't clobber the current state unless the caller
-    // explicitly asked to treat missing data as (not)breaching.
+    // No real datapoints in the evaluation window. How the alarm reacts depends
+    // on treat_missing_data:
+    //   * breaching    -> ALARM
+    //   * notBreaching -> OK
+    //   * ignore       -> keep the current state (None)
+    //   * missing (default) -> INSUFFICIENT_DATA
     if present == 0 {
         return match treat.as_str() {
             "breaching" => Some((
                 AlarmState::Alarm,
                 "Insufficient data treated as breaching.".to_string(),
+                false,
             )),
             "notbreaching" => Some((
                 AlarmState::Ok,
                 "Insufficient data treated as not breaching.".to_string(),
+                false,
             )),
-            _ => None,
+            "ignore" => None,
+            // Default treatment: a metric with no datapoints across the window
+            // transitions to INSUFFICIENT_DATA (so a stale OK/ALARM alarm does
+            // not stay pinned to a value it can no longer justify). A state
+            // forced via SetAlarmState is kept until real data arrives.
+            _ if manually_set => None,
+            _ => Some((
+                AlarmState::InsufficientData,
+                format!("Insufficient Data: {eval_periods} datapoints were unknown."),
+                false,
+            )),
         };
     }
 
@@ -251,14 +284,14 @@ pub(crate) fn evaluate_metric_alarm(
             latest_value.map(|v| v.to_string()).unwrap_or_default(),
             operator_phrase(&alarm.comparison_operator),
         );
-        Some((AlarmState::Alarm, reason))
+        Some((AlarmState::Alarm, reason, true))
     } else {
         let reason = format!(
             "Threshold not crossed: {breaching} out of the last {eval_periods} datapoints was {} \
              the threshold ({threshold}).",
             operator_phrase(&alarm.comparison_operator),
         );
-        Some((AlarmState::Ok, reason))
+        Some((AlarmState::Ok, reason, true))
     }
 }
 
@@ -609,5 +642,90 @@ mod tests {
         assert_eq!(evaluate_rule("ALARM(a)", &s), Some(AlarmState::Alarm));
         assert_eq!(evaluate_rule("OK(a)", &s), Some(AlarmState::Ok));
         assert_eq!(evaluate_rule("!!!", &s), None);
+    }
+
+    fn sum_alarm(state: AlarmState, treat: Option<&str>) -> MetricAlarm {
+        MetricAlarm {
+            alarm_name: "a".into(),
+            alarm_arn: "arn:aws:cloudwatch:us-east-1:123456789012:alarm:a".into(),
+            alarm_description: None,
+            actions_enabled: true,
+            ok_actions: vec![],
+            alarm_actions: vec![],
+            insufficient_data_actions: vec![],
+            state_value: state,
+            state_reason: String::new(),
+            state_updated_timestamp: Utc::now(),
+            metric_name: Some("M".into()),
+            namespace: Some("Test/NS".into()),
+            statistic: Some("Sum".into()),
+            extended_statistic: None,
+            dimensions: Default::default(),
+            period: Some(60),
+            unit: None,
+            evaluation_periods: 1,
+            datapoints_to_alarm: None,
+            threshold: Some(1.0),
+            comparison_operator: "GreaterThanThreshold".into(),
+            treat_missing_data: treat.map(|s| s.to_string()),
+            evaluate_low_sample_count_percentile: None,
+            threshold_metric_id: None,
+            configuration_updated_timestamp: Utc::now(),
+            alarm_configuration_updated_timestamp: Utc::now(),
+            metrics: vec![],
+            state_manually_set: false,
+        }
+    }
+
+    fn datum(value: f64, ts: DateTime<Utc>) -> MetricDatum {
+        MetricDatum {
+            metric_name: "M".into(),
+            dimensions: Default::default(),
+            timestamp: ts,
+            value: Some(value),
+            statistic_values: None,
+            unit: None,
+            storage_resolution: None,
+        }
+    }
+
+    // Default (missing) treatment: a stale alarm with no datapoints transitions
+    // to INSUFFICIENT_DATA rather than staying pinned to its old state.
+    #[test]
+    fn missing_data_default_transitions_to_insufficient_data() {
+        let now = Utc::now();
+        let alarm = sum_alarm(AlarmState::Alarm, None);
+        let out = evaluate_metric_alarm(&alarm, None, now, false);
+        assert!(matches!(
+            out,
+            Some((AlarmState::InsufficientData, _, false))
+        ));
+    }
+
+    // `ignore` keeps the current state when data is missing.
+    #[test]
+    fn missing_data_ignore_keeps_state() {
+        let now = Utc::now();
+        let alarm = sum_alarm(AlarmState::Alarm, Some("ignore"));
+        assert_eq!(evaluate_metric_alarm(&alarm, None, now, false), None);
+    }
+
+    // A manually-set state (SetAlarmState) is kept sticky when data is missing.
+    #[test]
+    fn manual_state_survives_missing_data() {
+        let now = Utc::now();
+        let alarm = sum_alarm(AlarmState::Alarm, None);
+        assert_eq!(evaluate_metric_alarm(&alarm, None, now, true), None);
+    }
+
+    // Real datapoints govern the state and report had_data = true so the caller
+    // can clear a stale manual override.
+    #[test]
+    fn present_data_drives_state_and_reports_had_data() {
+        let now = Utc::now();
+        let alarm = sum_alarm(AlarmState::InsufficientData, None);
+        let data = [datum(5.0, now)];
+        let out = evaluate_metric_alarm(&alarm, Some(&data), now, true);
+        assert!(matches!(out, Some((AlarmState::Alarm, _, true))), "{out:?}");
     }
 }

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -1463,6 +1463,12 @@ impl CloudWatchService {
                 .unwrap_or(now),
             alarm_configuration_updated_timestamp: now,
             metrics,
+            // Preserve a prior manual override across a config update; a brand
+            // new alarm has never been manually set.
+            state_manually_set: existing
+                .as_ref()
+                .map(|a| a.state_manually_set)
+                .unwrap_or(false),
         };
         let alarm_arn = alarm.alarm_arn.clone();
         let history_name = alarm_name.clone();
@@ -1652,6 +1658,16 @@ impl CloudWatchService {
         let namespace = required_query_param(req, "Namespace")?;
         let dim_filter = parse_dimensions_query(req, "Dimensions");
 
+        // Recompute alarm states from stored metric data first, so this returns
+        // the same fresh state DescribeAlarms would (a PutMetricData crossing a
+        // threshold is reflected here rather than a stale stored value).
+        {
+            let mut state = self.state.write();
+            if let Some(acct) = state.accounts.get_mut(&req.account_id) {
+                crate::alarm_eval::evaluate_alarms(acct, &req.region, Utc::now());
+            }
+        }
+
         let state = self.state.read();
         let mut inner = String::from("<MetricAlarms>");
         if let Some(acct) = state.get(&req.account_id) {
@@ -1769,6 +1785,9 @@ impl CloudWatchService {
                 alarm.state_value = new_state;
                 alarm.state_reason = state_reason.clone();
                 alarm.state_updated_timestamp = now;
+                // Mark this as a manual override so a later evaluation with no
+                // datapoints keeps it rather than resetting to INSUFFICIENT_DATA.
+                alarm.state_manually_set = true;
                 (old, "MetricAlarm")
             } else if let Some(composite) = acct
                 .composite_alarms_in_mut(&req.region)

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -273,6 +273,14 @@ pub struct MetricAlarm {
     /// alarm evaluates an expression or a metric in another account.
     #[serde(default)]
     pub metrics: Vec<AlarmMetricQuery>,
+    /// Whether the current state was forced by `SetAlarmState`. AWS reverts a
+    /// manual state on the next evaluation, but the emulator keeps it sticky
+    /// (so it can be used to drive composite alarms) until real datapoints
+    /// arrive — at which point evaluation clears this and data governs the
+    /// state. It only suppresses the default missing-data INSUFFICIENT_DATA
+    /// transition, never a real threshold crossing.
+    #[serde(default)]
+    pub state_manually_set: bool,
 }
 
 /// A single `MetricDataQuery` entry in a `PutMetricAlarm` `Metrics` list.

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -344,6 +344,81 @@ async fn metric_alarm_evaluates_to_ok_below_threshold() {
     );
 }
 
+// DescribeAlarmsForMetric returns freshly-evaluated state (not a stale stored
+// value) and filters by Dimensions.
+#[tokio::test]
+async fn describe_alarms_for_metric_returns_fresh_state_filtered_by_dimensions() {
+    let svc = service();
+    call(
+        &svc,
+        "PutMetricAlarm",
+        &[
+            ("AlarmName", "dfm-alarm"),
+            ("Namespace", "Test/DFM"),
+            ("MetricName", "CPU"),
+            ("Dimensions.member.1.Name", "Host"),
+            ("Dimensions.member.1.Value", "a"),
+            ("ComparisonOperator", "GreaterThanThreshold"),
+            ("Threshold", "50"),
+            ("EvaluationPeriods", "1"),
+            ("Period", "60"),
+            ("Statistic", "Average"),
+        ],
+    )
+    .await;
+    // Publish a breaching datapoint AFTER creating the alarm; the handler must
+    // re-evaluate rather than return the initial INSUFFICIENT_DATA.
+    call(
+        &svc,
+        "PutMetricData",
+        &[
+            ("Namespace", "Test/DFM"),
+            ("MetricData.member.1.MetricName", "CPU"),
+            ("MetricData.member.1.Value", "100"),
+            ("MetricData.member.1.Dimensions.member.1.Name", "Host"),
+            ("MetricData.member.1.Dimensions.member.1.Value", "a"),
+        ],
+    )
+    .await;
+
+    // Matching dimensions -> the alarm is returned with its fresh ALARM state.
+    let matched = call(
+        &svc,
+        "DescribeAlarmsForMetric",
+        &[
+            ("Namespace", "Test/DFM"),
+            ("MetricName", "CPU"),
+            ("Dimensions.member.1.Name", "Host"),
+            ("Dimensions.member.1.Value", "a"),
+        ],
+    )
+    .await;
+    let body = body_of(&matched);
+    assert!(body.contains("dfm-alarm"), "alarm should match: {body}");
+    assert!(
+        body.contains("<StateValue>ALARM</StateValue>"),
+        "fresh state should be ALARM: {body}"
+    );
+
+    // Non-matching dimensions -> filtered out.
+    let unmatched = call(
+        &svc,
+        "DescribeAlarmsForMetric",
+        &[
+            ("Namespace", "Test/DFM"),
+            ("MetricName", "CPU"),
+            ("Dimensions.member.1.Name", "Host"),
+            ("Dimensions.member.1.Value", "b"),
+        ],
+    )
+    .await;
+    assert!(
+        !body_of(&unmatched).contains("dfm-alarm"),
+        "different dimensions must not match: {}",
+        body_of(&unmatched)
+    );
+}
+
 // A manually-set state must survive DescribeAlarms re-evaluation when the
 // watched metric has no datapoints (default treat-missing-data).
 #[tokio::test]

--- a/crates/fakecloud-core/src/pagination.rs
+++ b/crates/fakecloud-core/src/pagination.rs
@@ -3,6 +3,12 @@
 /// Parses `next_token` as a numeric offset (defaulting to 0 if `None` or unparseable),
 /// slices `items` starting at that offset, and returns at most `max_results` items
 /// along with an optional next token for the following page.
+///
+/// Prefer [`paginate_checked`] for client-facing list ops: this variant treats a
+/// malformed `next_token` as offset 0, which can drive an infinite client
+/// pagination loop. It remains for callers whose service model declares no
+/// invalid-token error (returning one would be an undeclared error).
+#[must_use]
 pub fn paginate<T: Clone>(
     items: &[T],
     next_token: Option<&str>,

--- a/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/keys.rs
@@ -148,11 +148,23 @@ pub(crate) fn validate_attribute_value(v: &Value) -> Result<(), AwsServiceError>
             format!("The parameter cannot be converted to a numeric value: {n}"),
         )
     };
+    // DynamoDB Numbers are decimals with at most 38 significant digits; a longer
+    // coefficient is rejected with ValidationException.
+    const MAX_SIGNIFICANT_DIGITS: usize = 38;
+    let too_many_digits = || {
+        AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "ValidationException",
+            "Attempting to store more than 38 significant digits in a Number",
+        )
+    };
     match tag.as_str() {
         "N" => {
             let s = val.as_str().unwrap_or_default();
-            if !is_valid_number(s) {
-                return Err(bad_number(s));
+            match significant_digit_count(s) {
+                None => return Err(bad_number(s)),
+                Some(digits) if digits > MAX_SIGNIFICANT_DIGITS => return Err(too_many_digits()),
+                Some(_) => {}
             }
         }
         "SS" => {
@@ -180,8 +192,12 @@ pub(crate) fn validate_attribute_value(v: &Value) -> Result<(), AwsServiceError>
             validate_set_not_empty("number", members.is_empty())?;
             let mut seen = std::collections::HashSet::new();
             for s in &members {
-                if !is_valid_number(s) {
-                    return Err(bad_number(s));
+                match significant_digit_count(s) {
+                    None => return Err(bad_number(s)),
+                    Some(digits) if digits > MAX_SIGNIFICANT_DIGITS => {
+                        return Err(too_many_digits())
+                    }
+                    Some(_) => {}
                 }
                 // Number-set members are deduped by numeric value, so `"1"` and
                 // `"1.0"` collide. `canonical_number` never returns `None` here
@@ -366,6 +382,36 @@ mod attr_value_validation_tests {
             ("ns".to_string(), json!({"NS": ["1", "2.5"]})),
         ]);
         assert!(validate_item_attribute_values(&item).is_ok());
+    }
+
+    // DynamoDB rejects a Number with more than 38 significant digits.
+    #[test]
+    fn rejects_number_over_38_significant_digits() {
+        let thirty_nine = "1".repeat(39);
+        let err = err_of(json!({ "N": thirty_nine }));
+        assert_eq!(err.code(), "ValidationException");
+        assert!(
+            err.message().contains("38 significant digits"),
+            "{}",
+            err.message()
+        );
+
+        // Same limit inside a Number Set.
+        let err = err_of(json!({ "NS": ["1", "9".repeat(39)] }));
+        assert_eq!(err.code(), "ValidationException");
+    }
+
+    #[test]
+    fn accepts_number_at_and_below_38_digit_limit() {
+        // Exactly 38 significant digits is allowed.
+        assert!(validate_attribute_value(&json!({ "N": "1".repeat(38) })).is_ok());
+        // A 39-character string that is only 1 significant digit (1E38) is fine:
+        // trailing zeros collapse into the exponent, not the coefficient.
+        let one_e38 = format!("1{}", "0".repeat(38));
+        assert!(validate_attribute_value(&json!({ "N": one_e38 })).is_ok());
+        // Leading zeros in a fraction are likewise insignificant.
+        let small = format!("0.{}1", "0".repeat(40));
+        assert!(validate_attribute_value(&json!({ "N": small })).is_ok());
     }
 
     fn err_of(v: serde_json::Value) -> AwsServiceError {

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -75,6 +75,21 @@ pub(crate) fn is_valid_number(s: &str) -> bool {
     normalize_decimal(s).is_some()
 }
 
+/// Number of significant digits in a DynamoDB Number literal, or `None` if the
+/// string is not a valid number. Leading zeros, trailing zeros, the sign, the
+/// decimal point and the exponent are all insignificant — DynamoDB stores a
+/// number as a coefficient plus an exponent, so `1E38` (a 39-character string)
+/// is a single significant digit while `1234...` with 39 non-zero digits is 39.
+/// AWS rejects a Number with more than 38 significant digits.
+pub(crate) fn significant_digit_count(s: &str) -> Option<usize> {
+    let (_, (int_norm, frac_norm)) = normalize_decimal(s)?;
+    // `int_norm` already has leading zeros stripped and `frac_norm` trailing
+    // zeros stripped; the remaining leading zeros (value < 1) and trailing
+    // zeros (integer with a zeroed tail) collapse into the exponent.
+    let coeff = format!("{int_norm}{frac_norm}");
+    Some(coeff.trim_start_matches('0').trim_end_matches('0').len())
+}
+
 /// Canonical decimal form of a DynamoDB Number, so numerically-equal literals
 /// (`"1"`, `"1.0"`, `"1e0"`) collapse to one key. Used to detect duplicate
 /// members in a Number Set (`NS`), which AWS compares by numeric value rather

--- a/crates/fakecloud-glue/src/catalog.rs
+++ b/crates/fakecloud-glue/src/catalog.rs
@@ -231,7 +231,7 @@ impl GlueService {
                     .collect()
             })
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, list);
+        let (page, token) = crate::common::paginate_body(&body, list)?;
         let mut resp = json!({ "UserDefinedFunctions": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);

--- a/crates/fakecloud-glue/src/common.rs
+++ b/crates/fakecloud-glue/src/common.rs
@@ -100,16 +100,20 @@ pub(crate) fn resource_arn(account: &str, region: &str, kind: &str, name: &str) 
 /// absent the full remaining list (from any incoming offset) is returned in a
 /// single page with no continuation token — matching how AWS returns an
 /// unbounded page when the caller omits a page size.
-pub(crate) fn paginate_body(body: &Value, items: Vec<Value>) -> (Vec<Value>, Option<String>) {
+pub(crate) fn paginate_body(
+    body: &Value,
+    items: Vec<Value>,
+) -> Result<(Vec<Value>, Option<String>), AwsServiceError> {
     let token = body.get("NextToken").and_then(|v| v.as_str());
     let max = body
         .get("MaxResults")
         .and_then(|v| v.as_u64())
-        .map(|n| n as usize);
-    match max {
-        Some(m) => fakecloud_core::pagination::paginate(&items, token, m),
-        None => fakecloud_core::pagination::paginate(&items, token, usize::MAX),
-    }
+        .map(|n| n as usize)
+        .unwrap_or(usize::MAX);
+    // A malformed NextToken is rejected with InvalidInputException rather than
+    // silently restarting at page 0 (which can loop a client forever).
+    fakecloud_core::pagination::paginate_checked(&items, token, max)
+        .map_err(|_| invalid_input("Invalid value for NextToken."))
 }
 
 /// A small UUID-ish identifier (32 hex chars). Glue uses these for run ids,

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -88,7 +88,7 @@ impl GlueService {
             .get(&req.account_id)
             .map(|s| s.crawlers.values().cloned().collect())
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, crawlers);
+        let (page, token) = crate::common::paginate_body(&body, crawlers)?;
         let mut resp = json!({ "Crawlers": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);

--- a/crates/fakecloud-glue/src/jobs.rs
+++ b/crates/fakecloud-glue/src/jobs.rs
@@ -171,7 +171,7 @@ impl GlueService {
             .get(&req.account_id)
             .map(|s| s.jobs.values().map(job_to_json).collect())
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, jobs);
+        let (page, token) = crate::common::paginate_body(&body, jobs)?;
         let mut resp = json!({ "Jobs": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);
@@ -186,7 +186,7 @@ impl GlueService {
             .get(&req.account_id)
             .map(|s| s.jobs.keys().map(|k| json!(k)).collect())
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, names);
+        let (page, token) = crate::common::paginate_body(&body, names)?;
         let mut resp = json!({ "JobNames": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -1060,7 +1060,7 @@ impl GlueService {
             .and_then(|s| s.dbs_in(&req.region))
             .map(|map| map.values().map(database_json).collect())
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, dbs);
+        let (page, token) = crate::common::paginate_body(&body, dbs)?;
         let mut resp = json!({ "DatabaseList": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);
@@ -1197,7 +1197,7 @@ impl GlueService {
                 }
             }
         }
-        let (page, token) = crate::common::paginate_body(&body, tables);
+        let (page, token) = crate::common::paginate_body(&body, tables)?;
         let mut resp = json!({ "TableList": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);
@@ -1408,7 +1408,7 @@ impl GlueService {
                     .collect()
             })
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, parts);
+        let (page, token) = crate::common::paginate_body(&body, parts)?;
         let mut resp = json!({ "Partitions": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -898,7 +898,7 @@ impl GlueService {
                 None => vec![],
             }
         };
-        let (page, token) = crate::common::paginate_body(&body, versions);
+        let (page, token) = crate::common::paginate_body(&body, versions)?;
         let mut resp = json!({ "TableVersions": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);
@@ -1061,7 +1061,7 @@ impl GlueService {
                     .collect()
             })
             .unwrap_or_default();
-        let (page, token) = crate::common::paginate_body(&body, list);
+        let (page, token) = crate::common::paginate_body(&body, list)?;
         let mut resp = json!({ "PartitionIndexDescriptorList": page });
         if let Some(t) = token {
             resp["NextToken"] = json!(t);

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -552,11 +552,14 @@ pub(crate) fn resolve_calling_user(state: &crate::state::IamState, _account_id: 
 }
 
 pub(crate) fn generate_id() -> String {
-    // Generate 16 uppercase hex chars (used with 4-char prefixes like FKIA, AIDA = 20 chars)
+    // AWS unique IDs (AIDA/AROA/AGPA/ANPA/AIPA/ASCA...) are a 4-char prefix
+    // followed by 17 alphanumerics for 21 characters total, so this returns 17
+    // chars. Access-key-style IDs (AKIA/APKA) are 20 chars total and slice this
+    // down to 16 at their call sites.
     uuid::Uuid::new_v4()
         .to_string()
         .replace('-', "")
-        .to_uppercase()[..16]
+        .to_uppercase()[..17]
         .to_string()
 }
 
@@ -1122,4 +1125,24 @@ pub(crate) fn empty_response(action: &str, request_id: &str) -> String {
   </ResponseMetadata>
 </{action}Response>"#,
     )
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::*;
+
+    // AWS principal unique IDs are a 4-char prefix + 17 alphanumerics = 21 chars.
+    #[test]
+    fn generate_id_yields_21_char_unique_ids() {
+        let id = generate_id();
+        assert_eq!(id.len(), 17, "generate_id suffix must be 17 chars");
+        for prefix in ["AIDA", "AROA", "AGPA", "ANPA", "AIPA"] {
+            let unique = format!("{prefix}{}", generate_id());
+            assert_eq!(unique.len(), 21, "{unique} must be 21 chars total");
+            assert!(unique.starts_with(prefix));
+        }
+        // Access-key-style IDs stay 20 chars total (prefix + 16).
+        let access_key = format!("FKIA{}", &generate_id()[..16]);
+        assert_eq!(access_key.len(), 20);
+    }
 }

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -616,8 +616,10 @@ impl IamService {
         }
 
         let key = IamAccessKey {
-            access_key_id: format!("FKIA{}", generate_id()),
-            secret_access_key: format!("fake{}{}fake", generate_id(), generate_id()),
+            // Access key IDs are 20 chars total (4-char prefix + 16), unlike the
+            // 21-char principal unique IDs generate_id() now mints.
+            access_key_id: format!("FKIA{}", &generate_id()[..16]),
+            secret_access_key: format!("fake{}{}fake", &generate_id()[..16], &generate_id()[..16]),
             user_name: user_name.clone(),
             status: "Active".to_string(),
             created_at: Utc::now(),
@@ -1292,7 +1294,8 @@ impl IamService {
             ));
         }
 
-        let key_id = format!("APKA{}", generate_id());
+        // SSH public-key IDs are 20 chars total (APKA + 16), like access keys.
+        let key_id = format!("APKA{}", &generate_id()[..16]);
         // Generate a simple fingerprint from the body
         let fingerprint = format!(
             "{}:{}:{}:{}:{}",

--- a/crates/fakecloud-kinesis/src/service_helpers.rs
+++ b/crates/fakecloud-kinesis/src/service_helpers.rs
@@ -406,15 +406,26 @@ pub(crate) fn require_starting_sequence_number(body: &Value) -> Result<&str, Aws
         .ok_or_else(|| invalid_argument("StartingSequenceNumber is required"))
 }
 
+/// Extract the 5-digit shard discriminator packed into the front of a
+/// sequence number by [`append_record`]. Returns `None` for anything that is
+/// not a well-formed 56-digit sequence number, so a malformed or foreign token
+/// can never be mistaken for a value this shard minted.
+fn sequence_shard_discriminator(sequence_number: &str) -> Option<u32> {
+    if sequence_number.len() != 56 || !sequence_number.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    sequence_number[..5].parse::<u32>().ok()
+}
+
 /// Resolve an `AT_/AFTER_SEQUENCE_NUMBER` iterator start index.
 ///
 /// When the exact sequence number is still present we return its index (or
-/// the next one for `AFTER`). When it is *not* present but sorts before the
-/// earliest retained record, the record it named was aged out by the
-/// retention window, so — like real Kinesis — we resolve to the trim horizon
-/// (the earliest available record) instead of raising InvalidArgumentException.
-/// A sequence number that is neither present nor below the horizon is a
-/// genuinely invalid argument.
+/// the next one for `AFTER`). When it is *not* present but was minted by this
+/// shard and sorts before the earliest retained record, the record it named
+/// was aged out by the retention window, so — like real Kinesis — we resolve
+/// to the trim horizon (the earliest available record). A sequence number that
+/// belongs to a different shard, is malformed, or is otherwise not valid for
+/// this shard raises InvalidArgumentException, matching AWS.
 pub(crate) fn resolve_sequence_number_index(
     shard: &KinesisShard,
     sequence_number: &str,
@@ -427,11 +438,15 @@ pub(crate) fn resolve_sequence_number_index(
     {
         return Ok(if after { pos + 1 } else { pos });
     }
-    // Sequence numbers are fixed-width, zero-padded and per-shard monotonic,
-    // so a lexicographic comparison against the earliest retained record is
-    // an exact numeric ordering — a smaller value was trimmed off the front.
+    // A below-horizon token is only "trimmed off the front" if it could have
+    // been minted by THIS shard — its packed discriminator must match. A
+    // cross-shard or malformed token that merely happens to sort low is an
+    // invalid argument, not a trim-horizon resolution.
     if let Some(first) = shard.records.first() {
-        if sequence_number < first.sequence_number.as_str() {
+        if sequence_number < first.sequence_number.as_str()
+            && sequence_shard_discriminator(sequence_number)
+                == Some(shard_discriminator(&shard.shard_id))
+        {
             return Ok(0);
         }
     }

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -2320,6 +2320,48 @@ fn at_sequence_number_below_trim_horizon_resolves_to_earliest() {
     assert_eq!(records.len(), 1, "resolves to the surviving record");
 }
 
+// A sequence number minted by a *different* shard (its packed discriminator
+// doesn't match) must raise InvalidArgumentException even when it sorts below
+// this shard's earliest record, instead of silently resolving to trim horizon.
+#[test]
+fn at_sequence_number_from_another_shard_is_invalid() {
+    let (svc, state) = make_service();
+    svc.create_stream(&request(
+        "CreateStream",
+        json!({"StreamName": "xshard", "ShardCount": 2}),
+    ))
+    .unwrap();
+
+    // Seed shard 1 (discriminator 1) with a record directly.
+    {
+        let mut g = state.write();
+        let stream = g.default_mut().streams.get_mut("xshard").unwrap();
+        stream.shards[1].records.push(KinesisRecord {
+            sequence_number: format!("{:05}{:051}", 1, 10),
+            partition_key: "p".to_string(),
+            data: b"one".to_vec(),
+            approximate_arrival_timestamp: chrono::Utc::now(),
+        });
+    }
+
+    // A token with shard-0's discriminator sorts below shard 1's record but was
+    // never minted by shard 1.
+    let foreign_seq = format!("{:05}{:051}", 0, 5);
+    let err = match svc.get_shard_iterator(&request(
+        "GetShardIterator",
+        json!({
+            "StreamName": "xshard",
+            "ShardId": "shardId-000000000001",
+            "ShardIteratorType": "AT_SEQUENCE_NUMBER",
+            "StartingSequenceNumber": foreign_seq,
+        }),
+    )) {
+        Ok(_) => panic!("expected InvalidArgumentException"),
+        Err(e) => e,
+    };
+    assert_eq!(err.code(), "InvalidArgumentException");
+}
+
 // ── L2: shard-iterator tokens are unique per insert ──
 
 #[test]

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -102,9 +102,14 @@ fn rrset_value_key(r: &ResourceRecordSet) -> Vec<String> {
 /// True when two record sets carry identical TTL and value data, in
 /// addition to name/type/set-identifier. Used to gate `DELETE`.
 pub(crate) fn rrset_values_match(current: &ResourceRecordSet, want: &ResourceRecordSet) -> bool {
-    // AliasTarget-backed records have no TTL; only compare TTL when the
-    // caller supplied one (real Route 53 ignores TTL for alias deletes).
-    let ttl_ok = want.ttl.is_none() || current.ttl == want.ttl;
+    // Alias records carry no TTL, so Route 53 ignores TTL when matching an
+    // alias delete. For a standard record a DELETE must specify the TTL and it
+    // must match exactly — omitting it is a mismatch, not a wildcard.
+    let ttl_ok = if current.alias_target.is_some() {
+        true
+    } else {
+        current.ttl == want.ttl
+    };
     ttl_ok && rrset_value_key(current) == rrset_value_key(want)
 }
 
@@ -167,14 +172,20 @@ pub(crate) fn is_default_record(r: &ResourceRecordSet, zone_name: &str) -> bool 
     r.name == zone_name && (r.record_type == "SOA" || r.record_type == "NS")
 }
 
-/// Reversed-label sort key for a DNS name (`www.example.com.` ->
-/// `com.example.www`). Route 53's `ListHostedZonesByName` orders zones by
-/// this key rather than plain lexicographic name order.
+/// Reversed-label sort key for a DNS name. Route 53 orders record sets and
+/// zones by RFC 4034 canonical name ordering: compare labels right-to-left, and
+/// within a label octet-by-octet where the end of a label sorts before any
+/// octet.
+///
+/// The labels are reversed and joined with NUL (`0x00`) rather than `.` so that
+/// a label boundary sorts before every label octet. Joining with `.` (`0x2E`)
+/// mis-ranks any label containing an octet below `.` — e.g. `-` (`0x2D`) — so
+/// `a-.example.com.` would wrongly sort after `x.a.example.com.`.
 pub(crate) fn reverse_dns_key(name: &str) -> String {
-    let trimmed = name.trim_end_matches('.');
+    let trimmed = name.trim_end_matches('.').to_ascii_lowercase();
     let mut labels: Vec<&str> = trimmed.split('.').collect();
     labels.reverse();
-    labels.join(".").to_ascii_lowercase()
+    labels.join("\0")
 }
 
 /// Materialize a traffic-policy document into the record set AWS creates for
@@ -2280,10 +2291,22 @@ mod hardening_tests {
 
     #[test]
     fn reverse_dns_key_reverses_labels() {
-        assert_eq!(reverse_dns_key("www.example.com."), "com.example.www");
-        assert_eq!(reverse_dns_key("example.com"), "com.example");
+        // Labels are reversed and joined with NUL.
+        assert_eq!(reverse_dns_key("www.example.com."), "com\0example\0www");
+        assert_eq!(reverse_dns_key("example.com"), "com\0example");
+        assert_eq!(reverse_dns_key("WWW.Example.COM"), "com\0example\0www");
         // Zone apex sorts before its subdomains under the reversed key.
         assert!(reverse_dns_key("example.com.") < reverse_dns_key("a.example.com."));
+    }
+
+    // RFC 4034: end-of-label sorts before any octet, so a label that is a proper
+    // prefix of a sibling sorts first even when the sibling's next octet is
+    // below '.' (0x2E). `a` < `a-` -> `a.example.com.` < `a-.example.com.`.
+    #[test]
+    fn reverse_dns_key_orders_end_of_label_before_low_octet() {
+        assert!(reverse_dns_key("a.example.com.") < reverse_dns_key("a-.example.com."));
+        // And a deeper name under `a` still sorts before the `a-` sibling.
+        assert!(reverse_dns_key("z.a.example.com.") < reverse_dns_key("a-.example.com."));
     }
 
     #[test]
@@ -2310,6 +2333,34 @@ mod hardening_tests {
         assert!(rrset_values_match(&cur, &same));
         assert!(!rrset_values_match(&cur, &diff_val));
         assert!(!rrset_values_match(&cur, &diff_ttl));
+
+        // A DELETE that omits TTL for a standard record does NOT match — Route
+        // 53 requires the TTL on a non-alias delete.
+        let no_ttl = ResourceRecordSet {
+            ttl: None,
+            resource_records: rr(&["1.2.3.4"]),
+            ..cur.clone()
+        };
+        assert!(!rrset_values_match(&cur, &no_ttl));
+
+        // Alias records have no TTL; TTL is ignored when matching an alias.
+        let alias_cur = ResourceRecordSet {
+            name: "alias.example.com.".into(),
+            record_type: "A".into(),
+            ttl: None,
+            resource_records: None,
+            alias_target: Some(crate::model::AliasTarget {
+                hosted_zone_id: "Z1".into(),
+                dns_name: "target.example.com.".into(),
+                evaluate_target_health: false,
+            }),
+            ..Default::default()
+        };
+        let alias_want = ResourceRecordSet {
+            ttl: None,
+            ..alias_cur.clone()
+        };
+        assert!(rrset_values_match(&alias_cur, &alias_want));
     }
 
     #[test]

--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -1101,6 +1101,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn list_resource_record_sets_rejects_type_without_name() {
+        let (svc, zid) = svc_with_zone(vec![]);
+        let route = Route {
+            action: "ListResourceRecordSets",
+            id: Some(zid.clone()),
+            second_id: None,
+        };
+        let mut query_params = std::collections::HashMap::new();
+        // StartRecordType without StartRecordName is invalid.
+        query_params.insert("type".to_string(), "A".to_string());
+        let req = AwsRequest {
+            service: "route53".to_string(),
+            action: "ListResourceRecordSets".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: DEFAULT_ACCOUNT.to_string(),
+            request_id: "rid".to_string(),
+            headers: HeaderMap::new(),
+            query_params,
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![
+                "2013-04-01".into(),
+                "hostedzone".into(),
+                zid.clone(),
+                "rrset".into(),
+            ],
+            raw_path: format!("/2013-04-01/hostedzone/{zid}/rrset"),
+            raw_query: String::new(),
+            method: http::Method::GET,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        };
+        let err = match svc.list_resource_record_sets(&req, &route) {
+            Ok(_) => panic!("expected InvalidInput"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), "InvalidInput");
+    }
+
     fn empty_lookup() -> AliasLookup<'static> {
         AliasLookup {
             elbv2: None,

--- a/crates/fakecloud-route53/src/service/records.rs
+++ b/crates/fakecloud-route53/src/service/records.rs
@@ -134,6 +134,12 @@ impl Route53Service {
         let start_name = req.query_params.get("name").map(|s| s.to_ascii_lowercase());
         let start_type = req.query_params.get("type").cloned();
         let start_ident = req.query_params.get("identifier").cloned();
+        // Route 53 rejects StartRecordType supplied without StartRecordName.
+        if start_type.is_some() && start_name.is_none() {
+            return Err(invalid_argument(
+                "The input is not valid: StartRecordName must be specified when StartRecordType is specified",
+            ));
+        }
 
         let mut sorted: Vec<&crate::model::ResourceRecordSet> =
             zone.resource_record_sets.iter().collect();

--- a/crates/fakecloud-wafv2/src/service/api_keys.rs
+++ b/crates/fakecloud-wafv2/src/service/api_keys.rs
@@ -98,7 +98,8 @@ impl Wafv2Service {
             })
             .unwrap_or_default();
         all.sort_by(|a, b| a.api_key.cmp(&b.api_key));
-        let (page, next) = paginate(&all, next_marker.as_deref(), limit);
+        let (page, next) = paginate_checked(&all, next_marker.as_deref(), limit)
+            .map_err(|_| invalid_param("The specified NextMarker is not valid."))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|k| {

--- a/crates/fakecloud-wafv2/src/service/ip_sets.rs
+++ b/crates/fakecloud-wafv2/src/service/ip_sets.rs
@@ -87,7 +87,8 @@ impl Wafv2Service {
             })
             .unwrap_or_default();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_marker.as_deref(), limit);
+        let (page, next) = paginate_checked(&all, next_marker.as_deref(), limit)
+            .map_err(|_| invalid_param("The specified NextMarker is not valid."))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|s| {

--- a/crates/fakecloud-wafv2/src/service/mod.rs
+++ b/crates/fakecloud-wafv2/src/service/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use uuid::Uuid;
 
 use fakecloud_aws::arn::Arn;
-use fakecloud_core::pagination::paginate;
+use fakecloud_core::pagination::paginate_checked;
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceError};
 use fakecloud_persistence::SnapshotStore;
 

--- a/crates/fakecloud-wafv2/src/service/regex_pattern_sets.rs
+++ b/crates/fakecloud-wafv2/src/service/regex_pattern_sets.rs
@@ -106,7 +106,8 @@ impl Wafv2Service {
             })
             .unwrap_or_default();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_marker.as_deref(), limit);
+        let (page, next) = paginate_checked(&all, next_marker.as_deref(), limit)
+            .map_err(|_| invalid_param("The specified NextMarker is not valid."))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|s| {

--- a/crates/fakecloud-wafv2/src/service/rule_groups.rs
+++ b/crates/fakecloud-wafv2/src/service/rule_groups.rs
@@ -145,7 +145,8 @@ impl Wafv2Service {
             })
             .unwrap_or_default();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_marker.as_deref(), limit);
+        let (page, next) = paginate_checked(&all, next_marker.as_deref(), limit)
+            .map_err(|_| invalid_param("The specified NextMarker is not valid."))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|r| {

--- a/crates/fakecloud-wafv2/src/service/web_acls.rs
+++ b/crates/fakecloud-wafv2/src/service/web_acls.rs
@@ -146,7 +146,8 @@ impl Wafv2Service {
             })
             .unwrap_or_default();
         all.sort_by(|a, b| a.name.cmp(&b.name));
-        let (page, next) = paginate(&all, next_marker.as_deref(), limit);
+        let (page, next) = paginate_checked(&all, next_marker.as_deref(), limit)
+            .map_err(|_| invalid_param("The specified NextMarker is not valid."))?;
         let summaries: Vec<Value> = page
             .iter()
             .map(|a| {


### PR DESCRIPTION
Fixes a cluster of LOW-severity correctness divergences from real AWS, one per area. Each ships with regression tests.

## 1. core / pagination — bad NextToken no longer silently restarts (infinite-loop hazard)
`paginate()` treated an unparseable NextToken as offset 0, which can drive an infinite client loop. Changing its signature is too invasive (~200 callers), so the sanctioned fallback was taken: migrate the remaining unchecked list-op callers to the existing `paginate_checked` (which errors on a bad token). Migrated the documented stragglers — **application-autoscaling** (-> `InvalidNextTokenException`), **wafv2** (-> `WAFInvalidParameterException`), **glue** `paginate_body` + its 9 callers (-> `InvalidInputException`). All three already had `paginate_checked_rejects_invalid_token` test stubs / comments signalling an unfinished migration. `paginate()` gets a `#[must_use]` and a doc steering new callers to the checked variant.
- **eventbridge left as-is (verified false positive):** its list ops' Smithy models declare only `InternalException`; returning an invalid-token error would be an undeclared error that fails conformance shape validation. It has an explicit test (`list_event_buses_invalid_next_token_treated_as_first_page`) documenting the deliberate fall-back-to-first-page.

## 2. dynamodb — enforce the 38-significant-digit Number cap
Number attributes had no precision limit. Added `significant_digit_count` (trailing/leading zeros collapse into the exponent, so `1E38` = 1 significant digit) and enforce `<= 38` on `N` and `NS` members in `validate_attribute_value`, returning `ValidationException`.

## 3. cloudwatch — missing-data + DescribeAlarmsForMetric
- **(a)** `treatMissingData=missing` (the default) now transitions a stale alarm to `INSUFFICIENT_DATA` when its metric has no datapoints, instead of pinning the old OK/ALARM state. `ignore` still keeps state; `breaching`/`notBreaching` unchanged. A state forced via `SetAlarmState` is kept sticky (new `state_manually_set` flag) until real datapoints arrive, preserving the existing composite-alarm test utility.
- **(b)** `DescribeAlarmsForMetric` now re-evaluates alarms before returning (was serving stale stored state, unlike `DescribeAlarms`). The Dimensions filter was already correct (added in an earlier PR) — that half was a partial false positive; a test now covers both.

## 4. iam — 21-char unique IDs, consistently
`generate_id()` produced 16-char suffixes -> 20-char unique IDs; AWS principal unique IDs (AIDA/AROA/AGPA/ANPA/AIPA/ASCA) are a 4-char prefix + 17 = **21 chars**, and CreateRole (20) disagreed with service-linked roles (21). `generate_id()` now yields 17 chars; access-key-style IDs (FKIA/APKA), which are correctly 20 chars in AWS, slice back to 16. No conformance test pins the old 20-char length.

## 5. kinesis — reject cross-shard/invalid sequence numbers
`AT_/AFTER_SEQUENCE_NUMBER` with a below-horizon token silently resolved to trim horizon even when the token belonged to a different shard. Now the packed shard discriminator (first 5 digits of the 56-digit sequence number) must match this shard; a foreign/malformed token that merely sorts low raises `InvalidArgumentException`. A genuinely trimmed token from this shard still resolves to trim horizon.

## 6. route53 — list/delete/ordering fidelity
- **(a)** `StartRecordType` without `StartRecordName` -> `InvalidInput`.
- **(b)** DELETE now matches on TTL for standard records (omitting TTL is a mismatch, not a wildcard); alias records still ignore TTL, keyed on `alias_target`.
- **(c)** `reverse_dns_key` joins reversed labels with NUL (`0x00`) instead of `.` so an end-of-label sorts before every octet, matching RFC 4034 canonical ordering. The old `.` (`0x2E`) separator mis-ranked labels containing an octet below `.` (e.g. `-`), affecting common hostnames.

## Testing
- Touched-crate unit tests: **1545 passed** (new tests for every fix).
- Conformance: **kinesis** suite + **cloudwatch, dynamodb, iam, glue, wafv2, application_autoscaling, route53 (+ vpc/delegation)** = 217 tests, all pass.
- `cargo clippy -D warnings` clean on all touched crates; `cargo fmt --all --check` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple low-severity correctness gaps to better match AWS and prevent client-side loops. Tightens pagination errors, number precision, alarm evaluation, ID lengths, iterator validation, and Route 53 request/ordering rules.

- Bug Fixes
  - Pagination: reject malformed tokens instead of restarting at page 0 in `fakecloud-application-autoscaling`, `fakecloud-wafv2`, and `fakecloud-glue` (use `paginate_checked`); `fakecloud-core` `paginate()` is now `#[must_use]` and documented; EventBridge intentionally unchanged.
  - DynamoDB: enforce 38 significant digits for `N`/`NS` values; return `ValidationException`.
  - CloudWatch: with `treatMissingData=missing`, alarms with no datapoints become `INSUFFICIENT_DATA`; states set via `SetAlarmState` stay sticky until real datapoints arrive; `DescribeAlarmsForMetric` re-evaluates before returning.
  - IAM: principal unique IDs are now 21 chars (prefix + 17); access-key-style IDs remain 20 chars.
  - Kinesis: `AT_/AFTER_SEQUENCE_NUMBER` must use a sequence number minted by the shard; cross-shard or malformed tokens raise `InvalidArgumentException`; genuine below-horizon tokens resolve to trim horizon.
  - Route 53: `StartRecordType` without `StartRecordName` -> `InvalidInput`; DELETE of standard records requires matching TTL (aliases still ignore TTL); ordering uses reversed labels joined with NUL to match RFC 4034.

<sup>Written for commit 14a3a026c34b6f1e04bc6cef4c62367163d78de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

