### PR TITLE
fix(apigatewayv2): percent-decode stage-name path segment so $default is readable

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service/execute.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/execute.rs
@@ -185,8 +185,24 @@ impl ApiGatewayV2Service {
         // that has one; `resource_id` is segs[4] (the routes/integrations/
         // stages/... child id). We resolve both once here so the match
         // body only picks the action name.
-        let api_id = segs.get(2).map(|s| s.to_string());
-        let resource_id = segs.get(4).map(|s| s.to_string());
+        // Percent-decode the apis-collection ids: core dispatch splits the raw
+        // path without decoding, so the child id in segs[4] arrives URL-encoded
+        // (e.g. `%24default` for the `$default` stage). Decoding here restores
+        // the literal name handlers compare against stored keys. Server-generated
+        // ids (routes/integrations/authorizers/...) contain no encodable chars,
+        // so decoding is a no-op for them. This branch is guarded by
+        // `second == Some("apis")` above, so it never touches the tags ARN path
+        // (which intentionally keeps segments encoded and decodes later).
+        let api_id = segs.get(2).map(|s| {
+            percent_encoding::percent_decode_str(s)
+                .decode_utf8_lossy()
+                .into_owned()
+        });
+        let resource_id = segs.get(4).map(|s| {
+            percent_encoding::percent_decode_str(s)
+                .decode_utf8_lossy()
+                .into_owned()
+        });
         let collection = segs.get(3).map(|s| s.as_str());
         let method = &req.method;
 

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -149,6 +149,17 @@ fn resolve_action_stages() {
 }
 
 #[test]
+fn resolve_action_decodes_encoded_stage_name() {
+    // #2355: the `$default` stage arrives as `%24default` because core dispatch
+    // splits the raw path without percent-decoding. resolve_action must decode
+    // the apis-collection child id so handlers see the literal `$default`.
+    let req = make_request(Method::GET, "/v2/apis/a1/stages/%24default", "");
+    let (action, _, resource_id) = ApiGatewayV2Service::resolve_action(&req).unwrap();
+    assert_eq!(action, "GetStage");
+    assert_eq!(resource_id.as_deref(), Some("$default"));
+}
+
+#[test]
 fn resolve_action_deployments() {
     let req = make_request(Method::POST, "/v2/apis/a1/deployments", "{}");
     assert_eq!(
@@ -1114,6 +1125,51 @@ async fn delete_stage_removes() {
     svc.handle(req).await.unwrap();
 
     let req = make_request(Method::GET, &format!("/v2/apis/{api_id}/stages/todel"), "");
+    assert!(svc.handle(req).await.is_err());
+}
+
+#[tokio::test]
+async fn get_stage_reads_back_encoded_default_stage() {
+    // #2355: creating the `$default` stage stores the literal `$default`, but
+    // GetStage arrives with the name percent-encoded (`%24default`) because core
+    // dispatch does not decode path segments. It must still resolve.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+    create_stage_named(&svc, &api_id, "$default").await;
+
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/stages/%24default"),
+        "",
+    );
+    let resp = svc.handle(req).await.unwrap();
+    let body = body_json(&resp);
+    assert_eq!(body["stageName"].as_str(), Some("$default"));
+}
+
+#[tokio::test]
+async fn delete_stage_removes_encoded_default_stage() {
+    // #2355: DeleteStage for `$default` arrives percent-encoded and must remove
+    // the stored `$default` stage.
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+    create_stage_named(&svc, &api_id, "$default").await;
+
+    let req = make_request(
+        Method::DELETE,
+        &format!("/v2/apis/{api_id}/stages/%24default"),
+        "",
+    );
+    svc.handle(req).await.unwrap();
+
+    // Gone afterwards (encoded read now 404s).
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/stages/%24default"),
+        "",
+    );
     assert!(svc.handle(req).await.is_err());
 }
 


### PR DESCRIPTION
## Summary

apigatewayv2 HTTP API `$default` stages could be created but never read back: GetStage/UpdateStage/DeleteStage returned `Stage not found: %24default`.

Core dispatch splits the raw request path on `/` without percent-decoding (intentional — other paths like the apigatewayv2 tags ARN keep segments encoded and decode later). So the apis-collection child id in `segs[4]` arrived URL-encoded (`%24default`) and was compared against the stored literal `$default`, always missing.

Fix: in `resolve_action` (execute.rs), percent-decode only the apis-collection `api_id` (segs[2]) and `resource_id` (segs[4]) using the crate's existing `percent_encoding::percent_decode_str(...).decode_utf8_lossy()`. This branch is guarded by `second == Some("apis")`, so it does not touch the tags/domainnames/portals paths. Server-generated child ids contain no encodable chars, so decoding is a no-op for them and correctly turns `%24default` into `$default` — fixing GetStage, UpdateStage, DeleteStage and any other encodable apis-collection child.

## Test plan

- `resolve_action_decodes_encoded_stage_name` — asserts resolve_action decodes `%24default` to `$default` with action GetStage.
- `get_stage_reads_back_encoded_default_stage` — create `$default` stage, GET with `%24default` returns the stage (stageName == `$default`).
- `delete_stage_removes_encoded_default_stage` — DELETE with `%24default` removes the stored stage.
- `cargo fmt -p fakecloud-apigatewayv2`, `cargo clippy -p fakecloud-apigatewayv2 --all-targets -- -D warnings`, `cargo test -p fakecloud-apigatewayv2` all green (168 unit + 10 websocket e2e passing).

Fixes #2355

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Percent-decode the stage name in `apigatewayv2` HTTP API paths so the `$default` stage can be read, updated, and deleted instead of failing with "Stage not found: %24default".

- **Bug Fixes**
  - Decode `api_id` and `resource_id` for `apis` routes in `resolve_action` using `percent_encoding`, fixing GetStage/UpdateStage/DeleteStage for `$default` and any encoded names. Guarded to avoid affecting tags/domainnames/portals; server-generated IDs are unchanged.
  - Added tests for action resolution and CRUD with `%24default`.

<sup>Written for commit 1781b95e18cc4d7ed631621b7a6f99ebc751eb67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

