### PR TITLE
fix(elasticache): ListTagsForResource returns empty TagList for existing untagged resources

### DIFF
--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -3,6 +3,42 @@
 
 use super::*;
 
+/// Map a taggable resource ARN to the AWS not-found fault code appropriate for
+/// its resource type. The type is the prefix of the ARN's resource segment
+/// before the first `:` (e.g. `parametergroup:default.redis7`). Unparseable or
+/// unrecognized ARNs fall back to `CacheClusterNotFound`, matching the
+/// historical behavior of the tag handlers.
+fn tag_resource_not_found_code(resource_name: &str) -> &'static str {
+    let Ok(arn) = resource_name.parse::<fakecloud_aws::arn::Arn>() else {
+        return "CacheClusterNotFound";
+    };
+    match arn.resource.split(':').next().unwrap_or_default() {
+        "parametergroup" => "CacheParameterGroupNotFound",
+        "subnetgroup" => "CacheSubnetGroupNotFoundFault",
+        "cluster" => "CacheClusterNotFound",
+        "replicationgroup" => "ReplicationGroupNotFoundFault",
+        "globalreplicationgroup" => "GlobalReplicationGroupNotFoundFault",
+        "user" => "UserNotFound",
+        "usergroup" => "UserGroupNotFound",
+        "snapshot" => "SnapshotNotFoundFault",
+        "serverlesscache" => "ServerlessCacheNotFoundFault",
+        "serverlesssnapshot" => "ServerlessCacheSnapshotNotFoundFault",
+        "reserved-instance" => "ReservedCacheNodeNotFound",
+        "securitygroup" => "CacheSecurityGroupNotFound",
+        _ => "CacheClusterNotFound",
+    }
+}
+
+/// Build the resource-type-appropriate not-found fault for a tag operation on
+/// an ARN that does not correspond to an existing resource.
+fn tag_resource_not_found(resource_name: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::NOT_FOUND,
+        tag_resource_not_found_code(resource_name),
+        format!("The resource {resource_name} could not be found."),
+    )
+}
+
 impl ElastiCacheService {
     pub(super) fn describe_reserved_cache_nodes(
         &self,
@@ -408,13 +444,13 @@ impl ElastiCacheService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let tag_list = state.tags.get_mut(&resource_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "CacheClusterNotFound",
-                format!("The resource {resource_name} could not be found."),
-            )
-        })?;
+        // The resource must exist, but it need not already have a tag entry:
+        // freshly-created resources (e.g. parameter groups) register no tags
+        // until the first AddTagsToResource. Create the entry on demand.
+        if !state.resource_exists(&resource_name) {
+            return Err(tag_resource_not_found(&resource_name));
+        }
+        let tag_list = state.tags.entry(resource_name.clone()).or_default();
 
         merge_tags(tag_list, &tags);
 
@@ -440,13 +476,14 @@ impl ElastiCacheService {
         let accounts = self.state.read();
         let empty = ElastiCacheState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let tag_list = state.tags.get(&resource_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "CacheClusterNotFound",
-                format!("The resource {resource_name} could not be found."),
-            )
-        })?;
+        // Real ElastiCache returns an empty TagList for an existing untagged
+        // resource and only faults when the resource is genuinely missing.
+        // A missing tag entry must NOT be treated as "resource not found".
+        if !state.resource_exists(&resource_name) {
+            return Err(tag_resource_not_found(&resource_name));
+        }
+        let empty_tags = Vec::new();
+        let tag_list = state.tags.get(&resource_name).unwrap_or(&empty_tags);
 
         let tag_xml: String = tag_list.iter().map(tag_xml).collect();
 
@@ -470,13 +507,12 @@ impl ElastiCacheService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let tag_list = state.tags.get_mut(&resource_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
-                "CacheClusterNotFound",
-                format!("The resource {resource_name} could not be found."),
-            )
-        })?;
+        // Existence is keyed on the resource, not on a pre-existing tag entry:
+        // removing tags from an existing untagged resource is a no-op success.
+        if !state.resource_exists(&resource_name) {
+            return Err(tag_resource_not_found(&resource_name));
+        }
+        let tag_list = state.tags.entry(resource_name.clone()).or_default();
 
         tag_list.retain(|(key, _)| !tag_keys.contains(key));
 

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -3605,6 +3605,68 @@ fn list_tags_unknown_arn_errors() {
     assert!(svc.list_tags_for_resource(&req).is_err());
 }
 
+/// Regression for #2354: ListTagsForResource on a freshly-created parameter
+/// group (which registers no tag entry at create time) must return an empty
+/// TagList, not CacheClusterNotFound. Terraform's aws_elasticache_parameter_group
+/// apply calls ListTagsForResource right after create and previously 404'd.
+#[test]
+fn list_tags_existing_untagged_parameter_group_returns_empty() {
+    let svc = fresh_service();
+    let create = request(
+        "CreateCacheParameterGroup",
+        &[
+            ("CacheParameterGroupName", "pg-tags"),
+            ("CacheParameterGroupFamily", "redis7"),
+            ("Description", "test"),
+        ],
+    );
+    svc.create_cache_parameter_group(&create).unwrap();
+
+    let arn = "arn:aws:elasticache:us-east-1:123456789012:parametergroup:pg-tags";
+    let list = request("ListTagsForResource", &[("ResourceName", arn)]);
+    let resp = svc.list_tags_for_resource(&list).unwrap();
+    let out = body(resp);
+    assert!(
+        out.contains("<TagList></TagList>"),
+        "expected empty TagList, got {out}"
+    );
+}
+
+/// AddTagsToResource then ListTagsForResource round-trips on a freshly-created
+/// parameter group (no pre-seeded tag entry) — the add creates the entry.
+#[test]
+fn add_then_list_tags_on_parameter_group_roundtrips() {
+    let svc = fresh_service();
+    let create = request(
+        "CreateCacheParameterGroup",
+        &[
+            ("CacheParameterGroupName", "pg-tags2"),
+            ("CacheParameterGroupFamily", "redis7"),
+            ("Description", "test"),
+        ],
+    );
+    svc.create_cache_parameter_group(&create).unwrap();
+
+    let arn = "arn:aws:elasticache:us-east-1:123456789012:parametergroup:pg-tags2";
+    let add = request(
+        "AddTagsToResource",
+        &[
+            ("ResourceName", arn),
+            ("Tags.Tag.1.Key", "env"),
+            ("Tags.Tag.1.Value", "prod"),
+        ],
+    );
+    svc.add_tags_to_resource(&add).unwrap();
+
+    let list = request("ListTagsForResource", &[("ResourceName", arn)]);
+    let out = body(svc.list_tags_for_resource(&list).unwrap());
+    assert!(out.contains("<Key>env</Key>"), "missing tag key in {out}");
+    assert!(
+        out.contains("<Value>prod</Value>"),
+        "missing tag value in {out}"
+    );
+}
+
 // ── Coverage for the closure batch ──
 
 fn fresh_service() -> ElastiCacheService {

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -680,6 +680,35 @@ impl ElastiCacheState {
         self.update_actions.clear();
     }
 
+    /// Whether a taggable resource with the given ARN currently exists in this
+    /// account's state. Used by the tag handlers (Add/List/Remove) to tell
+    /// "resource exists but has no tags" (return an empty TagList) apart from
+    /// "resource genuinely missing" (return a not-found fault). Matching on the
+    /// stored `arn` field is robust regardless of a collection's map-key scheme.
+    pub fn resource_exists(&self, arn: &str) -> bool {
+        self.parameter_groups.iter().any(|g| g.arn == arn)
+            || self.subnet_groups.values().any(|g| g.arn == arn)
+            || self.cache_clusters.values().any(|c| c.arn == arn)
+            || self.replication_groups.values().any(|r| r.arn == arn)
+            || self
+                .global_replication_groups
+                .values()
+                .any(|g| g.arn == arn)
+            || self.users.values().any(|u| u.arn == arn)
+            || self.user_groups.values().any(|g| g.arn == arn)
+            || self.snapshots.values().any(|s| s.arn == arn)
+            || self.serverless_caches.values().any(|c| c.arn == arn)
+            || self
+                .serverless_cache_snapshots
+                .values()
+                .any(|s| s.arn == arn)
+            || self
+                .reserved_cache_nodes
+                .values()
+                .any(|n| n.reservation_arn == arn)
+            || self.security_groups.values().any(|g| g.arn == arn)
+    }
+
     /// Ensure an UpdateAction exists for every (service_update, target) pair,
     /// where targets are this account's cache clusters and replication groups.
     /// AWS auto-creates these when a service update is released; we materialize


### PR DESCRIPTION
## Summary

`ListTagsForResource` returned `CacheClusterNotFound` for ElastiCache resources that **exist but have no tags**. Real ElastiCache returns an empty `TagList` and only faults when the resource is genuinely missing. This broke `terraform apply` of `aws_elasticache_parameter_group`, which calls `ListTagsForResource` immediately after create.

Root cause: the tag handlers keyed existence off the presence of a `state.tags` entry for the ARN. Resources that pre-seed an empty tag vec at creation (clusters, replication groups, subnet groups, users, snapshots, serverless) worked by accident; resources that don't (parameter groups — including the 3 seeded defaults —, security groups, global replication groups, reserved cache nodes) were wrongly 404'd.

Fix:
- Add `ElastiCacheState::resource_exists(arn)` which checks the correct state collection by matching the stored `arn` field across all taggable resource types.
- `ListTagsForResource`: if the resource exists, return `state.tags.get(arn)` or an empty list; only fault when the resource is truly absent, using a resource-type-appropriate not-found code (e.g. `CacheParameterGroupNotFound`, derived from the ARN's resource-type prefix, falling back to `CacheClusterNotFound`).
- `AddTagsToResource` / `RemoveTagsFromResource`: apply the same existence-based check and create the tag entry on demand, so tagging a freshly-created untagged resource works.

No new API surface — behavioral bug fix only, so no SDK/website changes.

## Test plan

- `cargo fmt -p fakecloud-elasticache` — clean
- `cargo clippy -p fakecloud-elasticache --all-targets -- -D warnings` — clean
- `cargo test -p fakecloud-elasticache` — 243 passed, 0 failed

New tests (in `service_tests.rs`):
- `list_tags_existing_untagged_parameter_group_returns_empty` — repro of #2354: create parameter group, then `ListTagsForResource` on its ARN returns `Ok` with an empty `TagList`.
- `add_then_list_tags_on_parameter_group_roundtrips` — `AddTagsToResource` then `ListTagsForResource` round-trips on a freshly-created (tag-entry-less) parameter group.

Existing `list_tags_unknown_arn_errors` (fabricated/ghost ARN) still returns an error.

Fixes #2354

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tag APIs in `fakecloud-elasticache` so `ListTagsForResource` returns an empty TagList for existing untagged resources, matching AWS. This removes false 404s that broke `terraform apply` for ElastiCache parameter groups.

- **Bug Fixes**
  - `ListTagsForResource`: returns empty `TagList` when the resource exists; only errors if it does not. Not-found code is derived from the ARN’s resource type.
  - Added `ElastiCacheState::resource_exists(arn)` to check existence across all taggable resource types.
  - `AddTagsToResource` and `RemoveTagsFromResource`: create the tag entry on demand and succeed on untagged resources.
  - Tests added to cover empty-list behavior and tag round-trips on parameter groups.

<sup>Written for commit 96c3a5e6880e669a01608e9b894863a9f97e065a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

