### PR TITLE
fix(ecs,ec2,eventbridge,ssm): restart-reconcile persistence + PutRule tag preservation + SSM validation

### DIFF
--- a/crates/fakecloud-e2e/tests/eventbridge.rs
+++ b/crates/fakecloud-e2e/tests/eventbridge.rs
@@ -1418,7 +1418,8 @@ async fn eb_put_targets_full_field_roundtrip() {
         .id("full-target")
         .arn("arn:aws:sqs:us-east-1:123456789012:queue.fifo")
         .role_arn(target_role_arn)
-        .input_path("$.detail")
+        // InputPath / Input / InputTransformer are mutually exclusive on a Target
+        // (AWS returns a FailedEntry otherwise); this target exercises InputTransformer.
         .dead_letter_config(DeadLetterConfig::builder().arn(dlq_arn).build())
         .retry_policy(
             RetryPolicy::builder()
@@ -1560,7 +1561,8 @@ async fn eb_put_targets_full_field_roundtrip() {
     assert_eq!(got.id(), "full-target");
     assert_eq!(got.arn(), "arn:aws:sqs:us-east-1:123456789012:queue.fifo");
     assert_eq!(got.role_arn(), Some(target_role_arn));
-    assert_eq!(got.input_path(), Some("$.detail"));
+    // InputPath omitted: mutually exclusive with the InputTransformer this target sets.
+    assert_eq!(got.input_path(), None);
 
     let dlc = got.dead_letter_config().expect("dlc");
     assert_eq!(dlc.arn(), Some(dlq_arn));

--- a/crates/fakecloud-ec2/src/service/mod.rs
+++ b/crates/fakecloud-ec2/src/service/mod.rs
@@ -1225,6 +1225,8 @@ impl Ec2Service {
         {
             let runtime = runtime.clone();
             let state = self.state.clone();
+            let store = self.snapshot_store.clone();
+            let lock = self.snapshot_lock.clone();
             tokio::spawn(async move {
                 for h in handles {
                     let _ = h.await;
@@ -1232,6 +1234,14 @@ impl Ec2Service {
                 if runtime.network_isolation_enforced() {
                     firewall_model::reconcile(&state, &runtime).await;
                 }
+                // Persist the recovered fleet: each instance now carries a
+                // fresh container_id and a settled running/stopped state that
+                // the recovery loop wrote back in memory. Without this flush the
+                // snapshot still held the pre-restart container_ids (nulled at
+                // the top of this fn), so every restart re-drove recovery from
+                // stale data instead of reusing the freshly booted containers —
+                // unlike the RDS/ElastiCache siblings, which save after recover.
+                save_ec2_snapshot(&state, store, &lock).await;
             });
         }
     }
@@ -2836,5 +2846,118 @@ mod recover_guard_tests {
         let reap = apply_boot_failure(&mut row);
         assert!(!reap);
         assert_eq!(row.state_code, 80, "failed boot marks stopped");
+    }
+}
+
+#[cfg(test)]
+mod recover_persist_tests {
+    use super::*;
+    use crate::state::Instance;
+
+    /// Captures the last serialized snapshot (into a shared buffer the test also
+    /// holds) so a recovery flush is observable.
+    struct RecordingStore(Arc<std::sync::Mutex<Option<Vec<u8>>>>);
+    impl SnapshotStore for RecordingStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(None)
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.0.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    fn pending_instance(id: &str) -> Instance {
+        Instance {
+            instance_id: id.into(),
+            image_id: "ami-1".into(),
+            instance_type: "t3.micro".into(),
+            // state_code 0 == pending: a persisted mid-boot instance.
+            state_code: 0,
+            state_name: "pending".into(),
+            private_ip: "10.0.0.5".into(),
+            public_ip: None,
+            subnet_id: None,
+            vpc_id: Some("vpc-1".into()),
+            key_name: None,
+            security_group_ids: vec![],
+            reservation_id: "r-1".into(),
+            ami_launch_index: 0,
+            monitoring: false,
+            az: "us-east-1a".into(),
+            launch_time: "2024-01-01T00:00:00.000Z".into(),
+            container_id: None,
+            disable_api_termination: false,
+            disable_api_stop: false,
+            source_dest_check: true,
+            ebs_optimized: false,
+            instance_initiated_shutdown_behavior: "stop".into(),
+            user_data: None,
+            metadata_options: Default::default(),
+            cpu_options: None,
+            bandwidth_weighting: None,
+            maintenance_options: Default::default(),
+            placement_tenancy: None,
+            placement_affinity: None,
+            placement_group_name: None,
+            private_dns_hostname_type: None,
+            enable_resource_name_dns_a_record: false,
+            enable_resource_name_dns_aaaa_record: false,
+        }
+    }
+
+    /// Restart recovery must persist the recovered fleet, not just fix it in
+    /// memory. Exercised via the metadata-only recovery path (reachable without
+    /// a container runtime): a persisted `pending` instance is flipped to
+    /// `running` AND the snapshot is flushed so a subsequent restart doesn't
+    /// re-drive recovery from stale data. Same persist-after-recover guarantee
+    /// the runtime-backed path now honours.
+    #[tokio::test]
+    async fn recovery_persists_recovered_state() {
+        let recorded = Arc::new(std::sync::Mutex::new(None));
+        let svc = Ec2Service::new().with_snapshot_store(Arc::new(RecordingStore(recorded.clone())));
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state
+                .instances
+                .insert("i-1".into(), pending_instance("i-1"));
+        }
+
+        // No runtime wired -> metadata-only recovery, which flips pending
+        // instances to running and persists.
+        svc.recover_persisted_containers().await;
+
+        // In-memory state recovered to running.
+        {
+            let accounts = svc.state.read();
+            let inst = accounts
+                .get("000000000000")
+                .unwrap()
+                .instances
+                .get("i-1")
+                .unwrap();
+            assert_eq!(inst.state_code, 16);
+            assert_eq!(inst.state_name, "running");
+        }
+
+        // ...and that recovered state was flushed to the snapshot store.
+        let bytes = recorded
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("recovery should have flushed a snapshot");
+        let snap: crate::Ec2Snapshot = serde_json::from_slice(&bytes).unwrap();
+        let persisted = snap.accounts.expect("accounts present");
+        let inst = persisted
+            .get("000000000000")
+            .unwrap()
+            .instances
+            .get("i-1")
+            .unwrap();
+        assert_eq!(
+            inst.state_code, 16,
+            "persisted snapshot must reflect the recovered running state"
+        );
     }
 }

--- a/crates/fakecloud-ecs/src/runtime/k8s.rs
+++ b/crates/fakecloud-ecs/src/runtime/k8s.rs
@@ -252,6 +252,7 @@ impl EcsRuntime {
                     if !marked_running {
                         mark_running_multi(state, account_id, task_id, &started);
                         self.emit_state_change(state, account_id, task_id, "RUNNING", None);
+                        self.persist_snapshot().await;
                     }
                     return self
                         .k8s_finalize(
@@ -279,6 +280,7 @@ impl EcsRuntime {
                 mark_running_multi(state, account_id, task_id, &started);
                 self.register_lb_targets(state, account_id, task_id);
                 self.emit_state_change(state, account_id, task_id, "RUNNING", None);
+                self.persist_snapshot().await;
                 marked_running = true;
             }
 
@@ -389,6 +391,9 @@ impl EcsRuntime {
             "STOPPED",
             Some((final_stop_code, reason_msg)),
         );
+        // Persist the terminal STOPPED transition so a restart reflects the
+        // completed task instead of a stale RUNNING row.
+        self.persist_snapshot().await;
         Ok(())
     }
 }

--- a/crates/fakecloud-ecs/src/runtime/mod.rs
+++ b/crates/fakecloud-ecs/src/runtime/mod.rs
@@ -77,6 +77,17 @@ pub struct EcsRuntime {
     /// each task to a Pod instead of `docker run`. `None` is the default
     /// Docker/Podman backend, and the fields above drive it.
     k8s: Option<k8s::K8sTaskBackend>,
+    /// Persist hook wired after the owning `EcsService` is built (the store is
+    /// only known then). Runtime state transitions — PENDING->RUNNING via
+    /// `mark_running_multi`, and the stop/exit finalizers — mutate the shared
+    /// state in the background but did not previously flush to disk, so the
+    /// snapshot lagged live task status until the next control-plane write.
+    /// `reconcile_persisted_tasks` compensated on restart, but a task that ran
+    /// and stopped between restarts could still be mis-reported. Set via
+    /// [`EcsRuntime::set_snapshot_hook`] and invoked by
+    /// [`EcsRuntime::persist_snapshot`]. A `OnceLock` so the `Arc<EcsRuntime>`
+    /// can receive the hook through a shared reference after construction.
+    snapshot_hook: std::sync::OnceLock<fakecloud_persistence::SnapshotHook>,
 }
 
 mod config;
@@ -106,6 +117,7 @@ impl EcsRuntime {
             secretsmanager_state: None,
             ssm_state: None,
             k8s: None,
+            snapshot_hook: std::sync::OnceLock::new(),
         })
     }
 
@@ -132,6 +144,7 @@ impl EcsRuntime {
             secretsmanager_state: None,
             ssm_state: None,
             k8s: Some(backend),
+            snapshot_hook: std::sync::OnceLock::new(),
         })
     }
 
@@ -164,6 +177,25 @@ impl EcsRuntime {
     pub fn with_logs(mut self, logs: SharedLogsState) -> Self {
         self.logs_state = Some(logs);
         self
+    }
+
+    /// Wire the persistence hook that flushes the ECS snapshot to disk. Called
+    /// once, after the owning `EcsService` (which owns the snapshot store) is
+    /// constructed — hence a `&self` setter over a `OnceLock` rather than a
+    /// consuming builder, since the runtime is already behind an `Arc` by then.
+    /// A no-op in memory mode (the service hands back `None`, so this is never
+    /// called). Subsequent calls are ignored.
+    pub fn set_snapshot_hook(&self, hook: fakecloud_persistence::SnapshotHook) {
+        let _ = self.snapshot_hook.set(hook);
+    }
+
+    /// Persist the current ECS state through the wired snapshot hook, if any.
+    /// Invoked after each background task state transition so a restart sees
+    /// the latest task status without relying solely on restart reconciliation.
+    pub(crate) async fn persist_snapshot(&self) {
+        if let Some(hook) = self.snapshot_hook.get() {
+            hook().await;
+        }
     }
 }
 
@@ -1952,6 +1984,90 @@ mod tests {
             task.captured_logs.starts_with("[task failed to start]:"),
             "captured_logs missing prefix: {:?}",
             task.captured_logs
+        );
+    }
+
+    /// Records the last serialized snapshot so tests can assert what a runtime
+    /// state transition flushed to disk.
+    struct RecordingStore(Arc<std::sync::Mutex<Option<Vec<u8>>>>);
+    impl fakecloud_persistence::SnapshotStore for RecordingStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(None)
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.0.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    fn bare_runtime() -> EcsRuntime {
+        EcsRuntime {
+            cli: String::new(),
+            net: fakecloud_core::container_net::HostNetworking {
+                host_alias: String::new(),
+                add_host_arg: None,
+                sibling_host: String::new(),
+            },
+            server_port: 0,
+            docker_config: None,
+            containers: RwLock::new(std::collections::HashMap::new()),
+            delivery_bus: None,
+            logs_state: None,
+            secretsmanager_state: None,
+            ssm_state: None,
+            k8s: None,
+            snapshot_hook: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// The PENDING->RUNNING transition (`mark_running_multi`) must be flushed
+    /// through the runtime's persistence hook so a restart sees RUNNING without
+    /// relying solely on restart reconciliation. Regression for the Tier-4
+    /// bug-hunt finding that runtime transitions never called the snapshot.
+    #[tokio::test]
+    async fn running_transition_persists_snapshot() {
+        let mut accounts: MultiAccountState<EcsState> =
+            MultiAccountState::new("000000000000", "us-east-1", "http://localhost:4566");
+        let acct = accounts.get_or_create("000000000000");
+        acct.tasks.insert("t1".into(), make_task("t1"));
+        let state: SharedEcsState = Arc::new(RwLock::new(accounts));
+
+        // Build the production persistence hook backed by a recording store.
+        let recorded = Arc::new(std::sync::Mutex::new(None));
+        let store: Arc<dyn fakecloud_persistence::SnapshotStore> =
+            Arc::new(RecordingStore(recorded.clone()));
+        let hook = crate::service::EcsService::new(state.clone())
+            .with_snapshot_store(store)
+            .snapshot_hook()
+            .expect("hook present when a store is wired");
+
+        let rt = bare_runtime();
+        rt.set_snapshot_hook(hook);
+
+        // Nothing persisted before the transition.
+        assert!(recorded.lock().unwrap().is_none());
+
+        // Drive the PENDING->RUNNING transition + persist, exactly as
+        // run_task_inner does after launching containers.
+        mark_running_multi(&state, "000000000000", "t1", &[]);
+        rt.persist_snapshot().await;
+
+        let bytes = recorded
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("running transition should have flushed a snapshot");
+        let snap: crate::EcsSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let persisted = snap.accounts.expect("accounts present");
+        let task = persisted
+            .get("000000000000")
+            .unwrap()
+            .tasks
+            .get("t1")
+            .unwrap();
+        assert_eq!(
+            task.last_status, "RUNNING",
+            "persisted snapshot must reflect the RUNNING transition"
         );
     }
 

--- a/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
+++ b/crates/fakecloud-ecs/src/runtime/task_lifecycle.rs
@@ -23,6 +23,9 @@ impl EcsRuntime {
                     "STOPPED",
                     Some(("TaskFailedToStart", err.to_string())),
                 );
+                // Persist the STOPPED/failed transition so a restart sees the
+                // terminal status instead of a stale PENDING/RUNNING row.
+                rt.persist_snapshot().await;
             }
         });
     }
@@ -394,12 +397,16 @@ impl EcsRuntime {
                 "STOPPED",
                 Some(("UserInitiated", "Task stopped during launch".into())),
             );
+            self.persist_snapshot().await;
             return Ok(());
         }
 
         mark_running_multi(state, account_id, task_id, &started);
         self.register_lb_targets(state, account_id, task_id);
         self.emit_state_change(state, account_id, task_id, "RUNNING", None);
+        // Persist the PENDING->RUNNING transition so DescribeTasks reports
+        // RUNNING after a restart without waiting on restart reconciliation.
+        self.persist_snapshot().await;
 
         // Wait for the first essential container (or, if none are
         // essential, any container) to exit. ECS task lifetime is
@@ -540,6 +547,9 @@ impl EcsRuntime {
             "STOPPED",
             Some((wait_outcome.stop_code, format!("Exit code {}", exit_code))),
         );
+        // Persist the terminal STOPPED transition + captured exit codes so a
+        // restart reflects the completed task instead of a stale RUNNING row.
+        self.persist_snapshot().await;
         Ok(())
     }
 

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -720,13 +720,34 @@ impl EventBridgeService {
         };
 
         let key = (event_bus_name.clone(), name.clone());
-        let targets = state
+        // Preserve the mutable bookkeeping that PutRule must NOT clobber when it
+        // updates an existing rule: attached targets, tags, and the internal
+        // managed_by/created_by markers. Real AWS PutRule updates the rule's
+        // definition fields (pattern/schedule/state/etc.) but leaves targets
+        // attached and leaves tags untouched unless the request carries Tags
+        // (tags are otherwise managed via TagResource/UntagResource).
+        let (targets, existing_tags, existing_managed_by, existing_created_by) = state
             .rules
             .get(&key)
-            .map(|r| r.targets.clone())
+            .map(|r| {
+                (
+                    r.targets.clone(),
+                    r.tags.clone(),
+                    r.managed_by.clone(),
+                    r.created_by.clone(),
+                )
+            })
             .unwrap_or_default();
 
-        let tags = parse_tags(&body);
+        // Only replace tags when the request explicitly supplies a Tags array.
+        // A PutRule that omits Tags preserves whatever was already attached;
+        // previously this always overwrote tags with an empty map, silently
+        // dropping tags on every update.
+        let tags = if body.get("Tags").map(|t| t.is_array()).unwrap_or(false) {
+            parse_tags(&body)
+        } else {
+            existing_tags
+        };
 
         let rule = EventRule {
             name: name.clone(),
@@ -737,8 +758,8 @@ impl EventBridgeService {
             state: rule_state,
             description,
             role_arn,
-            managed_by: None,
-            created_by: None,
+            managed_by: existing_managed_by,
+            created_by: existing_created_by,
             targets,
             tags,
             last_fired: None,
@@ -1032,6 +1053,28 @@ impl EventBridgeService {
                     "ErrorCode": "ValidationException",
                     "ErrorMessage": format!(
                         "Parameter {target_arn} is not valid. Reason: Provided Arn is not in correct format."
+                    ),
+                }));
+                continue;
+            }
+
+            // Input, InputPath, and InputTransformer are mutually exclusive on a
+            // single target. AWS surfaces a violation as a per-entry
+            // FailedEntry (not a top-level ValidationException), which
+            // increments FailedEntryCount. Previously all three were accepted
+            // silently, letting a malformed target through and under-reporting
+            // the failed count.
+            let input_fields = ["Input", "InputPath", "InputTransformer"]
+                .iter()
+                .filter(|k| !target[**k].is_null())
+                .count();
+            if input_fields > 1 {
+                failed_entries.push(json!({
+                    "TargetId": target_id,
+                    "ErrorCode": "ValidationException",
+                    "ErrorMessage": format!(
+                        "Only one of Input, InputPath, or InputTransformer can be \
+                         specified for target: {target_id}."
                     ),
                 }));
                 continue;

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2028,6 +2028,156 @@ fn put_rule_persists_event_pattern_and_state() {
 }
 
 #[test]
+fn put_rule_without_tags_preserves_existing_tags() {
+    let svc = make_service();
+    // Create the rule WITH tags.
+    let create = make_request(
+        "PutRule",
+        json!({
+            "Name": "tagged",
+            "EventPattern": r#"{"source":["a"]}"#,
+            "Tags": [{"Key": "team", "Value": "platform"}]
+        }),
+    );
+    svc.put_rule(&create).unwrap();
+
+    let rule_arn = {
+        let _mas = svc.state.read();
+        let state = _mas.default_ref();
+        state
+            .rules
+            .get(&("default".to_string(), "tagged".to_string()))
+            .unwrap()
+            .arn
+            .clone()
+    };
+
+    // Update the rule WITHOUT Tags — must not wipe the existing tag.
+    let update = make_request(
+        "PutRule",
+        json!({
+            "Name": "tagged",
+            "EventPattern": r#"{"source":["b"]}"#,
+            "State": "DISABLED"
+        }),
+    );
+    svc.put_rule(&update).unwrap();
+
+    let resp = svc
+        .list_tags_for_resource(&make_request(
+            "ListTagsForResource",
+            json!({ "ResourceARN": rule_arn }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let tags = body["Tags"].as_array().unwrap();
+    assert_eq!(
+        tags.len(),
+        1,
+        "existing tag must survive a PutRule without Tags"
+    );
+    assert_eq!(tags[0]["Key"], json!("team"));
+    assert_eq!(tags[0]["Value"], json!("platform"));
+
+    // And the definition update still took effect.
+    let _mas = svc.state.read();
+    let state = _mas.default_ref();
+    let rule = state
+        .rules
+        .get(&("default".to_string(), "tagged".to_string()))
+        .unwrap();
+    assert_eq!(rule.state, "DISABLED");
+    assert_eq!(rule.event_pattern.as_deref(), Some(r#"{"source":["b"]}"#));
+}
+
+#[test]
+fn put_rule_with_tags_replaces_tags() {
+    let svc = make_service();
+    let create = make_request(
+        "PutRule",
+        json!({
+            "Name": "tagged2",
+            "EventPattern": r#"{"source":["a"]}"#,
+            "Tags": [{"Key": "team", "Value": "platform"}]
+        }),
+    );
+    svc.put_rule(&create).unwrap();
+    let update = make_request(
+        "PutRule",
+        json!({
+            "Name": "tagged2",
+            "EventPattern": r#"{"source":["a"]}"#,
+            "Tags": [{"Key": "env", "Value": "prod"}]
+        }),
+    );
+    svc.put_rule(&update).unwrap();
+
+    let _mas = svc.state.read();
+    let state = _mas.default_ref();
+    let rule = state
+        .rules
+        .get(&("default".to_string(), "tagged2".to_string()))
+        .unwrap();
+    assert_eq!(rule.tags.get("env").map(String::as_str), Some("prod"));
+    assert_eq!(rule.tags.get("team"), None);
+}
+
+#[test]
+fn put_targets_rejects_input_and_input_path_together() {
+    let svc = make_service();
+    put_rule_simple(&svc, "r_excl");
+    let req = make_request(
+        "PutTargets",
+        json!({
+            "Rule": "r_excl",
+            "Targets": [{
+                "Id": "t1",
+                "Arn": "arn:aws:lambda:us-east-1:123456789012:function:fn",
+                "Input": "{}",
+                "InputPath": "$.detail"
+            }]
+        }),
+    );
+    let resp = svc.put_targets(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["FailedEntryCount"], json!(1));
+    assert_eq!(body["FailedEntries"][0]["TargetId"], json!("t1"));
+    assert_eq!(
+        body["FailedEntries"][0]["ErrorCode"],
+        json!("ValidationException")
+    );
+
+    // The malformed target must NOT have been attached to the rule.
+    let _mas = svc.state.read();
+    let state = _mas.default_ref();
+    let rule = state
+        .rules
+        .get(&("default".to_string(), "r_excl".to_string()))
+        .unwrap();
+    assert!(rule.targets.is_empty());
+}
+
+#[test]
+fn put_targets_accepts_single_input_field() {
+    let svc = make_service();
+    put_rule_simple(&svc, "r_ok");
+    let req = make_request(
+        "PutTargets",
+        json!({
+            "Rule": "r_ok",
+            "Targets": [{
+                "Id": "t1",
+                "Arn": "arn:aws:lambda:us-east-1:123456789012:function:fn",
+                "InputPath": "$.detail"
+            }]
+        }),
+    );
+    let resp = svc.put_targets(&req).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["FailedEntryCount"], json!(0));
+}
+
+#[test]
 fn put_rule_accepts_schedule_on_non_default_bus() {
     // PutRule's Smithy model does not declare ValidationException; we accept
     // a ScheduleExpression on a non-default bus rather than rejecting it

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3344,6 +3344,14 @@ async fn main() {
     // scheduler ticker brings services back to desiredCount. Same
     // restart-bug class as RDS #1338.
     ecs_service.reconcile_persisted_tasks().await;
+    // Wire the persistence hook into the task runtime so background task state
+    // transitions (PENDING->RUNNING, exit/stop finalizers) flush the snapshot
+    // to disk. The store is only known here (after the service is built), and
+    // the runtime is already behind an Arc, so we hand it the hook by shared
+    // reference. No-op in memory mode (snapshot_hook() returns None).
+    if let (Some(rt), Some(hook)) = (ecs_runtime.as_ref(), ecs_service.snapshot_hook()) {
+        rt.set_snapshot_hook(hook);
+    }
     let ecs_service = Arc::new(ecs_service);
     let ecs_service_for_scheduler = ecs_service.clone();
     // ECS desiredCount scheduler ticker. reconcile_persisted_tasks STOPs all

--- a/crates/fakecloud-ssm/src/service/parameters.rs
+++ b/crates/fakecloud-ssm/src/service/parameters.rs
@@ -518,6 +518,21 @@ impl PutParameterInput {
         let tier_explicit = body["Tier"].as_str().is_some();
         let tier = body["Tier"].as_str().unwrap_or("Standard").to_string();
 
+        // Tier must be one of the AWS-documented values. An unrecognised tier
+        // (e.g. "advanced" lower-case, or a typo) is rejected up front rather
+        // than being silently stored — AWS returns a ValidationException.
+        if !["Standard", "Advanced", "Intelligent-Tiering"].contains(&tier.as_str()) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "1 validation error detected: Value '{tier}' at 'tier' failed to \
+                     satisfy constraint: Member must satisfy enum value set: \
+                     [Standard, Advanced, Intelligent-Tiering]"
+                ),
+            ));
+        }
+
         // Parse + validate the Policies JSON up front so PutParameter
         // can return InvalidPolicyAttributeException without touching
         // state. Empty/absent Policies -> empty list -> no-op.
@@ -760,6 +775,30 @@ impl SsmService {
                 Some(e) if !input.tier_explicit => e.tier.clone(),
                 _ => input.tier.clone(),
             };
+            // Enforce the per-tier value-size limit: Standard caps at 4KB,
+            // Advanced at 8KB. Intelligent-Tiering auto-upgrades to Advanced
+            // once the value exceeds 4KB, so its effective ceiling is also 8KB.
+            // The check runs against the plaintext value (SecureString values
+            // are encrypted only later), matching AWS which rejects an
+            // oversized value before storing it.
+            let value_limit = match effective_tier.as_str() {
+                "Advanced" | "Intelligent-Tiering" => 8192,
+                _ => 4096,
+            };
+            if input.value.len() > value_limit {
+                return Err(remap_validation_to(
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ValidationException",
+                        format!(
+                            "1 validation error detected: Value at 'value' failed to \
+                             satisfy constraint: Member must have length less than or \
+                             equal to {value_limit}"
+                        ),
+                    ),
+                    "InvalidAllowedPatternException",
+                ));
+            }
             let policies_present = match input.policies.as_deref() {
                 Some(s) => !s.trim().is_empty(),
                 None => existing
@@ -1320,21 +1359,37 @@ impl SsmService {
         let recursive = body["Recursive"].as_bool().unwrap_or(false);
         let with_decryption = body["WithDecryption"].as_bool().unwrap_or(false);
         let filters = body["ParameterFilters"].as_array().cloned();
-        let max_results = body["MaxResults"].as_i64().unwrap_or(10) as usize;
 
-        // Validate MaxResults
-        if max_results > 10 {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidFilterValue",
-                format!(
-                    "1 validation error detected: \
-                     Value {} at 'maxResults' failed to satisfy constraint: \
-                     Member must have value less than or equal to 10",
-                    max_results
-                ),
-            ));
-        }
+        // Validate MaxResults. AWS constrains it to 1..=10 for
+        // GetParametersByPath: a value of 0 (or negative) is rejected with the
+        // greater-than-or-equal-to-1 constraint, and anything above 10 with the
+        // less-than-or-equal-to-10 constraint. Absent -> default 10.
+        let max_results = match body["MaxResults"].as_i64() {
+            Some(n) if n < 1 => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidFilterValue",
+                    format!(
+                        "1 validation error detected: \
+                         Value {n} at 'maxResults' failed to satisfy constraint: \
+                         Member must have value greater than or equal to 1"
+                    ),
+                ));
+            }
+            Some(n) if n > 10 => {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidFilterValue",
+                    format!(
+                        "1 validation error detected: \
+                         Value {n} at 'maxResults' failed to satisfy constraint: \
+                         Member must have value less than or equal to 10"
+                    ),
+                ));
+            }
+            Some(n) => n as usize,
+            None => 10,
+        };
 
         // Validate path
         if !is_valid_param_path(path) {
@@ -2249,8 +2304,11 @@ pub(super) fn validate_parameter_filters(filters: &[Value]) -> Result<(), AwsSer
         }
 
         if key == "Name" {
+            // AWS only accepts BeginsWith / Equals for the Name key on
+            // DescribeParameters. Contains is valid for GetParametersByPath's
+            // path traversal but NOT here, so reject it.
             if let Some(opt) = option {
-                if !["BeginsWith", "Equals", "Contains"].contains(&opt) {
+                if !["BeginsWith", "Equals"].contains(&opt) {
                     return Err(AwsServiceError::aws_error(
                         StatusCode::BAD_REQUEST,
                         "ValidationException",

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -2493,6 +2493,132 @@ fn put_parameter_overwrite_bumps_version() {
 }
 
 #[test]
+fn put_parameter_rejects_invalid_tier() {
+    let svc = make_service();
+    let req = make_request(
+        "PutParameter",
+        json!({ "Name": "/a", "Value": "v", "Type": "String", "Tier": "Premium" }),
+    );
+    let err = svc.put_parameter(&req).err().expect("expected error");
+    // PutParameter remaps ValidationException to the declared shape.
+    assert_eq!(err.code(), "InvalidAllowedPatternException");
+    assert!(err
+        .message()
+        .contains("Standard, Advanced, Intelligent-Tiering"));
+}
+
+#[test]
+fn put_parameter_accepts_valid_tiers() {
+    let svc = make_service();
+    for (i, tier) in ["Standard", "Advanced", "Intelligent-Tiering"]
+        .iter()
+        .enumerate()
+    {
+        let req = make_request(
+            "PutParameter",
+            json!({ "Name": format!("/tier/{i}"), "Value": "v", "Type": "String", "Tier": tier }),
+        );
+        svc.put_parameter(&req)
+            .unwrap_or_else(|e| panic!("tier {tier}: {e:?}"));
+    }
+}
+
+#[test]
+fn put_parameter_rejects_standard_value_over_4kb() {
+    let svc = make_service();
+    let big = "x".repeat(4097);
+    let req = make_request(
+        "PutParameter",
+        json!({ "Name": "/big", "Value": big, "Type": "String" }),
+    );
+    let err = svc.put_parameter(&req).err().expect("expected error");
+    assert_eq!(err.code(), "InvalidAllowedPatternException");
+    assert!(err.message().contains("4096"));
+}
+
+#[test]
+fn put_parameter_advanced_allows_up_to_8kb() {
+    let svc = make_service();
+    // 6KB value: too big for Standard (4KB) but fine for Advanced (8KB).
+    let mid = "x".repeat(6000);
+    let req = make_request(
+        "PutParameter",
+        json!({ "Name": "/adv", "Value": mid, "Type": "String", "Tier": "Advanced" }),
+    );
+    svc.put_parameter(&req)
+        .expect("advanced 6KB value should be accepted");
+
+    // ...but 9KB exceeds even the Advanced ceiling.
+    let too_big = "x".repeat(8193);
+    let req = make_request(
+        "PutParameter",
+        json!({ "Name": "/adv2", "Value": too_big, "Type": "String", "Tier": "Advanced" }),
+    );
+    let err = svc.put_parameter(&req).err().expect("expected error");
+    assert_eq!(err.code(), "InvalidAllowedPatternException");
+    assert!(err.message().contains("8192"));
+}
+
+#[test]
+fn describe_parameters_rejects_contains_on_name() {
+    let svc = make_service();
+    let req = make_request(
+        "DescribeParameters",
+        json!({
+            "ParameterFilters": [
+                { "Key": "Name", "Option": "Contains", "Values": ["db"] }
+            ]
+        }),
+    );
+    let err = svc.describe_parameters(&req).err().expect("expected error");
+    assert_eq!(err.code(), "InvalidFilterKey");
+    assert!(err.message().contains("BeginsWith, Equals"));
+}
+
+#[test]
+fn describe_parameters_accepts_beginswith_and_equals_on_name() {
+    let svc = make_service();
+    for opt in ["BeginsWith", "Equals"] {
+        let req = make_request(
+            "DescribeParameters",
+            json!({
+                "ParameterFilters": [
+                    { "Key": "Name", "Option": opt, "Values": ["/a"] }
+                ]
+            }),
+        );
+        svc.describe_parameters(&req)
+            .unwrap_or_else(|e| panic!("option {opt}: {e:?}"));
+    }
+}
+
+#[test]
+fn get_parameters_by_path_rejects_max_results_zero() {
+    let svc = make_service();
+    let req = make_request(
+        "GetParametersByPath",
+        json!({ "Path": "/app", "MaxResults": 0 }),
+    );
+    let err = svc
+        .get_parameters_by_path(&req)
+        .err()
+        .expect("expected error");
+    assert_eq!(err.code(), "InvalidFilterValue");
+    assert!(err.message().contains("greater than or equal to 1"));
+}
+
+#[test]
+fn get_parameters_by_path_accepts_max_results_in_range() {
+    let svc = make_service();
+    let req = make_request(
+        "GetParametersByPath",
+        json!({ "Path": "/app", "MaxResults": 10 }),
+    );
+    svc.get_parameters_by_path(&req)
+        .expect("MaxResults=10 is valid");
+}
+
+#[test]
 fn get_parameter_returns_latest_version() {
     let svc = make_service();
     put_simple_string(&svc, "/a", "v1");
@@ -4016,7 +4142,11 @@ fn describe_parameters_name_begins_with_filter() {
 }
 
 #[test]
-fn describe_parameters_name_contains_filter() {
+fn describe_parameters_name_contains_filter_rejected() {
+    // AWS rejects the Contains option for the Name key on DescribeParameters:
+    // only BeginsWith / Equals are valid there (Contains is a
+    // GetParametersByPath concept). This previously accepted Contains and
+    // silently substring-matched, which no real AWS caller can rely on.
     let svc = make_service();
     for name in &["/app/db", "/system/app", "/misc/x"] {
         svc.put_parameter(&make_request(
@@ -4033,10 +4163,8 @@ fn describe_parameters_name_contains_filter() {
             ]
         }),
     );
-    let resp = svc.describe_parameters(&req).unwrap();
-    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
-    let params = body["Parameters"].as_array().unwrap();
-    assert_eq!(params.len(), 2);
+    let err = svc.describe_parameters(&req).err().expect("expected error");
+    assert_eq!(err.code(), "InvalidFilterKey");
 }
 
 #[test]


### PR DESCRIPTION
Fixes a batch of Tier-4 (restart-recovery/persistence) LOW findings plus two LOW correctness items across four disjoint crates.

## 1. ECS — runtime state transitions now persist (`fakecloud-ecs`)
`mark_running_multi` (PENDING->RUNNING) and the stop/exit/failure finalizers mutate shared task state in the background but never flushed the snapshot, so the on-disk snapshot lagged live status. `reconcile_persisted_tasks` compensated on restart, but the gap was real (a task that ran and stopped between restarts could be mis-reported).

- `EcsRuntime` gains a `snapshot_hook` (a `OnceLock<SnapshotHook>` set via `set_snapshot_hook`, since the runtime is already behind an `Arc` when the store becomes known) + a `persist_snapshot()` helper.
- `persist_snapshot().await` is called after every background transition in both the Docker and k8s paths (RUNNING, terminal STOPPED, race-stop, and TaskFailedToStart).
- Wired in `main.rs` after the `EcsService` is built.

## 2. EC2 — recovery now persists the recovered fleet (`fakecloud-ec2`)
`recover_persisted_containers` nulled each instance's `container_id` and re-drove recovery every restart without saving, unlike the RDS/ElastiCache siblings. Now saves the snapshot after the recovery tasks complete + firewall reconcile, so recovered `container_id`/state survive.

## 3. EventBridge — PutRule preserves tags + managed_by/created_by (`fakecloud-eventbridge`)
PutRule on an existing rule always overwrote tags with an empty map and reset `managed_by`/`created_by` to `None`. Now it preserves existing tags/markers when the request omits `Tags`, and only replaces tags when a `Tags` array is supplied (AWS-correct). Also added per-entry `Input`/`InputPath`/`InputTransformer` mutual-exclusivity validation to PutTargets (surfaced as a per-entry `FailedEntry`, matching AWS), which previously under-reported `FailedEntryCount`.

## 4. SSM — parameter validation gaps (`fakecloud-ssm`)
- **Tier** enum validated (Standard / Advanced / Intelligent-Tiering only).
- **Value size** enforced per effective tier (Standard 4KB / Advanced/Intelligent-Tiering 8KB) -> ValidationException.
- **DescribeParameters** rejects `Contains` on the `Name` key (only BeginsWith/Equals valid there).
- **GetParametersByPath** rejects `MaxResults` < 1 (was only capping the upper bound at 10).

## Tests
- New regression tests in each crate (ECS runtime persist, EC2 recovery persist, EventBridge tag-preservation + PutTargets exclusivity, SSM tier/size/Name-Contains/MaxResults). An existing SSM test that encoded the Name-Contains bug was updated to assert the AWS-correct rejection.
- Full-workspace `cargo build --all-targets`, `clippy --workspace --all-targets -D warnings`, and `fmt --all --check` all clean.
- Conformance: `cargo nextest run -p fakecloud-conformance` for ssm/ecs/ec2/eventbridge — 926 passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves restart persistence and correctness across ECS, EC2, EventBridge, and SSM. Tasks and instances keep accurate state across restarts, EventBridge updates no longer drop tags, and SSM enforces tier and value-size rules.

- **Bug Fixes**
  - `fakecloud-ecs`: Persist snapshots after PENDING->RUNNING and STOPPED transitions via a runtime snapshot hook; wired in `fakecloud-server` at startup.
  - `fakecloud-ec2`: Persist the recovered fleet after recovery and firewall reconcile so `container_id` and state survive restarts.
  - `fakecloud-eventbridge`: `PutRule` preserves existing tags and `managed_by`/`created_by` when `Tags` is omitted; `PutTargets` rejects multiple input fields (`Input`, `InputPath`, `InputTransformer`) with per-entry `FailedEntry`; updated `fakecloud-e2e` target roundtrip to drop `InputPath` when `InputTransformer` is set.
  - `fakecloud-ssm`: Validate `Tier` (`Standard`, `Advanced`, `Intelligent-Tiering`); enforce value size limits (Standard 4KB, Advanced/Intelligent-Tiering 8KB); `DescribeParameters` rejects `Name` + `Contains`; `GetParametersByPath` enforces `MaxResults` 1..10.

<sup>Written for commit 2e3470b6105dfab9ce23b732d4af8acf88c26e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

