### PR TITLE
feat(rds): support postgres 17.x in the engine-version matrix

### DIFF
--- a/.github/workflows/docker-rds-images.yml
+++ b/.github/workflows/docker-rds-images.yml
@@ -49,6 +49,7 @@ jobs:
           - { engine: postgres, version: "14", build_arg: "PG_VERSION" }
           - { engine: postgres, version: "15", build_arg: "PG_VERSION" }
           - { engine: postgres, version: "16", build_arg: "PG_VERSION" }
+          - { engine: postgres, version: "17", build_arg: "PG_VERSION" }
           # MySQL majors. 5.7 is excluded — Oracle ended community
           # support in October 2023 and the image base no longer ships
           # the build deps we'd need to compile the UDF.
@@ -133,6 +134,7 @@ jobs:
           - { engine: postgres, version: "14" }
           - { engine: postgres, version: "15" }
           - { engine: postgres, version: "16" }
+          - { engine: postgres, version: "17" }
           - { engine: mysql, version: "8.0" }
           - { engine: mariadb, version: "10.6" }
           - { engine: mariadb, version: "10.11" }
@@ -223,6 +225,7 @@ jobs:
           - { engine: postgres, version: "14" }
           - { engine: postgres, version: "15" }
           - { engine: postgres, version: "16" }
+          - { engine: postgres, version: "17" }
           - { engine: mysql, version: "8.0" }
           - { engine: mariadb, version: "10.6" }
           - { engine: mariadb, version: "10.11" }

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -16,9 +16,10 @@ async fn rds_describe_db_engine_versions() {
         .unwrap();
 
     let versions = response.db_engine_versions();
-    assert_eq!(versions.len(), 4); // All postgres versions
+    assert_eq!(versions.len(), 5); // All postgres versions
     assert!(versions.iter().all(|v| v.engine() == Some("postgres")));
     assert!(versions.iter().any(|v| v.engine_version() == Some("16.3")));
+    assert!(versions.iter().any(|v| v.engine_version() == Some("17.4")));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -400,7 +400,9 @@ pub(crate) fn validate_create_request(
     // full `<major>.<minor>.<patch>` triplets — AWS RDS validates both
     // forms and the runtime resolves the matching prebuilt image regardless.
     let supported_versions = match engine {
-        "postgres" => vec!["16", "15", "14", "13", "16.3", "15.5", "14.10", "13.13"],
+        "postgres" => vec![
+            "17", "16", "15", "14", "13", "17.4", "16.3", "15.5", "14.10", "13.13",
+        ],
         "mysql" => vec!["8.0", "8.0.35", "8.0.28", "5.7.44"],
         "mariadb" => vec!["10.6", "10.11", "11.4", "11.4.5", "10.11.6", "10.6.16"],
         "oracle-ee" | "oracle-se2" | "oracle-ee-cdb" | "oracle-se2-cdb" => {

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -90,6 +90,16 @@ fn validate_create_request_accepts_new_engines() {
 }
 
 #[test]
+fn validate_create_request_accepts_postgres_17() {
+    // Regression for #2352: real AWS RDS offers postgres 17.x. Both the
+    // major ("17") and full-triplet ("17.4") forms must validate.
+    for version in ["17", "17.4"] {
+        validate_create_request("test-db", 20, "db.t3.micro", "postgres", version, 5432)
+            .unwrap_or_else(|e| panic!("postgres {version} should be accepted: {e:?}"));
+    }
+}
+
+#[test]
 fn validate_create_request_rejects_unsupported_engine_version() {
     let err = validate_create_request("test-db", 20, "db.t3.micro", "oracle-ee", "12.0.0", 1521)
         .expect_err("12.x is not in the supported list");
@@ -103,7 +113,7 @@ fn filter_engine_versions_matches_requested_engine() {
 
     let filtered = filter_engine_versions(&versions, &Some("postgres".to_string()), &None, &None);
 
-    assert_eq!(filtered.len(), 4); // All postgres versions
+    assert_eq!(filtered.len(), 5); // All postgres versions
     assert!(filtered.iter().all(|v| v.engine == "postgres"));
 }
 

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -702,6 +702,14 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
         // PostgreSQL versions
         EngineVersionInfo {
             engine: "postgres".to_string(),
+            engine_version: "17.4".to_string(),
+            db_parameter_group_family: "postgres17".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 17.4".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),
             db_parameter_group_family: "postgres16".to_string(),
             db_engine_description: "PostgreSQL".to_string(),
@@ -788,6 +796,7 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
 pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
     let mut options = Vec::new();
     let engines_and_versions = vec![
+        ("postgres", "17.4", "postgresql-license"),
         ("postgres", "16.3", "postgresql-license"),
         ("postgres", "15.5", "postgresql-license"),
         ("postgres", "14.10", "postgresql-license"),
@@ -824,6 +833,7 @@ pub fn default_parameter_groups(
     let mut groups = BTreeMap::new();
 
     let families = vec![
+        ("postgres17", "Default parameter group for postgres17"),
         ("postgres16", "Default parameter group for postgres16"),
         ("postgres15", "Default parameter group for postgres15"),
         ("postgres14", "Default parameter group for postgres14"),
@@ -1024,11 +1034,11 @@ mod tests {
     fn default_engine_versions_are_postgres_metadata() {
         let versions = default_engine_versions();
 
-        assert_eq!(versions.len(), 10); // 4 postgres + 3 mysql + 3 mariadb
-                                        // Check first postgres version
+        assert_eq!(versions.len(), 11); // 5 postgres + 3 mysql + 3 mariadb
+                                        // Check first (newest) postgres version
         assert_eq!(versions[0].engine, "postgres");
-        assert_eq!(versions[0].engine_version, "16.3");
-        assert_eq!(versions[0].db_parameter_group_family, "postgres16");
+        assert_eq!(versions[0].engine_version, "17.4");
+        assert_eq!(versions[0].db_parameter_group_family, "postgres17");
     }
 
     #[test]
@@ -1036,7 +1046,7 @@ mod tests {
         let versions = default_engine_versions();
         let options = default_orderable_options();
 
-        assert_eq!(options.len(), 70); // 10 versions * 7 instance classes
+        assert_eq!(options.len(), 77); // 11 versions * 7 instance classes
                                        // Verify all engines and versions have orderable options
         for version in &versions {
             assert!(options.iter().any(|opt| {

--- a/website/content/docs/services/rds.md
+++ b/website/content/docs/services/rds.md
@@ -195,7 +195,7 @@ The Oracle / SQL Server / Db2 images are large (1-3 GB) and take 30-300 s to fir
 
 ### Prebuilt PostgreSQL image
 
-`ghcr.io/faiscadev/fakecloud-postgres:<major>-<fakecloud-version>` is published on every fakecloud release tag (workflow: `.github/workflows/docker-rds-images.yml`) for postgres `13`, `14`, `15`, `16`, both `linux/amd64` and `linux/arm64`. Each release also gets a rolling `:<major>` tag pointing at the latest version for that major. Resolution order at runtime:
+`ghcr.io/faiscadev/fakecloud-postgres:<major>-<fakecloud-version>` is published on every fakecloud release tag (workflow: `.github/workflows/docker-rds-images.yml`) for postgres `13`, `14`, `15`, `16`, `17`, both `linux/amd64` and `linux/arm64`. Each release also gets a rolling `:<major>` tag pointing at the latest version for that major. Resolution order at runtime:
 
 1. Image already on the local Docker daemon -> use it.
 2. `docker pull` of the version-pinned tag -> use it.


### PR DESCRIPTION
## Summary

fakecloud rejected `CreateDBInstance` with `Engine=postgres` `EngineVersion=17.x` (returning `InsufficientDBInstanceCapacity`), even though real AWS RDS has offered PostgreSQL 17 since Nov 2024.

This wires postgres 17 through the engine-version matrix:

- `service_helpers.rs::validate_create_request` — added `"17"` (major) and `"17.4"` (released minor) to the postgres `supported_versions` list, with `17` as the newest major.
- `state.rs` seed data:
  - `default_engine_versions()` — new `EngineVersionInfo` for postgres `17.4` / family `postgres17`, as the newest postgres entry.
  - `default_orderable_options()` — added `("postgres", "17.4", "postgresql-license")`.
  - `default_parameter_groups()` — added the `postgres17` default parameter group family.

No runtime change is needed: `RdsRuntime::ensure_postgres` already derives the image tag generically from the parsed major version via `bridge_image_tag`, and the Dockerfile is parameterized by `PG_VERSION`, so major `17` flows through unchanged. The restore default (`postgres` -> `16.3`) is intentionally left as-is (out of scope).

## Test plan

- Added `validate_create_request_accepts_postgres_17` asserting both `17` and `17.4` validate (previously `InsufficientDBInstanceCapacity`).
- Updated seed-data assertions to reflect `17.4`/`postgres17` as the newest postgres entry (`default_engine_versions_are_postgres_metadata`, `default_orderable_options_match_engine_versions`, `filter_engine_versions_matches_requested_engine`).
- `cargo fmt -p fakecloud-rds` — clean
- `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` — clean
- `cargo test -p fakecloud-rds` — 258 passed, 0 failed

Fixes #2352

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PostgreSQL 17.x to the RDS engine-version matrix and publish prebuilt `postgres` 17 images. `CreateDBInstance` now accepts "17" and "17.4", matching AWS RDS (fixes #2352).

- **New Features**
  - Validation: accept "17" and "17.4" for `postgres`.
  - Seed data: add 17.4 (family `postgres17`), orderable options for 17.4, and default parameter group `postgres17`.
  - CI/docs: build, smoke-test, and publish prebuilt `postgres` 17 images; docs list 13–17.
  - Tests: add regression for 17/17.4; e2e `DescribeDBEngineVersions` now expects 17.4 and 5 postgres versions.

<sup>Written for commit 76c140fa20fe4f2ba70f35fe8fe7b3e9e83b001d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

