### PR TITLE
fix(cloudformation): apply UpdateStack changes for all provisioned types + expand SAM Connector/Application/StateMachine-Events

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1799,7 +1799,15 @@ impl ResourceProvisioner {
             "AWS::ElasticBeanstalk::ConfigurationTemplate" => {
                 Some(self.update_eb_configuration_template(existing, new_def)?)
             }
-            _ => None,
+            // No dedicated in-place update arm for this type. Real
+            // CloudFormation, lacking an in-place mutator for a changed
+            // property, falls back to REPLACEMENT: it deletes the old backing
+            // resource and creates a new one from the updated definition. Do
+            // the same here so the update actually applies (the owning
+            // service's stored resource reflects the new properties) instead
+            // of silently reporting UPDATE_COMPLETE while the old config
+            // lingers. See `reprovision_resource`.
+            _ => self.reprovision_resource(existing, new_def)?,
         };
 
         Ok(result.map(|res| StackResource {
@@ -1809,6 +1817,40 @@ impl ResourceProvisioner {
             status: "UPDATE_COMPLETE".to_string(),
             service_token: existing.service_token.clone(),
             attributes: res.attributes,
+        }))
+    }
+
+    /// Fallback update path for resource types that have create/delete
+    /// provisioners but no dedicated in-place `update_*` arm.
+    ///
+    /// Before this existed, `update_resource` returned `Ok(None)` for every
+    /// such type and the update driver treated that as "leave the resource
+    /// untouched" while still transitioning the stack to `UPDATE_COMPLETE`
+    /// and recording no `ResourceChange` -- so `update-stack` / `cdk deploy`
+    /// changing a property on any of the many write-through services
+    /// (AppConfig, Timestream, OpenSearch, EMR, Glue, RDS DBCluster, ...)
+    /// reported success while the backing resource kept its old config.
+    ///
+    /// Mirroring CloudFormation replacement semantics, this tears down the
+    /// old backing resource and re-provisions it from the new definition
+    /// through the exact same write-through path `create_resource` uses, so
+    /// the stored resource reflects the update. For name-keyed services the
+    /// physical id is derived from an unchanged `Name`/`Id` property and stays
+    /// stable (an effectively in-place update); for others it is regenerated,
+    /// matching replacement. Genuinely-unmodeled types (no backing state) have
+    /// a no-op delete and a create that records `physical_id == logical_id`;
+    /// they still yield `Some(..)` here so the caller records a
+    /// `ResourceChange` rather than a silent no-op.
+    fn reprovision_resource(
+        &self,
+        existing: &StackResource,
+        new_def: &ResourceDefinition,
+    ) -> Result<Option<ProvisionResult>, String> {
+        self.delete_resource(existing)?;
+        let created = self.create_resource(new_def)?;
+        Ok(Some(ProvisionResult {
+            physical_id: created.physical_id,
+            attributes: created.attributes,
         }))
     }
 
@@ -6990,6 +7032,60 @@ mod tests {
         assert_eq!(data.databases.get("metrics").unwrap().table_count, 1);
         let key = fakecloud_timestream::shared::table_key("metrics", "cpu");
         assert!(data.tables.contains_key(&key));
+    }
+
+    // Fix 1: UpdateStack changing a property on a type that has a create/delete
+    // provisioner but no dedicated `update_*` arm must re-provision so the
+    // service's stored resource reflects the change -- and must return a
+    // resource (not `None`) so the driver records a ResourceChange -- instead
+    // of silently reporting UPDATE_COMPLETE while applying nothing.
+    #[test]
+    fn update_reprovisions_type_without_update_arm() {
+        let prov = make_provisioner();
+        let created = prov
+            .create_resource(&make_resource(
+                "AWS::Timestream::Database",
+                "Db",
+                serde_json::json!({
+                    "DatabaseName": "metrics",
+                    "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/old"
+                }),
+            ))
+            .expect("db provisions");
+        // Sanity: stored with the old KMS key.
+        {
+            let g = prov.timestream_state.read();
+            let data = g.get("123456789012").unwrap();
+            assert_eq!(
+                data.databases.get("metrics").unwrap().kms_key_id.as_deref(),
+                Some("arn:aws:kms:us-east-1:123456789012:key/old")
+            );
+        }
+
+        // Change the KmsKeyId. Timestream::Database has no dedicated update arm.
+        let new_def = make_resource(
+            "AWS::Timestream::Database",
+            "Db",
+            serde_json::json!({
+                "DatabaseName": "metrics",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/new"
+            }),
+        );
+        let updated = prov
+            .update_resource(&created, &new_def)
+            .expect("update ok")
+            .expect("update returns a resource (not None) so a ResourceChange is recorded");
+        // Name-keyed service: physical id is preserved (in-place-style update).
+        assert_eq!(updated.physical_id, "metrics");
+        assert_eq!(updated.status, "UPDATE_COMPLETE");
+
+        // The stored resource now reflects the new property -- not a no-op.
+        let g = prov.timestream_state.read();
+        let data = g.get("123456789012").unwrap();
+        assert_eq!(
+            data.databases.get("metrics").unwrap().kms_key_id.as_deref(),
+            Some("arn:aws:kms:us-east-1:123456789012:key/new")
+        );
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/template/for_each.rs
+++ b/crates/fakecloud-cloudformation/src/template/for_each.rs
@@ -138,6 +138,11 @@ pub(super) fn expand_sam(value: &Value) -> Value {
         return value;
     };
 
+    // Immutable snapshot of the original resource set, used to resolve a
+    // Connector's Source/Destination types (a Connector references other
+    // logical resources by id) while the main loop iterates.
+    let resources_map_snapshot = resources_map.clone();
+
     let mut new_resources = serde_json::Map::new();
     // Api/HttpApi routes collected from every function's Events, synthesized
     // into the implicit API after the loop.
@@ -344,10 +349,18 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                 if let Some(machine_type) = sfn_props.remove("Type") {
                     sfn_props.insert("StateMachineType".to_string(), machine_type);
                 }
-                // TODO: expand `Events` (Api/Schedule/EventBridge/SQS/etc.)
-                // into the corresponding trigger resources. Deferred — the
-                // state machine itself expands and provisions without it.
-                sfn_props.remove("Events");
+                // Expand `Events` (Schedule/ScheduleV2/EventBridgeRule/
+                // CloudWatchEvent/Api/HttpApi) into the corresponding native
+                // trigger resources targeting the state machine, mirroring the
+                // function-events expansion. Without this a scheduled/event-
+                // driven SAM state machine deployed with no trigger at all.
+                let sfn_extras = sfn_props
+                    .remove("Events")
+                    .and_then(|e| e.as_object().cloned())
+                    .map(|events| {
+                        super::sam_events::expand_state_machine_events(logical_id, &events)
+                    })
+                    .unwrap_or_default();
 
                 let mut sfn_resource = serde_json::Map::new();
                 sfn_resource.insert(
@@ -361,6 +374,36 @@ pub(super) fn expand_sam(value: &Value) -> Value {
                     }
                 }
                 new_resources.insert(logical_id.clone(), Value::Object(sfn_resource));
+                for (extra_id, extra) in sfn_extras {
+                    new_resources.entry(extra_id).or_insert(extra);
+                }
+            }
+            "AWS::Serverless::Connector" => {
+                // A Connector is pure IAM sugar: it grants the Source's role the
+                // requested Read/Write actions on the Destination. Expand it into
+                // the equivalent IAM policy resource(s) so the deploy actually
+                // wires up access instead of recording a phantom resource with no
+                // backing. `resources_map` is consulted to resolve the
+                // Destination's (SAM or native) type when the connector doesn't
+                // state it inline.
+                let connector_extras = super::sam_events::expand_connector(
+                    logical_id,
+                    &properties,
+                    &resources_map_snapshot,
+                );
+                for (extra_id, extra) in connector_extras {
+                    new_resources.entry(extra_id).or_insert(extra);
+                }
+            }
+            "AWS::Serverless::Application" => {
+                // A nested SAR/template application. Expand it into a native
+                // `AWS::CloudFormation::Stack` (which has a real provisioner +
+                // nested-stack persistence) pointing at the referenced template,
+                // carrying the `Parameters` through, instead of recording a
+                // no-backing phantom.
+                let stack_resource =
+                    super::sam_events::expand_application(&properties, resource_obj);
+                new_resources.insert(logical_id.clone(), stack_resource);
             }
             _ => {
                 new_resources.insert(logical_id.clone(), resource.clone());
@@ -772,6 +815,217 @@ mod tests {
         assert_eq!(
             props["RoleArn"],
             json!("arn:aws:iam::123456789012:role/sfn-role")
+        );
+    }
+
+    // Fix 3: a SAM StateMachine with a Schedule event expands into an
+    // EventBridge rule targeting the state machine + a StartExecution role,
+    // instead of dropping `Events`.
+    #[test]
+    fn expand_sam_statemachine_schedule_event() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "MySM": {
+                    "Type": "AWS::Serverless::StateMachine",
+                    "Properties": {
+                        "Definition": {"StartAt": "Done", "States": {"Done": {"Type": "Succeed"}}},
+                        "Events": {
+                            "Nightly": {
+                                "Type": "Schedule",
+                                "Properties": { "Schedule": "rate(1 day)" }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let expanded = expand_sam(&template);
+        let resources = &expanded["Resources"];
+        // The state machine no longer carries Events.
+        assert!(resources["MySM"]["Properties"].get("Events").is_none());
+        // A trigger rule was synthesized targeting the state machine.
+        let rule = &resources["MySMNightlyRule"];
+        assert_eq!(rule["Type"], json!("AWS::Events::Rule"));
+        assert_eq!(
+            rule["Properties"]["ScheduleExpression"],
+            json!("rate(1 day)")
+        );
+        assert_eq!(
+            rule["Properties"]["Targets"][0]["Arn"],
+            json!({"Fn::GetAtt": ["MySM", "Arn"]})
+        );
+        // The shared StartExecution role was synthesized and referenced.
+        let role = &resources["MySMEventsRole"];
+        assert_eq!(role["Type"], json!("AWS::IAM::Role"));
+        assert_eq!(
+            rule["Properties"]["Targets"][0]["RoleArn"],
+            json!({"Fn::GetAtt": ["MySMEventsRole", "Arn"]})
+        );
+        assert_eq!(
+            role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"][0]["Action"],
+            json!("states:StartExecution")
+        );
+    }
+
+    // Fix 3: an EventBridgeRule state-machine event expands into an
+    // EventPattern rule targeting the state machine.
+    #[test]
+    fn expand_sam_statemachine_eventbridge_event() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "MySM": {
+                    "Type": "AWS::Serverless::StateMachine",
+                    "Properties": {
+                        "Definition": {"StartAt": "Done", "States": {"Done": {"Type": "Succeed"}}},
+                        "Events": {
+                            "OnOrder": {
+                                "Type": "EventBridgeRule",
+                                "Properties": { "Pattern": {"source": ["orders"]} }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let resources = expand_sam(&template)["Resources"].clone();
+        let rule = &resources["MySMOnOrderRule"];
+        assert_eq!(rule["Type"], json!("AWS::Events::Rule"));
+        assert_eq!(
+            rule["Properties"]["EventPattern"],
+            json!({"source": ["orders"]})
+        );
+        assert_eq!(
+            rule["Properties"]["Targets"][0]["Arn"],
+            json!({"Fn::GetAtt": ["MySM", "Arn"]})
+        );
+    }
+
+    // Fix 2: a SAM Connector (Lambda -> DynamoDB, [Read, Write]) expands into
+    // an IAM policy on the source function's implicit role granting the CRUD
+    // actions on the table, instead of a no-backing phantom.
+    #[test]
+    fn expand_sam_connector_lambda_to_dynamodb() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "Writer": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": { "Handler": "i.h", "Runtime": "python3.13", "InlineCode": "x" }
+                },
+                "Table": { "Type": "AWS::Serverless::SimpleTable" },
+                "WriterToTable": {
+                    "Type": "AWS::Serverless::Connector",
+                    "Properties": {
+                        "Source": { "Id": "Writer" },
+                        "Destination": { "Id": "Table" },
+                        "Permissions": ["Read", "Write"]
+                    }
+                }
+            }
+        });
+
+        let resources = expand_sam(&template)["Resources"].clone();
+        // The connector itself is gone; an IAM policy took its place.
+        assert!(resources.get("WriterToTable").is_none());
+        let policy = &resources["WriterToTablePolicy"];
+        assert_eq!(policy["Type"], json!("AWS::IAM::Policy"));
+        // Attached to the function's implicit execution role.
+        assert_eq!(
+            policy["Properties"]["Roles"][0],
+            json!({"Ref": "WriterRole"})
+        );
+        let stmt = &policy["Properties"]["PolicyDocument"]["Statement"][0];
+        let actions = stmt["Action"].as_array().unwrap();
+        assert!(actions.iter().any(|a| a == "dynamodb:GetItem"));
+        assert!(actions.iter().any(|a| a == "dynamodb:PutItem"));
+        // Resource scoped to the table + its indexes.
+        let resource = stmt["Resource"].as_array().unwrap();
+        assert_eq!(resource[0], json!({"Fn::GetAtt": ["Table", "Arn"]}));
+    }
+
+    // Fix 2: a SAM Connector write-only permission grants only the write action
+    // set (no read actions), proving Permissions is honored.
+    #[test]
+    fn expand_sam_connector_write_only_sqs() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "Producer": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": { "Handler": "i.h", "Runtime": "python3.13", "InlineCode": "x" }
+                },
+                "Queue": { "Type": "AWS::SQS::Queue" },
+                "ProducerToQueue": {
+                    "Type": "AWS::Serverless::Connector",
+                    "Properties": {
+                        "Source": { "Id": "Producer" },
+                        "Destination": { "Id": "Queue", "Type": "AWS::SQS::Queue" },
+                        "Permissions": ["Write"]
+                    }
+                }
+            }
+        });
+
+        let resources = expand_sam(&template)["Resources"].clone();
+        let stmt =
+            &resources["ProducerToQueuePolicy"]["Properties"]["PolicyDocument"]["Statement"][0];
+        let actions = stmt["Action"].as_array().unwrap();
+        assert!(actions.iter().any(|a| a == "sqs:SendMessage"));
+        assert!(!actions.iter().any(|a| a == "sqs:ReceiveMessage"));
+    }
+
+    // Fix 2: a SAM Application expands into a native nested
+    // AWS::CloudFormation::Stack pointing at the referenced template, carrying
+    // Parameters through, instead of a no-backing phantom.
+    #[test]
+    fn expand_sam_application_to_nested_stack() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "Nested": {
+                    "Type": "AWS::Serverless::Application",
+                    "Properties": {
+                        "Location": "https://s3.amazonaws.com/bucket/child.template",
+                        "Parameters": { "Env": "prod" }
+                    }
+                }
+            }
+        });
+
+        let resources = expand_sam(&template)["Resources"].clone();
+        let stack = &resources["Nested"];
+        assert_eq!(stack["Type"], json!("AWS::CloudFormation::Stack"));
+        assert_eq!(
+            stack["Properties"]["TemplateURL"],
+            json!("https://s3.amazonaws.com/bucket/child.template")
+        );
+        assert_eq!(stack["Properties"]["Parameters"], json!({"Env": "prod"}));
+    }
+
+    // Fix 2: an Application whose Location is an S3 object form maps to an
+    // s3:// TemplateURL.
+    #[test]
+    fn expand_sam_application_s3_location_object() {
+        let template = json!({
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "Nested": {
+                    "Type": "AWS::Serverless::Application",
+                    "Properties": {
+                        "Location": { "Bucket": "b", "Key": "k/child.yaml" }
+                    }
+                }
+            }
+        });
+
+        let resources = expand_sam(&template)["Resources"].clone();
+        assert_eq!(
+            resources["Nested"]["Properties"]["TemplateURL"],
+            json!("s3://b/k/child.yaml")
         );
     }
 }

--- a/crates/fakecloud-cloudformation/src/template/sam_events.rs
+++ b/crates/fakecloud-cloudformation/src/template/sam_events.rs
@@ -545,6 +545,552 @@ pub(super) fn synthesize_api_resources(routes: &[ApiRoute]) -> Vec<(String, Valu
     out
 }
 
+// ============================================================================
+// AWS::Serverless::StateMachine `Events` expansion
+// ============================================================================
+
+/// Expand an `AWS::Serverless::StateMachine`'s `Events` into native trigger
+/// resources, mirroring [`expand_function_extras`] for functions.
+///
+/// - `Schedule` / `ScheduleV2` and `EventBridgeRule` / `CloudWatchEvent`
+///   become `AWS::Events::Rule`s whose target is the state machine's ARN, with
+///   a shared execution role granting `states:StartExecution`.
+/// - `Api` / `HttpApi` become an `AWS::ApiGateway::RestApi` + `Resource` +
+///   `Method` with an AWS service integration that calls `StartExecution`,
+///   plus the role API Gateway assumes to do so.
+///
+/// Returns the extra native resources keyed by logical id. Previously the
+/// transform dropped `Events` entirely (`sfn_props.remove("Events")`), so an
+/// event-driven SAM state machine deployed with no trigger.
+pub(super) fn expand_state_machine_events(
+    state_machine_id: &str,
+    events: &Map<String, Value>,
+) -> Vec<(String, Value)> {
+    let mut extras: Vec<(String, Value)> = Vec::new();
+    let start_role_id = format!("{state_machine_id}EventsRole");
+    let mut needs_start_role = false;
+
+    for (event_name, event) in events {
+        let Some(event_obj) = event.as_object() else {
+            continue;
+        };
+        let event_type = event_obj.get("Type").and_then(|v| v.as_str()).unwrap_or("");
+        let props = event_obj
+            .get("Properties")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+        let id_base = format!("{state_machine_id}{event_name}");
+        match event_type {
+            "Schedule" | "ScheduleV2" => {
+                needs_start_role = true;
+                extras.push(sfn_schedule_rule(
+                    state_machine_id,
+                    &start_role_id,
+                    &id_base,
+                    &props,
+                ));
+            }
+            "EventBridgeRule" | "CloudWatchEvent" => {
+                needs_start_role = true;
+                extras.push(sfn_eventbridge_rule(
+                    state_machine_id,
+                    &start_role_id,
+                    &id_base,
+                    &props,
+                ));
+            }
+            "Api" | "HttpApi" => {
+                extras.extend(sfn_api_resources(state_machine_id, &id_base, &props));
+            }
+            _ => {}
+        }
+    }
+
+    if needs_start_role {
+        extras.insert(
+            0,
+            (
+                start_role_id.clone(),
+                start_execution_role(state_machine_id, "events.amazonaws.com"),
+            ),
+        );
+    }
+    extras
+}
+
+/// An IAM role that `assume_principal` can assume to call
+/// `states:StartExecution` on the given state machine.
+fn start_execution_role(state_machine_id: &str, assume_principal: &str) -> Value {
+    json!({
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Principal": { "Service": assume_principal },
+                    "Action": "sts:AssumeRole"
+                }]
+            },
+            "Policies": [{
+                "PolicyName": "StartExecution",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": "states:StartExecution",
+                        "Resource": { "Ref": state_machine_id }
+                    }]
+                }
+            }]
+        }
+    })
+}
+
+/// `Schedule`/`ScheduleV2` state-machine event -> `Events::Rule` whose target
+/// is the state machine, invoked through the shared StartExecution role.
+fn sfn_schedule_rule(
+    state_machine_id: &str,
+    role_id: &str,
+    id_base: &str,
+    props: &Map<String, Value>,
+) -> (String, Value) {
+    let schedule = props
+        .get("Schedule")
+        .or_else(|| props.get("ScheduleExpression"))
+        .cloned()
+        .unwrap_or(json!("rate(1 day)"));
+    let mut rule_props = json!({
+        "ScheduleExpression": schedule,
+        "State": props.get("Enabled").map(|e| if e.as_bool() == Some(false) { json!("DISABLED") } else { json!("ENABLED") }).unwrap_or(json!("ENABLED")),
+        "Targets": [{
+            "Id": format!("{state_machine_id}Target"),
+            "Arn": { "Fn::GetAtt": [state_machine_id, "Arn"] },
+            "RoleArn": { "Fn::GetAtt": [role_id, "Arn"] }
+        }]
+    });
+    if let Some(name) = props.get("Name") {
+        rule_props["Name"] = name.clone();
+    }
+    if let Some(input) = props.get("Input") {
+        rule_props["Targets"][0]["Input"] = input.clone();
+    }
+    (
+        format!("{id_base}Rule"),
+        json!({ "Type": "AWS::Events::Rule", "Properties": rule_props }),
+    )
+}
+
+/// `EventBridgeRule`/`CloudWatchEvent` state-machine event -> `Events::Rule`
+/// (EventPattern) targeting the state machine via the StartExecution role.
+fn sfn_eventbridge_rule(
+    state_machine_id: &str,
+    role_id: &str,
+    id_base: &str,
+    props: &Map<String, Value>,
+) -> (String, Value) {
+    let mut rule_props = json!({
+        "Targets": [{
+            "Id": format!("{state_machine_id}Target"),
+            "Arn": { "Fn::GetAtt": [state_machine_id, "Arn"] },
+            "RoleArn": { "Fn::GetAtt": [role_id, "Arn"] }
+        }]
+    });
+    if let Some(pattern) = props.get("Pattern").or_else(|| props.get("EventPattern")) {
+        rule_props["EventPattern"] = pattern.clone();
+    }
+    if let Some(bus) = props.get("EventBusName") {
+        rule_props["EventBusName"] = bus.clone();
+    }
+    if let Some(input) = props.get("Input") {
+        rule_props["Targets"][0]["Input"] = input.clone();
+    }
+    (
+        format!("{id_base}Rule"),
+        json!({ "Type": "AWS::Events::Rule", "Properties": rule_props }),
+    )
+}
+
+/// `Api`/`HttpApi` state-machine event -> a dedicated REST API + resource +
+/// method whose integration is the AWS service action `states:StartExecution`,
+/// plus the API-Gateway role that performs it. Structural (matches what SAM
+/// synthesizes) so the state machine is reachable over HTTP.
+fn sfn_api_resources(
+    state_machine_id: &str,
+    id_base: &str,
+    props: &Map<String, Value>,
+) -> Vec<(String, Value)> {
+    let path = props
+        .get("Path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("/")
+        .to_string();
+    let method = props
+        .get("Method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("POST")
+        .to_uppercase();
+
+    let api_id = format!("{id_base}Api");
+    let role_id = format!("{id_base}ApiRole");
+    let mut out: Vec<(String, Value)> = Vec::new();
+
+    out.push((
+        api_id.clone(),
+        json!({
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": { "Name": api_id, "EndpointConfiguration": { "Types": ["REGIONAL"] } }
+        }),
+    ));
+    out.push((
+        role_id.clone(),
+        start_execution_role(state_machine_id, "apigateway.amazonaws.com"),
+    ));
+
+    // Resolve (creating as needed) the resource tree for the path.
+    let mut parent_ref = json!({ "Fn::GetAtt": [api_id, "RootResourceId"] });
+    let mut prefix = String::new();
+    let mut leaf_resource_id: Option<String> = None;
+    for segment in path.split('/').filter(|s| !s.is_empty()) {
+        prefix.push('/');
+        prefix.push_str(segment);
+        let res_id = format!("{api_id}Resource{}", sanitize(&prefix));
+        out.push((
+            res_id.clone(),
+            json!({
+                "Type": "AWS::ApiGateway::Resource",
+                "Properties": {
+                    "RestApiId": { "Ref": api_id },
+                    "ParentId": parent_ref,
+                    "PathPart": segment,
+                }
+            }),
+        ));
+        parent_ref = json!({ "Fn::GetAtt": [res_id, "ResourceId"] });
+        leaf_resource_id = Some(res_id);
+    }
+    let resource_ref = match &leaf_resource_id {
+        Some(id) => json!({ "Ref": id }),
+        None => json!({ "Fn::GetAtt": [api_id, "RootResourceId"] }),
+    };
+
+    out.push((
+        format!("{api_id}Method"),
+        json!({
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+                "RestApiId": { "Ref": api_id },
+                "ResourceId": resource_ref,
+                "HttpMethod": method,
+                "AuthorizationType": "NONE",
+                "Integration": {
+                    "Type": "AWS",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": { "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:states:action/StartExecution" },
+                    "Credentials": { "Fn::GetAtt": [role_id, "Arn"] },
+                }
+            }
+        }),
+    ));
+    out
+}
+
+// ============================================================================
+// AWS::Serverless::Connector expansion
+// ============================================================================
+
+/// Expand an `AWS::Serverless::Connector` into the IAM policy that grants the
+/// Source's role the requested Read/Write actions on the Destination.
+///
+/// SAM connectors are IAM sugar: `{Source, Destination, Permissions}` becomes a
+/// policy on the source's role scoped to the destination. This implements the
+/// common source (Lambda function) -> destination (DynamoDB table, SQS queue,
+/// SNS topic, S3 bucket, Lambda function) pairs. The policy is attached to the
+/// source's implicit execution role (`<SourceId>Role`, the role the SAM
+/// function transform synthesizes) unless the source *is* an IAM role.
+/// `resources` is the original resource set, used to resolve a
+/// Source/Destination type that the connector doesn't state inline.
+pub(super) fn expand_connector(
+    connector_id: &str,
+    properties: &Value,
+    resources: &Map<String, Value>,
+) -> Vec<(String, Value)> {
+    let Some(props) = properties.as_object() else {
+        return Vec::new();
+    };
+    let source = props.get("Source").and_then(|v| v.as_object());
+    let dest = props.get("Destination").and_then(|v| v.as_object());
+    let (Some(source), Some(dest)) = (source, dest) else {
+        return Vec::new();
+    };
+
+    let dest_id = dest.get("Id").and_then(|v| v.as_str());
+    let Some(dest_id) = dest_id else {
+        return Vec::new();
+    };
+    let dest_type = resolve_ref_type(dest, dest_id, resources);
+
+    // Permissions: ["Read", "Write"] (default to both when omitted).
+    let perms: Vec<String> = props
+        .get("Permissions")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|p| p.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_else(|| vec!["Read".to_string(), "Write".to_string()]);
+    let want_read = perms.iter().any(|p| p.eq_ignore_ascii_case("Read"));
+    let want_write = perms.iter().any(|p| p.eq_ignore_ascii_case("Write"));
+
+    let Some((actions, resource_arns)) =
+        connector_actions(&dest_type, dest_id, want_read, want_write)
+    else {
+        // Unknown/unsupported destination pairing: nothing to synthesize.
+        return Vec::new();
+    };
+
+    // Which role does the policy attach to? If the source is itself an IAM
+    // role, attach directly; otherwise the source's implicit execution role.
+    let Some(source_id) = source.get("Id").and_then(|v| v.as_str()) else {
+        return Vec::new();
+    };
+    let source_type = resolve_ref_type(source, source_id, resources);
+    let role_ref = if source_type == "AWS::IAM::Role" {
+        json!({ "Ref": source_id })
+    } else {
+        json!({ "Ref": format!("{source_id}Role") })
+    };
+
+    let policy = json!({
+        "Type": "AWS::IAM::Policy",
+        "Properties": {
+            "PolicyName": format!("{connector_id}Policy"),
+            "Roles": [role_ref],
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": actions,
+                    "Resource": resource_arns
+                }]
+            }
+        }
+    });
+
+    vec![(format!("{connector_id}Policy"), policy)]
+}
+
+/// Resolve the AWS resource type of a Source/Destination reference: prefer an
+/// inline `Type`, else look the id up in the template and map SAM sugar to its
+/// native type.
+fn resolve_ref_type(
+    reference: &Map<String, Value>,
+    id: &str,
+    resources: &Map<String, Value>,
+) -> String {
+    if let Some(t) = reference.get("Type").and_then(|v| v.as_str()) {
+        return t.to_string();
+    }
+    let raw = resources
+        .get(id)
+        .and_then(|r| r.get("Type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match raw {
+        "AWS::Serverless::Function" => "AWS::Lambda::Function".to_string(),
+        "AWS::Serverless::SimpleTable" => "AWS::DynamoDB::Table".to_string(),
+        "AWS::Serverless::StateMachine" => "AWS::StepFunctions::StateMachine".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Build the `(actions, resource_arns)` a connector policy grants for a given
+/// destination type and Read/Write selection. Returns `None` for unsupported
+/// destination types.
+fn connector_actions(
+    dest_type: &str,
+    dest_id: &str,
+    read: bool,
+    write: bool,
+) -> Option<(Vec<Value>, Vec<Value>)> {
+    let mut actions: Vec<Value> = Vec::new();
+    let arn = json!({ "Fn::GetAtt": [dest_id, "Arn"] });
+    let arns: Vec<Value> = match dest_type {
+        "AWS::DynamoDB::Table" => {
+            if read {
+                for a in [
+                    "dynamodb:GetItem",
+                    "dynamodb:Query",
+                    "dynamodb:Scan",
+                    "dynamodb:BatchGetItem",
+                    "dynamodb:ConditionCheckItem",
+                    "dynamodb:DescribeTable",
+                ] {
+                    actions.push(json!(a));
+                }
+            }
+            if write {
+                for a in [
+                    "dynamodb:PutItem",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:BatchWriteItem",
+                ] {
+                    actions.push(json!(a));
+                }
+            }
+            vec![
+                arn.clone(),
+                json!({ "Fn::Sub": [ "${Arn}/index/*", { "Arn": arn } ] }),
+            ]
+        }
+        "AWS::SQS::Queue" => {
+            if read {
+                for a in [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                    "sqs:GetQueueAttributes",
+                    "sqs:GetQueueUrl",
+                ] {
+                    actions.push(json!(a));
+                }
+            }
+            if write {
+                for a in [
+                    "sqs:SendMessage",
+                    "sqs:GetQueueAttributes",
+                    "sqs:GetQueueUrl",
+                ] {
+                    actions.push(json!(a));
+                }
+            }
+            vec![arn]
+        }
+        "AWS::SNS::Topic" => {
+            if read {
+                for a in ["sns:GetTopicAttributes", "sns:ListSubscriptionsByTopic"] {
+                    actions.push(json!(a));
+                }
+            }
+            if write {
+                actions.push(json!("sns:Publish"));
+            }
+            // SNS `Ref` resolves to the topic ARN.
+            vec![json!({ "Ref": dest_id })]
+        }
+        "AWS::S3::Bucket" => {
+            if read {
+                for a in [
+                    "s3:GetObject",
+                    "s3:GetObjectVersion",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                ] {
+                    actions.push(json!(a));
+                }
+            }
+            if write {
+                for a in ["s3:PutObject", "s3:DeleteObject"] {
+                    actions.push(json!(a));
+                }
+            }
+            vec![
+                arn.clone(),
+                json!({ "Fn::Sub": [ "${Arn}/*", { "Arn": arn } ] }),
+            ]
+        }
+        "AWS::Lambda::Function" => {
+            // Invoking a function is a "write" in connector terms.
+            for a in ["lambda:InvokeFunction", "lambda:InvokeAsync"] {
+                actions.push(json!(a));
+            }
+            vec![arn]
+        }
+        "AWS::StepFunctions::StateMachine" => {
+            if write {
+                actions.push(json!("states:StartExecution"));
+            }
+            if read {
+                for a in ["states:DescribeExecution", "states:DescribeStateMachine"] {
+                    actions.push(json!(a));
+                }
+            }
+            vec![json!({ "Ref": dest_id })]
+        }
+        _ => return None,
+    };
+    if actions.is_empty() {
+        return None;
+    }
+    Some((actions, arns))
+}
+
+// ============================================================================
+// AWS::Serverless::Application expansion
+// ============================================================================
+
+/// Expand an `AWS::Serverless::Application` into a native
+/// `AWS::CloudFormation::Stack` (nested stack) pointing at the referenced
+/// template, carrying `Parameters` through. `Location` may be a template URL /
+/// `s3://` path (string), an object with `{Bucket, Key, Version}` or
+/// `{TemplateURL}`, or a SAR reference (`{ApplicationId, SemanticVersion}`);
+/// each is mapped onto the nested stack's `TemplateURL` so the resource has a
+/// real backing instead of being recorded as a no-backing phantom.
+pub(super) fn expand_application(properties: &Value, resource_obj: &Map<String, Value>) -> Value {
+    let props = properties.as_object().cloned().unwrap_or_default();
+    let template_url = match props.get("Location") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Object(loc)) => {
+            if let Some(url) = loc.get("TemplateURL").and_then(|v| v.as_str()) {
+                url.to_string()
+            } else if let (Some(bucket), Some(key)) = (
+                loc.get("Bucket").and_then(|v| v.as_str()),
+                loc.get("Key").and_then(|v| v.as_str()),
+            ) {
+                format!("s3://{bucket}/{key}")
+            } else if let Some(app_id) = loc.get("ApplicationId").and_then(|v| v.as_str()) {
+                // SAR reference we can't resolve to a template body; still
+                // record it as a real nested stack keyed by the SAR app id +
+                // version so the resource isn't a phantom.
+                match loc.get("SemanticVersion").and_then(|v| v.as_str()) {
+                    Some(ver) => format!("{app_id}/{ver}"),
+                    None => app_id.to_string(),
+                }
+            } else {
+                String::new()
+            }
+        }
+        _ => String::new(),
+    };
+
+    let mut stack_props = serde_json::Map::new();
+    stack_props.insert("TemplateURL".to_string(), json!(template_url));
+    if let Some(params) = props.get("Parameters") {
+        stack_props.insert("Parameters".to_string(), params.clone());
+    }
+    if let Some(tags) = props.get("Tags") {
+        stack_props.insert("Tags".to_string(), tags.clone());
+    }
+    if let Some(notif) = props.get("NotificationARNs") {
+        stack_props.insert("NotificationARNs".to_string(), notif.clone());
+    }
+    if let Some(timeout) = props.get("TimeoutInMinutes") {
+        stack_props.insert("TimeoutInMinutes".to_string(), timeout.clone());
+    }
+
+    let mut stack_resource = serde_json::Map::new();
+    stack_resource.insert("Type".to_string(), json!("AWS::CloudFormation::Stack"));
+    stack_resource.insert("Properties".to_string(), Value::Object(stack_props));
+    for (k, v) in resource_obj {
+        if k != "Type" && k != "Properties" {
+            stack_resource.insert(k.clone(), v.clone());
+        }
+    }
+    Value::Object(stack_resource)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
Three CloudFormation/SAM orchestration bugs from the 2026-07-22 bug hunt (CFN is the largest issue-tracker cluster).

- **UpdateStack silently dropped property changes for any type without an `update_resource` arm** (the 12 recently-write-through services + RDS DBCluster/Redshift/DocDB/Neptune, CloudFront, Route53/-Resolver, WAFv2, EKS, Batch, Athena, Glue, EC2 VPC/Subnet/SG, …): `Ok(None)` → no-op, no `ResourceChange`, but the stack still went `UPDATE_COMPLETE`. A deploy looked green while the backing resource kept its old config and drift showed nothing. The `_ => None` catch-all now routes to a generic `reprovision_resource` (delete-then-create through the same write-through path create uses), which records a `ResourceChange`. For name-keyed control-plane services the physical id is derived from the unchanged Name/Id and stays stable (effectively in-place); the ~70 types with dedicated update arms are untouched.
- **SAM `Serverless::Connector` / `Serverless::Application` were not transformed** (recorded with no backing → Connector's IAM grants never synthesized → function deploys "green" but `AccessDenied`). Connector now expands into an `AWS::IAM::Policy` on the source's role granting Read/Write on the destination (DynamoDB/SQS/SNS/S3/Lambda/StepFunctions, correct ARNs incl. index/* and /*). Application expands into a native `AWS::CloudFormation::Stack` (real provisioner + nested-stack persistence), mapping every `Location` form onto `TemplateURL` and carrying Parameters/Tags/etc.
- **SAM `Serverless::StateMachine` `Events` were dropped** (`sfn_props.remove("Events")` TODO) → machine deployed but nothing triggered it. Events now expand like function events: Schedule/EventBridgeRule → `AWS::Events::Rule` targeting the state machine with a `states:StartExecution` role; Api/HttpApi → REST API + method with a StartExecution AWS integration.

## Review note
Fix 1's generic update is delete-then-create (CFN replacement semantics). For name-keyed control-plane services this is effectively in-place (stable physical id, no backing teardown); for the few container-backed types (e.g. RDS DBCluster) an UpdateStack triggers an async backing restart. This is a deliberate tradeoff over the prior silent no-op — a visibly-applied update. Happy to refine to property-merge-in-place for specific stateful types if preferred.

## Test plan
- 7 new tests: UpdateStack re-provisions a type without an update arm (Timestream `KmsKeyId`, physical id preserved, ResourceChange recorded); SAM StateMachine Schedule/EventBridge events expand; Connector Lambda→DynamoDB (Read/Write) and write-only SQS; Application → nested stack (URL + S3-object Location).
- `cargo nextest run -p fakecloud-cloudformation`: 303 passed. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply CloudFormation UpdateStack changes across all provisioned types and expand SAM transforms (Connector, Application, StateMachine Events) so updates, permissions, and triggers are correctly applied.

- **Bug Fixes**
  - UpdateStack: types without a dedicated update now re-provision via the create path, recording a ResourceChange; name-keyed services keep the same physical ID.
  - SAM Connector/Application: Connector expands to an `AWS::IAM::Policy` on the source role with correct Read/Write actions and ARNs; Application expands to a nested `AWS::CloudFormation::Stack` with `TemplateURL`, `Parameters`, and `Tags`.
  - SAM StateMachine Events: `Schedule`/`EventBridgeRule` synthesize `AWS::Events::Rule` + a `states:StartExecution` role; `Api`/`HttpApi` synthesize a REST API method that calls StartExecution.

- **Migration**
  - Updates to types without an in-place arm may replace the backing resource (delete-then-create). Some stateful services can restart during UpdateStack.

<sup>Written for commit e07febb60392ad6c91a114c1242da56e7299fd62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

