### PR TITLE
fix(acm,ecr,kafka): ACM PEM panic guard, ECR OCI blob-commit offload, MSK UPDATING restart recovery

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -3172,7 +3172,9 @@ mod tests {
             }),
         );
         match svc.handle(req).await {
-            Err(AwsServiceError::AwsError { code, .. }) => assert_eq!(code, "InvalidParameterException"),
+            Err(AwsServiceError::AwsError { code, .. }) => {
+                assert_eq!(code, "InvalidParameterException")
+            }
             Err(other) => panic!("expected an InvalidParameterException, got {other:?}"),
             Ok(_) => panic!("expected import of a malformed key to be rejected"),
         }
@@ -3203,7 +3205,9 @@ mod tests {
             json!({ "CertificateArn": arn, "Passphrase": passphrase }),
         );
         match svc.handle(req).await {
-            Err(AwsServiceError::AwsError { code, .. }) => assert_eq!(code, "InvalidParameterException"),
+            Err(AwsServiceError::AwsError { code, .. }) => {
+                assert_eq!(code, "InvalidParameterException")
+            }
             Err(other) => panic!("expected an InvalidParameterException, got {other:?}"),
             Ok(_) => panic!("expected export of a malformed key to error, not panic"),
         }

--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -735,6 +735,15 @@ impl AcmService {
             .ok_or_else(|| invalid_param("Certificate is required"))?;
         let key_pem = decode_blob(body.get("PrivateKey"))
             .ok_or_else(|| invalid_param("PrivateKey is required"))?;
+        // Reject a structurally-invalid private key up front. Without this,
+        // a malformed key is stored as-is and only blows up later when
+        // ExportCertificate tries to PEM-decode it (IMPORTED certs are
+        // always exportable), which previously panicked the request task.
+        if !is_pem_private_key(&key_pem) {
+            return Err(invalid_param(
+                "PrivateKey could not be decoded as a PEM-encoded private key",
+            ));
+        }
         let chain_pem = decode_blob(body.get("CertificateChain"));
         let arn_in = body
             .get("CertificateArn")
@@ -1994,16 +2003,57 @@ fn pem_decode_private_key(pem: &str) -> Result<Vec<u8>, String> {
         .find("-----END PRIVATE KEY-----")
         .ok_or("missing END line")?;
     let body_start = begin + 11 + dash + 5;
+    // A well-formed block has END after the base64 body. A malformed
+    // single-line block (`BEGIN...X-----END...`) or an END-before-BEGIN
+    // ordering leaves `body_start > end`, and the first newline after
+    // `body_start` can also fall beyond END. Guard both before slicing so
+    // a bad key returns a validation error instead of panicking the task.
+    if end < body_start {
+        return Err("malformed PEM: END marker precedes the key body".to_string());
+    }
     let nl = pem[body_start..]
         .find('\n')
         .ok_or("missing newline after BEGIN")?;
-    let body: String = pem[body_start + nl + 1..end]
+    let body_from = body_start + nl + 1;
+    if body_from > end {
+        return Err("malformed PEM: no key body between BEGIN and END".to_string());
+    }
+    let body: String = pem[body_from..end]
         .chars()
         .filter(|c| !c.is_whitespace())
         .collect();
     base64::engine::general_purpose::STANDARD
         .decode(body.as_bytes())
         .map_err(|e| format!("PEM body is not valid base64: {e}"))
+}
+
+/// Structural check that `pem` looks like a PEM-encoded private key: a
+/// `-----BEGIN ... PRIVATE KEY-----` marker followed by a matching
+/// `-----END ... PRIVATE KEY-----`, with a non-empty body between them.
+/// Accepts any private-key label (PKCS#8 `PRIVATE KEY`, `RSA PRIVATE KEY`,
+/// `EC PRIVATE KEY`); it does not validate the inner DER. ACM
+/// ImportCertificate rejects a key that is not structurally a PEM private
+/// key with a validation error rather than storing an unusable blob.
+fn is_pem_private_key(pem: &str) -> bool {
+    let Some(begin) = pem.find("-----BEGIN ") else {
+        return false;
+    };
+    let after_begin = &pem[begin + 11..];
+    let Some(dash) = after_begin.find("-----") else {
+        return false;
+    };
+    let label = after_begin[..dash].trim();
+    if !label.ends_with("PRIVATE KEY") {
+        return false;
+    }
+    let body_start = begin + 11 + dash + 5;
+    let end_marker = format!("-----END {label}-----");
+    let Some(end_rel) = pem[body_start..].find(&end_marker) else {
+        return false;
+    };
+    let end = body_start + end_rel;
+    // Body between BEGIN and END must be non-empty (whitespace aside).
+    pem[body_start..end].chars().any(|c| !c.is_whitespace())
 }
 
 #[cfg(test)]
@@ -3071,5 +3121,91 @@ mod tests {
         }))
         .await;
         assert!(got.is_empty());
+    }
+
+    #[test]
+    fn pem_decode_private_key_rejects_malformed_without_panic() {
+        // Single-line block: the first newline falls after END, so the body
+        // range would be inverted and slice-panic without the guard.
+        assert!(
+            pem_decode_private_key("-----BEGIN PRIVATE KEY-----X-----END PRIVATE KEY-----\n")
+                .is_err()
+        );
+        // END marker appears before BEGIN.
+        assert!(
+            pem_decode_private_key("-----END PRIVATE KEY-----\n-----BEGIN PRIVATE KEY-----\n")
+                .is_err()
+        );
+        // No markers, and empty input.
+        assert!(pem_decode_private_key("not a pem at all").is_err());
+        assert!(pem_decode_private_key("").is_err());
+        // A real PKCS#8 key still decodes.
+        let (_c, key) = generate_self_signed_cert("example.com", &[]).unwrap();
+        assert!(pem_decode_private_key(&key).is_ok());
+    }
+
+    #[test]
+    fn is_pem_private_key_accepts_real_key_rejects_junk() {
+        let (_c, key) = generate_self_signed_cert("example.com", &[]).unwrap();
+        assert!(is_pem_private_key(&key));
+        // Certificate label is not a private key.
+        assert!(!is_pem_private_key(
+            "-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n"
+        ));
+        // Markers present but empty body.
+        assert!(!is_pem_private_key(
+            "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"
+        ));
+        // No markers.
+        assert!(!is_pem_private_key("definitely not a pem key"));
+    }
+
+    #[tokio::test]
+    async fn import_certificate_rejects_malformed_private_key() {
+        use base64::engine::general_purpose::STANDARD as B64;
+        let svc = AcmService::default();
+        let req = make_req(
+            "ImportCertificate",
+            json!({
+                "Certificate": B64.encode("-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n"),
+                "PrivateKey": B64.encode("definitely not a pem key"),
+            }),
+        );
+        match svc.handle(req).await {
+            Err(AwsServiceError::AwsError { code, .. }) => assert_eq!(code, "InvalidParameterException"),
+            Err(other) => panic!("expected an InvalidParameterException, got {other:?}"),
+            Ok(_) => panic!("expected import of a malformed key to be rejected"),
+        }
+    }
+
+    #[tokio::test]
+    async fn export_with_passphrase_on_malformed_stored_key_errors_not_panics() {
+        // A cert whose stored private key is structurally malformed (e.g. it
+        // slipped in before validation existed) must surface a validation
+        // error on export-with-passphrase, never panic the request task.
+        let svc = AcmService::default();
+        let arn = make_exportable_cert(&svc).await;
+        {
+            let mut state = svc.state.write();
+            let cert = state
+                .accounts
+                .get_mut("123456789012")
+                .unwrap()
+                .certificates
+                .get_mut(&arn)
+                .unwrap();
+            cert.private_key_pem =
+                Some("-----BEGIN PRIVATE KEY-----X-----END PRIVATE KEY-----\n".to_string());
+        }
+        let passphrase = base64::engine::general_purpose::STANDARD.encode("hunter2");
+        let req = make_req(
+            "ExportCertificate",
+            json!({ "CertificateArn": arn, "Passphrase": passphrase }),
+        );
+        match svc.handle(req).await {
+            Err(AwsServiceError::AwsError { code, .. }) => assert_eq!(code, "InvalidParameterException"),
+            Err(other) => panic!("expected an InvalidParameterException, got {other:?}"),
+            Ok(_) => panic!("expected export of a malformed key to error, not panic"),
+        }
     }
 }

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -868,14 +868,32 @@ async fn blob_upload_finish(
     })?;
     append_stream(&spool, stream).await?;
 
-    let combined = read_spool(&spool).map_err(|e| {
-        AwsServiceError::aws_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "InternalError",
-            format!("failed to read upload spool: {e}"),
-        )
-    })?;
-    let computed = sha256_digest(&combined);
+    // Read the full spool and compute its SHA-256 on a blocking thread so a
+    // large-layer `docker push` (100s of MB) doesn't stall a tokio worker and
+    // starve concurrent pushes. Mirrors the JSON CompleteLayerUpload path
+    // (service/layers.rs, bug-audit 2026-06-13, 3.2).
+    let read_path = spool.clone();
+    let (combined, computed) =
+        tokio::task::spawn_blocking(move || -> std::io::Result<(Vec<u8>, String)> {
+            let bytes = read_spool(&read_path)?;
+            let digest = sha256_digest(&bytes);
+            Ok((bytes, digest))
+        })
+        .await
+        .map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                format!("layer read/hash task failed: {e}"),
+            )
+        })?
+        .map_err(|e| {
+            AwsServiceError::aws_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                format!("failed to read upload spool: {e}"),
+            )
+        })?;
     if digest != computed {
         // Spool stays in place — the OCI client can retry the final
         // PUT with the correct digest instead of re-uploading every
@@ -1290,5 +1308,56 @@ mod immutability_tests {
         manifest_put(&svc, &manifest_req(&manifest("aaaa")), "app", "v1").unwrap();
         // Overwrite allowed on a MUTABLE repo.
         manifest_put(&svc, &manifest_req(&manifest("bbbb")), "app", "v1").unwrap();
+    }
+
+    // A multi-MB blob commit must produce the exact SHA-256 the client sent,
+    // proving the read+hash offloaded to spawn_blocking preserves correctness.
+    #[tokio::test]
+    async fn blob_upload_finish_commits_correct_digest_for_multi_mb_layer() {
+        let svc = svc_with_repo("MUTABLE");
+        let data: Vec<u8> = (0..(4 * 1024 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        let expected = super::sha256_digest(&data);
+
+        let dir = tempfile::tempdir().unwrap();
+        let spool = dir.path().join("spool.bin");
+        let upload_id = "upload-1";
+        {
+            let mut guard = svc.state_handle().write();
+            let s = guard.get_or_create(ACCT);
+            s.layer_uploads.insert(
+                upload_id.to_string(),
+                crate::state::LayerUpload {
+                    upload_id: upload_id.to_string(),
+                    repository_name: "app".to_string(),
+                    created_at: chrono::Utc::now(),
+                    spool_path: spool.to_string_lossy().into_owned(),
+                    last_byte_received: 0,
+                },
+            );
+        }
+
+        let mut req = manifest_req("");
+        req.query_params
+            .insert("digest".to_string(), expected.clone());
+        *req.body_stream.lock() = Some(fakecloud_core::service::RequestBodyStream::from(
+            data.clone(),
+        ));
+
+        let resp = blob_upload_finish(&svc, &req, "app", upload_id)
+            .await
+            .expect("blob commit should succeed");
+        assert_eq!(
+            resp.headers
+                .get("Docker-Content-Digest")
+                .and_then(|v| v.to_str().ok()),
+            Some(expected.as_str())
+        );
+
+        let guard = svc.state_handle().read();
+        let repo = guard.get(ACCT).unwrap().repositories.get("app").unwrap();
+        let layer = repo.layers.get(&expected).expect("layer stored by digest");
+        assert_eq!(layer.size, data.len() as u64);
+        // The upload spool is consumed on a successful commit.
+        assert!(guard.get(ACCT).unwrap().layer_uploads.is_empty());
     }
 }

--- a/crates/fakecloud-kafka/src/service.rs
+++ b/crates/fakecloud-kafka/src/service.rs
@@ -771,6 +771,21 @@ pub(crate) async fn settle_cluster_up(
     }
 }
 
+/// Whether a persisted cluster in this state should have its backing broker
+/// container re-spawned on restart. `UPDATING` is included: an `Update*` in
+/// flight when the snapshot was taken left the cluster mid-window, and
+/// `state.rs` `reconcile` settles `UPDATING -> ACTIVE` on the next read -- so
+/// without re-spawning here a describe would report ACTIVE with a dead broker
+/// (RDS #1338 class). `HEALING`/`MAINTENANCE` are never persisted (they only
+/// appear transiently in the reconcile match), but are treated as recoverable
+/// too so any future code path that persists them stays safe.
+fn cluster_state_recoverable(state: &str) -> bool {
+    matches!(
+        state,
+        "ACTIVE" | "CREATING" | "REBOOTING_BROKER" | "UPDATING" | "HEALING" | "MAINTENANCE"
+    )
+}
+
 /// Bring a persisted cluster's broker back after a restart: re-attach the
 /// persisted container if it still exists (preserving the topic log), otherwise
 /// create a fresh one. Both phases retry with backoff so a transient failure
@@ -1164,9 +1179,7 @@ impl KafkaService {
                     if !runtime_present || serverless {
                         continue;
                     }
-                    let recoverable =
-                        matches!(st.as_str(), "ACTIVE" | "CREATING" | "REBOOTING_BROKER");
-                    if !recoverable {
+                    if !cluster_state_recoverable(&st) {
                         continue;
                     }
                     // Mark CREATING so a describe during recovery doesn't advertise
@@ -2932,6 +2945,22 @@ mod tests {
             "",
         )));
         KafkaService::new(state)
+    }
+
+    #[test]
+    fn updating_cluster_is_recoverable_on_restart() {
+        // A cluster snapshotted mid-Update (state UPDATING) must be re-spawned
+        // on restart, otherwise reconcile settles it to ACTIVE with a dead
+        // broker container.
+        assert!(cluster_state_recoverable("UPDATING"));
+        // Existing recoverable states stay recoverable.
+        assert!(cluster_state_recoverable("ACTIVE"));
+        assert!(cluster_state_recoverable("CREATING"));
+        assert!(cluster_state_recoverable("REBOOTING_BROKER"));
+        // Terminal / not-yet-provisioned states are not recovered.
+        assert!(!cluster_state_recoverable("DELETING"));
+        assert!(!cluster_state_recoverable("FAILED"));
+        assert!(!cluster_state_recoverable(""));
     }
 
     fn ctx(region: &str) -> Ctx {


### PR DESCRIPTION
## Summary
Three robustness bugs from the 2026-07-22 bug hunt, in disjoint crates.

- **ACM (HIGH — panic → dropped connection).** `pem_decode_private_key` sliced `pem[body_start+nl+1..end]` with no `start <= end` guard; a malformed private key (single-line PEM, or END-before-BEGIN) panicked the request task *before* any `.map_err`, so the client saw a dropped connection. `ImportCertificate` stored the key blob with no PEM-structure validation and `IMPORTED` certs bypass the export gate, so any imported cert reached it. Now: `ImportCertificate` rejects a structurally-invalid `PrivateKey` with `InvalidParameterException`, and `pem_decode_private_key` guards the slice and returns an error — no panic path.
- **ECR (MED — blocking tokio worker).** OCI `docker push` blob commit (`blob_upload_finish`) read the whole spooled layer (`std::fs::read`) and hashed it inline on the tokio worker; the sibling JSON `CompleteLayerUpload` path already offloads this to `spawn_blocking`. Large layers (100s of MB → ~1 GB) stalled a worker and starved concurrent pushes. Now offloaded to `spawn_blocking`, behavior identical.
- **Kafka/MSK (HIGH — restart dangling-status).** `recover_persisted_containers` only re-spawned clusters in `ACTIVE|CREATING|REBOOTING_BROKER`; a cluster snapshotted mid-`Update*` (state `UPDATING`) was skipped, then `reconcile` settled it `UPDATING→ACTIVE` — reporting ACTIVE with a dead/absent broker (RDS #1338 class). `UPDATING` is now recoverable (extracted `cluster_state_recoverable`).

## Test plan
- ACM: 4 new tests — malformed PEM decode returns Err not panic; `is_pem_private_key` accept/reject; ImportCertificate rejects malformed key; ExportCertificate-with-passphrase on a malformed stored key errors, not panics.
- ECR: `blob_upload_finish_commits_correct_digest_for_multi_mb_layer` (4 MiB streamed blob → correct digest + size + spool consumed).
- Kafka: `updating_cluster_is_recoverable_on_restart`.
- `cargo nextest run -p fakecloud-acm -p fakecloud-ecr -p fakecloud-kafka`: 146 passed. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes panics, blocked workers, and bad cluster recovery across `fakecloud-acm`, `fakecloud-ecr`, and `fakecloud-kafka`. Stabilizes certificate import/export, large layer pushes, and MSK restarts.

- **Bug Fixes**
  - `fakecloud-acm`: Validate PEM in `ImportCertificate` and guard `pem_decode_private_key` slicing. Malformed keys now return `InvalidParameterException`; no panic/dropped connection.
  - `fakecloud-ecr`: Offload OCI blob commit read and SHA-256 to `spawn_blocking`, matching the JSON path. Large layers no longer block a `tokio` worker.
  - `fakecloud-kafka`: Recover clusters in `UPDATING` on restart via `cluster_state_recoverable`, preventing `ACTIVE` with a missing broker.

<sup>Written for commit d3abbc839fec06515efcebe37c0e836f4c61f1c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

