### PR TITLE
fix(redshift,config,eks,route53resolver): persist dropped Modify/Put fields

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/eks.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/eks.rs
@@ -350,6 +350,8 @@ impl ResourceProvisioner {
             asg_name: format!("eks-{name}-{}", &id[..8]),
             tags: parse_eks_tags(props.get("Tags")),
             updates: Default::default(),
+            node_repair_config: props.get("NodeRepairConfig").cloned(),
+            warm_pool_config: None,
         };
         state
             .nodegroups

--- a/crates/fakecloud-config/src/e2e_tests.rs
+++ b/crates/fakecloud-config/src/e2e_tests.rs
@@ -567,3 +567,40 @@ async fn put_configuration_aggregator_persists_create_time_tags() {
     assert_eq!(tags["Tags"][0]["Key"], "owner");
     assert_eq!(tags["Tags"][0]["Value"], "data");
 }
+
+/// PutRemediationExceptions must store the supplied ExpirationTime and
+/// DescribeRemediationExceptions must echo it back (it was previously dropped,
+/// producing a Terraform perpetual diff on the expiration field).
+#[tokio::test]
+async fn remediation_exception_round_trips_expiration_time() {
+    let svc = service();
+    let acct = "111111111111";
+    // 2026-08-01T00:00:00Z in epoch seconds.
+    let expiration = 1_785_542_400_f64;
+    call(
+        &svc,
+        "PutRemediationExceptions",
+        acct,
+        json!({
+            "ConfigRuleName": "my-rule",
+            "ResourceKeys": [
+                { "ResourceType": "AWS::S3::Bucket", "ResourceId": "b-1" }
+            ],
+            "Message": "temporary waiver",
+            "ExpirationTime": expiration,
+        }),
+    )
+    .await;
+
+    let out = call(
+        &svc,
+        "DescribeRemediationExceptions",
+        acct,
+        json!({ "ConfigRuleName": "my-rule" }),
+    )
+    .await;
+    let exc = &out["RemediationExceptions"][0];
+    assert_eq!(exc["ConfigRuleName"], json!("my-rule"));
+    assert_eq!(exc["ResourceId"], json!("b-1"));
+    assert_eq!(exc["ExpirationTime"], json!(expiration));
+}

--- a/crates/fakecloud-config/src/service.rs
+++ b/crates/fakecloud-config/src/service.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use http::StatusCode;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
@@ -2394,6 +2394,11 @@ impl ConfigService {
             .get("Message")
             .and_then(Value::as_str)
             .map(String::from);
+        // ExpirationTime is a request-level field applied to every supplied key.
+        let expiration_time = body
+            .get("ExpirationTime")
+            .and_then(Value::as_f64)
+            .and_then(|s| DateTime::from_timestamp(s as i64, 0));
         let mut st = self.state.write();
         let acc = st.account_mut(account);
         for k in &keys {
@@ -2415,7 +2420,7 @@ impl ConfigService {
                     resource_type: rt,
                     resource_id: rid,
                     message: message.clone(),
-                    expiration_time: None,
+                    expiration_time,
                 },
             );
         }
@@ -2436,12 +2441,16 @@ impl ConfigService {
                     .values()
                     .filter(|e| e.config_rule_name == rule_name)
                     .map(|e| {
-                        json!({
+                        let mut v = json!({
                             "ConfigRuleName": e.config_rule_name,
                             "ResourceType": e.resource_type,
                             "ResourceId": e.resource_id,
                             "Message": e.message,
-                        })
+                        });
+                        if let Some(exp) = e.expiration_time {
+                            v["ExpirationTime"] = json!(exp.timestamp() as f64);
+                        }
+                        v
                     })
                     .collect()
             })

--- a/crates/fakecloud-eks/src/eks_helpers.rs
+++ b/crates/fakecloud-eks/src/eks_helpers.rs
@@ -656,6 +656,12 @@ pub(crate) fn nodegroup_json(n: &Nodegroup) -> Value {
     if let Some(lt) = &n.launch_template {
         out["launchTemplate"] = lt.clone();
     }
+    if let Some(nrc) = &n.node_repair_config {
+        out["nodeRepairConfig"] = nrc.clone();
+    }
+    if let Some(wpc) = &n.warm_pool_config {
+        out["warmPoolConfig"] = wpc.clone();
+    }
     out
 }
 

--- a/crates/fakecloud-eks/src/service.rs
+++ b/crates/fakecloud-eks/src/service.rs
@@ -1092,6 +1092,8 @@ impl EksService {
             asg_name: format!("eks-{name}-{}", &id[..8]),
             tags: parse_tag_map(body.get("tags")),
             updates: Default::default(),
+            node_repair_config: body.get("nodeRepairConfig").cloned(),
+            warm_pool_config: body.get("warmPoolConfig").cloned(),
         };
 
         let out = nodegroup_json(&ng);
@@ -1251,6 +1253,14 @@ impl EksService {
         if let Some(update_config) = body.get("updateConfig") {
             ng.update_config = build_nodegroup_update_config(Some(update_config));
             params.push(("MaxUnavailable".to_string(), update_config.to_string()));
+        }
+        if let Some(node_repair) = body.get("nodeRepairConfig") {
+            ng.node_repair_config = Some(node_repair.clone());
+            params.push(("NodeRepairConfig".to_string(), node_repair.to_string()));
+        }
+        if let Some(warm_pool) = body.get("warmPoolConfig") {
+            ng.warm_pool_config = Some(warm_pool.clone());
+            params.push(("WarmPoolConfig".to_string(), warm_pool.to_string()));
         }
         ng.modified_at = Utc::now();
 

--- a/crates/fakecloud-eks/src/service_tests.rs
+++ b/crates/fakecloud-eks/src/service_tests.rs
@@ -2393,3 +2393,70 @@ async fn create_cluster_stores_encryption_config() {
         "arn:aws:kms:us-east-1:111122223333:key/abc"
     );
 }
+
+#[tokio::test]
+async fn nodegroup_round_trips_node_repair_and_warm_pool_config() {
+    let svc = EksService::new(make_state());
+    svc.handle(make_request(
+        Method::POST,
+        "/clusters",
+        &create_body("ng-cl"),
+    ))
+    .await
+    .unwrap();
+
+    let create = json!({
+        "nodegroupName": "ng1",
+        "nodeRole": "arn:aws:iam::111122223333:role/eks-node",
+        "subnets": ["subnet-1", "subnet-2"],
+        "nodeRepairConfig": { "enabled": true },
+        "warmPoolConfig": { "enabled": true, "minSize": 1, "maxGroupPreparedCapacity": 3 },
+    })
+    .to_string();
+    let resp = svc
+        .handle(make_request(
+            Method::POST,
+            "/clusters/ng-cl/node-groups",
+            &create,
+        ))
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v["nodegroup"]["nodeRepairConfig"]["enabled"], true);
+    assert_eq!(v["nodegroup"]["warmPoolConfig"]["minSize"], 1);
+
+    // Describe echoes both configs back.
+    let resp = svc
+        .handle(make_request(
+            Method::GET,
+            "/clusters/ng-cl/node-groups/ng1",
+            "",
+        ))
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v["nodegroup"]["nodeRepairConfig"]["enabled"], true);
+    assert_eq!(
+        v["nodegroup"]["warmPoolConfig"]["maxGroupPreparedCapacity"],
+        3
+    );
+
+    // UpdateNodegroupConfig toggling nodeRepairConfig is reflected on Describe.
+    svc.handle(make_request(
+        Method::POST,
+        "/clusters/ng-cl/node-groups/ng1/update-config",
+        &json!({ "nodeRepairConfig": { "enabled": false } }).to_string(),
+    ))
+    .await
+    .unwrap();
+    let resp = svc
+        .handle(make_request(
+            Method::GET,
+            "/clusters/ng-cl/node-groups/ng1",
+            "",
+        ))
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(v["nodegroup"]["nodeRepairConfig"]["enabled"], false);
+}

--- a/crates/fakecloud-eks/src/state.rs
+++ b/crates/fakecloud-eks/src/state.rs
@@ -74,6 +74,12 @@ pub struct Nodegroup {
     /// Per-nodegroup updates keyed by update id, disambiguated from cluster
     /// updates by the `nodegroupName` query param on Describe/ListUpdates.
     pub updates: BTreeMap<String, Update>,
+    /// Present only when the caller supplied `nodeRepairConfig`.
+    #[serde(default)]
+    pub node_repair_config: Option<serde_json::Value>,
+    /// Present only when the caller supplied `warmPoolConfig`.
+    #[serde(default)]
+    pub warm_pool_config: Option<serde_json::Value>,
 }
 
 /// An EKS add-on, a sub-resource of a cluster (e.g. `vpc-cni`, `coredns`).

--- a/crates/fakecloud-redshift/src/service/clusters.rs
+++ b/crates/fakecloud-redshift/src/service/clusters.rs
@@ -292,6 +292,28 @@ impl RedshiftService {
         if let Some(v) = param(req, "MaintenanceTrackName") {
             c.maintenance_track_name = v;
         }
+        if let Some(v) = bool_param(req, "Encrypted") {
+            c.encrypted = v;
+        }
+        if let Some(v) = param(req, "KmsKeyId") {
+            c.kms_key_id = Some(v);
+        }
+        if let Some(v) = param(req, "ElasticIp") {
+            c.elastic_ip = Some(v);
+        }
+        if let Some(v) = int_param(req, "Port") {
+            c.endpoint_port = v;
+        }
+        if let Some(v) = param(req, "AvailabilityZone") {
+            c.availability_zone = v;
+        }
+        if let Some(v) = bool_param(req, "AvailabilityZoneRelocation") {
+            c.availability_zone_relocation_status = if v {
+                "enabled".to_string()
+            } else {
+                "disabled".to_string()
+            };
+        }
         let sgs = member_list(req, "ClusterSecurityGroups", "ClusterSecurityGroupName");
         if !sgs.is_empty() {
             c.cluster_security_groups = sgs;
@@ -300,7 +322,19 @@ impl RedshiftService {
         if !vpc_sgs.is_empty() {
             c.vpc_security_group_ids = vpc_sgs;
         }
+        // A rename stamps the new identifier onto the cluster before it is
+        // rendered so the response echoes the new name.
+        let new_id = param(req, "NewClusterIdentifier").filter(|n| n != &id);
+        if let Some(nid) = &new_id {
+            c.cluster_identifier = nid.clone();
+        }
         let out = render_cluster(c);
+        // Re-key the cluster in the map so subsequent Describe/Modify/Delete
+        // resolve under the new identifier (the old name 404s).
+        if let Some(nid) = new_id {
+            let renamed = acct.clusters.remove(&id).expect("cluster fetched above");
+            acct.clusters.insert(nid, renamed);
+        }
         Ok(xml_resp(
             "ModifyCluster",
             format!("<Cluster>{out}</Cluster>"),

--- a/crates/fakecloud-redshift/src/service/tests.rs
+++ b/crates/fakecloud-redshift/src/service/tests.rs
@@ -698,3 +698,82 @@ fn scheduled_action_start_end_time_round_trip() {
     assert!(after.contains("<StartTime>2026-08-15T12:30:00.000Z</StartTime>"));
     assert!(after.contains("<EndTime>2026-09-01T00:00:00.000Z</EndTime>"));
 }
+
+#[test]
+fn modify_cluster_rename_rekeys_the_cluster() {
+    let svc = service();
+    ok(
+        &svc,
+        "CreateCluster",
+        &[
+            ("ClusterIdentifier", "old-name"),
+            ("NodeType", "ra3.xlplus"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "Passw0rd123"),
+        ],
+    );
+    // The rename echoes the new identifier in the ModifyCluster response.
+    let renamed = ok(
+        &svc,
+        "ModifyCluster",
+        &[
+            ("ClusterIdentifier", "old-name"),
+            ("NewClusterIdentifier", "new-name"),
+        ],
+    );
+    assert!(renamed.contains("<ClusterIdentifier>new-name</ClusterIdentifier>"));
+
+    // DescribeClusters on the new id returns it; the old id 404s.
+    let listed = ok(
+        &svc,
+        "DescribeClusters",
+        &[("ClusterIdentifier", "new-name")],
+    );
+    assert!(listed.contains("<ClusterIdentifier>new-name</ClusterIdentifier>"));
+    assert_eq!(
+        err_code(
+            &svc,
+            "DescribeClusters",
+            &[("ClusterIdentifier", "old-name")]
+        ),
+        "ClusterNotFound"
+    );
+    // A later op on the new name resolves (delete succeeds, no 404).
+    ok(&svc, "DeleteCluster", &[("ClusterIdentifier", "new-name")]);
+}
+
+#[test]
+fn modify_cluster_persists_encryption_kms_and_port() {
+    let svc = service();
+    ok(
+        &svc,
+        "CreateCluster",
+        &[
+            ("ClusterIdentifier", "enc"),
+            ("NodeType", "ra3.xlplus"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "Passw0rd123"),
+        ],
+    );
+    let out = ok(
+        &svc,
+        "ModifyCluster",
+        &[
+            ("ClusterIdentifier", "enc"),
+            ("Encrypted", "true"),
+            ("KmsKeyId", "arn:aws:kms:us-east-1:123456789012:key/abcd"),
+            ("Port", "5555"),
+            ("AvailabilityZone", "us-east-1b"),
+            ("AvailabilityZoneRelocation", "true"),
+        ],
+    );
+    assert!(out.contains("<Encrypted>true</Encrypted>"));
+
+    let listed = ok(&svc, "DescribeClusters", &[("ClusterIdentifier", "enc")]);
+    assert!(listed.contains("<Encrypted>true</Encrypted>"));
+    assert!(listed.contains("<KmsKeyId>arn:aws:kms:us-east-1:123456789012:key/abcd</KmsKeyId>"));
+    assert!(listed.contains("<Port>5555</Port>"));
+    assert!(listed.contains("<AvailabilityZone>us-east-1b</AvailabilityZone>"));
+    assert!(listed
+        .contains("<AvailabilityZoneRelocationStatus>enabled</AvailabilityZoneRelocationStatus>"));
+}

--- a/crates/fakecloud-route53resolver/src/service.rs
+++ b/crates/fakecloud-route53resolver/src/service.rs
@@ -2330,6 +2330,15 @@ impl Route53ResolverService {
             {
                 rule.firewall_domain_redirection_action = Some(a.to_string());
             }
+            if let Some(d) = e.get("DnsThreatProtection").and_then(Value::as_str) {
+                rule.dns_threat_protection = Some(d.to_string());
+            }
+            if let Some(c) = e.get("ConfidenceThreshold").and_then(Value::as_str) {
+                rule.confidence_threshold = Some(c.to_string());
+            }
+            if let Some(frt) = e.get("FirewallRuleType").filter(|v| !v.is_null()) {
+                rule.firewall_rule_type = Some(frt.clone());
+            }
             rule.modification_time = now_rfc3339();
             updated.push(to_val(&rule.clone()));
         }
@@ -3702,6 +3711,69 @@ mod tests {
         let listed_rule = &listed["FirewallRules"][0];
         assert_eq!(listed_rule["DnsThreatProtection"], "DGA");
         assert_eq!(listed_rule["ConfidenceThreshold"], "HIGH");
+    }
+
+    // BatchUpdateFirewallRule must apply DnsThreatProtection / ConfidenceThreshold
+    // / FirewallRuleType exactly like the single-rule update, so the batch path
+    // persists them and they round-trip on List.
+    #[tokio::test]
+    async fn batch_update_firewall_rule_persists_threat_protection_fields() {
+        let svc = Route53ResolverService::default();
+        let (_, g) = call(
+            &svc,
+            "CreateFirewallRuleGroup",
+            json!({ "CreatorRequestId": "c", "Name": "g" }),
+        )
+        .await;
+        let group_id = g["FirewallRuleGroup"]["Id"].as_str().unwrap().to_string();
+        let (s, _) = call(
+            &svc,
+            "CreateFirewallRule",
+            json!({
+                "FirewallRuleGroupId": group_id,
+                "Name": "r",
+                "Priority": 5,
+                "Action": "BLOCK",
+                "BlockResponse": "NODATA",
+                "DnsThreatProtection": "DGA",
+                "ConfidenceThreshold": "LOW",
+            }),
+        )
+        .await;
+        assert_eq!(s, 200);
+
+        let (s, upd) = call(
+            &svc,
+            "BatchUpdateFirewallRule",
+            json!({
+                "UpdateFirewallRuleEntries": [{
+                    "FirewallRuleGroupId": group_id,
+                    "DnsThreatProtection": "DNS_TUNNELING",
+                    "ConfidenceThreshold": "HIGH",
+                    "FirewallRuleType": { "DnsThreatProtection": { "Detector": "DNS_TUNNELING" } },
+                }],
+            }),
+        )
+        .await;
+        assert_eq!(s, 200, "{upd}");
+        let updated = &upd["UpdatedFirewallRules"][0];
+        assert_eq!(updated["DnsThreatProtection"], "DNS_TUNNELING");
+        assert_eq!(updated["ConfidenceThreshold"], "HIGH");
+
+        // The change persists to state, visible on List.
+        let (_, listed) = call(
+            &svc,
+            "ListFirewallRules",
+            json!({ "FirewallRuleGroupId": group_id }),
+        )
+        .await;
+        let listed_rule = &listed["FirewallRules"][0];
+        assert_eq!(listed_rule["DnsThreatProtection"], "DNS_TUNNELING");
+        assert_eq!(listed_rule["ConfidenceThreshold"], "HIGH");
+        assert_eq!(
+            listed_rule["FirewallRuleType"]["DnsThreatProtection"]["Detector"],
+            "DNS_TUNNELING"
+        );
     }
 
     // Finding 5: a NextToken that this service never minted is rejected with


### PR DESCRIPTION
## Summary
Four write/read-asymmetry bugs from the 2026-07-22 bug hunt (Create/Modify persists a subset; the read path shows the default → Terraform perpetual-diff). Each confirmed against write + read-back paths, each with a regression test.

- **Redshift `ModifyCluster` dropped fields → rename fully broken.** It never applied `NewClusterIdentifier`, `Encrypted`, `KmsKeyId`, `ElasticIp`, `Port`, `AvailabilityZone`, `AvailabilityZoneRelocation`. A rename returned 200 but the cluster stayed keyed by its old id, so later ops 404'd. Now all are applied; a rename re-keys the map (old id 404s, new id resolves).
- **config `PutRemediationExceptions` dropped `ExpirationTime`** (request-level per the model). Now stored and emitted by `DescribeRemediationExceptions`.
- **EKS nodegroup dropped `nodeRepairConfig` + `warmPoolConfig`** (both in the model). Added to state, parsed in Create/UpdateNodegroupConfig, echoed by DescribeNodegroup.
- **route53resolver `BatchUpdateFirewallRule` dropped `DnsThreatProtection`/`ConfidenceThreshold`/`FirewallRuleType`** that the single-rule update persists. Now applied in the batch loop too.

Includes a one-line CFN `AWS::EKS::Nodegroup` provisioner ctor update required by the new struct fields.

## Test plan
- 4 new tests: Redshift rename re-key + encryption/kms/port round-trip; config ExpirationTime round-trip; EKS nodeRepairConfig/warmPoolConfig create+describe+update; route53resolver batch threat-field persistence.
- `cargo nextest` on the four crates: 132 passed. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes write/read asymmetry by persisting previously dropped fields across Redshift, Config, EKS, and Route53Resolver so updates stick and perpetual Terraform diffs stop. Redshift rename now re-keys the cluster and all Modify fields are applied.

- **Bug Fixes**
  - `fakecloud-redshift`: `ModifyCluster` now applies `NewClusterIdentifier` (re-keys the cluster), `Encrypted`, `KmsKeyId`, `ElasticIp`, `Port`, `AvailabilityZone`, and `AvailabilityZoneRelocation`.
  - `fakecloud-config`: `PutRemediationExceptions` stores `ExpirationTime` and `DescribeRemediationExceptions` returns it.
  - `fakecloud-eks`: `CreateNodegroup`/`UpdateNodegroupConfig` persist `nodeRepairConfig` and `warmPoolConfig`; `DescribeNodegroup` echoes them. `fakecloud-cloudformation` `AWS::EKS::Nodegroup` provisioner updated to pass `NodeRepairConfig`.
  - `fakecloud-route53resolver`: `BatchUpdateFirewallRule` now persists `DnsThreatProtection`, `ConfidenceThreshold`, and `FirewallRuleType` like the single-rule update.

<sup>Written for commit 4a9c7bda8bae40618932fdb355828706ae024417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

