### PR TITLE
fix(ec2,elasticache,apigatewayv2): SG IPv4+IPv6 aggregation, ListTags on untagged resources, $default stage decode

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/service/management.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/management.rs
@@ -12,7 +12,21 @@ impl ApiGatewayV2Service {
         // (and our internal conformance probe) serialize with the raw
         // PascalCase member names instead. Normalize both shapes here so
         // every handler can read a single canonical lowercase-first form.
-        let req = normalize_request_body_keys(req);
+        let mut req = normalize_request_body_keys(req);
+        // Path-label segments (stage names, route/integration/authorizer ids,
+        // domain names, ...) arrive percent-encoded on the wire. The `$default`
+        // stage travels as `%24default`, so an undecoded segment never matches
+        // the stored `$default` literal and GetStage/DeleteStage/UpdateStage
+        // (and any other encodable id) fail with "Stage not found: %24default".
+        // Decode every segment once here so all downstream lookups compare the
+        // literal id. (Only the control plane is affected — the execute-api data
+        // plane keeps its raw path.)
+        for seg in &mut req.path_segments {
+            let decoded = percent_encoding::percent_decode_str(seg)
+                .decode_utf8_lossy()
+                .into_owned();
+            *seg = decoded;
+        }
         let (action, api_id, resource_id) = Self::resolve_action(&req).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,

--- a/crates/fakecloud-apigatewayv2/src/service_tests.rs
+++ b/crates/fakecloud-apigatewayv2/src/service_tests.rs
@@ -460,6 +460,49 @@ async fn stage_crud_lifecycle() {
     assert!(svc.handle(req).await.is_err());
 }
 
+#[tokio::test]
+async fn get_stage_default_is_percent_decoded() {
+    // Regression for #2355: the `$default` stage travels on the wire as the
+    // percent-encoded segment `%24default`. Without decoding the path label,
+    // GetStage/DeleteStage/UpdateStage compared `%24default` against the stored
+    // `$default` and 404'd with "Stage not found: %24default".
+    let state = make_state();
+    let svc = ApiGatewayV2Service::new(state);
+    let api_id = create_api(&svc);
+
+    // Create the $default stage (name comes from the JSON body).
+    let body = serde_json::json!({"stageName": "$default"});
+    let req = make_request(
+        Method::POST,
+        &format!("/v2/apis/{api_id}/stages"),
+        &body.to_string(),
+    );
+    let resp = svc.handle(req).await.unwrap();
+    assert_eq!(body_json(&resp)["stageName"], "$default");
+
+    // GetStage via the encoded path segment must resolve to the stage.
+    let req = make_request(
+        Method::GET,
+        &format!("/v2/apis/{api_id}/stages/%24default"),
+        "",
+    );
+    let resp = svc
+        .handle(req)
+        .await
+        .expect("GetStage on %24default must not 404");
+    assert_eq!(body_json(&resp)["stageName"], "$default");
+
+    // DeleteStage via the encoded segment resolves too.
+    let req = make_request(
+        Method::DELETE,
+        &format!("/v2/apis/{api_id}/stages/%24default"),
+        "",
+    );
+    svc.handle(req)
+        .await
+        .expect("DeleteStage on %24default must not 404");
+}
+
 // ── Deployment CRUD ──
 
 #[tokio::test]

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -56,77 +56,118 @@ fn rule_xml(r: &SecurityGroupRule, owner: &str, region: &str) -> String {
     out
 }
 
-/// Render one `<item>` IpPermission from a rule.
-fn ip_permission_xml(r: &SecurityGroupRule) -> String {
+/// Render the aggregated IpPermission `<item>` elements for one direction.
+///
+/// Rules are stored one-per-range, but real EC2 collapses every range that
+/// shares the same (protocol, from-port, to-port) into a SINGLE `ipPermissions`
+/// entry that carries all of its IpRanges, Ipv6Ranges, prefix-list ids, and
+/// referenced-group pairs. The terraform `aws_security_group_rule` create-waiter
+/// polls `DescribeSecurityGroups` for exactly that aggregated shape (one
+/// permission holding both the v4 and v6 range it authorized); rendering each
+/// stored range as its own permission never matches, so the waiter spins for
+/// ~5 minutes and then reports "couldn't find resource". Grouping preserves the
+/// first-seen order of the permission keys and each range's own Description.
+fn aggregated_ip_permissions_xml(rules: &[&SecurityGroupRule]) -> Vec<String> {
+    let mut order: Vec<(String, i64, i64)> = Vec::new();
+    let mut groups: HashMap<(String, i64, i64), Vec<&SecurityGroupRule>> = HashMap::new();
+    for r in rules {
+        let key = (r.ip_protocol.clone(), r.from_port, r.to_port);
+        groups.entry(key.clone()).or_default().push(r);
+        if !order.contains(&key) {
+            order.push(key);
+        }
+    }
+    order
+        .into_iter()
+        .map(|key| ip_permission_group_xml(&key.0, key.1, key.2, &groups[&key]))
+        .collect()
+}
+
+/// Render one aggregated IpPermission `<item>` for a group of rules that all
+/// share `proto`/`from`/`to`.
+fn ip_permission_group_xml(
+    proto: &str,
+    from: i64,
+    to: i64,
+    rules: &[&SecurityGroupRule],
+) -> String {
     // For the "all traffic" protocol (`-1`), AWS omits FromPort/ToPort entirely;
     // the provider then normalises them to 0. Emitting `-1` here makes the
     // `aws_security_group` resource see a perpetual port diff. tcp/udp/icmp
     // always carry their port range.
-    let mut inner = if r.ip_protocol == "-1" {
-        ec2_elem("ipProtocol", &r.ip_protocol)
+    let mut inner = if proto == "-1" {
+        ec2_elem("ipProtocol", proto)
     } else {
         format!(
             "{}<fromPort>{}</fromPort><toPort>{}</toPort>",
-            ec2_elem("ipProtocol", &r.ip_protocol),
-            r.from_port,
-            r.to_port,
+            ec2_elem("ipProtocol", proto),
+            from,
+            to,
         )
     };
-    let mut ranges = String::new();
-    if let Some(c) = &r.cidr_ipv4 {
-        ranges.push_str(&format!(
-            "<ipRanges><item>{}{}</item></ipRanges>",
-            ec2_elem("cidrIp", c),
-            ec2_elem("description", &r.description)
-        ));
-    }
-    if let Some(c) = &r.cidr_ipv6 {
-        ranges.push_str(&format!(
-            "<ipv6Ranges><item>{}{}</item></ipv6Ranges>",
-            ec2_elem("cidrIpv6", c),
-            ec2_elem("description", &r.description)
-        ));
-    }
-    if let Some(p) = &r.prefix_list_id {
-        ranges.push_str(&format!(
-            "<prefixListIds><item>{}{}</item></prefixListIds>",
-            ec2_elem("prefixListId", p),
-            ec2_elem("description", &r.description)
-        ));
-    }
-    if r.referenced_group_id.is_some() || r.referenced_group_name.is_some() {
-        let mut item = String::new();
-        if let Some(u) = &r.referenced_user_id {
-            item.push_str(&ec2_elem("userId", u));
+    let mut v4 = String::new();
+    let mut v6 = String::new();
+    let mut prefix = String::new();
+    let mut group_refs = String::new();
+    for r in rules {
+        if let Some(c) = &r.cidr_ipv4 {
+            v4.push_str(&format!(
+                "<item>{}{}</item>",
+                ec2_elem("cidrIp", c),
+                ec2_elem("description", &r.description)
+            ));
         }
-        if let Some(g) = &r.referenced_group_id {
-            item.push_str(&ec2_elem("groupId", g));
+        if let Some(c) = &r.cidr_ipv6 {
+            v6.push_str(&format!(
+                "<item>{}{}</item>",
+                ec2_elem("cidrIpv6", c),
+                ec2_elem("description", &r.description)
+            ));
         }
-        if let Some(n) = &r.referenced_group_name {
-            item.push_str(&ec2_elem("groupName", n));
+        if let Some(p) = &r.prefix_list_id {
+            prefix.push_str(&format!(
+                "<item>{}{}</item>",
+                ec2_elem("prefixListId", p),
+                ec2_elem("description", &r.description)
+            ));
         }
-        if !r.description.is_empty() {
-            item.push_str(&ec2_elem("description", &r.description));
+        if r.referenced_group_id.is_some() || r.referenced_group_name.is_some() {
+            let mut item = String::new();
+            if let Some(u) = &r.referenced_user_id {
+                item.push_str(&ec2_elem("userId", u));
+            }
+            if let Some(g) = &r.referenced_group_id {
+                item.push_str(&ec2_elem("groupId", g));
+            }
+            if let Some(n) = &r.referenced_group_name {
+                item.push_str(&ec2_elem("groupName", n));
+            }
+            if !r.description.is_empty() {
+                item.push_str(&ec2_elem("description", &r.description));
+            }
+            group_refs.push_str(&format!("<item>{item}</item>"));
         }
-        ranges.push_str(&format!("<groups><item>{item}</item></groups>"));
     }
-    inner.push_str(&ranges);
+    if !v4.is_empty() {
+        inner.push_str(&format!("<ipRanges>{v4}</ipRanges>"));
+    }
+    if !v6.is_empty() {
+        inner.push_str(&format!("<ipv6Ranges>{v6}</ipv6Ranges>"));
+    }
+    if !prefix.is_empty() {
+        inner.push_str(&format!("<prefixListIds>{prefix}</prefixListIds>"));
+    }
+    if !group_refs.is_empty() {
+        inner.push_str(&format!("<groups>{group_refs}</groups>"));
+    }
     inner
 }
 
 fn sg_xml(sg: &SecurityGroup, tags: &[Tag], owner: &str, region: &str) -> String {
-    let ingress: Vec<String> = sg
-        .rules
-        .iter()
-        .filter(|r| !r.is_egress)
-        .map(ip_permission_xml)
-        .collect();
-    let egress: Vec<String> = sg
-        .rules
-        .iter()
-        .filter(|r| r.is_egress)
-        .map(ip_permission_xml)
-        .collect();
+    let ingress_rules: Vec<&SecurityGroupRule> = sg.rules.iter().filter(|r| !r.is_egress).collect();
+    let egress_rules: Vec<&SecurityGroupRule> = sg.rules.iter().filter(|r| r.is_egress).collect();
+    let ingress = aggregated_ip_permissions_xml(&ingress_rules);
+    let egress = aggregated_ip_permissions_xml(&egress_rules);
     format!(
         "{}{}{}{}{}{}{}{}",
         ec2_elem("groupId", &sg.group_id),
@@ -1441,6 +1482,72 @@ mod modify_tests {
         assert_eq!(r.referenced_group_name.as_deref(), Some("peer-sg"));
         assert_eq!(r.referenced_user_id.as_deref(), Some("111122223333"));
         assert_eq!(r.description, "from peer");
+    }
+
+    #[test]
+    fn describe_aggregates_ipv4_and_ipv6_into_one_permission() {
+        // Authorizing ONE egress permission carrying both an IpRange and an
+        // Ipv6Range is stored as two per-range rules, but DescribeSecurityGroups
+        // must re-aggregate them into a single ipPermissionsEgress entry holding
+        // both ranges (the real EC2 shape the terraform aws_security_group_rule
+        // waiter polls for). A distinct protocol/port is used so it forms its
+        // own permission entry alongside the default all-traffic egress rule =
+        // 2 aggregated entries total (real EC2 would merge same-protocol ranges,
+        // so a `-1` authorize would instead fold into the default's entry).
+        let svc = Ec2Service::new();
+        let resp = create_security_group(
+            &svc,
+            &req(
+                "CreateSecurityGroup",
+                &[
+                    ("GroupName", "agg"),
+                    ("GroupDescription", "d"),
+                    ("VpcId", "vpc-1"),
+                ],
+            ),
+        )
+        .unwrap();
+        let sg_id = {
+            let body = String::from_utf8_lossy(resp.body.expect_bytes());
+            body.split("<groupId>")
+                .nth(1)
+                .and_then(|s| s.split("</groupId>").next())
+                .unwrap()
+                .to_string()
+        };
+        authorize_security_group_egress(
+            &svc,
+            &req(
+                "AuthorizeSecurityGroupEgress",
+                &[
+                    ("GroupId", &sg_id),
+                    ("IpPermissions.1.IpProtocol", "tcp"),
+                    ("IpPermissions.1.FromPort", "443"),
+                    ("IpPermissions.1.ToPort", "443"),
+                    ("IpPermissions.1.IpRanges.1.CidrIp", "0.0.0.0/0"),
+                    ("IpPermissions.1.Ipv6Ranges.1.CidrIpv6", "::/0"),
+                ],
+            ),
+        )
+        .unwrap();
+
+        let account = svc.state.read();
+        let rules = &account.get("000000000000").unwrap().security_groups[&sg_id].rules;
+        // Storage stays per-range: default(1) + tcp/443 v4 + tcp/443 v6 = 3 rules.
+        assert_eq!(rules.iter().filter(|r| r.is_egress).count(), 3);
+        let egress_refs: Vec<&SecurityGroupRule> = rules.iter().filter(|r| r.is_egress).collect();
+        let perms = aggregated_ip_permissions_xml(&egress_refs);
+        // ...but only 2 aggregated permission entries are rendered.
+        assert_eq!(perms.len(), 2, "expected 2 aggregated egress permissions");
+        // The tcp/443 entry is a SINGLE permission holding BOTH ranges.
+        let tcp = perms
+            .iter()
+            .find(|p| p.contains("<ipProtocol>tcp</ipProtocol>"))
+            .expect("no tcp/443 permission");
+        assert!(
+            tcp.contains("<cidrIp>0.0.0.0/0</cidrIp>") && tcp.contains("<cidrIpv6>::/0</cidrIpv6>"),
+            "v4 and v6 ranges not aggregated into one permission: {tcp}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -440,15 +440,28 @@ impl ElastiCacheService {
         let accounts = self.state.read();
         let empty = ElastiCacheState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let tag_list = state.tags.get(&resource_name).ok_or_else(|| {
-            AwsServiceError::aws_error(
+        // A resource that exists but has never been tagged has no entry in the
+        // tags map yet (CreateCacheParameterGroup and friends do not seed one).
+        // Real ElastiCache returns an empty TagList for such a resource and only
+        // errors when the resource itself is absent, so resolve existence
+        // against the resource collections instead of the tags map — keying off
+        // tags 404'd every freshly-created untagged resource, which broke every
+        // `aws_elasticache_parameter_group` apply (it reads tags right after
+        // create to populate tags_all).
+        if !resource_arn_exists(state, &resource_name) {
+            let resource_type = resource_name.split(':').nth(5).unwrap_or("");
+            return Err(AwsServiceError::aws_error(
                 StatusCode::NOT_FOUND,
-                "CacheClusterNotFound",
+                resource_not_found_code(resource_type),
                 format!("The resource {resource_name} could not be found."),
-            )
-        })?;
+            ));
+        }
 
-        let tag_xml: String = tag_list.iter().map(tag_xml).collect();
+        let tag_xml: String = state
+            .tags
+            .get(&resource_name)
+            .map(|t| t.iter().map(tag_xml).collect())
+            .unwrap_or_default();
 
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -885,6 +898,49 @@ impl ElastiCacheService {
             StatusCode::OK,
             query_response_xml(action, ELASTICACHE_NS, &body, &request.request_id),
         ))
+    }
+}
+
+/// True when `arn` matches an existing ElastiCache resource in `state`,
+/// scanning every tag-bearing resource collection. Used to decide whether a
+/// tags lookup should return an empty list (resource exists, no tags) or a
+/// not-found error (resource absent) — independent of the tags map, which is
+/// only populated once a resource is actually tagged.
+fn resource_arn_exists(state: &ElastiCacheState, arn: &str) -> bool {
+    state.cache_clusters.values().any(|c| c.arn == arn)
+        || state.parameter_groups.iter().any(|g| g.arn == arn)
+        || state.subnet_groups.values().any(|g| g.arn == arn)
+        || state.replication_groups.values().any(|g| g.arn == arn)
+        || state
+            .global_replication_groups
+            .values()
+            .any(|g| g.arn == arn)
+        || state.users.values().any(|u| u.arn == arn)
+        || state.user_groups.values().any(|g| g.arn == arn)
+        || state.snapshots.values().any(|s| s.arn == arn)
+        || state.serverless_caches.values().any(|c| c.arn == arn)
+        || state
+            .serverless_cache_snapshots
+            .values()
+            .any(|s| s.arn == arn)
+}
+
+/// AWS not-found error code for an ElastiCache ARN resource-type segment
+/// (`arn:aws:elasticache:region:account:<type>:<name>`), so a genuinely-absent
+/// resource errors with the code AWS uses for that type.
+fn resource_not_found_code(resource_type: &str) -> &'static str {
+    match resource_type {
+        "parametergroup" => "CacheParameterGroupNotFound",
+        "subnetgroup" => "CacheSubnetGroupNotFoundFault",
+        "replicationgroup" => "ReplicationGroupNotFoundFault",
+        "globalreplicationgroup" => "GlobalReplicationGroupNotFoundFault",
+        "user" => "UserNotFound",
+        "usergroup" => "UserGroupNotFound",
+        "snapshot" => "SnapshotNotFoundFault",
+        "serverlesscache" => "ServerlessCacheNotFoundFault",
+        "serverlesssnapshot" => "ServerlessCacheSnapshotNotFoundFault",
+        // "cluster" and any unrecognised type default to the cluster error.
+        _ => "CacheClusterNotFound",
     }
 }
 

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -3605,6 +3605,45 @@ fn list_tags_unknown_arn_errors() {
     assert!(svc.list_tags_for_resource(&req).is_err());
 }
 
+#[test]
+fn list_tags_existing_untagged_resource_returns_empty_list() {
+    // Real ElastiCache returns an empty TagList for a resource that exists but
+    // has never been tagged. Keying the lookup off the tags map 404'd every
+    // freshly-created parameter group, breaking `aws_elasticache_parameter_group`
+    // apply (it reads tags right after create). Regression for #2354.
+    let svc = fresh_service();
+    svc.create_cache_parameter_group(&request(
+        "CreateCacheParameterGroup",
+        &[
+            ("CacheParameterGroupName", "pg-untagged"),
+            ("CacheParameterGroupFamily", "redis7"),
+            ("Description", "test"),
+        ],
+    ))
+    .unwrap();
+
+    let arn = "arn:aws:elasticache:us-east-1:123456789012:parametergroup:pg-untagged";
+    let resp = svc
+        .list_tags_for_resource(&request("ListTagsForResource", &[("ResourceName", arn)]))
+        .expect("existing untagged resource must not 404");
+    let xml = body(resp);
+    assert!(
+        xml.contains("<TagList></TagList>") || xml.contains("<TagList/>"),
+        "{xml}"
+    );
+
+    // A genuinely-nonexistent resource still errors.
+    let missing = "arn:aws:elasticache:us-east-1:123456789012:parametergroup:does-not-exist";
+    let err = match svc.list_tags_for_resource(&request(
+        "ListTagsForResource",
+        &[("ResourceName", missing)],
+    )) {
+        Err(e) => e,
+        Ok(_) => panic!("nonexistent resource should error"),
+    };
+    assert_eq!(err.code(), "CacheParameterGroupNotFound");
+}
+
 // ── Coverage for the closure batch ──
 
 fn fresh_service() -> ElastiCacheService {


### PR DESCRIPTION
## Summary
Three filed, Terraform-breaking divergences found by the 2026-07-22 bug hunt. Each is fixed with a regression test.

- **#2353 — EC2 SG IPv4+IPv6 not aggregated.** `AuthorizeSecurityGroup*` with one `IpPermission` carrying both `IpRanges` and `Ipv6Ranges` was stored per-range and `DescribeSecurityGroups` emitted each as its own permission. Real EC2 collapses every range sharing `(protocol, from-port, to-port)` into one `ipPermissions`/`ipPermissionsEgress` entry. The terraform `aws_security_group_rule` create-waiter polls for that aggregated shape, never matched, and failed after ~5 min. Describe now re-aggregates (storage stays per-rule; `DescribeSecurityGroupRules` still lists individually).
- **#2354 — ElastiCache `ListTagsForResource` 404 on untagged resource.** It resolved existence via the tags map and returned `CacheClusterNotFound` for an existing-but-untagged resource; every `aws_elasticache_parameter_group` apply calls it right after create. Now checks the resource collections for existence, returns an empty `TagList` when the resource exists, and only errors (with the correct per-type code) when it's genuinely absent.
- **#2355 — apigatewayv2 `$default` stage unreadable.** The management-API lookup compared the URL-encoded path segment (`%24default`) against the stored literal (`$default`). Path-label segments are now percent-decoded before lookup, fixing get/delete/patch on `$default` and any other encodable id. Execute-api data plane keeps its raw path.

## Test plan
- New unit tests: `describe_aggregates_ipv4_and_ipv6_into_one_permission` (ec2), `list_tags_existing_untagged_resource_returns_empty_list` (elasticache), `get_stage_default_is_percent_decoded` (apigatewayv2).
- `cargo nextest run -p fakecloud-ec2 -p fakecloud-elasticache -p fakecloud-apigatewayv2`: 600 passed, existing `security_group` suite green.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; `cargo fmt` applied.

Conformance unaffected: the aggregation only changes multi-range describe rendering; the probe's single-range shape is unchanged.

Closes #2353, closes #2354, closes #2355.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three AWS compatibility gaps that broke Terraform flows: EC2 SG permission aggregation, ElastiCache ListTags on untagged resources, and API Gateway v2 `$default` stage decoding. Prevents Terraform timeouts and 404s during create/read.

- **Bug Fixes**
  - `ec2`: `DescribeSecurityGroups` now aggregates rules with the same protocol/ports into a single permission, combining IPv4 and IPv6 ranges; unblocks the `aws_security_group_rule` waiter.
  - `elasticache`: `ListTagsForResource` returns an empty `TagList` for existing untagged resources and uses the correct not-found code per type when absent; fixes reads after create for `aws_elasticache_parameter_group`.
  - `apigatewayv2`: Percent-decodes path-label segments in the management API so `$default` (sent as `%24default`) works for get/delete/patch; execute-api data plane unchanged.

<sup>Written for commit fe086d7a277ade8233718860a385d90b36b99339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

