### PR TITLE
fix(sqs,kms,logs,stepfunctions,eventbridge,cfn): build client-visible ARNs from the request region

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cwlogs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cwlogs.rs
@@ -24,7 +24,7 @@ impl ResourceProvisioner {
         let state = logs_accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:logs:{}:{}:log-group:{}:*",
-            state.region, state.account_id, log_group_name
+            self.region, state.account_id, log_group_name
         );
 
         let log_group = fakecloud_logs::LogGroup {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/dynamodb.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/dynamodb.rs
@@ -143,7 +143,7 @@ impl ResourceProvisioner {
         let state = __ddb_mas.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
-            state.region, state.account_id, table_name
+            self.region, state.account_id, table_name
         );
 
         let stream_arn = if stream_enabled {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/elasticache.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/elasticache.rs
@@ -408,9 +408,9 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:elasticache:{}:{}:cluster:{}",
-            state.region, state.account_id, id
+            self.region, state.account_id, id
         );
-        let endpoint_address = format!("{id}.fakecloud.{}.cache.amazonaws.com", state.region);
+        let endpoint_address = format!("{id}.fakecloud.{}.cache.amazonaws.com", self.region);
         let cluster = EcCacheCluster {
             cache_cluster_id: id.clone(),
             cache_node_type,
@@ -603,16 +603,14 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:elasticache:{}:{}:replicationgroup:{}",
-            state.region, state.account_id, id
+            self.region, state.account_id, id
         );
-        let endpoint_address = format!(
-            "{id}.fakecloud.ng.0001.{}.cache.amazonaws.com",
-            state.region
-        );
+        let endpoint_address =
+            format!("{id}.fakecloud.ng.0001.{}.cache.amazonaws.com", self.region);
         let configuration_endpoint = if cluster_enabled {
             Some(format!(
                 "{id}.fakecloud.cfg.{}.cache.amazonaws.com",
-                state.region
+                self.region
             ))
         } else {
             None

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/eventbridge.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/eventbridge.rs
@@ -33,12 +33,12 @@ impl ResourceProvisioner {
         let arn = if event_bus_name == "default" {
             format!(
                 "arn:aws:events:{}:{}:rule/{}",
-                state.region, state.account_id, rule_name
+                self.region, state.account_id, rule_name
             )
         } else {
             format!(
                 "arn:aws:events:{}:{}:rule/{}/{}",
-                state.region, state.account_id, event_bus_name, rule_name
+                self.region, state.account_id, event_bus_name, rule_name
             )
         };
 
@@ -204,14 +204,14 @@ impl ResourceProvisioner {
         let now = Utc::now();
         let arn = format!(
             "arn:aws:events:{}:{}:connection/{}/{}",
-            state.region,
+            self.region,
             state.account_id,
             name,
             Uuid::new_v4().as_simple()
         );
         let secret_arn = format!(
             "arn:aws:secretsmanager:{}:{}:secret:events!connection/{}-{}",
-            state.region,
+            self.region,
             state.account_id,
             name,
             Uuid::new_v4().as_simple()
@@ -283,7 +283,7 @@ impl ResourceProvisioner {
         let now = Utc::now();
         let arn = format!(
             "arn:aws:events:{}:{}:api-destination/{}/{}",
-            state.region,
+            self.region,
             state.account_id,
             name,
             Uuid::new_v4().as_simple()
@@ -355,7 +355,7 @@ impl ResourceProvisioner {
         }
         let arn = format!(
             "arn:aws:events:{}:{}:archive/{}",
-            state.region, state.account_id, name
+            self.region, state.account_id, name
         );
         state.archives.insert(
             name.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/kinesis.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/kinesis.rs
@@ -43,7 +43,7 @@ impl ResourceProvisioner {
         }
         let stream_arn = format!(
             "arn:aws:kinesis:{}:{}:stream/{}",
-            state.region, state.account_id, stream_name
+            self.region, state.account_id, stream_name
         );
         let stream = KinesisStream {
             stream_name: stream_name.clone(),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -465,10 +465,18 @@ impl ResourceProvisioner {
 
         let mut accounts = self.rds_state.write();
         let state = accounts.get_or_create(&self.account_id);
-        let arn = state.db_instance_arn(&identifier);
+        // Build the instance ARN from the stack's request region (self.region),
+        // not the RDS sub-service state's frozen startup region.
+        let arn = Arn::new(
+            "rds",
+            &self.region,
+            &state.account_id,
+            &format!("db:{identifier}"),
+        )
+        .to_string();
         let endpoint_address = format!(
             "{identifier}.cluster-fakecloud.{}.rds.amazonaws.com",
-            state.region
+            self.region
         );
         let dbi_resource_id = format!("db-{}", Uuid::new_v4().simple());
         let dbi_resource_id_attr = dbi_resource_id.clone();
@@ -800,16 +808,16 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:rds:{}:{}:cluster:{}",
-            state.region, state.account_id, identifier
+            self.region, state.account_id, identifier
         );
         let cluster_resource_id = format!("cluster-{}", Uuid::new_v4().simple());
         let endpoint = format!(
             "{identifier}.cluster-fakecloud.{}.rds.amazonaws.com",
-            state.region
+            self.region
         );
         let reader_endpoint = format!(
             "{identifier}.cluster-ro-fakecloud.{}.rds.amazonaws.com",
-            state.region
+            self.region
         );
         let body = serde_json::json!({
             "DBClusterIdentifier": identifier,

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/s3.rs
@@ -42,8 +42,8 @@ impl ResourceProvisioner {
 
         let mut __s3_mas = self.s3_state.write();
         let state = __s3_mas.get_or_create(&self.account_id);
-        let region = state.region.clone();
-        let mut bucket = S3Bucket::new(bucket_name, &state.region, &state.account_id);
+        let region = self.region.clone();
+        let mut bucket = S3Bucket::new(bucket_name, &self.region, &state.account_id);
         // Translate every modeled CFN property (VersioningConfiguration,
         // BucketEncryption, PublicAccessBlockConfiguration,
         // NotificationConfiguration, Tags, Website/Cors/Lifecycle/Logging) into
@@ -87,7 +87,7 @@ impl ResourceProvisioner {
         let bucket_name = &existing.physical_id;
         let mut __s3_mas = self.s3_state.write();
         let state = __s3_mas.get_or_create(&self.account_id);
-        let region = state.region.clone();
+        let region = self.region.clone();
         {
             let bucket = state
                 .buckets

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/secrets.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/secrets.rs
@@ -47,7 +47,7 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         let arn = format!(
             "arn:aws:secretsmanager:{}:{}:secret:{}",
-            state.region, state.account_id, name
+            self.region, state.account_id, name
         );
 
         if state.secrets.contains_key(&arn) {
@@ -242,7 +242,7 @@ impl ResourceProvisioner {
         } else {
             let candidate = format!(
                 "arn:aws:secretsmanager:{}:{}:secret:{}",
-                state.region, state.account_id, secret_id
+                self.region, state.account_id, secret_id
             );
             if state.secrets.contains_key(&candidate) {
                 candidate
@@ -304,7 +304,7 @@ impl ResourceProvisioner {
         } else {
             let candidate = format!(
                 "arn:aws:secretsmanager:{}:{}:secret:{}",
-                state.region, state.account_id, secret_id
+                self.region, state.account_id, secret_id
             );
             if state.secrets.contains_key(&candidate) {
                 candidate
@@ -359,7 +359,7 @@ impl ResourceProvisioner {
         } else {
             let candidate = format!(
                 "arn:aws:secretsmanager:{}:{}:secret:{}",
-                state.region, state.account_id, secret_id
+                self.region, state.account_id, secret_id
             );
             if state.secrets.contains_key(&candidate) {
                 candidate

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sns.rs
@@ -73,7 +73,7 @@ impl ResourceProvisioner {
         let state = __sns_mas.get_or_create(&self.account_id);
         let topic_arn = format!(
             "arn:aws:sns:{}:{}:{}",
-            state.region, state.account_id, topic_name
+            self.region, state.account_id, topic_name
         );
 
         // Carry the topic configuration attributes a CFN topic can set, so

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sqs.rs
@@ -85,7 +85,7 @@ impl ResourceProvisioner {
         let queue_url = format!("{}/{}/{}", state.endpoint, state.account_id, queue_name);
         let arn = format!(
             "arn:aws:sqs:{}:{}:{}",
-            state.region, state.account_id, queue_name
+            self.region, state.account_id, queue_name
         );
 
         let is_fifo = queue_name.ends_with(".fifo");

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -47,6 +47,28 @@ pub(crate) fn validate_put_events_entry(
 /// accepts (RFC 3339 string, fractional seconds as a float, integer
 /// seconds). Falls back to "now" if the field is absent or
 /// unparseable, which matches the real service.
+/// Re-stamp the region segment of an ARN with the caller's request region.
+///
+/// The default event bus is created at account-state bootstrap, which only
+/// has access to the server's frozen startup region — not the caller's
+/// credential-scope region. Custom buses created through `CreateEventBus`
+/// already carry the request region, so this rewrite is idempotent for them
+/// and only corrects the bootstrap default bus when a client is configured
+/// for a non-default region. ARNs that don't have the expected
+/// `arn:partition:service:region:account:resource` shape are returned
+/// unchanged.
+pub(crate) fn arn_with_request_region(arn: &str, region: &str) -> String {
+    let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    if parts.len() == 6 && parts[0] == "arn" {
+        format!(
+            "{}:{}:{}:{}:{}:{}",
+            parts[0], parts[1], parts[2], region, parts[4], parts[5]
+        )
+    } else {
+        arn.to_string()
+    }
+}
+
 pub(crate) fn parse_put_events_time(raw: &Value) -> DateTime<Utc> {
     if let Some(s) = raw.as_str() {
         return DateTime::parse_from_rfc3339(s)

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -417,7 +417,7 @@ impl EventBridgeService {
                 // aws_cloudwatch_event_buses data source expects to be set.
                 json!({
                     "Name": b.name,
-                    "Arn": b.arn,
+                    "Arn": arn_with_request_region(&b.arn, &req.region),
                     "CreationTime": b.creation_time.timestamp() as f64,
                     "LastModifiedTime": b.last_modified_time.timestamp() as f64,
                 })
@@ -449,7 +449,7 @@ impl EventBridgeService {
 
         let mut resp = json!({
             "Name": bus.name,
-            "Arn": bus.arn,
+            "Arn": arn_with_request_region(&bus.arn, &req.region),
             "CreationTime": bus.creation_time.timestamp() as f64,
             "LastModifiedTime": bus.last_modified_time.timestamp() as f64,
         });
@@ -533,7 +533,7 @@ impl EventBridgeService {
             "Effect": "Allow",
             "Principal": principal_value,
             "Action": action,
-            "Resource": bus.arn,
+            "Resource": arn_with_request_region(&bus.arn, &req.region),
         });
 
         let policy = bus.policy.get_or_insert_with(|| {
@@ -1311,7 +1311,7 @@ impl EventBridgeService {
         }
         bus.last_modified_time = Utc::now();
 
-        let arn = bus.arn.clone();
+        let arn = arn_with_request_region(&bus.arn, &req.region);
         let bus_name = bus.name.clone();
 
         Ok(AwsResponse::ok_json(json!({

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -41,7 +41,7 @@ impl EventBridgeService {
         }
         let arn = format!(
             "arn:aws:events:{}::event-source/aws.partner/{}",
-            state.region, name
+            req.region, name
         );
         let now = Utc::now();
         let ps = PartnerEventSource {

--- a/crates/fakecloud-eventbridge/src/service_tests.rs
+++ b/crates/fakecloud-eventbridge/src/service_tests.rs
@@ -2748,6 +2748,40 @@ fn describe_event_bus_default_returns_arn() {
 }
 
 #[test]
+fn default_bus_arn_uses_request_region_not_server_default() {
+    // The default bus is created at account-state bootstrap with the server's
+    // frozen startup region (us-east-1). A client scoped to eu-central-1 must
+    // still see an eu-central-1 ARN on DescribeEventBus / ListEventBuses.
+    let svc = make_service();
+
+    let mut describe = make_request("DescribeEventBus", json!({}));
+    describe.region = "eu-central-1".to_string();
+    let resp = svc.describe_event_bus(&describe).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        body["Arn"].as_str().unwrap(),
+        "arn:aws:events:eu-central-1:123456789012:event-bus/default"
+    );
+
+    let mut list = make_request("ListEventBuses", json!({}));
+    list.region = "eu-central-1".to_string();
+    let resp = svc.list_event_buses(&list).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let default_arn = body["EventBuses"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|b| b["Name"].as_str() == Some("default"))
+        .expect("default bus present")["Arn"]
+        .as_str()
+        .unwrap();
+    assert_eq!(
+        default_arn,
+        "arn:aws:events:eu-central-1:123456789012:event-bus/default"
+    );
+}
+
+#[test]
 fn delete_event_bus_default_fails() {
     let svc = make_service();
     let req = make_request("DeleteEventBus", json!({ "Name": "default" }));

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -561,7 +561,7 @@ impl KmsService {
 
         let arn = format!(
             "arn:aws:kms:{}:{}:key/{}",
-            state.region, state.account_id, key_id
+            req.region, state.account_id, key_id
         );
         let now = Utc::now().timestamp() as f64;
 
@@ -1388,7 +1388,14 @@ impl KmsService {
             })?
             .clone();
         let account_id = state.account_id.clone();
-        let source_region = state.region.clone();
+        // The primary key's region is whatever region its ARN was minted in
+        // (the request region at CreateKey time), not the server default.
+        let source_region = source_key
+            .arn
+            .split(':')
+            .nth(3)
+            .unwrap_or(&state.region)
+            .to_string();
 
         let replica_arn = format!(
             "arn:aws:kms:{}:{}:key/{}",

--- a/crates/fakecloud-kms/src/service_aliases.rs
+++ b/crates/fakecloud-kms/src/service_aliases.rs
@@ -40,7 +40,7 @@ impl KmsService {
         if state.aliases.contains_key(&alias_name) {
             let alias_arn = format!(
                 "arn:aws:kms:{}:{}:{}",
-                state.region, state.account_id, alias_name
+                req.region, state.account_id, alias_name
             );
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -51,7 +51,7 @@ impl KmsService {
 
         let alias_arn = format!(
             "arn:aws:kms:{}:{}:{}",
-            state.region, state.account_id, alias_name
+            req.region, state.account_id, alias_name
         );
 
         state.aliases.insert(
@@ -93,7 +93,7 @@ impl KmsService {
         if state.aliases.remove(alias_name).is_none() {
             let alias_arn = format!(
                 "arn:aws:kms:{}:{}:{}",
-                state.region, state.account_id, alias_name
+                req.region, state.account_id, alias_name
             );
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -43,6 +43,48 @@ fn create_key(svc: &KmsService) -> String {
     body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string()
 }
 
+#[test]
+fn key_and_alias_arns_use_request_region_not_server_default() {
+    // Server default region is us-east-1 (see make_service); a client scoped
+    // to eu-central-1 must get eu-central-1 key + alias ARNs.
+    let svc = make_service();
+
+    let mut create = make_request("CreateKey", json!({}));
+    create.region = "eu-central-1".to_string();
+    let resp = svc.create_key(&create).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let key_arn = body["KeyMetadata"]["Arn"].as_str().unwrap();
+    let key_id = body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string();
+    assert!(
+        key_arn.starts_with("arn:aws:kms:eu-central-1:123456789012:key/"),
+        "key ARN must carry the request region, got {key_arn}"
+    );
+
+    let mut alias = make_request(
+        "CreateAlias",
+        json!({ "AliasName": "alias/region-test", "TargetKeyId": key_id }),
+    );
+    alias.region = "eu-central-1".to_string();
+    svc.create_alias(&alias).unwrap();
+
+    let mut list = make_request("ListAliases", json!({}));
+    list.region = "eu-central-1".to_string();
+    let resp = svc.list_aliases(&list).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let alias_arn = body["Aliases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["AliasName"].as_str() == Some("alias/region-test"))
+        .expect("created alias present")["AliasArn"]
+        .as_str()
+        .unwrap();
+    assert_eq!(
+        alias_arn,
+        "arn:aws:kms:eu-central-1:123456789012:alias/region-test"
+    );
+}
+
 /// Helper: run GetParametersForImport, RSA-OAEP-wrap `material` under
 /// the returned public key, and call ImportKeyMaterial. Used by every
 /// import-flow test so they exercise the real OAEP unwrap path

--- a/crates/fakecloud-logs/src/service/anomaly.rs
+++ b/crates/fakecloud-logs/src/service/anomaly.rs
@@ -79,7 +79,7 @@ impl LogsService {
         let detector_id = uuid::Uuid::new_v4().to_string();
         let arn = format!(
             "arn:aws:logs:{}:{}:anomaly-detector:{}",
-            state.region, state.account_id, detector_id
+            req.region, state.account_id, detector_id
         );
 
         let detector = AnomalyDetector {

--- a/crates/fakecloud-logs/src/service/deliveries.rs
+++ b/crates/fakecloud-logs/src/service/deliveries.rs
@@ -112,7 +112,7 @@ impl LogsService {
 
         let arn = format!(
             "arn:aws:logs:{}:{}:delivery-destination:{}",
-            state.region, state.account_id, name
+            req.region, state.account_id, name
         );
 
         // The destination type is either supplied explicitly or inferred from
@@ -503,7 +503,7 @@ impl LogsService {
 
         let arn = format!(
             "arn:aws:logs:{}:{}:delivery-source:{}",
-            state.region, state.account_id, name
+            req.region, state.account_id, name
         );
 
         let created_at = state
@@ -757,7 +757,7 @@ impl LogsService {
         let delivery_id = uuid::Uuid::new_v4().to_string();
         let arn = format!(
             "arn:aws:logs:{}:{}:delivery:{}",
-            state.region, state.account_id, delivery_id
+            req.region, state.account_id, delivery_id
         );
 
         let delivery = Delivery {

--- a/crates/fakecloud-logs/src/service/destinations.rs
+++ b/crates/fakecloud-logs/src/service/destinations.rs
@@ -62,7 +62,7 @@ impl LogsService {
         let state = accounts.get_or_create(&req.account_id);
         let arn = format!(
             "arn:aws:logs:{}:{}:destination:{}",
-            state.region, state.account_id, destination_name
+            req.region, state.account_id, destination_name
         );
         let now = Utc::now().timestamp_millis();
 

--- a/crates/fakecloud-logs/src/service/groups.rs
+++ b/crates/fakecloud-logs/src/service/groups.rs
@@ -68,7 +68,7 @@ impl LogsService {
 
         let arn = format!(
             "arn:aws:logs:{}:{}:log-group:{}:*",
-            state.region, state.account_id, name
+            req.region, state.account_id, name
         );
         let now = Utc::now().timestamp_millis();
 

--- a/crates/fakecloud-logs/src/service/streams.rs
+++ b/crates/fakecloud-logs/src/service/streams.rs
@@ -47,7 +47,7 @@ impl LogsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let region = state.region.clone();
+        let region = req.region.clone();
         let account_id = state.account_id.clone();
 
         let group = state.log_groups.get_mut(group_name).ok_or_else(|| {
@@ -507,7 +507,7 @@ impl LogsService {
             .filter(|f| f.log_group_name == group_name_owned)
             .cloned()
             .collect();
-        let region_owned = state.region.clone();
+        let region_owned = req.region.clone();
         let account_id_for_metrics = state.account_id.clone();
 
         // Collect delivery pipeline info: find active deliveries whose source

--- a/crates/fakecloud-sqs/src/service/queues.rs
+++ b/crates/fakecloud-sqs/src/service/queues.rs
@@ -188,8 +188,8 @@ impl SqsService {
         let queue = SqsQueue {
             arn: format!(
                 "arn:{}:sqs:{}:{}:{}",
-                fakecloud_aws::arn::partition_for(&state.region),
-                state.region,
+                fakecloud_aws::arn::partition_for(&req.region),
+                req.region,
                 state.account_id,
                 queue_name
             ),

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -558,6 +558,31 @@ fn get_queue_attributes_all() {
 }
 
 #[test]
+fn queue_arn_uses_request_region_not_server_default() {
+    // The server default region is us-east-1 (see make_service), but a client
+    // whose credential scope resolves to eu-central-1 must get an ARN carrying
+    // eu-central-1 — not the frozen startup region.
+    let svc = make_service();
+    let mut create = make_request("CreateQueue", json!({ "QueueName": "region-queue" }));
+    create.region = "eu-central-1".to_string();
+    let resp = svc.create_queue(&create).unwrap();
+    let url = {
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        body["QueueUrl"].as_str().unwrap().to_string()
+    };
+
+    let mut get = make_request(
+        "GetQueueAttributes",
+        json!({ "QueueUrl": url, "AttributeNames": ["QueueArn"] }),
+    );
+    get.region = "eu-central-1".to_string();
+    let resp = svc.get_queue_attributes(&get).unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let arn = body["Attributes"]["QueueArn"].as_str().unwrap();
+    assert_eq!(arn, "arn:aws:sqs:eu-central-1:123456789012:region-queue");
+}
+
+#[test]
 fn get_queue_attributes_specific() {
     let svc = make_service();
     let url = create_queue(&svc, "specific-attrs-queue");
@@ -3204,23 +3229,30 @@ async fn redriven_message_resets_receive_count_in_dlq() {
 
 /// In a non-`aws` partition (cn / gov-cloud) the queue ARN must carry the
 /// region's partition, and that partition-correct ARN must resolve back to the
-/// queue on send/receive.
+/// queue on send/receive. The partition/region come from the request's
+/// credential scope, not the server's startup region — so the request itself
+/// carries cn-north-1 here.
 #[test]
 fn queue_arn_uses_region_partition_and_resolves() {
-    let state: SharedSqsState = Arc::new(RwLock::new(
-        fakecloud_core::multi_account::MultiAccountState::new(
-            "123456789012",
-            "cn-north-1",
-            "http://localhost:4566",
-        ),
-    ));
-    let svc = SqsService::new(state);
-    let url = create_queue(&svc, "cn-queue");
+    let svc = make_service();
+    let cn_request = |action: &str, body: Value| {
+        let mut req = make_request(action, body);
+        req.region = "cn-north-1".to_string();
+        req
+    };
+
+    let create_resp = svc
+        .create_queue(&cn_request("CreateQueue", json!({ "QueueName": "cn-queue" })))
+        .unwrap();
+    let url = body_json(create_resp)["QueueUrl"]
+        .as_str()
+        .unwrap()
+        .to_string();
     let arn = "arn:aws-cn:sqs:cn-north-1:123456789012:cn-queue";
 
     // GetQueueAttributes reports the aws-cn ARN.
     let resp = svc
-        .get_queue_attributes(&make_request(
+        .get_queue_attributes(&cn_request(
             "GetQueueAttributes",
             json!({ "QueueUrl": url, "AttributeNames": ["QueueArn"] }),
         ))

--- a/crates/fakecloud-sqs/src/service_tests.rs
+++ b/crates/fakecloud-sqs/src/service_tests.rs
@@ -3242,7 +3242,10 @@ fn queue_arn_uses_region_partition_and_resolves() {
     };
 
     let create_resp = svc
-        .create_queue(&cn_request("CreateQueue", json!({ "QueueName": "cn-queue" })))
+        .create_queue(&cn_request(
+            "CreateQueue",
+            json!({ "QueueName": "cn-queue" }),
+        ))
         .unwrap();
     let url = body_json(create_resp)["QueueUrl"]
         .as_str()

--- a/crates/fakecloud-stepfunctions/src/service/activities.rs
+++ b/crates/fakecloud-stepfunctions/src/service/activities.rs
@@ -13,7 +13,7 @@ impl StepFunctionsService {
         let state = accounts.get_or_create(&req.account_id);
         let arn = format!(
             "arn:aws:states:{}:{}:activity:{}",
-            state.region, state.account_id, name
+            req.region, state.account_id, name
         );
         if state.activities.contains_key(&arn) {
             return Err(AwsServiceError::aws_error(

--- a/crates/fakecloud-stepfunctions/src/service/executions.rs
+++ b/crates/fakecloud-stepfunctions/src/service/executions.rs
@@ -45,7 +45,7 @@ impl StepFunctionsService {
         let sm_name = sm.name.clone();
         let sm_type = sm.machine_type;
         let definition = sm.definition.clone();
-        let exec_arn = state.execution_arn(&sm_name, &execution_name);
+        let exec_arn = state.execution_arn(&req.region, &sm_name, &execution_name);
 
         // Handle name collisions. For STANDARD workflows, StartExecution is
         // idempotent: re-issuing the same name AND the same input returns the
@@ -438,7 +438,7 @@ impl StepFunctionsService {
                 let candidate = format!("sync-{}", uuid::Uuid::new_v4());
                 let arn = format!(
                     "arn:aws:states:{}:{}:express:{}:{}",
-                    state.region, state.account_id, sm.name, candidate
+                    req.region, state.account_id, sm.name, candidate
                 );
                 if !state.executions.contains_key(&arn) {
                     break (candidate, arn);

--- a/crates/fakecloud-stepfunctions/src/service/mod.rs
+++ b/crates/fakecloud-stepfunctions/src/service/mod.rs
@@ -1033,7 +1033,14 @@ pub fn start_execution_from_delivery(
 
     let sm_name = sm.name.clone();
     let definition = sm.definition.clone();
-    let exec_arn = st.execution_arn(&sm_name, &execution_name);
+    // No request in this delivery path; the execution inherits the region its
+    // state machine ARN was minted in (the request region at CreateStateMachine).
+    let region = state_machine_arn
+        .split(':')
+        .nth(3)
+        .unwrap_or("us-east-1")
+        .to_string();
+    let exec_arn = st.execution_arn(&region, &sm_name, &execution_name);
 
     let now = Utc::now();
     let execution = Execution {

--- a/crates/fakecloud-stepfunctions/src/service/state_machines.rs
+++ b/crates/fakecloud-stepfunctions/src/service/state_machines.rs
@@ -42,7 +42,7 @@ impl StepFunctionsService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let arn = state.state_machine_arn(name);
+        let arn = state.state_machine_arn(&req.region, name);
 
         // Check if name already exists
         if state.state_machines.values().any(|sm| sm.name == name) {

--- a/crates/fakecloud-stepfunctions/src/state.rs
+++ b/crates/fakecloud-stepfunctions/src/state.rs
@@ -284,17 +284,22 @@ impl StepFunctionsState {
         self.task_tokens.clear();
     }
 
-    pub fn state_machine_arn(&self, name: &str) -> String {
+    pub fn state_machine_arn(&self, region: &str, name: &str) -> String {
         format!(
             "arn:aws:states:{}:{}:stateMachine:{}",
-            self.region, self.account_id, name
+            region, self.account_id, name
         )
     }
 
-    pub fn execution_arn(&self, state_machine_name: &str, execution_name: &str) -> String {
+    pub fn execution_arn(
+        &self,
+        region: &str,
+        state_machine_name: &str,
+        execution_name: &str,
+    ) -> String {
         format!(
             "arn:aws:states:{}:{}:execution:{}:{}",
-            self.region, self.account_id, state_machine_name, execution_name
+            region, self.account_id, state_machine_name, execution_name
         )
     }
 }
@@ -342,7 +347,7 @@ mod tests {
     fn state_machine_arn_format() {
         let state = StepFunctionsState::new("123456789012", "us-east-1");
         assert_eq!(
-            state.state_machine_arn("my-sm"),
+            state.state_machine_arn("us-east-1", "my-sm"),
             "arn:aws:states:us-east-1:123456789012:stateMachine:my-sm"
         );
     }
@@ -351,8 +356,23 @@ mod tests {
     fn execution_arn_format() {
         let state = StepFunctionsState::new("123456789012", "us-east-1");
         assert_eq!(
-            state.execution_arn("sm", "exec-1"),
+            state.execution_arn("us-east-1", "sm", "exec-1"),
             "arn:aws:states:us-east-1:123456789012:execution:sm:exec-1"
+        );
+    }
+
+    #[test]
+    fn arns_use_request_region_not_server_default() {
+        // Server default region is us-east-1, but a client whose credential
+        // scope resolves to eu-central-1 must get eu-central-1 ARNs.
+        let state = StepFunctionsState::new("123456789012", "us-east-1");
+        assert_eq!(
+            state.state_machine_arn("eu-central-1", "my-sm"),
+            "arn:aws:states:eu-central-1:123456789012:stateMachine:my-sm"
+        );
+        assert_eq!(
+            state.execution_arn("eu-central-1", "sm", "exec-1"),
+            "arn:aws:states:eu-central-1:123456789012:execution:sm:exec-1"
         );
     }
 


### PR DESCRIPTION
## Summary
Systemic bug found by the 2026-07-22 bug hunt: client-visible ARNs were stamped from the server's frozen startup region (`state.region`), not the request's credential-scope region (`req.region`, already threaded into every handler). Any client (Terraform, boto3, an SDK) configured for a region other than the server default (`us-east-1`) got wrong-region ARNs — breaking IAM/KMS `Condition` matches, cross-service ARN references, and causing perpetual Terraform drift. `secretsmanager`/`sns` already build ARNs from the request region; this makes the rest consistent.

Sibling family of #2356 (Lambda's own `FunctionArn` region is handled in a separate PR).

## Changed ARN builders (switched to the request region)
- **SQS** — `CreateQueue` ARN (GetQueueAttributes reads the stored ARN).
- **KMS** — `CreateKey` ARN, alias ARNs (create + AlreadyExists/NotFound error ARNs), `ReplicateKey` source-region derivation so `PrimaryKey.Region` matches.
- **CloudWatch Logs** — log-group/stream/destination/delivery/anomaly ARNs + the cross-service metric-publish region.
- **Step Functions** — `stateMachineArn` / `executionArn` (region threaded into the builders) + activity ARN + the express/sync execution paths.
- **EventBridge** — default-bus ARN (corrected at emit time via a request-region helper) + partner event-source ARN.
- **CloudFormation provisioners** — every arm that read the frozen *sub-service* `state.region` (secrets, eventbridge, sqs, sns, kinesis, dynamodb, cwlogs, rds, elasticache, s3) now uses the stack's request region, incl. co-located region-bearing endpoint hostnames / bucket region.

## Test plan
- New unit tests asserting a non-default (`eu-central-1`/`cn-north-1`) request produces that-region ARNs: SQS, KMS (key+alias), Step Functions, EventBridge default bus.
- Rewrote one pre-existing SQS test that asserted the *server*-region ARN (the buggy behavior) to send region-scoped *requests*, preserving its aws-cn partition intent.
- `cargo nextest`: fakecloud-sqs/kms/stepfunctions/eventbridge/logs 1203/1203, fakecloud-cloudformation 296/296.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

Conformance unaffected: the probe signs with the default `us-east-1` scope, so `req.region == state.region` and ARNs are unchanged there — the fix only alters behavior when the client's region differs from the server default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where client-visible ARNs were minted with the server’s startup region instead of the caller’s request region. This restores correct IAM/KMS condition matching, cross-service references, and stops Terraform drift when clients use non-default regions.

- **Bug Fixes**
  - SQS: Queue ARNs now use the request region and correct partition; `GetQueueAttributes` returns the stored, region-correct ARN.
  - KMS: `CreateKey` and alias ARNs use the request region; `ReplicateKey` derives the primary’s region from its key ARN so `PrimaryKey.Region` is accurate.
  - CloudWatch Logs: ARNs for groups, streams, destinations, deliveries, and anomalies use the request region; metric-publish region fixed.
  - Step Functions: `stateMachineArn`, `executionArn`, and activity ARNs use the request region; express/sync paths updated; delivery path infers region from the state machine ARN.
  - EventBridge: Default bus ARN is restamped to the request region on `DescribeEventBus`/`ListEventBuses`; partner event-source ARNs use the request region; bus policy `Resource` uses the request-region ARN.
  - CloudFormation provisioners: Now mint ARNs and region-bearing endpoints from the stack’s request region across `secrets`, `eventbridge` (rule, connection, api-destination, archive), `sqs`, `sns`, `kinesis`, `dynamodb`, `logs`, `rds` (DB/cluster ARNs + endpoints), `elasticache` (cluster/replication-group endpoints), and `s3`.

<sup>Written for commit 008bc50e8f83c39fc291fa7557938f201eb39d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

