### PR TITLE
fix(dynamodb): numeric-equality for Number-set ADD/DELETE + validate values on BatchWrite/TransactWrite

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -23,7 +23,8 @@ use super::{
     apply_update_expression, build_consumed_capacity, evaluate_condition, execute_partiql_in_state,
     extract_key, get_table, get_table_mut, keys_equal, parse_expression_attribute_names,
     parse_expression_attribute_values, require_str_with_code, return_consumed_mode,
-    return_icm_mode, validate_key_attributes_in_key, validate_key_in_item, DynamoDbService,
+    return_icm_mode, validate_attribute_value, validate_item_attribute_values,
+    validate_key_attributes_in_key, validate_key_in_item, DynamoDbService,
 };
 
 impl DynamoDbService {
@@ -238,6 +239,11 @@ impl DynamoDbService {
                             )
                         })?;
                     validate_key_in_item(table, &item)?;
+                    // Reject malformed values (bad numbers, empty/duplicate
+                    // sets) up front, before applying any write, so
+                    // BatchWriteItem enforces the same per-attribute validation
+                    // single PutItem does and a bad item persists nothing.
+                    validate_item_attribute_values(&item)?;
                     extract_key(table, &item)
                 } else if let Some(del_req) = request.get("DeleteRequest") {
                     let key: HashMap<String, AttributeValue> =
@@ -800,12 +806,26 @@ impl DynamoDbService {
                 if let Some(table) = state.tables.get(table_name) {
                     validate_key_in_item(table, &item)?;
                 }
+                // Malformed values (bad numbers, empty/duplicate sets) are a
+                // structural error surfaced as a plain ValidationException
+                // before the transaction runs — the same per-attribute
+                // validation single PutItem enforces.
+                validate_item_attribute_values(&item)?;
             } else if let Some(op) = ti.get("Delete").or_else(|| ti.get("Update")) {
                 let table_name = op["TableName"].as_str().unwrap_or_default();
                 let key: HashMap<String, AttributeValue> =
                     serde_json::from_value(op["Key"].clone()).unwrap_or_default();
                 if let Some(table) = state.tables.get(table_name) {
                     validate_key_attributes_in_key(table, &key)?;
+                }
+                // An Update's ExpressionAttributeValues get the same value
+                // validation single UpdateItem enforces, so a malformed number
+                // or empty/duplicate set never reaches an item.
+                if ti.get("Update").is_some() {
+                    let expr_attr_values = parse_expression_attribute_values(op);
+                    for v in expr_attr_values.values() {
+                        validate_attribute_value(v)?;
+                    }
                 }
             }
         }
@@ -1787,6 +1807,131 @@ mod tests {
             .get("Widgets")
             .unwrap();
         assert_eq!(table.items.len(), 0);
+    }
+
+    // bug-hunt 2026-07-22: BatchWriteItem PutRequest must run the same
+    // per-attribute value validation single PutItem does. A malformed number
+    // is rejected with ValidationException and nothing is persisted.
+    #[tokio::test]
+    async fn batch_write_item_rejects_malformed_value() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        let err = svc
+            .batch_write_item(&req_for(
+                "BatchWriteItem",
+                json!({"RequestItems": {"Widgets": [
+                    {"PutRequest": {"Item": {"pk": {"S": "a"}, "n": {"N": "abc"}}}},
+                ]}}),
+            ))
+            .err()
+            .expect("malformed number rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+        // All-or-nothing up front: nothing persisted.
+        let accts = state.read();
+        let table = accts
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("Widgets")
+            .unwrap();
+        assert_eq!(table.items.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn batch_write_item_valid_batch_still_succeeds() {
+        // Regression guard: a well-formed batch is unaffected by the new
+        // per-value validation.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        svc.batch_write_item(&req_for(
+            "BatchWriteItem",
+            json!({"RequestItems": {"Widgets": [
+                {"PutRequest": {"Item": {"pk": {"S": "a"}, "n": {"N": "1"}, "s": {"SS": ["x", "y"]}}}},
+                {"PutRequest": {"Item": {"pk": {"S": "b"}, "n": {"N": "2.5"}}}},
+            ]}}),
+        ))
+        .unwrap();
+        let accts = state.read();
+        let table = accts
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("Widgets")
+            .unwrap();
+        assert_eq!(table.items.len(), 2);
+    }
+
+    // bug-hunt 2026-07-22: TransactWriteItems Put must reject a malformed value
+    // (here an empty set) with ValidationException, persisting nothing.
+    #[tokio::test]
+    async fn transact_write_items_put_rejects_empty_set() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        let err = svc
+            .transact_write_items(&req_for(
+                "TransactWriteItems",
+                json!({"TransactItems": [
+                    {"Put": {"TableName": "Widgets", "Item": {"pk": {"S": "a"}, "s": {"SS": []}}}},
+                ]}),
+            ))
+            .err()
+            .expect("empty set rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+        let accts = state.read();
+        let table = accts
+            .get("123456789012")
+            .unwrap()
+            .tables
+            .get("Widgets")
+            .unwrap();
+        assert_eq!(table.items.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn transact_write_items_put_rejects_duplicate_set_member() {
+        // A Number Set with two numerically-equal members ("1"/"1.0") is a
+        // duplicate-member set: rejected with ValidationException.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        let err = svc
+            .transact_write_items(&req_for(
+                "TransactWriteItems",
+                json!({"TransactItems": [
+                    {"Put": {"TableName": "Widgets", "Item": {"pk": {"S": "a"}, "ns": {"NS": ["1", "1.0"]}}}},
+                ]}),
+            ))
+            .err()
+            .expect("duplicate-member set rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
+    }
+
+    #[tokio::test]
+    async fn transact_write_items_update_validates_expr_attr_values() {
+        // The Update path's ExpressionAttributeValues get the same validation
+        // single UpdateItem enforces: a malformed number is rejected.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+        let err = svc
+            .transact_write_items(&req_for(
+                "TransactWriteItems",
+                json!({"TransactItems": [
+                    {"Update": {
+                        "TableName": "Widgets",
+                        "Key": {"pk": {"S": "a"}},
+                        "UpdateExpression": "SET #c = :bad",
+                        "ExpressionAttributeNames": {"#c": "c"},
+                        "ExpressionAttributeValues": {":bad": {"N": "abc"}},
+                    }},
+                ]}),
+            ))
+            .err()
+            .expect("malformed expr value rejected");
+        assert!(format!("{err:?}").contains("ValidationException"));
     }
 
     /// 1.26: ExecuteStatement must keep a genuine PartiQL

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -376,6 +376,21 @@ pub(crate) fn values_equal(a: Option<&Value>, b: Option<&Value>) -> bool {
     }
 }
 
+/// Whether two Number-set (`NS`) members are the same member. AWS compares NS
+/// members by numeric value, so `"1"` and `"1.0"` are one member: a set can
+/// never hold both, `ADD` dedups by value, and `DELETE` removes by value. The
+/// members are the bare decimal strings stored inside the `NS` array. Malformed
+/// members fall back to exact string equality so a bad operand can never be
+/// mistaken for a valid stored member. Mirrors the read side's `values_equal`.
+pub(crate) fn ns_members_equal(a: &Value, b: &Value) -> bool {
+    match (a.as_str(), b.as_str()) {
+        (Some(x), Some(y)) if is_valid_number(x) && is_valid_number(y) => {
+            compare_number_strings(x, y) == std::cmp::Ordering::Equal
+        }
+        _ => a == b,
+    }
+}
+
 pub(crate) fn execute_partiql_in_state(
     state: &mut crate::state::DynamoDbState,
     statement: &str,

--- a/crates/fakecloud-dynamodb/src/service/helpers/updates.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/updates.rs
@@ -212,7 +212,16 @@ pub(crate) fn apply_add_assignment(
                 };
                 let mut merged: Vec<Value> = existing_set.clone();
                 for v in add_set {
-                    if !merged.contains(v) {
+                    // A Number Set dedups by numeric value ("1" and "1.0" are
+                    // the same member), so a raw `contains` (exact JSON-string
+                    // match) would produce an invalid set holding two
+                    // numerically-equal members. SS/BS keep exact equality.
+                    let already = if *set_type == "NS" {
+                        merged.iter().any(|m| ns_members_equal(m, v))
+                    } else {
+                        merged.contains(v)
+                    };
+                    if !already {
                         merged.push(v.clone());
                     }
                 }
@@ -331,9 +340,12 @@ pub(crate) fn apply_delete_assignment(
             existing.get("NS").and_then(|v| v.as_array()),
             del_val.get("NS").and_then(|v| v.as_array()),
         ) {
+            // Number-set members are removed by numeric value, so `DELETE`ing
+            // "1.0" drops the stored "1". A raw `contains` (exact string match)
+            // would miss it.
             let filtered: Vec<Value> = existing_set
                 .iter()
-                .filter(|v| !del_set.contains(v))
+                .filter(|v| !del_set.iter().any(|d| ns_members_equal(d, v)))
                 .cloned()
                 .collect();
             if filtered.is_empty() {
@@ -465,6 +477,70 @@ mod remove_path_tests {
         .unwrap();
         assert_eq!(item["count"], json!({"N": "8"}));
         assert_eq!(item["tags"], json!({"SS": ["x", "y"]}));
+    }
+
+    #[test]
+    fn add_number_set_dedups_by_numeric_value() {
+        // A Number Set compares members by numeric value, so ADD of "1.0" to a
+        // set already holding "1" is a no-op: the result must stay {"1","2"}
+        // and never become an invalid set with two numerically-equal members
+        // (bug-hunt 2026-07-22).
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("scores".to_string(), json!({"NS": ["1", "2"]}));
+        apply_add_assignment(
+            &mut item,
+            "scores :n",
+            &names(),
+            &vals(&[(":n", json!({"NS": ["1.0"]}))]),
+        )
+        .unwrap();
+        assert_eq!(item["scores"], json!({"NS": ["1", "2"]}));
+    }
+
+    #[test]
+    fn add_number_set_appends_genuinely_new_member() {
+        // A numerically-distinct member is still added.
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("scores".to_string(), json!({"NS": ["1", "2"]}));
+        apply_add_assignment(
+            &mut item,
+            "scores :n",
+            &names(),
+            &vals(&[(":n", json!({"NS": ["1.0", "3"]}))]),
+        )
+        .unwrap();
+        assert_eq!(item["scores"], json!({"NS": ["1", "2", "3"]}));
+    }
+
+    #[test]
+    fn delete_number_set_removes_by_numeric_value() {
+        // DELETE of "1.0" removes the stored "1" (numeric equality), leaving
+        // {"2"} (bug-hunt 2026-07-22).
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("scores".to_string(), json!({"NS": ["1", "2"]}));
+        apply_delete_assignment(
+            &mut item,
+            "scores :n",
+            &names(),
+            &vals(&[(":n", json!({"NS": ["1.0"]}))]),
+        )
+        .unwrap();
+        assert_eq!(item["scores"], json!({"NS": ["2"]}));
+    }
+
+    #[test]
+    fn delete_string_set_keeps_exact_equality() {
+        // SS keeps exact string equality: "1.0" does not remove "1".
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("tags".to_string(), json!({"SS": ["1", "2"]}));
+        apply_delete_assignment(
+            &mut item,
+            "tags :s",
+            &names(),
+            &vals(&[(":s", json!({"SS": ["1.0"]}))]),
+        )
+        .unwrap();
+        assert_eq!(item["tags"], json!({"SS": ["1", "2"]}));
     }
 
     #[test]

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -8,7 +8,7 @@ use fakecloud_core::validation::*;
 
 use super::{
     apply_update_expression, build_consumed_capacity, build_item_collection_metrics,
-    evaluate_condition_with_return, extract_key, get_table, get_table_mut,
+    evaluate_condition_with_return, extract_key, get_table, get_table_mut, ns_members_equal,
     parse_expression_attribute_names, parse_expression_attribute_values, project_item,
     require_object, require_str, resolve_write_condition, return_consumed_mode, return_icm_mode,
     validate_attribute_value, validate_item_attribute_values, validate_key_attributes_in_key,
@@ -681,7 +681,15 @@ fn add_to_attribute(
                     ) {
                         let mut merged = a.clone();
                         for e in b {
-                            if !merged.contains(e) {
+                            // A Number Set dedups by numeric value ("1" == "1.0"),
+                            // so a raw `contains` would build an invalid set.
+                            // SS/BS keep exact equality.
+                            let already = if set_type == "NS" {
+                                merged.iter().any(|m| ns_members_equal(m, e))
+                            } else {
+                                merged.contains(e)
+                            };
+                            if !already {
                                 merged.push(e.clone());
                             }
                         }
@@ -708,7 +716,14 @@ fn remove_set_elements(
         if let Some(remove) = val.get(set_type).and_then(|v| v.as_array()) {
             if let Some(cur) = item.get_mut(attr).and_then(|v| v.get_mut(set_type)) {
                 if let Some(arr) = cur.as_array_mut() {
-                    arr.retain(|e| !remove.contains(e));
+                    // Number-set members are removed by numeric value, so
+                    // DELETEing "1.0" drops the stored "1". SS/BS use exact
+                    // string equality.
+                    if set_type == "NS" {
+                        arr.retain(|e| !remove.iter().any(|r| ns_members_equal(r, e)));
+                    } else {
+                        arr.retain(|e| !remove.contains(e));
+                    }
                 }
             }
             return;
@@ -859,5 +874,31 @@ mod tests {
         let post = map(&[("a", "1")]);
         assert!(diff_updated_attributes(Some(&pre), &post, UpdatedSide::New).is_empty());
         assert!(diff_updated_attributes(Some(&pre), &post, UpdatedSide::Old).is_empty());
+    }
+
+    // Legacy AttributeUpdates ADD/DELETE path: a Number Set compares members by
+    // numeric value, so "1" and "1.0" are the same member (bug-hunt 2026-07-22).
+    #[test]
+    fn legacy_add_number_set_dedups_by_numeric_value() {
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("scores".to_string(), json!({"NS": ["1", "2"]}));
+        add_to_attribute(&mut item, "scores", &json!({"NS": ["1.0"]})).unwrap();
+        assert_eq!(item["scores"], json!({"NS": ["1", "2"]}));
+    }
+
+    #[test]
+    fn legacy_add_string_set_keeps_exact_equality() {
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("tags".to_string(), json!({"SS": ["1", "2"]}));
+        add_to_attribute(&mut item, "tags", &json!({"SS": ["1.0"]})).unwrap();
+        assert_eq!(item["tags"], json!({"SS": ["1", "2", "1.0"]}));
+    }
+
+    #[test]
+    fn legacy_delete_number_set_removes_by_numeric_value() {
+        let mut item: HashMap<String, AttributeValue> = HashMap::new();
+        item.insert("scores".to_string(), json!({"NS": ["1", "2"]}));
+        remove_set_elements(&mut item, "scores", &json!({"NS": ["1.0"]}));
+        assert_eq!(item["scores"], json!({"NS": ["2"]}));
     }
 }


### PR DESCRIPTION
## Summary
Two DynamoDB correctness bugs from the 2026-07-22 bug hunt (both confirmed against write + read paths).

- **Number-set ADD/DELETE used raw string equality.** A Number Set compares members by numeric value (`"1"` and `"1.0"` are the same member), but the write side deduped/removed with exact JSON-string match in four places (`UpdateExpression` ADD/DELETE and the legacy `AttributeUpdates` paths, shared by TransactWriteItems Update). So `ADD {"NS":["1.0"]}` to `{"NS":["1","2"]}` produced an invalid `["1","2","1.0"]` (which PutItem's own validator rejects), and `DELETE {"NS":["1.0"]}` failed to remove `"1"`. Now dedup/remove by numeric value, reusing the read side's `values_equal` canonicalization. SS/BS keep exact equality.
- **BatchWriteItem/TransactWriteItems Put skipped per-attribute value validation.** Single `PutItem` validates every attribute (malformed numbers, >38 sig digits, empty/duplicate sets → `ValidationException`); the batch/transact Put paths only validated keys, so malformed values persisted and poisoned later numeric logic. Now both run the same `validate_item_attribute_values` up front (nothing persists on failure), and TransactWriteItems Update validates `expr_attr_values`.

## Test plan
- 12 new tests: NS numeric dedup/remove on both the UpdateExpression and legacy paths (+ SS exact-equality preserved); BatchWrite/Transact reject malformed/empty/duplicate-set values; valid batch still succeeds.
- `cargo nextest run -p fakecloud-dynamodb`: 399 passed, no regressions. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB Number Set handling and write-path validation to match AWS behavior, preventing invalid sets and rejecting malformed values before any write.

- **Bug Fixes**
  - Number-set `ADD`/`DELETE` now use numeric equality, so `"1"` and `"1.0"` are the same member. Applies to `UpdateExpression` and legacy `AttributeUpdates` (including `TransactWriteItems` Update). `SS`/`BS` still use exact string equality.
  - `BatchWriteItem` and `TransactWriteItems` `Put` now run the same per-attribute validation as `PutItem` (malformed numbers, empty sets, duplicate set members → `ValidationException`). `TransactWriteItems` `Update` also validates `ExpressionAttributeValues`.

<sup>Written for commit 0158d9a3e63c00f76a9f4df8c713837272daedd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

