### PR TITLE
fix(ssm,eventbridge): persist SendCommand completion and EventBridge→Logs delivery through the durable save path

### DIFF
--- a/crates/fakecloud-eventbridge/src/delivery.rs
+++ b/crates/fakecloud-eventbridge/src/delivery.rs
@@ -17,6 +17,7 @@ pub struct EventBridgeDeliveryImpl {
     delivery: Arc<DeliveryBus>,
     lambda_state: Option<SharedLambdaState>,
     logs_state: Option<SharedLogsState>,
+    logs_persist: Option<fakecloud_persistence::SnapshotHook>,
     container_runtime: Option<Arc<ContainerRuntime>>,
 }
 
@@ -27,6 +28,7 @@ impl EventBridgeDeliveryImpl {
             delivery,
             lambda_state: None,
             logs_state: None,
+            logs_persist: None,
             container_runtime: None,
         }
     }
@@ -38,6 +40,14 @@ impl EventBridgeDeliveryImpl {
 
     pub fn with_logs(mut self, logs_state: SharedLogsState) -> Self {
         self.logs_state = Some(logs_state);
+        self
+    }
+
+    /// Wire the CloudWatch Logs persist hook so events this bus delivers to a
+    /// Logs target are written through to the Logs snapshot (see
+    /// `EventDispatchContext::logs_persist`).
+    pub fn with_logs_persist(mut self, hook: fakecloud_persistence::SnapshotHook) -> Self {
+        self.logs_persist = Some(hook);
         self
     }
 
@@ -134,6 +144,7 @@ impl EventBridgeDeliveryImpl {
             delivery: &self.delivery,
             lambda_state: self.lambda_state.as_ref(),
             logs_state: self.logs_state.as_ref(),
+            logs_persist: self.logs_persist.as_ref(),
             container_runtime: &self.container_runtime,
             account_id: &resolved_account,
             region: &region,

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -1179,6 +1179,37 @@ pub(crate) fn deliver_to_logs(
     }
 }
 
+/// Deliver an EventBridge event to CloudWatch Logs and persist the mutated
+/// Logs state through its snapshot hook, so an event delivered to a Logs
+/// target survives a restart. Every other target type routes through
+/// `DeliveryBus`, which persists the target service; the Logs path is a
+/// direct `logs_state.write()`, so without firing `logs_persist` here the
+/// delivered `LogEvent` would be lost on the next restart.
+///
+/// The write is synchronous (under the Logs state lock); the persist is
+/// offloaded to a detached task because the dispatch path is synchronous
+/// (the `EventBridgeDelivery` trait and the scheduler tick are not async at
+/// this layer). This fire-and-forget shape matches the other target types.
+/// When invoked outside a tokio runtime (e.g. a direct unit test), the
+/// persist is skipped rather than panicking.
+pub(crate) fn deliver_to_logs_and_persist(
+    logs_state: &SharedLogsState,
+    logs_persist: Option<&fakecloud_persistence::SnapshotHook>,
+    log_group_arn: &str,
+    payload: &str,
+    timestamp: chrono::DateTime<chrono::Utc>,
+) {
+    deliver_to_logs(logs_state, log_group_arn, payload, timestamp);
+    if let Some(hook) = logs_persist {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let hook = hook.clone();
+            tokio::spawn(async move {
+                hook().await;
+            });
+        }
+    }
+}
+
 /// Apply connection auth parameters to an outgoing HTTP request.
 pub(crate) fn apply_connection_auth(
     mut builder: reqwest::RequestBuilder,
@@ -1231,6 +1262,11 @@ pub(crate) struct EventDispatchContext<'a> {
     pub(crate) delivery: &'a std::sync::Arc<fakecloud_core::delivery::DeliveryBus>,
     pub(crate) lambda_state: Option<&'a fakecloud_lambda::SharedLambdaState>,
     pub(crate) logs_state: Option<&'a fakecloud_logs::SharedLogsState>,
+    /// Persist hook for the CloudWatch Logs state, fired after a delivery to a
+    /// Logs target so the written `LogEvent` survives a restart. `None` when no
+    /// Logs snapshot store is wired (memory mode) or the caller doesn't route
+    /// to Logs.
+    pub(crate) logs_persist: Option<&'a fakecloud_persistence::SnapshotHook>,
     pub(crate) container_runtime:
         &'a Option<std::sync::Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
     pub(crate) account_id: &'a str,
@@ -1333,7 +1369,7 @@ pub(crate) fn dispatch_event_target(
             });
         }
         if let Some(log_state) = ctx.logs_state {
-            deliver_to_logs(log_state, arn, &body_str, now);
+            deliver_to_logs_and_persist(log_state, ctx.logs_persist, arn, &body_str, now);
         }
     } else if arn.contains(":kinesis:") {
         tracing::info!(
@@ -1414,5 +1450,116 @@ pub(crate) fn dispatch_event_target(
                 );
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod logs_persist_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Snapshot store that records the last bytes written, so the test can
+    /// assert the delivered LogEvent was actually persisted.
+    #[derive(Default)]
+    struct CapturingSnapshotStore {
+        last: std::sync::Mutex<Option<Vec<u8>>>,
+    }
+
+    impl fakecloud_persistence::SnapshotStore for CapturingSnapshotStore {
+        fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+            Ok(self.last.lock().unwrap().clone())
+        }
+        fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+            *self.last.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    fn empty_logs_state() -> fakecloud_logs::SharedLogsState {
+        Arc::new(parking_lot::RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
+    }
+
+    /// Delivering an EventBridge event to a CloudWatch Logs target must persist
+    /// the mutated Logs state through the snapshot hook, so the LogEvent
+    /// survives a restart. Every other target type persists via the
+    /// DeliveryBus; the Logs path is a direct `logs_state.write()` that
+    /// previously had no persistence at all.
+    #[tokio::test]
+    async fn deliver_to_logs_persists_through_hook() {
+        let logs_state = empty_logs_state();
+        let store: Arc<CapturingSnapshotStore> = Arc::new(CapturingSnapshotStore::default());
+
+        // Build the same persist hook shape the server wires from main.rs.
+        let hook: fakecloud_persistence::SnapshotHook = {
+            let state = logs_state.clone();
+            let store_dyn: Arc<dyn fakecloud_persistence::SnapshotStore> = store.clone();
+            let lock = Arc::new(tokio::sync::Mutex::new(()));
+            Arc::new(move || {
+                let state = state.clone();
+                let store_dyn = store_dyn.clone();
+                let lock = lock.clone();
+                Box::pin(async move {
+                    fakecloud_logs::save_logs_snapshot(&state, Some(store_dyn), &lock).await;
+                })
+            })
+        };
+
+        let arn = "arn:aws:logs:us-east-1:123456789012:log-group:/eb/target:*";
+        deliver_to_logs_and_persist(
+            &logs_state,
+            Some(&hook),
+            arn,
+            "{\"hello\":\"world\"}",
+            chrono::Utc::now(),
+        );
+
+        // The persist is a detached task; poll the capturing store until it
+        // records the write (bounded so a regression fails fast).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if store.last.lock().unwrap().is_some() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "logs persist hook never fired after a Logs-target delivery"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        // The persisted snapshot must round-trip and contain the delivered event.
+        let bytes = store.last.lock().unwrap().clone().unwrap();
+        let snapshot: fakecloud_logs::LogsSnapshot = serde_json::from_slice(&bytes).unwrap();
+        let accounts = snapshot.accounts.expect("multi-account snapshot");
+        let logs = accounts.get("123456789012").expect("account present");
+        let group = logs
+            .log_groups
+            .get("/eb/target")
+            .expect("auto-created log group persisted");
+        let stream = group
+            .log_streams
+            .get("events")
+            .expect("events stream persisted");
+        assert_eq!(stream.events.len(), 1, "one delivered event persisted");
+        assert_eq!(stream.events[0].message, "{\"hello\":\"world\"}");
+    }
+
+    /// Without a persist hook (memory mode), delivery still writes to the live
+    /// Logs state and does not panic.
+    #[tokio::test]
+    async fn deliver_to_logs_without_hook_still_writes_state() {
+        let logs_state = empty_logs_state();
+        let arn = "arn:aws:logs:us-east-1:123456789012:log-group:/eb/nohook:*";
+        deliver_to_logs_and_persist(&logs_state, None, arn, "payload", chrono::Utc::now());
+
+        let accounts = logs_state.read();
+        let logs = accounts.get("123456789012").unwrap();
+        assert!(logs.log_groups.contains_key("/eb/nohook"));
     }
 }

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -312,6 +312,11 @@ pub struct Scheduler {
     delivery: Arc<DeliveryBus>,
     lambda_state: Option<SharedLambdaState>,
     logs_state: Option<SharedLogsState>,
+    /// Persist hook for CloudWatch Logs, fired after a scheduled rule delivers
+    /// to a Logs target. The rule scheduler is the pure side-channel: it fires
+    /// on a timer with no request-path snapshot, so without writing through
+    /// here the delivered `LogEvent` would vanish on the next restart.
+    logs_persist: Option<fakecloud_persistence::SnapshotHook>,
     container_runtime: Option<Arc<ContainerRuntime>>,
     /// Persist hook. Firing a rule advances its `last_fired` directly, outside
     /// the service's action-dispatch path that is otherwise the only thing that
@@ -330,6 +335,7 @@ impl Scheduler {
             delivery,
             lambda_state: None,
             logs_state: None,
+            logs_persist: None,
             container_runtime: None,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
@@ -350,6 +356,13 @@ impl Scheduler {
 
     pub fn with_logs(mut self, logs_state: SharedLogsState) -> Self {
         self.logs_state = Some(logs_state);
+        self
+    }
+
+    /// Wire the CloudWatch Logs persist hook so a scheduled rule delivering to
+    /// a Logs target writes the event through to the Logs snapshot.
+    pub fn with_logs_persist(mut self, hook: fakecloud_persistence::SnapshotHook) -> Self {
+        self.logs_persist = Some(hook);
         self
     }
 
@@ -506,6 +519,7 @@ impl Scheduler {
                 delivery: &self.delivery,
                 lambda_state: self.lambda_state.as_ref(),
                 logs_state: self.logs_state.as_ref(),
+                logs_persist: self.logs_persist.as_ref(),
                 container_runtime: &self.container_runtime,
                 account_id: &account_id,
                 region: &region,

--- a/crates/fakecloud-eventbridge/src/service.rs
+++ b/crates/fakecloud-eventbridge/src/service.rs
@@ -30,6 +30,7 @@ pub struct EventBridgeService {
     delivery: Arc<DeliveryBus>,
     lambda_state: Option<SharedLambdaState>,
     logs_state: Option<SharedLogsState>,
+    logs_persist: Option<fakecloud_persistence::SnapshotHook>,
     container_runtime: Option<Arc<ContainerRuntime>>,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
     snapshot_lock: Arc<AsyncMutex<()>>,
@@ -42,6 +43,7 @@ impl EventBridgeService {
             delivery,
             lambda_state: None,
             logs_state: None,
+            logs_persist: None,
             container_runtime: None,
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
@@ -55,6 +57,14 @@ impl EventBridgeService {
 
     pub fn with_logs(mut self, logs_state: SharedLogsState) -> Self {
         self.logs_state = Some(logs_state);
+        self
+    }
+
+    /// Wire the CloudWatch Logs persist hook so PutEvents/StartReplay deliveries
+    /// to a Logs target are written through to the Logs snapshot (see
+    /// `EventDispatchContext::logs_persist`).
+    pub fn with_logs_persist(mut self, hook: fakecloud_persistence::SnapshotHook) -> Self {
+        self.logs_persist = Some(hook);
         self
     }
 
@@ -1532,6 +1542,7 @@ impl EventBridgeService {
                 delivery: &self.delivery,
                 lambda_state: self.lambda_state.as_ref(),
                 logs_state: self.logs_state.as_ref(),
+                logs_persist: self.logs_persist.as_ref(),
                 container_runtime: &self.container_runtime,
                 account_id: &req.account_id,
                 region: &req.region,

--- a/crates/fakecloud-eventbridge/src/service_archives_replays.rs
+++ b/crates/fakecloud-eventbridge/src/service_archives_replays.rs
@@ -547,7 +547,13 @@ impl EventBridgeService {
             });
             drop(accounts);
             if let Some(ref log_state) = self.logs_state {
-                deliver_to_logs(log_state, target_arn, &body_str, Utc::now());
+                deliver_to_logs_and_persist(
+                    log_state,
+                    self.logs_persist.as_ref(),
+                    target_arn,
+                    &body_str,
+                    Utc::now(),
+                );
             }
         } else if target_arn.contains(":states:") {
             self.delivery

--- a/crates/fakecloud-eventbridge/src/service_partner_sources.rs
+++ b/crates/fakecloud-eventbridge/src/service_partner_sources.rs
@@ -443,6 +443,7 @@ impl EventBridgeService {
                 delivery: &self.delivery,
                 lambda_state: self.lambda_state.as_ref(),
                 logs_state: self.logs_state.as_ref(),
+                logs_persist: self.logs_persist.as_ref(),
                 container_runtime: &self.container_runtime,
                 account_id: &req.account_id,
                 region: &req.region,

--- a/crates/fakecloud-eventbridge/src/simulation.rs
+++ b/crates/fakecloud-eventbridge/src/simulation.rs
@@ -26,6 +26,9 @@ pub struct FireRuleContext<'a> {
     pub delivery: &'a Arc<DeliveryBus>,
     pub lambda_state: &'a Option<SharedLambdaState>,
     pub logs_state: &'a Option<SharedLogsState>,
+    /// Persist hook for CloudWatch Logs, fired after a fire-rule delivery to a
+    /// Logs target so the written event survives a restart.
+    pub logs_persist: &'a Option<fakecloud_persistence::SnapshotHook>,
     pub container_runtime: &'a Option<Arc<fakecloud_lambda::runtime::ContainerRuntime>>,
 }
 
@@ -43,6 +46,7 @@ pub fn fire_rule(
     let delivery = ctx.delivery;
     let lambda_state = ctx.lambda_state;
     let logs_state = ctx.logs_state;
+    let logs_persist = ctx.logs_persist;
     let container_runtime = ctx.container_runtime;
 
     let (targets, rule_arn, account_id, region) = {
@@ -113,6 +117,7 @@ pub fn fire_rule(
         delivery,
         lambda_state: lambda_state.as_ref(),
         logs_state: logs_state.as_ref(),
+        logs_persist: logs_persist.as_ref(),
         container_runtime,
         account_id: &account_id,
         region: &region,
@@ -240,6 +245,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let result = fire_rule(&ctx, "default", "my-rule");
@@ -267,6 +273,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let result = fire_rule(&ctx, "default", "no-such-rule");
@@ -300,6 +307,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let result = fire_rule(&ctx, "default", "disabled-rule");
@@ -317,6 +325,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let err = fire_rule(&ctx, "missing-bus", "rule").unwrap_err();
@@ -333,6 +342,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let targets = fire_rule(&ctx, "default", "no-targets").unwrap();
@@ -383,6 +393,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let fired = fire_rule(&ctx, "default", "multi").unwrap();
@@ -416,6 +427,7 @@ mod tests {
             delivery: &delivery,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let fired = fire_rule(&ctx, "default", "fifo").unwrap();
@@ -448,6 +460,7 @@ mod tests {
             delivery: &bus,
             lambda_state: &None,
             logs_state: &None,
+            logs_persist: &None,
             container_runtime: &None,
         };
         let fired = fire_rule(&ctx, "default", "constant").unwrap();

--- a/crates/fakecloud-logs/src/lib.rs
+++ b/crates/fakecloud-logs/src/lib.rs
@@ -6,7 +6,7 @@ pub(crate) mod state;
 pub mod transformer;
 pub(crate) mod validation;
 
-pub use service::{infer_delivery_destination_type, LogsService};
+pub use service::{infer_delivery_destination_type, save_logs_snapshot, LogsService};
 pub use state::{
     Delivery, DeliveryDestination, DeliverySource, Destination, LogAnomaly, LogEvent, LogGroup,
     LogStream, LogsSnapshot, LogsState, MetricFilter, MetricTransformation, QueryDefinition,

--- a/crates/fakecloud-logs/src/service/mod.rs
+++ b/crates/fakecloud-logs/src/service/mod.rs
@@ -108,6 +108,15 @@ impl LogsService {
         self
     }
 
+    /// Share the snapshot lock with another writer of the Logs state (e.g. the
+    /// EventBridge -> Logs delivery persist hook). Serialising both writers on
+    /// the same lock prevents a stale-last-write where an older clone-serialize
+    /// overwrites a newer one when the two persist paths interleave.
+    pub fn with_snapshot_lock(mut self, lock: Arc<AsyncMutex<()>>) -> Self {
+        self.snapshot_lock = lock;
+        self
+    }
+
     /// Persist current state as a snapshot. Held across the
     /// clone-serialize-write sequence to prevent stale-last writes,
     /// with serde + file I/O offloaded to the blocking pool.

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -1780,9 +1780,97 @@ async fn main() {
         } else {
             None
         };
+    // CloudWatch Logs persistence store + a shared save-lock, created ahead of
+    // the EventBridge service/scheduler so their Logs-target delivery can write
+    // through to the same snapshot LogsService persists to. Loading here (before
+    // the scheduler is spawned) also means the background rule scheduler fires
+    // against the restored Logs state rather than an empty one. The lock is
+    // shared with LogsService (below) so the two Logs writers can't
+    // stale-overwrite each other's clone-serialize-write.
+    let logs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
+        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+            let data_path = persistence_config
+                .data_path
+                .as_ref()
+                .expect("validated above")
+                .clone();
+            let path = data_path.join("logs").join("snapshot.json");
+            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
+            match fakecloud_persistence::SnapshotStore::load(&store) {
+                Ok(Some(bytes)) => {
+                    match serde_json::from_slice::<fakecloud_logs::LogsSnapshot>(&bytes) {
+                        Ok(snapshot) => {
+                            if snapshot.schema_version
+                                > fakecloud_logs::LOGS_SNAPSHOT_SCHEMA_VERSION
+                            {
+                                fatal_exit(format_args!(
+                                    "logs persistence schema too new: on-disk={}, max supported={}",
+                                    snapshot.schema_version,
+                                    fakecloud_logs::LOGS_SNAPSHOT_SCHEMA_VERSION,
+                                ));
+                            }
+                            if let Some(accounts) = snapshot.accounts {
+                                let account_count = accounts.account_count();
+                                *logs_state.write() = accounts;
+                                tracing::info!(
+                                    accounts = account_count,
+                                    "loaded logs persistence snapshot (multi-account)"
+                                );
+                            } else if let Some(single_state) = snapshot.state {
+                                let group_count = single_state.log_groups.len();
+                                let account_id = single_state.account_id.clone();
+                                let mut mas = logs_state.write();
+                                *mas.get_or_create(&account_id) = single_state;
+                                tracing::info!(
+                                    log_groups = group_count,
+                                    "loaded logs persistence snapshot (migrated from v1)"
+                                );
+                            } else {
+                                tracing::warn!("logs persistence snapshot has neither accounts nor state; starting empty");
+                            }
+                        }
+                        Err(err) => fatal_exit(format_args!(
+                            "failed to parse logs persistence snapshot: {err}"
+                        )),
+                    }
+                }
+                Ok(None) => {
+                    tracing::info!("no logs persistence snapshot found; starting empty");
+                }
+                Err(err) => fatal_exit(format_args!(
+                    "failed to read logs persistence snapshot: {err}"
+                )),
+            }
+            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
+        } else {
+            None
+        };
+    let logs_snapshot_lock = Arc::new(tokio::sync::Mutex::new(()));
+    // Persist hook routing EventBridge -> CloudWatch Logs deliveries through the
+    // Logs snapshot store, so an event delivered to a Logs target (including
+    // from the background rule scheduler) survives a restart, matching every
+    // other target type (which persists via the DeliveryBus).
+    let logs_persist_hook: Option<fakecloud_persistence::SnapshotHook> =
+        logs_snapshot_store.clone().map(|store| {
+            let state = logs_state.clone();
+            let lock = logs_snapshot_lock.clone();
+            Arc::new(move || {
+                let state = state.clone();
+                let store = store.clone();
+                let lock = lock.clone();
+                Box::pin(async move {
+                    fakecloud_logs::save_logs_snapshot(&state, Some(store), &lock).await;
+                })
+                    as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+            }) as fakecloud_persistence::SnapshotHook
+        });
+    let eb_sim_logs_persist = logs_persist_hook.clone();
     let mut eb_service = EventBridgeService::new(eb_state.clone(), delivery_for_eb.clone())
         .with_lambda(lambda_state.clone())
         .with_logs(logs_state.clone());
+    if let Some(ref hook) = logs_persist_hook {
+        eb_service = eb_service.with_logs_persist(hook.clone());
+    }
     if let Some(ref rt) = container_runtime {
         eb_service = eb_service.with_runtime(rt.clone());
     }
@@ -1803,6 +1891,9 @@ async fn main() {
         fakecloud_eventbridge::scheduler::Scheduler::new(eb_state.clone(), delivery_for_eb)
             .with_lambda(lambda_state.clone())
             .with_logs(logs_state.clone());
+    if let Some(ref hook) = logs_persist_hook {
+        scheduler = scheduler.with_logs_persist(hook.clone());
+    }
     if let Some(ref rt) = container_runtime {
         scheduler = scheduler.with_runtime(rt.clone());
     }
@@ -1965,6 +2056,10 @@ async fn main() {
     if let Some(h) = ssm_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("ssm", h);
     }
+    // Re-arm the async lifecycle tick for any SendCommand restored as
+    // Pending/InProgress, so a command that only completed in the background
+    // before a restart still settles to Success instead of being stranded.
+    ssm_service.rearm_in_flight_commands();
     registry.register(Arc::new(ssm_service));
     // DynamoDB is registered later, after s3_store is constructed, so the
     // export path can persist result objects through the S3 store.
@@ -2146,66 +2241,12 @@ async fn main() {
         cfn_snapshot_hooks.insert("secretsmanager", h);
     }
     registry.register(Arc::new(secretsmanager_service));
-    let logs_snapshot_store: Option<Arc<dyn fakecloud_persistence::SnapshotStore>> =
-        if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
-            let data_path = persistence_config
-                .data_path
-                .as_ref()
-                .expect("validated above")
-                .clone();
-            let path = data_path.join("logs").join("snapshot.json");
-            let store = fakecloud_persistence::DiskSnapshotStore::new(path);
-            match fakecloud_persistence::SnapshotStore::load(&store) {
-                Ok(Some(bytes)) => {
-                    match serde_json::from_slice::<fakecloud_logs::LogsSnapshot>(&bytes) {
-                        Ok(snapshot) => {
-                            if snapshot.schema_version
-                                > fakecloud_logs::LOGS_SNAPSHOT_SCHEMA_VERSION
-                            {
-                                fatal_exit(format_args!(
-                                    "logs persistence schema too new: on-disk={}, max supported={}",
-                                    snapshot.schema_version,
-                                    fakecloud_logs::LOGS_SNAPSHOT_SCHEMA_VERSION,
-                                ));
-                            }
-                            if let Some(accounts) = snapshot.accounts {
-                                let account_count = accounts.account_count();
-                                *logs_state.write() = accounts;
-                                tracing::info!(
-                                    accounts = account_count,
-                                    "loaded logs persistence snapshot (multi-account)"
-                                );
-                            } else if let Some(single_state) = snapshot.state {
-                                let group_count = single_state.log_groups.len();
-                                let account_id = single_state.account_id.clone();
-                                let mut mas = logs_state.write();
-                                *mas.get_or_create(&account_id) = single_state;
-                                tracing::info!(
-                                    log_groups = group_count,
-                                    "loaded logs persistence snapshot (migrated from v1)"
-                                );
-                            } else {
-                                tracing::warn!("logs persistence snapshot has neither accounts nor state; starting empty");
-                            }
-                        }
-                        Err(err) => fatal_exit(format_args!(
-                            "failed to parse logs persistence snapshot: {err}"
-                        )),
-                    }
-                }
-                Ok(None) => {
-                    tracing::info!("no logs persistence snapshot found; starting empty");
-                }
-                Err(err) => fatal_exit(format_args!(
-                    "failed to read logs persistence snapshot: {err}"
-                )),
-            }
-            Some(Arc::new(store) as Arc<dyn fakecloud_persistence::SnapshotStore>)
-        } else {
-            None
-        };
+    // `logs_snapshot_store` + `logs_snapshot_lock` are created earlier (ahead of
+    // the EventBridge service/scheduler) so the EventBridge -> Logs delivery can
+    // persist through the same store; see that block above.
     let logs_anomalies_state = logs_state.clone();
-    let mut logs_service = LogsService::new(logs_state.clone(), delivery_for_logs);
+    let mut logs_service = LogsService::new(logs_state.clone(), delivery_for_logs)
+        .with_snapshot_lock(logs_snapshot_lock);
     if let Some(store) = logs_snapshot_store {
         logs_service = logs_service.with_snapshot_store(store);
     }
@@ -8399,6 +8440,7 @@ async fn main() {
                 let delivery = eb_sim_delivery;
                 let lambda_state = eb_sim_lambda_state;
                 let logs_state = eb_sim_logs_state;
+                let logs_persist = eb_sim_logs_persist;
                 let container_runtime = eb_sim_container_runtime;
                 move |axum::Json(body): axum::Json<types::FireRuleRequest>| async move {
                     let bus_name = body.bus_name.as_deref().unwrap_or("default");
@@ -8407,6 +8449,7 @@ async fn main() {
                         delivery: &delivery,
                         lambda_state: &lambda_state,
                         logs_state: &logs_state,
+                        logs_persist: &logs_persist,
                         container_runtime: &container_runtime,
                     };
                     match fakecloud_eventbridge::simulation::fire_rule(

--- a/crates/fakecloud-ssm/src/service/commands.rs
+++ b/crates/fakecloud-ssm/src/service/commands.rs
@@ -255,21 +255,7 @@ impl SsmService {
 
         // Spawn the lifecycle transition. Detached on purpose — clients
         // poll `GetCommandInvocation`; we don't await completion here.
-        // When the test harness runs a `send_command` outside a tokio
-        // runtime (e.g. plain `#[test]`), `try_current` returns `Err`
-        // and the command stays `Pending` forever, which the unit tests
-        // assert against directly.
-        if tokio::runtime::Handle::try_current().is_ok() {
-            let state_handle = self.state.clone();
-            let account_id = req.account_id.clone();
-            let cid = command_id.clone();
-            tokio::spawn(async move {
-                tokio::time::sleep(PENDING_TO_IN_PROGRESS).await;
-                advance_pending_to_in_progress(&state_handle, &account_id, &cid);
-                tokio::time::sleep(IN_PROGRESS_TO_SUCCESS).await;
-                advance_in_progress_to_success(&state_handle, &account_id, &cid);
-            });
-        }
+        self.spawn_command_advance(req.account_id.clone(), command_id.clone());
 
         let mut cmd_obj = json!({
             "CommandId": command_id,
@@ -302,6 +288,64 @@ impl SsmService {
         }
 
         Ok(AwsResponse::ok_json(json!({ "Command": cmd_obj })))
+    }
+
+    /// Spawn the background lifecycle transition for a submitted (or
+    /// restored) command: `Pending -> InProgress -> Success`, persisting a
+    /// snapshot after each flip so the completed command survives a restart
+    /// instead of reverting to `Pending`. Detached on purpose — clients poll
+    /// `GetCommandInvocation`; we don't await completion here.
+    ///
+    /// When invoked outside a tokio runtime (e.g. a plain `#[test]` that
+    /// calls `send_command` directly), `try_current` returns `Err` and the
+    /// command stays `Pending`, which those unit tests assert against.
+    pub(super) fn spawn_command_advance(&self, account_id: String, command_id: String) {
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let state = self.state.clone();
+        let store = self.snapshot_store.clone();
+        let lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(PENDING_TO_IN_PROGRESS).await;
+            if advance_pending_to_in_progress(&state, &account_id, &command_id) {
+                super::save_ssm_snapshot(&state, store.clone(), &lock).await;
+            }
+            tokio::time::sleep(IN_PROGRESS_TO_SUCCESS).await;
+            if advance_in_progress_to_success(&state, &account_id, &command_id) {
+                super::save_ssm_snapshot(&state, store, &lock).await;
+            }
+        });
+    }
+
+    /// Re-arm the async lifecycle tick for any command restored as
+    /// `Pending` or `InProgress` (or whose invocations are still in flight)
+    /// when the previous process exited. Without this, a completed command
+    /// that was only advanced in the background before a restart would be
+    /// stranded in a non-terminal state forever. Called by the server after
+    /// loading a persistence snapshot. Mirrors
+    /// `OrganizationsService::rearm_in_progress_account_creations` and
+    /// `AcmService::rearm_pending_validations`.
+    pub fn rearm_in_flight_commands(&self) {
+        let in_flight: Vec<(String, String)> = {
+            let accounts = self.state.read();
+            let mut out = Vec::new();
+            for (account_id, state) in accounts.iter() {
+                for cmd in state.commands.iter() {
+                    let non_terminal =
+                        cmd.invocations.iter().any(|inv| {
+                            matches!(inv.status.as_str(), "Pending" | "InProgress" | "Delayed")
+                        }) || matches!(cmd.status.as_str(), "Pending" | "InProgress" | "Delayed");
+                    if non_terminal {
+                        out.push((account_id.to_string(), cmd.command_id.clone()));
+                    }
+                }
+            }
+            out
+        };
+        for (account_id, command_id) in in_flight {
+            self.spawn_command_advance(account_id, command_id);
+        }
     }
 
     pub(super) fn list_commands(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
@@ -551,48 +595,57 @@ impl SsmService {
 
 /// Flip pending invocations + parent command to `InProgress`. Skips any
 /// invocation that has already moved into a terminal state via the
-/// admin force-fail endpoint or `CancelCommand`.
-fn advance_pending_to_in_progress(
+/// admin force-fail endpoint or `CancelCommand`. Returns `true` when at
+/// least one invocation was flipped, so the caller can persist a
+/// snapshot only when the transition actually changed durable state.
+pub(super) fn advance_pending_to_in_progress(
     state: &crate::state::SharedSsmState,
     account_id: &str,
     command_id: &str,
-) {
+) -> bool {
     let mut accounts = state.write();
     let st = accounts.get_or_create(account_id);
     let Some(cmd) = st.commands.iter_mut().find(|c| c.command_id == command_id) else {
-        return;
+        return false;
     };
     let now = Utc::now();
+    let mut changed = false;
     for inv in cmd.invocations.iter_mut() {
         if inv.status == "Pending" {
             inv.status = "InProgress".to_string();
             inv.status_details = friendly_status_details("InProgress");
             inv.last_update_at = now;
+            changed = true;
         }
     }
     cmd.status = aggregate_command_status(&cmd.invocations);
+    changed
 }
 
 /// Flip in-flight invocations + parent command to `Success`. Same
-/// terminal-state guard as the pending->in-progress hop.
-fn advance_in_progress_to_success(
+/// terminal-state guard as the pending->in-progress hop. Returns `true`
+/// when at least one invocation reached `Success`.
+pub(super) fn advance_in_progress_to_success(
     state: &crate::state::SharedSsmState,
     account_id: &str,
     command_id: &str,
-) {
+) -> bool {
     let mut accounts = state.write();
     let st = accounts.get_or_create(account_id);
     let Some(cmd) = st.commands.iter_mut().find(|c| c.command_id == command_id) else {
-        return;
+        return false;
     };
     let now = Utc::now();
+    let mut changed = false;
     for inv in cmd.invocations.iter_mut() {
         if matches!(inv.status.as_str(), "Pending" | "InProgress" | "Delayed") {
             inv.status = "Success".to_string();
             inv.status_details = friendly_status_details("Success");
             inv.response_code = 0;
             inv.last_update_at = now;
+            changed = true;
         }
     }
     cmd.status = aggregate_command_status(&cmd.invocations);
+    changed
 }

--- a/crates/fakecloud-ssm/src/service/tests.rs
+++ b/crates/fakecloud-ssm/src/service/tests.rs
@@ -5547,3 +5547,138 @@ fn get_parameters_resolves_full_arn() {
     assert!(body["InvalidParameters"].as_array().unwrap().is_empty());
     assert_eq!(body["Parameters"][0]["Value"], "v");
 }
+
+// ===== SendCommand completion persistence (bug-hunt: side-channel skips save) =====
+
+/// Snapshot store that records the last bytes written, so tests can assert the
+/// background `SendCommand` advance actually persisted a completed command.
+#[derive(Default)]
+struct CapturingSnapshotStore {
+    last: std::sync::Mutex<Option<Vec<u8>>>,
+}
+
+impl fakecloud_persistence::SnapshotStore for CapturingSnapshotStore {
+    fn load(&self) -> std::io::Result<Option<Vec<u8>>> {
+        Ok(self.last.lock().unwrap().clone())
+    }
+    fn save(&self, bytes: &[u8]) -> std::io::Result<()> {
+        *self.last.lock().unwrap() = Some(bytes.to_vec());
+        Ok(())
+    }
+}
+
+/// Decode the last-persisted snapshot and return the status of `command_id`,
+/// or `None` if no snapshot was written or the command isn't present.
+fn persisted_command_status(store: &CapturingSnapshotStore, command_id: &str) -> Option<String> {
+    let bytes = store.last.lock().unwrap().clone()?;
+    let snapshot: SsmSnapshot = serde_json::from_slice(&bytes).ok()?;
+    let accounts = snapshot.accounts?;
+    accounts
+        .get("123456789012")?
+        .commands
+        .iter()
+        .find(|c| c.command_id == command_id)
+        .map(|c| c.status.clone())
+}
+
+fn insert_pending_command(svc: &SsmService, command_id: &str, instance_id: &str) {
+    let now = chrono::Utc::now();
+    let mut accounts = svc.state.write();
+    let state = accounts.get_or_create("123456789012");
+    state.commands.push(crate::state::SsmCommand {
+        command_id: command_id.to_string(),
+        document_name: "AWS-RunShellScript".to_string(),
+        instance_ids: vec![instance_id.to_string()],
+        parameters: std::collections::BTreeMap::new(),
+        status: "Pending".to_string(),
+        requested_date_time: now,
+        expires_after: now + chrono::Duration::hours(1),
+        comment: None,
+        output_s3_bucket_name: None,
+        output_s3_key_prefix: None,
+        output_s3_region: None,
+        timeout_seconds: None,
+        service_role_arn: None,
+        notification_config: None,
+        targets: vec![],
+        document_hash: None,
+        document_hash_type: None,
+        invocations: vec![crate::state::SsmCommandInvocation {
+            instance_id: instance_id.to_string(),
+            status: "Pending".to_string(),
+            status_details: "Pending".to_string(),
+            standard_output_content: String::new(),
+            standard_error_content: String::new(),
+            response_code: -1,
+            requested_date_time: now,
+            last_update_at: now,
+        }],
+    });
+}
+
+/// Poll the in-memory command status until it reaches `Success` or the deadline
+/// elapses. Returns the final status.
+async fn wait_for_command_status(svc: &SsmService, command_id: &str, want: &str) -> String {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let status = {
+            let accounts = svc.state.read();
+            accounts
+                .get("123456789012")
+                .and_then(|s| s.commands.iter().find(|c| c.command_id == command_id))
+                .map(|c| c.status.clone())
+        };
+        if status.as_deref() == Some(want) || std::time::Instant::now() >= deadline {
+            return status.unwrap_or_default();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+/// The background advance task must persist a snapshot after the terminal
+/// `Success` flip. Previously the detached task mutated `cmd.status` under the
+/// write lock but never called `save_snapshot`, so a completed command reverted
+/// to `Pending` on the next restart.
+#[tokio::test]
+async fn send_command_completion_persists_success() {
+    let store: Arc<CapturingSnapshotStore> = Arc::new(CapturingSnapshotStore::default());
+    let svc = make_service().with_snapshot_store(store.clone());
+
+    let command_id = send_command(&svc, "AWS-RunShellScript");
+    let status = wait_for_command_status(&svc, &command_id, "Success").await;
+    assert_eq!(status, "Success", "command should complete in-memory");
+
+    // The completed command must be on disk as Success, not stranded at Pending.
+    assert_eq!(
+        persisted_command_status(&store, &command_id).as_deref(),
+        Some("Success"),
+        "background advance must persist the Success transition"
+    );
+}
+
+/// A command restored as `Pending` (its background completion never having run
+/// before the previous process exited) must be re-advanced to `Success` on
+/// restore rather than stranded forever.
+#[tokio::test]
+async fn rearm_in_flight_commands_settles_restored_pending() {
+    let store: Arc<CapturingSnapshotStore> = Arc::new(CapturingSnapshotStore::default());
+    let svc = make_service().with_snapshot_store(store.clone());
+
+    // Simulate a snapshot restored with an in-flight (Pending) command.
+    let command_id = "11111111-2222-3333-4444-555555555555";
+    insert_pending_command(&svc, command_id, "i-restore0");
+
+    // Re-arm as the server does after loading a snapshot.
+    svc.rearm_in_flight_commands();
+
+    let status = wait_for_command_status(&svc, command_id, "Success").await;
+    assert_eq!(
+        status, "Success",
+        "restored Pending command must be re-advanced, not stranded"
+    );
+    assert_eq!(
+        persisted_command_status(&store, command_id).as_deref(),
+        Some("Success"),
+        "re-armed completion must persist the terminal status"
+    );
+}


### PR DESCRIPTION
## Summary
Two remaining instances of the #1766 side-channel-persistence family from the 2026-07-22 bug hunt (the prior batch #2331-2349 fixed Firehose→S3, DDB import, SQS-Pipes, EB-scheduler, nested CFN).

- **SSM `SendCommand` completion was never persisted.** The command is saved as `Pending`, then a detached task flips it `Pending→InProgress→Success` without ever calling `save_snapshot`, and there was no load-time re-arm — so after a restart a completed command reverts to / stays `Pending` forever, and RunCommand automation polling for `Success` never sees it. The advance task now saves a snapshot after each transition (via `spawn_command_advance`, cloning the store+lock), and `rearm_in_flight_commands()` (wired in main.rs next to the other services' recover calls) re-advances any restored `Pending`/`InProgress` command.
- **EventBridge→CloudWatch Logs delivery never persisted Logs state.** `deliver_to_logs` wrote a LogEvent directly into Logs state with no snapshot hook, while every other target type routes through the persisting `DeliveryBus` — so events delivered to a Logs target (including from the background rule scheduler) vanished on restart. Delivery now fires the Logs `SnapshotHook`; the hook is threaded through the PutEvents path, the scheduler timer side-channel, StartReplay, and the fire-rule simulation context. Logs' own saves and the EventBridge-side persist share one snapshot lock.

## Test plan
- SSM: `send_command_completion_persists_success` (background advance persists a `Success` command to a capturing store), `rearm_in_flight_commands_settles_restored_pending` (restored `Pending` re-advanced + persisted).
- EventBridge: `deliver_to_logs_persists_through_hook` (delivered LogEvent round-trips a Logs save/restore), `deliver_to_logs_without_hook_still_writes_state` (memory mode unaffected).
- `cargo nextest`: ssm 824, eventbridge+logs 575, all green. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists SSM `SendCommand` completion and EventBridge deliveries to CloudWatch Logs so they survive restarts, and re-arms in-flight SSM commands on restore. Also adds a shared snapshot lock to prevent stale overwrites when multiple writers persist Logs state.

- **Bug Fixes**
  - `fakecloud-ssm`: Background `SendCommand` transitions now snapshot after `Pending→InProgress` and `InProgress→Success`, and `rearm_in_flight_commands()` runs at startup to advance restored `Pending/InProgress` commands.
  - `fakecloud-eventbridge` → `fakecloud-logs`: Logs-target deliveries now persist via a `logs_persist` hook threaded through PutEvents, scheduler ticks, StartReplay, and fire-rule simulation.
  - `fakecloud-logs`: Exposes `save_logs_snapshot` and shares the snapshot lock with EventBridge’s persist hook to avoid stale-last-write races.
  - `fakecloud-server`: Wires the Logs snapshot store + shared lock early, injects the Logs persist hook into EventBridge service/scheduler, and calls SSM `rearm_in_flight_commands()` after load.

<sup>Written for commit b88b110381abea59d9ce8e77536f60df2ad421d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

