### PR TITLE
fix(lambda): derive function/alias/layer ARNs from the request region

### DIFF
--- a/crates/fakecloud-lambda/src/extras/account.rs
+++ b/crates/fakecloud-lambda/src/extras/account.rs
@@ -75,7 +75,9 @@ impl LambdaService {
             "PutProvisionedConcurrencyConfig" => self.put_provisioned_concurrency(res, req),
             "GetProvisionedConcurrencyConfig" => self.get_provisioned_concurrency(res, req),
             "DeleteProvisionedConcurrencyConfig" => self.delete_provisioned_concurrency(res, req),
-            "ListProvisionedConcurrencyConfigs" => self.list_provisioned_concurrency(res, aid),
+            "ListProvisionedConcurrencyConfigs" => {
+                self.list_provisioned_concurrency(res, aid, req.region.as_str())
+            }
 
             // Code signing
             "CreateCodeSigningConfig" => self.create_code_signing_config(req),

--- a/crates/fakecloud-lambda/src/extras/aliases.rs
+++ b/crates/fakecloud-lambda/src/extras/aliases.rs
@@ -56,9 +56,12 @@ impl LambdaService {
         if !state.functions.contains_key(function_name) {
             return Err(not_found("Function", function_name));
         }
+        // Derive the alias ARN from the request's credential-scope region
+        // (`req.region`), consistent with the function's own ARN, rather than
+        // the server default (`state.region`).
         let alias_arn = format!(
             "arn:aws:lambda:{}:{}:function:{}:{}",
-            state.region, state.account_id, function_name, name
+            req.region, state.account_id, function_name, name
         );
         let alias = FunctionAlias {
             alias_arn: alias_arn.clone(),

--- a/crates/fakecloud-lambda/src/extras/code_signing.rs
+++ b/crates/fakecloud-lambda/src/extras/code_signing.rs
@@ -15,7 +15,7 @@ impl LambdaService {
         let id = id_from_time("csc-");
         let arn = format!(
             "arn:aws:lambda:{}:{}:code-signing-config:{}",
-            state.region, state.account_id, id
+            req.region, state.account_id, id
         );
         let publishers: Vec<String> = body
             .get("AllowedPublishers")

--- a/crates/fakecloud-lambda/src/extras/concurrency.rs
+++ b/crates/fakecloud-lambda/src/extras/concurrency.rs
@@ -149,9 +149,10 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        region: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let region = self.region_for(account_id);
-        self.with_state_read(account_id, &region, |state| {
+        let state_region = self.region_for(account_id);
+        self.with_state_read(account_id, &state_region, |state| {
             let prefix = format!("{function_name}:");
             let configs: Vec<Value> = state
                 .provisioned_concurrency
@@ -162,7 +163,7 @@ impl LambdaService {
                     json!({
                         "FunctionArn": format!(
                             "arn:aws:lambda:{}:{}:function:{}:{}",
-                            state.region, state.account_id, function_name, qualifier
+                            region, state.account_id, function_name, qualifier
                         ),
                         "Status": cfg.status,
                         "RequestedProvisionedConcurrentExecutions": cfg.requested,
@@ -229,7 +230,7 @@ impl LambdaService {
             }
             let function_arn = format!(
                 "arn:aws:lambda:{}:{}:function:{}",
-                state.region, state.account_id, function_name
+                req.region, state.account_id, function_name
             );
             ok(json!({
                 "FunctionArn": function_arn,

--- a/crates/fakecloud-lambda/src/extras/event_invoke.rs
+++ b/crates/fakecloud-lambda/src/extras/event_invoke.rs
@@ -16,11 +16,12 @@ impl LambdaService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = body(req);
         let qualifier = parse_qualifier(req);
+        // Persist the FunctionArn under the request's credential-scope region
+        // (`req.region`), consistent with the function's own ARN, not the
+        // server default. Get/Update/List re-emit this stored value.
         let function_arn = format!(
             "arn:aws:lambda:{}:{}:function:{}",
-            self.region_for(&req.account_id),
-            req.account_id,
-            function_name
+            req.region, req.account_id, function_name
         );
         // Validate Smithy ranges before persisting:
         //   MaximumEventAgeInSeconds: 60..=21600

--- a/crates/fakecloud-lambda/src/extras/function_url.rs
+++ b/crates/fakecloud-lambda/src/extras/function_url.rs
@@ -53,16 +53,17 @@ impl LambdaService {
         if !state.functions.contains_key(function_name) {
             return Err(not_found("Function", function_name));
         }
+        // Derive the FunctionArn and the function URL's region label from the
+        // request's credential-scope region (`req.region`), matching the
+        // function's own ARN, not the server default (`state.region`). Both
+        // are persisted and re-emitted by Get/Update/List.
         let function_arn = format!(
             "arn:aws:lambda:{}:{}:function:{}",
-            state.region, state.account_id, function_name
+            req.region, state.account_id, function_name
         );
         let cfg = FunctionUrlConfig {
             function_arn: function_arn.clone(),
-            function_url: format!(
-                "https://{function_name}.lambda-url.{}.on.aws/",
-                state.region
-            ),
+            function_url: format!("https://{function_name}.lambda-url.{}.on.aws/", req.region),
             auth_type: auth_type.clone(),
             cors: body.get("Cors").cloned(),
             creation_time: now,

--- a/crates/fakecloud-lambda/src/extras/layers.rs
+++ b/crates/fakecloud-lambda/src/extras/layers.rs
@@ -88,9 +88,13 @@ impl LambdaService {
             .entry(layer_name.to_string())
             .or_insert_with(|| Layer {
                 layer_name: layer_name.to_string(),
+                // Layer ARN carries the request's credential-scope region
+                // (`req.region`), not the server default (`state.region`);
+                // the version ARN below is derived from it, so both stay in
+                // the caller's region.
                 layer_arn: format!(
                     "arn:aws:lambda:{}:{}:layer:{}",
-                    state.region, state.account_id, layer_name
+                    req.region, state.account_id, layer_name
                 ),
                 versions: Vec::new(),
             });

--- a/crates/fakecloud-lambda/src/extras/mod.rs
+++ b/crates/fakecloud-lambda/src/extras/mod.rs
@@ -934,7 +934,7 @@ impl LambdaService {
         if let Some(name) = body["FunctionName"].as_str() {
             esm.function_arn = format!(
                 "arn:aws:lambda:{}:{}:function:{}",
-                state.region, state.account_id, name
+                req.region, state.account_id, name
             );
         }
         if let Some(filters) = body

--- a/crates/fakecloud-lambda/src/extras/runtime.rs
+++ b/crates/fakecloud-lambda/src/extras/runtime.rs
@@ -75,7 +75,7 @@ impl LambdaService {
             .runtime_management
             .insert(format!("{function_name}:{qualifier}"), cfg.clone());
         let mut resp = json!({
-            "FunctionArn": Arn::new("lambda", &state.region, &state.account_id, &format!("function:{function_name}:{qualifier}")).to_string(),
+            "FunctionArn": Arn::new("lambda", &req.region, &state.account_id, &format!("function:{function_name}:{qualifier}")).to_string(),
             "UpdateRuntimeOn": cfg.update_runtime_on,
         });
         // RuntimeVersionArn is an ARN-typed field; an empty value fails the
@@ -112,7 +112,7 @@ impl LambdaService {
             let mut resp = json!({
                 "FunctionArn": format!(
                     "arn:aws:lambda:{}:{}:function:{}:{}",
-                    state.region, state.account_id, function_name, qualifier
+                    req.region, state.account_id, function_name, qualifier
                 ),
                 "UpdateRuntimeOn": cfg.update_runtime_on,
             });

--- a/crates/fakecloud-lambda/src/extras/stream.rs
+++ b/crates/fakecloud-lambda/src/extras/stream.rs
@@ -57,7 +57,7 @@ impl LambdaService {
                     "ResourceNotFoundException",
                     format!(
                         "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                        state.region, state.account_id, function_name
+                        req.region, state.account_id, function_name
                     ),
                 )
             })?;

--- a/crates/fakecloud-lambda/src/service/functions.rs
+++ b/crates/fakecloud-lambda/src/service/functions.rs
@@ -66,9 +66,15 @@ impl LambdaService {
         let code_sha256 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash);
         let code_size = code_bytes.len() as i64;
 
+        // Build the FunctionArn from the request's SigV4 credential-scope
+        // region (`req.region`), not the server default (`state.region`).
+        // A CreateFunction signed for eu-central-1 must advertise an
+        // eu-central-1 ARN; fakecloud's own lookups are region-insensitive
+        // (see `normalize_function_name`), so follow-up calls still resolve,
+        // but Terraform / cross-service IAM compare the ARN region.
         let function_arn = format!(
             "arn:aws:lambda:{}:{}:function:{}",
-            state.region, state.account_id, input.function_name
+            req.region, state.account_id, input.function_name
         );
         let now = Utc::now();
 
@@ -171,7 +177,7 @@ impl LambdaService {
                 "ResourceNotFoundException",
                 format!(
                     "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                    state.region, state.account_id, function_name
+                    req.region, state.account_id, function_name
                 ),
             )
         })?;
@@ -194,7 +200,7 @@ impl LambdaService {
                             "ResourceNotFoundException",
                             format!(
                                 "Function not found: arn:aws:lambda:{}:{}:function:{}:{v}",
-                                state.region, state.account_id, function_name
+                                req.region, state.account_id, function_name
                             ),
                         )
                     })?;
@@ -247,11 +253,11 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        region: &str,
         qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(account_id);
-        let region = state.region.clone();
         let account_id_owned = state.account_id.clone();
 
         // Qualifier=N targets a single immutable version snapshot; the

--- a/crates/fakecloud-lambda/src/service/invoke.rs
+++ b/crates/fakecloud-lambda/src/service/invoke.rs
@@ -5,11 +5,13 @@ use base64::Engine as _;
 use super::*;
 
 impl LambdaService {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn invoke(
         &self,
         function_name: &str,
         payload: &[u8],
         account_id: &str,
+        region: &str,
         invocation_type: InvocationType,
         qualifier: Option<&str>,
         log_tail: bool,
@@ -32,7 +34,7 @@ impl LambdaService {
                         "ResourceNotFoundException",
                         format!(
                             "Function not found: arn:aws:lambda:{}:{}:function:{function_name}:{q}",
-                            state.region, state.account_id
+                            region, state.account_id
                         ),
                     ));
                 }
@@ -93,7 +95,7 @@ impl LambdaService {
                     "ResourceNotFoundException",
                     format!(
                         "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                        state.region, state.account_id, function_name
+                        region, state.account_id, function_name
                     ),
                 )
             })?;

--- a/crates/fakecloud-lambda/src/service/mod.rs
+++ b/crates/fakecloud-lambda/src/service/mod.rs
@@ -1375,6 +1375,7 @@ impl AwsService for LambdaService {
             "DeleteFunction" => self.delete_function(
                 resource_name.as_deref().unwrap_or(""),
                 aid,
+                req.region.as_str(),
                 req.query_params.get("Qualifier").map(String::as_str),
             ),
             "Invoke" => {
@@ -1399,6 +1400,7 @@ impl AwsService for LambdaService {
                     resource_name.as_deref().unwrap_or(""),
                     &req.body,
                     aid,
+                    req.region.as_str(),
                     invocation_type,
                     qualifier,
                     log_tail,
@@ -1437,6 +1439,7 @@ impl AwsService for LambdaService {
             "GetPolicy" => self.get_policy(
                 resource_name.as_deref().unwrap_or(""),
                 aid,
+                req.region.as_str(),
                 req.query_params.get("Qualifier").map(String::as_str),
             ),
             "RemovePermission" => {
@@ -1446,6 +1449,7 @@ impl AwsService for LambdaService {
                     resource_name.as_deref().unwrap_or(""),
                     &sid,
                     aid,
+                    req.region.as_str(),
                     req.query_params.get("Qualifier").map(String::as_str),
                 )
             }
@@ -1734,7 +1738,7 @@ impl AwsService for LambdaService {
                     let name = normalize_function_name(&raw);
                     format!(
                         "arn:aws:lambda:{}:{}:function:{}",
-                        state.region, state.account_id, name
+                        request.region, state.account_id, name
                     )
                 }
             }
@@ -1749,7 +1753,7 @@ impl AwsService for LambdaService {
                         v.get("FunctionName").and_then(|f| f.as_str()).map(|n| {
                             format!(
                                 "arn:aws:lambda:{}:{}:function:{}",
-                                state.region, state.account_id, n
+                                request.region, state.account_id, n
                             )
                         })
                     })

--- a/crates/fakecloud-lambda/src/service/publish.rs
+++ b/crates/fakecloud-lambda/src/service/publish.rs
@@ -25,7 +25,7 @@ impl LambdaService {
                 "ResourceNotFoundException",
                 format!(
                     "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                    state.region, state.account_id, function_name
+                    req.region, state.account_id, function_name
                 ),
             )
         })?;

--- a/crates/fakecloud-lambda/src/service_event_sources.rs
+++ b/crates/fakecloud-lambda/src/service_event_sources.rs
@@ -51,7 +51,7 @@ impl LambdaService {
                     "ResourceNotFoundException",
                     format!(
                         "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                        state.region, state.account_id, function_name
+                        req.region, state.account_id, function_name
                     ),
                 )
             })?;

--- a/crates/fakecloud-lambda/src/service_permissions.rs
+++ b/crates/fakecloud-lambda/src/service_permissions.rs
@@ -82,7 +82,8 @@ impl LambdaService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let func = resolve_policy_target_mut(state, function_name, qualifier.as_deref())?;
+        let func =
+            resolve_policy_target_mut(state, function_name, &req.region, qualifier.as_deref())?;
 
         // Load current policy or seed a fresh canonical doc. Any
         // stored blob that doesn't parse as a JSON object is treated
@@ -198,11 +199,12 @@ impl LambdaService {
         function_name: &str,
         statement_id: &str,
         account_id: &str,
+        region: &str,
         qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(account_id);
-        let func = resolve_policy_target_mut(state, function_name, qualifier)?;
+        let func = resolve_policy_target_mut(state, function_name, region, qualifier)?;
         let policy_str = func.policy.as_deref().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -247,12 +249,13 @@ impl LambdaService {
         &self,
         function_name: &str,
         account_id: &str,
+        region: &str,
         qualifier: Option<&str>,
     ) -> Result<AwsResponse, AwsServiceError> {
         let accounts = self.state.read();
         let empty = LambdaState::new(account_id, "");
         let state = accounts.get(account_id).unwrap_or(&empty);
-        let func = resolve_policy_target_ref(state, function_name, qualifier)?;
+        let func = resolve_policy_target_ref(state, function_name, region, qualifier)?;
         let policy = func.policy.as_deref().ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
@@ -281,11 +284,11 @@ impl LambdaService {
 fn resolve_policy_target_mut<'a>(
     state: &'a mut crate::state::LambdaState,
     function_name: &str,
+    region: &str,
     qualifier: Option<&str>,
 ) -> Result<&'a mut crate::state::LambdaFunction, AwsServiceError> {
     let resolved_version =
         crate::service::resolve_qualifier_to_version(state, function_name, qualifier);
-    let region = state.region.clone();
     let account_id = state.account_id.clone();
     match resolved_version {
         None => state.functions.get_mut(function_name).ok_or_else(|| {
@@ -316,6 +319,7 @@ fn resolve_policy_target_mut<'a>(
 fn resolve_policy_target_ref<'a>(
     state: &'a crate::state::LambdaState,
     function_name: &str,
+    region: &str,
     qualifier: Option<&str>,
 ) -> Result<&'a crate::state::LambdaFunction, AwsServiceError> {
     let resolved_version =
@@ -327,7 +331,7 @@ fn resolve_policy_target_ref<'a>(
                 "ResourceNotFoundException",
                 format!(
                     "Function not found: arn:aws:lambda:{}:{}:function:{}",
-                    state.region, state.account_id, function_name
+                    region, state.account_id, function_name
                 ),
             )
         }),
@@ -341,7 +345,7 @@ fn resolve_policy_target_ref<'a>(
                     "ResourceNotFoundException",
                     format!(
                         "Function not found: arn:aws:lambda:{}:{}:function:{}:{v}",
-                        state.region, state.account_id, function_name
+                        region, state.account_id, function_name
                     ),
                 )
             }),

--- a/crates/fakecloud-lambda/src/service_tests.rs
+++ b/crates/fakecloud-lambda/src/service_tests.rs
@@ -1373,7 +1373,92 @@ async fn get_function_unknown_errors() {
 #[tokio::test]
 async fn delete_function_unknown_errors() {
     let svc = LambdaService::new(make_state());
-    assert!(svc.delete_function("ghost", "123456789012", None).is_err());
+    assert!(svc
+        .delete_function("ghost", "123456789012", "us-east-1", None)
+        .is_err());
+}
+
+#[tokio::test]
+async fn arns_derive_from_request_region_not_server_default() {
+    // Regression for #2356. The server default region is us-east-1 (see
+    // `make_state`), but a request signed for eu-central-1 must get
+    // eu-central-1 ARNs back. fakecloud's own lookups ignore the ARN region
+    // (see `normalize_function_name`), yet Terraform / cross-service IAM
+    // compare it, so a wrong-region ARN is a real break.
+    let svc = LambdaService::new(make_state());
+
+    // Build a request scoped to eu-central-1 (SigV4 credential-scope region).
+    let eu = |method: Method, path: &str, body: &str| {
+        let mut r = make_request(method, path, body);
+        r.region = "eu-central-1".to_string();
+        r
+    };
+
+    // CreateFunction -> eu-central-1 FunctionArn (the persisted base ARN).
+    let body = json!({
+        "FunctionName": "eufn",
+        "Runtime": "python3.12",
+        "Role": "arn:aws:iam::123456789012:role/r",
+        "Handler": "index.handler",
+        "Code": {}
+    });
+    let resp = svc
+        .handle(eu(Method::POST, "/2015-03-31/functions", &body.to_string()))
+        .await
+        .unwrap();
+    let created: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        created["FunctionArn"].as_str().unwrap(),
+        "arn:aws:lambda:eu-central-1:123456789012:function:eufn"
+    );
+
+    // GetFunction re-emits the stored ARN unchanged (no re-derivation from
+    // the server default).
+    let resp = svc
+        .handle(eu(Method::GET, "/2015-03-31/functions/eufn", ""))
+        .await
+        .unwrap();
+    let got: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        got["Configuration"]["FunctionArn"].as_str().unwrap(),
+        "arn:aws:lambda:eu-central-1:123456789012:function:eufn"
+    );
+
+    // CreateAlias -> eu-central-1 AliasArn.
+    let alias_body = json!({"Name": "PROD", "FunctionVersion": "$LATEST"});
+    let resp = svc
+        .handle(eu(
+            Method::POST,
+            "/2015-03-31/functions/eufn/aliases",
+            &alias_body.to_string(),
+        ))
+        .await
+        .unwrap();
+    let alias: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        alias["AliasArn"].as_str().unwrap(),
+        "arn:aws:lambda:eu-central-1:123456789012:function:eufn:PROD"
+    );
+
+    // PublishLayerVersion -> eu-central-1 LayerArn and version ARN.
+    let layer_body = json!({"Content": {"ZipFile": ""}});
+    let resp = svc
+        .handle(eu(
+            Method::POST,
+            "/2018-10-31/layers/eulayer/versions",
+            &layer_body.to_string(),
+        ))
+        .await
+        .unwrap();
+    let layer: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        layer["LayerArn"].as_str().unwrap(),
+        "arn:aws:lambda:eu-central-1:123456789012:layer:eulayer"
+    );
+    assert_eq!(
+        layer["LayerVersionArn"].as_str().unwrap(),
+        "arn:aws:lambda:eu-central-1:123456789012:layer:eulayer:1"
+    );
 }
 
 #[tokio::test]
@@ -3537,6 +3622,7 @@ async fn invoke_unknown_alias_returns_not_found() {
             "afn",
             b"{}",
             "123456789012",
+            "us-east-1",
             InvocationType::RequestResponse,
             Some("no-such-alias"),
             false,


### PR DESCRIPTION
## Summary

Lambda built `FunctionArn` from the server default region (`state.region` / `FAKECLOUD_REGION`, default `us-east-1`) instead of the request's SigV4 credential-scope region (`req.region`). A `CreateFunction` signed for `eu-central-1` returned a `us-east-1` ARN.

fakecloud's own lookups are region-insensitive (`normalize_function_name` strips the region), so follow-up calls still resolve here — but the returned ARN advertised the wrong region, which breaks Terraform and cross-service IAM that compare the ARN region. The fix is safe precisely because lookup ignores the ARN region.

This threads `req.region` into every stored/returned ARN and the matching error-message ARNs:

- `CreateFunction` base ARN (persisted; cascades to Get/List/Update/PublishVersion).
- `CreateAlias` alias ARN.
- `PublishLayerVersion` layer ARN + version ARN.
- `CreateFunctionUrlConfig` (stored FunctionArn + URL region label), `PutFunctionEventInvokeConfig` (stored FunctionArn), `CreateCodeSigningConfig` (CSC ARN), `UpdateEventSourceMapping` (stored FunctionArn) — same stored-ARN bug class.
- Reconstruct-on-read ARNs: `GetRuntimeManagementConfig`/`PutRuntimeManagementConfig`, `GetFunctionScalingConfig`, `ListProvisionedConcurrencyConfigs`.
- The IAM resource-ARN derivation used for policy matching (so an `eu-central-1`-scoped policy matches an `eu-central-1` request).
- Error-message ARNs in GetFunction / DeleteFunction / Invoke / PublishVersion / CreateEventSourceMapping / permission resolution / response-stream invoke.

Function storage keying is unchanged (functions are keyed by account only); only ARN strings change. No new API surface, so no SDK/website/docs changes.

## Test plan

- New unit test `arns_derive_from_request_region_not_server_default`: under a request scoped to `eu-central-1` (server default is `us-east-1`), asserts `CreateFunction`, the `GetFunction` re-emit, `CreateAlias`, and `PublishLayerVersion` all return `arn:aws:lambda:eu-central-1:...` ARNs.
- Existing `us-east-1` tests stay green.
- `cargo fmt -p fakecloud-lambda` clean.
- `cargo clippy -p fakecloud-lambda --all-targets -- -D warnings` clean.
- `cargo test -p fakecloud-lambda`: 213 passed, 0 failed.

Fixes #2356

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Lambda to build all ARNs from the request’s SigV4 region (`req.region`), not the server default. This returns correct regioned ARNs and unblocks Terraform and cross-service IAM comparisons.

- **Bug Fixes**
  - Functions: `CreateFunction` now persists a request-region `FunctionArn` (propagates to Get/List/Update/PublishVersion).
  - Aliases/Layers: `CreateAlias` and `PublishLayerVersion` return request-region ARNs (including version ARNs).
  - Stored FunctionArn configs: `CreateFunctionUrlConfig` (URL region label too), `PutFunctionEventInvokeConfig`, `UpdateEventSourceMapping`, provisioned concurrency, runtime management, and code signing now persist/emit request-region ARNs.
  - IAM and errors: policy resource-ARN derivation and error-message ARNs use the request region; Invoke/Get/Delete/PublishVersion/CreateEventSourceMapping reflect it.
  - Safe change: storage keys stay the same (region-insensitive lookups); added a unit test to assert ARNs derive from the request region.

<sup>Written for commit 75edf3514ff2c8a7a547c96304c443168dccc0bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

