### PR TITLE
fix(appsync,athena,glue): real introspection/schema-merge, workgroup engine version, no dangling calc results, real schema diff, settle stuck runs

### DIFF
--- a/crates/fakecloud-appsync/src/service.rs
+++ b/crates/fakecloud-appsync/src/service.rs
@@ -513,7 +513,7 @@ impl AppSyncService {
             "StartSchemaMerge" => self.start_schema_merge(&ctx, l(1)),
 
             // ---- Data-source introspection ----
-            "StartDataSourceIntrospection" => Self::start_ds_introspection(),
+            "StartDataSourceIntrospection" => self.start_ds_introspection(&ctx, &body),
             "GetDataSourceIntrospection" => self.get_ds_introspection(&ctx, l(0)),
 
             // ---- Tags ----
@@ -1798,14 +1798,18 @@ impl AppSyncService {
         require_label(assoc_id, "associationId")?;
         require_query(q, "format")?;
         let guard = self.state.read();
-        let exists = guard
+        let data = guard
             .get(&ctx.account)
-            .map(|d| d.source_api_associations.contains_key(assoc_id))
-            .unwrap_or(false);
-        if !exists {
-            return Err(not_found(&format!("Association {assoc_id} not found.")));
-        }
-        Ok(ok(json!({ "types": [] })))
+            .filter(|d| d.source_api_associations.contains_key(assoc_id))
+            .ok_or_else(|| not_found(&format!("Association {assoc_id} not found.")))?;
+        // Types merged into the merged API by StartSchemaMerge. Empty until a
+        // merge has run for this association.
+        let items: Vec<Value> = data
+            .association_types
+            .get(assoc_id)
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default();
+        Ok(ok(json!({ "types": items })))
     }
 
     fn update_source_api_association(
@@ -1853,42 +1857,118 @@ impl AppSyncService {
         assoc_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         require_label(assoc_id, "associationId")?;
-        let guard = self.state.read();
-        let exists = guard
-            .get(&ctx.account)
-            .map(|d| d.source_api_associations.contains_key(assoc_id))
-            .unwrap_or(false);
-        if exists {
-            Ok(ok(
-                json!({ "sourceApiAssociationStatus": "MERGE_IN_PROGRESS" }),
-            ))
-        } else {
-            Err(not_found(&format!("Association {assoc_id} not found.")))
+        let mut guard = self.state.write();
+        let data = guard.get_or_create(&ctx.account);
+        // Resolve the source + merged APIs from the association before mutating.
+        let (source_id, merged_id) = {
+            let assoc = data
+                .source_api_associations
+                .get(assoc_id)
+                .ok_or_else(|| not_found(&format!("Association {assoc_id} not found.")))?;
+            let source_id = assoc
+                .get("sourceApiId")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let merged_id = assoc
+                .get("mergedApiId")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            (source_id, merged_id)
+        };
+        // Copy the source API's types into both the association's merged-type set
+        // (returned by ListTypesByAssociation) and the merged API's own type
+        // store, so the merge is observable rather than a no-op.
+        let source_types: Vec<(String, Value)> = data
+            .types
+            .get(&source_id)
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+        let merged_types = data
+            .association_types
+            .entry(assoc_id.to_string())
+            .or_default();
+        for (name, ty) in &source_types {
+            merged_types.insert(name.clone(), ty.clone());
         }
+        if !merged_id.is_empty() {
+            let dest = data.types.entry(merged_id).or_default();
+            for (name, ty) in &source_types {
+                dest.insert(name.clone(), ty.clone());
+            }
+        }
+        // Reflect the completed synchronous merge on the association record.
+        if let Some(assoc) = data
+            .source_api_associations
+            .get_mut(assoc_id)
+            .and_then(Value::as_object_mut)
+        {
+            assoc.insert("sourceApiAssociationStatus".into(), json!("MERGE_SUCCESS"));
+        }
+        Ok(ok(json!({ "sourceApiAssociationStatus": "MERGE_SUCCESS" })))
     }
 
     // ===================== Data-source introspection =====================
 
-    fn start_ds_introspection() -> Result<AwsResponse, AwsServiceError> {
+    fn start_ds_introspection(
+        &self,
+        ctx: &Ctx,
+        body: &Value,
+    ) -> Result<AwsResponse, AwsServiceError> {
         let id = gen_hex(20);
+        // The emulator has no live RDS instance to introspect, so the discovered
+        // schema is an empty-but-well-formed IntrospectionResult. The record is
+        // persisted so the Start -> Get poll flow retrieves it instead of a
+        // permanent 404. The RDS config the caller supplied is echoed back on the
+        // stored record so a reader can see what was requested.
+        let rds_config = body.get("rdsDataApiConfig").cloned().unwrap_or(Value::Null);
+        let record = json!({
+            "introspectionId": id,
+            "introspectionStatus": "SUCCESS",
+            "introspectionStatusDetail": "Introspection completed.",
+            "introspectionResult": {
+                "models": [],
+            },
+            // Retained for reads/introspection; not part of the Get output shape.
+            "rdsDataApiConfig": rds_config,
+        });
+        let mut guard = self.state.write();
+        let data = guard.get_or_create(&ctx.account);
+        data.introspections.insert(id.clone(), record);
         Ok(ok(json!({
             "introspectionId": id,
-            "introspectionStatus": "PROCESSING",
-            "introspectionStatusDetail": "Introspection started.",
+            "introspectionStatus": "SUCCESS",
+            "introspectionStatusDetail": "Introspection completed.",
         })))
     }
 
     fn get_ds_introspection(
         &self,
-        _ctx: &Ctx,
+        ctx: &Ctx,
         introspection_id: &str,
     ) -> Result<AwsResponse, AwsServiceError> {
         require_label(introspection_id, "introspectionId")?;
-        // Introspection jobs are ephemeral; a synthetic/unknown id is a
-        // declared NotFoundException. Real jobs would settle here.
-        Err(not_found(&format!(
-            "Introspection {introspection_id} not found."
-        )))
+        let guard = self.state.read();
+        let record = guard
+            .get(&ctx.account)
+            .and_then(|d| d.introspections.get(introspection_id))
+            .ok_or_else(|| not_found(&format!("Introspection {introspection_id} not found.")))?;
+        Ok(ok(json!({
+            "introspectionId": record.get("introspectionId").cloned().unwrap_or(Value::Null),
+            "introspectionStatus": record
+                .get("introspectionStatus")
+                .cloned()
+                .unwrap_or(Value::Null),
+            "introspectionStatusDetail": record
+                .get("introspectionStatusDetail")
+                .cloned()
+                .unwrap_or(Value::Null),
+            "introspectionResult": record
+                .get("introspectionResult")
+                .cloned()
+                .unwrap_or(json!({ "models": [] })),
+        })))
     }
 
     // ===================== Tags =====================
@@ -2509,6 +2589,87 @@ mod tests {
             .unwrap();
         let listed = body_json(&s.list_tags_for_resource(&ctx(), arn).unwrap());
         assert_eq!(listed["tags"]["team"], json!("obs"));
+    }
+
+    #[test]
+    fn data_source_introspection_start_then_get_is_retrievable() {
+        // Regression: StartDataSourceIntrospection persisted nothing and
+        // GetDataSourceIntrospection unconditionally 404'd, so the Start -> Get
+        // poll flow could never retrieve the discovered schema.
+        let s = svc();
+        let started = body_json(
+            &s.start_ds_introspection(
+                &ctx(),
+                &json!({
+                    "rdsDataApiConfig": {
+                        "resourceArn": "arn:aws:rds:us-east-1:000000000000:cluster:db",
+                        "secretArn": "arn:aws:secretsmanager:us-east-1:000000000000:secret:s",
+                        "databaseName": "app",
+                    }
+                }),
+            )
+            .unwrap(),
+        );
+        let id = started["introspectionId"].as_str().unwrap().to_string();
+        assert_eq!(started["introspectionStatus"], json!("SUCCESS"));
+
+        let got = body_json(&s.get_ds_introspection(&ctx(), &id).unwrap());
+        assert_eq!(got["introspectionId"], json!(id));
+        assert_eq!(got["introspectionStatus"], json!("SUCCESS"));
+        assert!(got["introspectionResult"]["models"].is_array());
+
+        // Unknown id is still a declared NotFoundException.
+        let err = err_of(s.get_ds_introspection(&ctx(), "does-not-exist"));
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn schema_merge_populates_types_by_association() {
+        // Regression: StartSchemaMerge never merged source types and
+        // ListTypesByAssociation always returned an empty list.
+        let s = svc();
+        let source_id = make_api(&s);
+        let merged_id = make_api(&s);
+        // Define a type on the source API.
+        s.create_type(
+            &ctx(),
+            &source_id,
+            &json!({ "definition": "type Widget { id: ID! }", "format": "SDL" }),
+        )
+        .unwrap();
+        // Before a merge there is nothing to list.
+        let assoc = body_json(
+            &s.associate_source_api(
+                &ctx(),
+                &merged_id,
+                &json!({ "sourceApiIdentifier": source_id }),
+            )
+            .unwrap(),
+        );
+        let assoc_id = assoc["sourceApiAssociation"]["associationId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let fmt = [("format".to_string(), "SDL".to_string())];
+        let empty = body_json(
+            &s.list_types_by_association(&ctx(), &merged_id, &assoc_id, &fmt)
+                .unwrap(),
+        );
+        assert!(empty["types"].as_array().unwrap().is_empty());
+
+        // After the merge the source type is associated with the merged API.
+        let merged = body_json(&s.start_schema_merge(&ctx(), &assoc_id).unwrap());
+        assert_eq!(merged["sourceApiAssociationStatus"], json!("MERGE_SUCCESS"));
+        let listed = body_json(
+            &s.list_types_by_association(&ctx(), &merged_id, &assoc_id, &fmt)
+                .unwrap(),
+        );
+        let types = listed["types"].as_array().unwrap();
+        assert_eq!(types.len(), 1);
+        assert_eq!(types[0]["name"], json!("Widget"));
+        // The merged API's own type store now carries the merged type too.
+        let on_merged = body_json(&s.list_types(&ctx(), &merged_id, &fmt).unwrap());
+        assert_eq!(on_merged["types"].as_array().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/fakecloud-appsync/src/state.rs
+++ b/crates/fakecloud-appsync/src/state.rs
@@ -79,6 +79,12 @@ pub struct AppSyncData {
     /// Source-API associations keyed by `associationId` -> `SourceApiAssociation`.
     #[serde(default)]
     pub source_api_associations: BTreeMap<String, Value>,
+    /// Types merged into a merged API by `StartSchemaMerge`, keyed by
+    /// `associationId` -> `typeName` -> `Type` wire object. Populated when a
+    /// schema merge copies the source API's types so `ListTypesByAssociation`
+    /// can return them instead of a constant empty list.
+    #[serde(default)]
+    pub association_types: BTreeMap<String, BTreeMap<String, Value>>,
     /// Data-source introspection jobs keyed by `introspectionId`.
     #[serde(default)]
     pub introspections: BTreeMap<String, Value>,

--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -966,10 +966,13 @@ fn calculation_detail_json(c: &Calculation) -> Value {
             .unwrap()
             .insert("Description".to_string(), Value::String(d.clone()));
     }
-    if let Some(w) = &c.working_directory {
+    // Only advertise a Result when a result object was actually written (a real,
+    // resolvable ResultS3Uri). A COMPLETED calculation with no written result
+    // carries no Result block rather than a dangling URI.
+    if let (Some(w), Some(rt)) = (&c.working_directory, &c.result_type) {
         obj.as_object_mut().unwrap().insert(
             "Result".to_string(),
-            json!({ "ResultS3Uri": w, "ResultType": "JSON" }),
+            json!({ "ResultS3Uri": w, "ResultType": rt }),
         );
     }
     obj
@@ -1442,6 +1445,109 @@ mod tests {
             .unwrap();
         let qe = parse_json(&qe_resp).get("QueryExecution").unwrap().clone();
         assert_eq!(qe.get("Query").unwrap(), "SELECT 1 AS id");
+    }
+
+    #[test]
+    fn query_records_workgroup_engine_version() {
+        // Regression: StartQueryExecution stored a hardcoded AUTO / v3
+        // EngineVersion, ignoring the workgroup's pinned version.
+        let svc = AthenaService::new(SharedAthenaState::default());
+        svc.create_work_group(&req(
+            "CreateWorkGroup",
+            json!({
+                "Name": "v2wg",
+                "Configuration": {
+                    "EngineVersion": { "SelectedEngineVersion": "Athena engine version 2" }
+                }
+            }),
+        ))
+        .unwrap();
+
+        let exec = parse_json(
+            &svc.start_query_execution(&req(
+                "StartQueryExecution",
+                json!({ "QueryString": "SELECT 1 AS id", "WorkGroup": "v2wg" }),
+            ))
+            .unwrap(),
+        );
+        let qe_id = exec["QueryExecutionId"].as_str().unwrap().to_string();
+        let qe = parse_json(
+            &svc.get_query_execution(&req(
+                "GetQueryExecution",
+                json!({ "QueryExecutionId": qe_id }),
+            ))
+            .unwrap(),
+        );
+        let ev = &qe["QueryExecution"]["EngineVersion"];
+        assert_eq!(ev["SelectedEngineVersion"], "Athena engine version 2");
+        assert_eq!(ev["EffectiveEngineVersion"], "Athena engine version 2");
+
+        // The default primary workgroup pins nothing, so it falls back to AUTO/v3.
+        let exec2 = parse_json(
+            &svc.start_query_execution(&req(
+                "StartQueryExecution",
+                json!({ "QueryString": "SELECT 1 AS id", "WorkGroup": "primary" }),
+            ))
+            .unwrap(),
+        );
+        let qe2_id = exec2["QueryExecutionId"].as_str().unwrap().to_string();
+        let qe2 = parse_json(
+            &svc.get_query_execution(&req(
+                "GetQueryExecution",
+                json!({ "QueryExecutionId": qe2_id }),
+            ))
+            .unwrap(),
+        );
+        let ev2 = &qe2["QueryExecution"]["EngineVersion"];
+        assert_eq!(ev2["SelectedEngineVersion"], "AUTO");
+        assert_eq!(ev2["EffectiveEngineVersion"], "Athena engine version 3");
+    }
+
+    #[test]
+    fn calculation_execution_advertises_no_dangling_result() {
+        // Regression: StartCalculationExecution fabricated a COMPLETED state with
+        // a dangling s3://athena-calc-results/{uuid} ResultS3Uri and reported a
+        // hardcoded DpuExecutionInMillis:100. With no result location configured
+        // no Result block is advertised, and Statistics come from the record.
+        let svc = AthenaService::new(SharedAthenaState::default());
+        let sess = parse_json(
+            &svc.start_session(&req("StartSession", json!({ "WorkGroup": "primary" })))
+                .unwrap(),
+        );
+        let session_id = sess["SessionId"].as_str().unwrap().to_string();
+
+        let calc = parse_json(
+            &svc.start_calculation_execution(&req(
+                "StartCalculationExecution",
+                json!({ "SessionId": session_id, "CodeBlock": "print(1)" }),
+            ))
+            .unwrap(),
+        );
+        let calc_id = calc["CalculationExecutionId"].as_str().unwrap().to_string();
+
+        let detail = parse_json(
+            &svc.get_calculation_execution(&req(
+                "GetCalculationExecution",
+                json!({ "CalculationExecutionId": calc_id }),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(detail["Status"]["State"], "COMPLETED");
+        assert!(
+            detail.get("Result").is_none(),
+            "no dangling ResultS3Uri should be advertised, got {:?}",
+            detail.get("Result")
+        );
+
+        let status = parse_json(
+            &svc.get_calculation_execution_status(&req(
+                "GetCalculationExecutionStatus",
+                json!({ "CalculationExecutionId": calc_id }),
+            ))
+            .unwrap(),
+        );
+        assert_eq!(status["Statistics"]["DpuExecutionInMillis"], 0);
+        assert_eq!(status["Statistics"]["Progress"], "100%");
     }
 
     #[test]

--- a/crates/fakecloud-athena/src/service/notebooks.rs
+++ b/crates/fakecloud-athena/src/service/notebooks.rs
@@ -391,12 +391,46 @@ impl AthenaService {
             .get("CodeBlock")
             .and_then(Value::as_str)
             .map(str::to_owned);
+        let id = synth_uuid();
+        let now = Utc::now();
+
+        // Resolve the result location from the session's workgroup so any written
+        // result is addressable. Without a configured location we advertise no
+        // ResultS3Uri at all rather than a dangling one pointing at a nonexistent
+        // object (the pre-fix behaviour fabricated s3://athena-calc-results/...).
+        let output_location = {
+            let mut state = self.state.write();
+            let account = account_mut(&mut state, &req.account_id);
+            let session = account
+                .sessions
+                .get(&session_id)
+                .ok_or_else(|| invalid_request(format!("Session {session_id} not found")))?;
+            let wg = session.work_group.clone();
+            account
+                .work_groups
+                .get(&wg)
+                .and_then(|w| w.configuration.as_ref())
+                .and_then(|c| c.get("ResultConfiguration"))
+                .and_then(|rc| rc.get("OutputLocation"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        };
+
+        // Write a small result object to the fake S3 store so the ResultS3Uri
+        // resolves. Only when both a location and its bucket exist; otherwise no
+        // result URI is advertised.
+        let (working_directory, result_type) = self.write_calculation_result(
+            &req.account_id,
+            output_location.as_deref(),
+            &id,
+            code_block.as_deref(),
+        );
+
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
         if !account.sessions.contains_key(&session_id) {
             return Err(invalid_request(format!("Session {session_id} not found")));
         }
-        let id = synth_uuid();
         account.calculations.insert(
             id.clone(),
             Calculation {
@@ -405,16 +439,73 @@ impl AthenaService {
                 description,
                 state: "COMPLETED".to_string(),
                 state_change_reason: None,
-                working_directory: Some(format!("s3://athena-calc-results/{}", Uuid::new_v4())),
+                working_directory,
                 code_block,
-                submission_date_time: Utc::now(),
-                completion_date_time: Some(Utc::now()),
+                submission_date_time: now,
+                completion_date_time: Some(now),
+                dpu_execution_in_millis: Some(0),
+                progress: Some("100%".to_string()),
+                result_type,
             },
         );
         Ok(AwsResponse::ok_json(json!({
             "CalculationExecutionId": id,
             "State": "COMPLETED",
         })))
+    }
+
+    /// Persist a small JSON result object for a calculation to the fake S3 store
+    /// so the advertised `ResultS3Uri` resolves. Returns `(working_directory,
+    /// result_type)`; both `None` when there is no configured result location,
+    /// no S3 store wired, or the target bucket does not exist (in which case the
+    /// calculation advertises no downloadable result rather than a dangling URI).
+    fn write_calculation_result(
+        &self,
+        account_id: &str,
+        output_location: Option<&str>,
+        calc_id: &str,
+        code_block: Option<&str>,
+    ) -> (Option<String>, Option<String>) {
+        let (Some(base), Some(s3)) = (output_location, self.s3.as_ref()) else {
+            return (None, None);
+        };
+        let Some((bucket_name, mut prefix)) = parse_s3_location(base) else {
+            return (None, None);
+        };
+        if !prefix.is_empty() && !prefix.ends_with('/') {
+            prefix.push('/');
+        }
+        let key = format!("{prefix}{calc_id}/result.json");
+        let payload = serde_json::to_vec(&json!({
+            "calculationExecutionId": calc_id,
+            "codeBlock": code_block.unwrap_or_default(),
+        }))
+        .unwrap_or_default();
+        let size = payload.len() as u64;
+        let etag = format!("\"{}\"", Uuid::new_v4().simple());
+
+        let mut guard = s3.write();
+        let acct = guard.get_or_create(account_id);
+        let Some(bucket) = acct.buckets.get_mut(&bucket_name) else {
+            return (None, None);
+        };
+        bucket.objects.insert(
+            key.clone(),
+            fakecloud_s3::S3Object {
+                key: key.clone(),
+                body: fakecloud_s3::memory_body(bytes::Bytes::from(payload)),
+                content_type: "application/json".to_string(),
+                etag,
+                size,
+                last_modified: Utc::now(),
+                storage_class: "STANDARD".to_string(),
+                ..Default::default()
+            },
+        );
+        (
+            Some(format!("s3://{bucket_name}/{key}")),
+            Some("JSON".to_string()),
+        )
     }
 
     pub(super) fn stop_calculation_execution(
@@ -481,8 +572,8 @@ impl AthenaService {
         Ok(AwsResponse::ok_json(json!({
             "Status": calculation_status_json(c),
             "Statistics": {
-                "DpuExecutionInMillis": 100,
-                "Progress": "100%",
+                "DpuExecutionInMillis": c.dpu_execution_in_millis.unwrap_or(0),
+                "Progress": c.progress.clone().unwrap_or_else(|| "100%".to_string()),
             }
         })))
     }
@@ -546,4 +637,18 @@ impl AthenaService {
         }
         Ok(AwsResponse::ok_json(response))
     }
+}
+
+/// Split an `s3://bucket/prefix` URL into `(bucket, prefix)`. Returns `None` for
+/// a non-`s3://` URL or an empty bucket.
+fn parse_s3_location(url: &str) -> Option<(String, String)> {
+    let rest = url.strip_prefix("s3://")?;
+    let (bucket, prefix) = match rest.split_once('/') {
+        Some((b, p)) => (b.to_string(), p.to_string()),
+        None => (rest.to_string(), String::new()),
+    };
+    if bucket.is_empty() {
+        return None;
+    }
+    Some((bucket, prefix))
 }

--- a/crates/fakecloud-athena/src/service/queries.rs
+++ b/crates/fakecloud-athena/src/service/queries.rs
@@ -62,14 +62,20 @@ impl AthenaService {
         }
 
         // Workgroup existence check before kicking off SQL execution so we
-        // surface the same error users hit on real Athena.
-        {
+        // surface the same error users hit on real Athena. Resolve the query's
+        // EngineVersion from the workgroup it runs in (the workgroup's
+        // Configuration/EngineVersion, set at Create/UpdateWorkGroup) rather than
+        // hardcoding AUTO/v3.
+        let engine_version = {
             let mut state = self.state.write();
             let account = account_mut(&mut state, &req.account_id);
-            if !account.work_groups.contains_key(&work_group) {
-                return Err(invalid_request(format!("Workgroup {work_group} not found")));
+            match account.work_groups.get(&work_group) {
+                Some(wg) => resolve_engine_version(wg),
+                None => {
+                    return Err(invalid_request(format!("Workgroup {work_group} not found")));
+                }
             }
-        }
+        };
 
         let id = synth_uuid();
         let now = Utc::now();
@@ -141,10 +147,7 @@ impl AthenaService {
             completion_time: Some(now),
             query_execution_context: context,
             result_configuration: effective_result_config,
-            engine_version: Some(json!({
-                "SelectedEngineVersion": "AUTO",
-                "EffectiveEngineVersion": "Athena engine version 3",
-            })),
+            engine_version: Some(engine_version),
             data_scanned_bytes: scanned,
             engine_execution_time_ms: 1,
             query_planning_time_ms: 1,
@@ -387,5 +390,54 @@ impl AthenaService {
                 },
             }
         })))
+    }
+}
+
+/// Resolve the `EngineVersion` a query should run under from the workgroup it
+/// runs in. Athena pins the effective engine version to the workgroup's
+/// configured `EngineVersion`; only when the workgroup pins nothing does it fall
+/// back to AUTO / "Athena engine version 3".
+fn resolve_engine_version(wg: &WorkGroup) -> Value {
+    // Prefer the EngineVersion object stored in the workgroup Configuration.
+    if let Some(ev) = wg
+        .configuration
+        .as_ref()
+        .and_then(|c| c.get("EngineVersion"))
+        .filter(|v| v.is_object())
+    {
+        let selected = ev
+            .get("SelectedEngineVersion")
+            .and_then(Value::as_str)
+            .unwrap_or("AUTO");
+        let effective = ev
+            .get("EffectiveEngineVersion")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| effective_engine_version(selected));
+        return json!({
+            "SelectedEngineVersion": selected,
+            "EffectiveEngineVersion": effective,
+        });
+    }
+    // Fall back to the summary's SelectedEngineVersion string.
+    if let Some(selected) = wg.engine_version.as_deref() {
+        return json!({
+            "SelectedEngineVersion": selected,
+            "EffectiveEngineVersion": effective_engine_version(selected),
+        });
+    }
+    json!({
+        "SelectedEngineVersion": "AUTO",
+        "EffectiveEngineVersion": "Athena engine version 3",
+    })
+}
+
+/// The effective engine version for a `SelectedEngineVersion`: an explicit pin
+/// is its own effective version; AUTO resolves to the current default.
+fn effective_engine_version(selected: &str) -> String {
+    if selected.eq_ignore_ascii_case("AUTO") {
+        "Athena engine version 3".to_string()
+    } else {
+        selected.to_string()
     }
 }

--- a/crates/fakecloud-athena/src/state.rs
+++ b/crates/fakecloud-athena/src/state.rs
@@ -221,6 +221,17 @@ pub struct Calculation {
     pub code_block: Option<String>,
     pub submission_date_time: DateTime<Utc>,
     pub completion_date_time: Option<DateTime<Utc>>,
+    /// Per-calculation execution statistics reported by
+    /// `GetCalculationExecutionStatus`, stored on the record rather than emitted
+    /// as a hardcoded global constant.
+    #[serde(default)]
+    pub dpu_execution_in_millis: Option<i64>,
+    #[serde(default)]
+    pub progress: Option<String>,
+    /// Result type advertised alongside `working_directory` when a result object
+    /// was actually written; `None` when no downloadable result exists.
+    #[serde(default)]
+    pub result_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-glue/src/blueprints.rs
+++ b/crates/fakecloud-glue/src/blueprints.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::common::{entity_not_found, new_id, now_ts, req_str};
+use crate::common::{entity_not_found, new_id, now_ts, req_str, settle_run_status};
 use crate::generic;
 use crate::service::GlueService;
 
@@ -146,12 +146,15 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_str(&body, "BlueprintName")?;
-        let run_id = req_str(&body, "RunId")?;
-        let accounts = self.state.read();
-        let run = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.blueprint_runs.get(run_id))
+        let run_id = req_str(&body, "RunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let run = st
+            .blueprint_runs
+            .get_mut(&run_id)
             .ok_or_else(|| entity_not_found(format!("BlueprintRun {run_id} not found")))?;
+        settle_run_status(run, "State", "SUCCEEDED", Some("CompletedOn"));
+        let run = run.clone();
         Ok(AwsResponse::ok_json(json!({ "BlueprintRun": run })))
     }
 
@@ -160,18 +163,18 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let bp = req_str(&body, "BlueprintName")?;
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| {
-                s.blueprint_runs
-                    .values()
-                    .filter(|r| r.get("BlueprintName").and_then(|n| n.as_str()) == Some(bp))
-                    .cloned()
-                    .collect()
+        let bp = req_str(&body, "BlueprintName")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .blueprint_runs
+            .values_mut()
+            .filter(|r| r.get("BlueprintName").and_then(|n| n.as_str()) == Some(bp.as_str()))
+            .map(|r| {
+                settle_run_status(r, "State", "SUCCEEDED", Some("CompletedOn"));
+                r.clone()
             })
-            .unwrap_or_default();
+            .collect();
         Ok(AwsResponse::ok_json(json!({ "BlueprintRuns": runs })))
     }
 

--- a/crates/fakecloud-glue/src/blueprints.rs
+++ b/crates/fakecloud-glue/src/blueprints.rs
@@ -168,12 +168,9 @@ impl GlueService {
         let st = accounts.get_or_create(&req.account_id, &req.region);
         let runs: Vec<Value> = st
             .blueprint_runs
-            .values_mut()
+            .values()
             .filter(|r| r.get("BlueprintName").and_then(|n| n.as_str()) == Some(bp.as_str()))
-            .map(|r| {
-                settle_run_status(r, "State", "SUCCEEDED", Some("CompletedOn"));
-                r.clone()
-            })
+            .cloned()
             .collect();
         Ok(AwsResponse::ok_json(json!({ "BlueprintRuns": runs })))
     }

--- a/crates/fakecloud-glue/src/common.rs
+++ b/crates/fakecloud-glue/src/common.rs
@@ -61,6 +61,41 @@ pub(crate) fn now_ts() -> f64 {
     Utc::now().timestamp() as f64
 }
 
+/// Settle a still-`RUNNING` async run/task to a terminal state when it is read,
+/// so poll-until-done loops terminate instead of hanging forever. Glue's real
+/// runs finish asynchronously; the emulator has no background worker, so
+/// `StartJobRun` completes synchronously and every other `Start*Run` op must
+/// likewise reach a terminal state. Doing it on read (rather than at start)
+/// keeps the resource's initially persisted state `RUNNING`, so a `Stop*`/
+/// `Cancel*` call issued before the first poll still finds a running resource.
+///
+/// `status_field` is the member carrying the lifecycle state (`Status` for most
+/// runs, `State` for crawler/blueprint runs). When a transition happens and
+/// `completed_field` is `Some`, that timestamp member is stamped with the
+/// current time. Returns `true` when a transition occurred (so callers can
+/// attach op-specific completion fields such as `ResultIds`).
+pub(crate) fn settle_run_status(
+    run: &mut Value,
+    status_field: &str,
+    terminal: &str,
+    completed_field: Option<&str>,
+) -> bool {
+    let running = matches!(
+        run.get(status_field).and_then(Value::as_str),
+        Some("RUNNING") | Some("STARTING")
+    );
+    if !running {
+        return false;
+    }
+    if let Some(obj) = run.as_object_mut() {
+        obj.insert(status_field.to_string(), json!(terminal));
+        if let Some(cf) = completed_field {
+            obj.insert(cf.to_string(), json!(now_ts()));
+        }
+    }
+    true
+}
+
 /// Copy the entries of `src` whose keys appear in `allowed` into a fresh
 /// object. Lets handlers echo the real stored input while guaranteeing the
 /// response carries only fields the Smithy output shape declares.

--- a/crates/fakecloud-glue/src/common.rs
+++ b/crates/fakecloud-glue/src/common.rs
@@ -87,7 +87,22 @@ pub(crate) fn settle_run_status(
     if !running {
         return false;
     }
+    // Real Glue reports a just-started run as RUNNING on the first read and only
+    // moves to a terminal state once it finishes. Settling on a read counter keeps
+    // the first Get*Run after Start*Run at RUNNING (matching AWS) while still
+    // guaranteeing a poll-until-terminal loop converges instead of hanging.
+    let reads = run
+        .get("_settle_reads")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if reads < 1 {
+        if let Some(obj) = run.as_object_mut() {
+            obj.insert("_settle_reads".to_string(), json!(reads + 1));
+        }
+        return false;
+    }
     if let Some(obj) = run.as_object_mut() {
+        obj.remove("_settle_reads");
         obj.insert(status_field.to_string(), json!(terminal));
         if let Some(cf) = completed_field {
             obj.insert(cf.to_string(), json!(now_ts()));

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -45,6 +45,26 @@ fn crawler_not_running(name: &str) -> AwsServiceError {
     )
 }
 
+/// Settle a crawler that is still `RUNNING` to `READY` on read, attaching a
+/// `LastCrawl` summary. Without this a `StartCrawler` left the crawler `RUNNING`
+/// forever: poll-until-`READY` loops hung, a second `StartCrawler` returned a
+/// permanent `CrawlerRunningException`, and `DeleteCrawler` stayed blocked. The
+/// emulator has no background crawl worker, so the crawl is treated as complete
+/// once the caller polls its state.
+fn settle_crawler(crawler: &mut Value) {
+    if crawler.get("State").and_then(Value::as_str) != Some("RUNNING") {
+        return;
+    }
+    let now = now_ts();
+    if let Some(obj) = crawler.as_object_mut() {
+        obj.insert("State".into(), json!("READY"));
+        obj.insert(
+            "LastCrawl".into(),
+            json!({ "Status": "SUCCEEDED", "StartTime": now }),
+        );
+    }
+}
+
 impl GlueService {
     pub(crate) fn create_crawler(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
@@ -72,22 +92,30 @@ impl GlueService {
 
     pub(crate) fn get_crawler(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let name = req_str(&body, "Name")?;
-        let accounts = self.state.read();
-        let crawler = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.crawlers.get(name))
+        let name = req_str(&body, "Name")?.to_string();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id, &req.region);
+        let crawler = state
+            .crawlers
+            .get_mut(&name)
             .ok_or_else(|| entity_not_found(format!("Crawler {name} not found")))?;
+        settle_crawler(crawler);
+        let crawler = crawler.clone();
         Ok(AwsResponse::ok_json(json!({ "Crawler": crawler })))
     }
 
     pub(crate) fn get_crawlers(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let accounts = self.state.read();
-        let crawlers: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| s.crawlers.values().cloned().collect())
-            .unwrap_or_default();
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id, &req.region);
+        let crawlers: Vec<Value> = state
+            .crawlers
+            .values_mut()
+            .map(|c| {
+                settle_crawler(c);
+                c.clone()
+            })
+            .collect();
         let (page, token) = crate::common::paginate_body(&body, crawlers)?;
         let mut resp = json!({ "Crawlers": page });
         if let Some(t) = token {
@@ -102,14 +130,17 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         let names = body["CrawlerNames"].as_array().cloned().unwrap_or_default();
-        let accounts = self.state.read();
-        let store = accounts.get(&req.account_id).map(|s| &s.crawlers);
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id, &req.region);
         let mut found = Vec::new();
         let mut not_found = Vec::new();
         for n in &names {
             let Some(name) = n.as_str() else { continue };
-            match store.and_then(|m| m.get(name)) {
-                Some(c) => found.push(c.clone()),
+            match state.crawlers.get_mut(name) {
+                Some(c) => {
+                    settle_crawler(c);
+                    found.push(c.clone());
+                }
                 None => not_found.push(json!(name)),
             }
         }

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -124,14 +124,7 @@ impl GlueService {
         let body = req.json_body();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id, &req.region);
-        let crawlers: Vec<Value> = state
-            .crawlers
-            .values_mut()
-            .map(|c| {
-                settle_crawler(c);
-                c.clone()
-            })
-            .collect();
+        let crawlers: Vec<Value> = state.crawlers.values().cloned().collect();
         let (page, token) = crate::common::paginate_body(&body, crawlers)?;
         let mut resp = json!({ "Crawlers": page });
         if let Some(t) = token {
@@ -152,9 +145,8 @@ impl GlueService {
         let mut not_found = Vec::new();
         for n in &names {
             let Some(name) = n.as_str() else { continue };
-            match state.crawlers.get_mut(name) {
+            match state.crawlers.get(name) {
                 Some(c) => {
-                    settle_crawler(c);
                     found.push(c.clone());
                 }
                 None => not_found.push(json!(name)),

--- a/crates/fakecloud-glue/src/crawlers.rs
+++ b/crates/fakecloud-glue/src/crawlers.rs
@@ -55,8 +55,24 @@ fn settle_crawler(crawler: &mut Value) {
     if crawler.get("State").and_then(Value::as_str) != Some("RUNNING") {
         return;
     }
+    // Real Glue reports a just-started crawler as RUNNING on the first read and
+    // only transitions to READY once the crawl finishes. Settling on a read
+    // counter keeps the first GetCrawler after StartCrawler at RUNNING (matching
+    // AWS) while still guaranteeing a poll-until-READY loop terminates instead of
+    // hanging forever.
+    let reads = crawler
+        .get("_settle_reads")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if reads < 1 {
+        if let Some(obj) = crawler.as_object_mut() {
+            obj.insert("_settle_reads".into(), json!(reads + 1));
+        }
+        return;
+    }
     let now = now_ts();
     if let Some(obj) = crawler.as_object_mut() {
+        obj.remove("_settle_reads");
         obj.insert("State".into(), json!("READY"));
         obj.insert(
             "LastCrawl".into(),
@@ -207,6 +223,7 @@ impl GlueService {
         }
         if let Some(obj) = crawler.as_object_mut() {
             obj.insert("State".into(), json!("RUNNING"));
+            obj.insert("_settle_reads".into(), json!(0));
         }
         Ok(AwsResponse::ok_json(json!({})))
     }

--- a/crates/fakecloud-glue/src/ml.rs
+++ b/crates/fakecloud-glue/src/ml.rs
@@ -246,14 +246,11 @@ impl GlueService {
         let st = accounts.get_or_create(&req.account_id, &req.region);
         let runs: Vec<Value> = st
             .ml_task_runs
-            .values_mut()
+            .values()
             .filter(|r| {
                 r.get("TransformId").and_then(|v| v.as_str()) == Some(transform_id.as_str())
             })
-            .map(|r| {
-                settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
-                r.clone()
-            })
+            .cloned()
             .collect();
         Ok(AwsResponse::ok_json(json!({ "TaskRuns": runs })))
     }
@@ -479,14 +476,7 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id, &req.region);
-        let runs: Vec<Value> = st
-            .dq_ruleset_runs
-            .values_mut()
-            .map(|r| {
-                settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
-                r.clone()
-            })
-            .collect();
+        let runs: Vec<Value> = st.dq_ruleset_runs.values().cloned().collect();
         Ok(AwsResponse::ok_json(json!({ "Runs": runs })))
     }
 
@@ -559,14 +549,7 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id, &req.region);
-        let runs: Vec<Value> = st
-            .dq_recommendation_runs
-            .values_mut()
-            .map(|r| {
-                settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
-                r.clone()
-            })
-            .collect();
+        let runs: Vec<Value> = st.dq_recommendation_runs.values().cloned().collect();
         Ok(AwsResponse::ok_json(json!({ "Runs": runs })))
     }
 

--- a/crates/fakecloud-glue/src/ml.rs
+++ b/crates/fakecloud-glue/src/ml.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::common::{entity_not_found, new_id, now_ts, req_present, req_str};
+use crate::common::{entity_not_found, new_id, now_ts, req_present, req_str, settle_run_status};
 use crate::generic;
 use crate::service::GlueService;
 
@@ -225,12 +225,14 @@ impl GlueService {
     pub(crate) fn get_ml_task_run(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_str(&body, "TransformId")?;
-        let task_id = req_str(&body, "TaskRunId")?;
-        let accounts = self.state.read();
-        let r = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.ml_task_runs.get(task_id))
+        let task_id = req_str(&body, "TaskRunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let r = st
+            .ml_task_runs
+            .get_mut(&task_id)
             .ok_or_else(|| entity_not_found(format!("MLTaskRun {task_id} not found")))?;
+        settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
         Ok(AwsResponse::ok_json(r.clone()))
     }
 
@@ -239,18 +241,20 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let transform_id = req_str(&body, "TransformId")?;
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| {
-                s.ml_task_runs
-                    .values()
-                    .filter(|r| r.get("TransformId").and_then(|v| v.as_str()) == Some(transform_id))
-                    .cloned()
-                    .collect()
+        let transform_id = req_str(&body, "TransformId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .ml_task_runs
+            .values_mut()
+            .filter(|r| {
+                r.get("TransformId").and_then(|v| v.as_str()) == Some(transform_id.as_str())
             })
-            .unwrap_or_default();
+            .map(|r| {
+                settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
+                r.clone()
+            })
+            .collect();
         Ok(AwsResponse::ok_json(json!({ "TaskRuns": runs })))
     }
 
@@ -409,13 +413,46 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let run_id = req_str(&body, "RunId")?;
-        let accounts = self.state.read();
-        let r = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.dq_ruleset_runs.get(run_id))
+        let run_id = req_str(&body, "RunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let r = st
+            .dq_ruleset_runs
+            .get_mut(&run_id)
             .ok_or_else(|| entity_not_found(format!("Run {run_id} not found")))?;
-        Ok(AwsResponse::ok_json(r.clone()))
+        // Settle to a terminal state on read and, on the transition, publish a
+        // DataQuality result so ResultIds/GetDataQualityResult resolve.
+        let mut new_result: Option<Value> = None;
+        if settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn")) {
+            let result_id = format!("dqresult-{}", new_id());
+            let ruleset0 = r
+                .get("RulesetNames")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .cloned()
+                .unwrap_or(Value::Null);
+            let data_source = r.get("DataSource").cloned().unwrap_or(Value::Null);
+            let started_on = r.get("StartedOn").cloned().unwrap_or(Value::Null);
+            if let Some(obj) = r.as_object_mut() {
+                obj.insert("ResultIds".into(), json!([result_id]));
+            }
+            new_result = Some(json!({
+                "ResultId": result_id,
+                "RulesetName": ruleset0,
+                "Score": 1.0,
+                "DataSource": data_source,
+                "StartedOn": started_on,
+                "CompletedOn": now_ts(),
+                "RuleResults": [],
+            }));
+        }
+        let run_json = r.clone();
+        if let Some(result) = new_result {
+            if let Some(rid) = result.get("ResultId").and_then(|v| v.as_str()) {
+                st.dq_results.insert(rid.to_string(), result);
+            }
+        }
+        Ok(AwsResponse::ok_json(run_json))
     }
 
     pub(crate) fn cancel_data_quality_ruleset_evaluation_run(
@@ -440,11 +477,16 @@ impl GlueService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| s.dq_ruleset_runs.values().cloned().collect())
-            .unwrap_or_default();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .dq_ruleset_runs
+            .values_mut()
+            .map(|r| {
+                settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
+                r.clone()
+            })
+            .collect();
         Ok(AwsResponse::ok_json(json!({ "Runs": runs })))
     }
 
@@ -475,12 +517,21 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let run_id = req_str(&body, "RunId")?;
-        let accounts = self.state.read();
-        let r = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.dq_recommendation_runs.get(run_id))
+        let run_id = req_str(&body, "RunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let r = st
+            .dq_recommendation_runs
+            .get_mut(&run_id)
             .ok_or_else(|| entity_not_found(format!("Run {run_id} not found")))?;
+        // Settle on read and attach a recommended ruleset so the completed run
+        // carries the output a poller expects.
+        if settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn")) {
+            if let Some(obj) = r.as_object_mut() {
+                obj.entry("RecommendedRuleset".to_string())
+                    .or_insert(json!("Rules = [ ]"));
+            }
+        }
         Ok(AwsResponse::ok_json(r.clone()))
     }
 
@@ -506,11 +557,16 @@ impl GlueService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| s.dq_recommendation_runs.values().cloned().collect())
-            .unwrap_or_default();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .dq_recommendation_runs
+            .values_mut()
+            .map(|r| {
+                settle_run_status(r, "Status", "SUCCEEDED", Some("CompletedOn"));
+                r.clone()
+            })
+            .collect();
         Ok(AwsResponse::ok_json(json!({ "Runs": runs })))
     }
 

--- a/crates/fakecloud-glue/src/schema_registry.rs
+++ b/crates/fakecloud-glue/src/schema_registry.rs
@@ -60,6 +60,76 @@ fn schema_key(id: &Value) -> Option<String> {
     Some(format!("{reg}\u{1f}{name}"))
 }
 
+/// Compute a diff between two schema-definition strings. Returns an empty string
+/// when the definitions are identical, and a JSON-encoded structural (for JSON
+/// definitions) or line-level (otherwise) diff when they differ. AWS returns a
+/// jsondiffpatch-style `SchemaDiff`; this is a faithful, self-consistent
+/// approximation that is non-empty exactly when the versions differ.
+fn schema_definition_diff(first: &str, second: &str) -> String {
+    if first == second {
+        return String::new();
+    }
+    if let (Ok(a), Ok(b)) = (
+        serde_json::from_str::<Value>(first),
+        serde_json::from_str::<Value>(second),
+    ) {
+        return serde_json::to_string(&json_value_diff(&a, &b)).unwrap_or_default();
+    }
+    let a_lines: Vec<&str> = first.lines().collect();
+    let b_lines: Vec<&str> = second.lines().collect();
+    let added: Vec<&str> = b_lines
+        .iter()
+        .filter(|l| !a_lines.contains(l))
+        .copied()
+        .collect();
+    let removed: Vec<&str> = a_lines
+        .iter()
+        .filter(|l| !b_lines.contains(l))
+        .copied()
+        .collect();
+    serde_json::to_string(&json!({ "added": added, "removed": removed })).unwrap_or_default()
+}
+
+/// Structural diff of two JSON values: added/removed/changed keys, recursing into
+/// nested objects.
+fn json_value_diff(a: &Value, b: &Value) -> Value {
+    match (a, b) {
+        (Value::Object(am), Value::Object(bm)) => {
+            let mut added = serde_json::Map::new();
+            let mut removed = serde_json::Map::new();
+            let mut changed = serde_json::Map::new();
+            for (k, bv) in bm {
+                match am.get(k) {
+                    None => {
+                        added.insert(k.clone(), bv.clone());
+                    }
+                    Some(av) if av != bv => {
+                        changed.insert(k.clone(), json_value_diff(av, bv));
+                    }
+                    _ => {}
+                }
+            }
+            for (k, av) in am {
+                if !bm.contains_key(k) {
+                    removed.insert(k.clone(), av.clone());
+                }
+            }
+            let mut out = serde_json::Map::new();
+            if !added.is_empty() {
+                out.insert("added".into(), Value::Object(added));
+            }
+            if !removed.is_empty() {
+                out.insert("removed".into(), Value::Object(removed));
+            }
+            if !changed.is_empty() {
+                out.insert("changed".into(), Value::Object(changed));
+            }
+            Value::Object(out)
+        }
+        _ => json!({ "old": a, "new": b }),
+    }
+}
+
 impl GlueService {
     // --- registries ---
 
@@ -492,11 +562,50 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        req_present(&body, "SchemaId")?;
-        req_present(&body, "FirstSchemaVersionNumber")?;
-        req_present(&body, "SecondSchemaVersionNumber")?;
+        let schema_id = req_present(&body, "SchemaId")?.clone();
+        let first = req_present(&body, "FirstSchemaVersionNumber")?.clone();
+        let second = req_present(&body, "SecondSchemaVersionNumber")?.clone();
         req_str(&body, "SchemaDiffType")?;
-        Ok(AwsResponse::ok_json(json!({ "Diff": "" })))
+        let key = schema_key(&schema_id)
+            .ok_or_else(|| invalid_input("SchemaId.SchemaName or SchemaId.SchemaArn required"))?;
+        let (reg, name) = key.split_once('\u{1f}').unwrap_or(("", ""));
+
+        let accounts = self.state.read();
+        let st = accounts.get(&req.account_id);
+        // Resolve the two version definitions from stored state rather than
+        // returning a constant empty diff. A version selector is a
+        // `SchemaVersionNumber` ({VersionNumber} or {LatestVersion: true}).
+        let resolve = |selector: &Value| -> Option<String> {
+            let st = st?;
+            let vnum = selector.get("VersionNumber").and_then(|v| v.as_i64());
+            let latest = selector
+                .get("LatestVersion")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            st.schema_versions
+                .values()
+                .filter(|v| {
+                    (v["RegistryName"].as_str() == Some(reg)
+                        && v["SchemaName"].as_str() == Some(name))
+                        || v["SchemaArn"]
+                            .as_str()
+                            .is_some_and(|a| a.ends_with(&format!("/{reg}/{name}")))
+                })
+                .filter(|v| match vnum {
+                    Some(n) if !latest => v["VersionNumber"].as_i64() == Some(n),
+                    _ => true,
+                })
+                .max_by_key(|v| v["VersionNumber"].as_i64().unwrap_or(0))
+                .and_then(|v| v["SchemaDefinition"].as_str().map(str::to_string))
+        };
+        let first_def =
+            resolve(&first).ok_or_else(|| entity_not_found("First schema version not found"))?;
+        let second_def =
+            resolve(&second).ok_or_else(|| entity_not_found("Second schema version not found"))?;
+
+        Ok(AwsResponse::ok_json(json!({
+            "Diff": schema_definition_diff(&first_def, &second_def),
+        })))
     }
 
     // --- schema version metadata ---

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -519,15 +519,12 @@ impl GlueService {
         let st = accounts.get_or_create(&req.account_id, &req.region);
         let runs: Vec<Value> = st
             .column_stats_task_runs
-            .values_mut()
+            .values()
             .filter(|r| {
                 r.get("DatabaseName").and_then(|v| v.as_str()) == Some(db.as_str())
                     && r.get("TableName").and_then(|v| v.as_str()) == Some(table.as_str())
             })
-            .map(|r| {
-                settle_run_status(r, "Status", "SUCCEEDED", Some("EndTime"));
-                r.clone()
-            })
+            .cloned()
             .collect();
         Ok(AwsResponse::ok_json(json!({
             "ColumnStatisticsTaskRuns": runs,
@@ -1250,14 +1247,7 @@ impl GlueService {
         req_str(&body, "CatalogId")?;
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id, &req.region);
-        let runs: Vec<Value> = st
-            .mv_refresh_runs
-            .values_mut()
-            .map(|r| {
-                settle_run_status(r, "Status", "SUCCEEDED", Some("EndTime"));
-                r.clone()
-            })
-            .collect();
+        let runs: Vec<Value> = st.mv_refresh_runs.values().cloned().collect();
         Ok(AwsResponse::ok_json(json!({
             "MaterializedViewRefreshTaskRuns": runs,
         })))

--- a/crates/fakecloud-glue/src/tail.rs
+++ b/crates/fakecloud-glue/src/tail.rs
@@ -9,6 +9,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::common::{
     entity_not_found, error_detail, new_id, now_ts, req_present, req_str, resource_arn,
+    settle_run_status,
 };
 use crate::service::GlueService;
 
@@ -493,12 +494,15 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let id = req_str(&body, "ColumnStatisticsTaskRunId")?;
-        let accounts = self.state.read();
-        let r = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.column_stats_task_runs.get(id))
+        let id = req_str(&body, "ColumnStatisticsTaskRunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let r = st
+            .column_stats_task_runs
+            .get_mut(&id)
             .ok_or_else(|| entity_not_found(format!("Task run {id} not found")))?;
+        settle_run_status(r, "Status", "SUCCEEDED", Some("EndTime"));
+        let r = r.clone();
         Ok(AwsResponse::ok_json(
             json!({ "ColumnStatisticsTaskRun": r }),
         ))
@@ -509,22 +513,22 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let db = req_str(&body, "DatabaseName")?;
-        let table = req_str(&body, "TableName")?;
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| {
-                s.column_stats_task_runs
-                    .values()
-                    .filter(|r| {
-                        r.get("DatabaseName").and_then(|v| v.as_str()) == Some(db)
-                            && r.get("TableName").and_then(|v| v.as_str()) == Some(table)
-                    })
-                    .cloned()
-                    .collect()
+        let db = req_str(&body, "DatabaseName")?.to_string();
+        let table = req_str(&body, "TableName")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .column_stats_task_runs
+            .values_mut()
+            .filter(|r| {
+                r.get("DatabaseName").and_then(|v| v.as_str()) == Some(db.as_str())
+                    && r.get("TableName").and_then(|v| v.as_str()) == Some(table.as_str())
             })
-            .unwrap_or_default();
+            .map(|r| {
+                settle_run_status(r, "Status", "SUCCEEDED", Some("EndTime"));
+                r.clone()
+            })
+            .collect();
         Ok(AwsResponse::ok_json(json!({
             "ColumnStatisticsTaskRuns": runs,
         })))
@@ -1224,12 +1228,15 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_str(&body, "CatalogId")?;
-        let id = req_str(&body, "MaterializedViewRefreshTaskRunId")?;
-        let accounts = self.state.read();
-        let r = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.mv_refresh_runs.get(id))
+        let id = req_str(&body, "MaterializedViewRefreshTaskRunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let r = st
+            .mv_refresh_runs
+            .get_mut(&id)
             .ok_or_else(|| entity_not_found(format!("Task run {id} not found")))?;
+        settle_run_status(r, "Status", "SUCCEEDED", Some("EndTime"));
+        let r = r.clone();
         Ok(AwsResponse::ok_json(json!({
             "MaterializedViewRefreshTaskRun": r,
         })))
@@ -1241,11 +1248,16 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_str(&body, "CatalogId")?;
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| s.mv_refresh_runs.values().cloned().collect())
-            .unwrap_or_default();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .mv_refresh_runs
+            .values_mut()
+            .map(|r| {
+                settle_run_status(r, "Status", "SUCCEEDED", Some("EndTime"));
+                r.clone()
+            })
+            .collect();
         Ok(AwsResponse::ok_json(json!({
             "MaterializedViewRefreshTaskRuns": runs,
         })))

--- a/crates/fakecloud-glue/src/tests.rs
+++ b/crates/fakecloud-glue/src/tests.rs
@@ -58,12 +58,20 @@ fn crawler_state_transitions() {
     svc.start_crawler(&req("StartCrawler", json!({"Name": "c"})))
         .unwrap();
     // A back-to-back start (before the crawl is polled) is still rejected: the
-    // crawler is RUNNING in storage until the first read settles it.
+    // crawler is RUNNING in storage until a read settles it.
     assert!(svc
         .start_crawler(&req("StartCrawler", json!({"Name": "c"})))
         .is_err());
 
-    // Reading the crawler settles the finished crawl to READY with a LastCrawl
+    // The first read after StartCrawler still reports RUNNING, matching AWS
+    // (the crawl is in progress).
+    let got = body_of(
+        svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
+            .unwrap(),
+    );
+    assert_eq!(got["Crawler"]["State"], "RUNNING");
+
+    // A subsequent read settles the finished crawl to READY with a LastCrawl
     // summary. Before the fix it stayed RUNNING forever, hanging poll loops.
     let got = body_of(
         svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
@@ -80,7 +88,10 @@ fn crawler_state_transitions() {
     // A second start after completion now succeeds.
     svc.start_crawler(&req("StartCrawler", json!({"Name": "c"})))
         .unwrap();
-    // Poll again to settle, then delete is no longer permanently blocked.
+    // Poll twice to settle back to READY (first read RUNNING, second READY),
+    // then delete is no longer permanently blocked.
+    svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
+        .unwrap();
     svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
         .unwrap();
     svc.delete_crawler(&req("DeleteCrawler", json!({"Name": "c"})))
@@ -365,6 +376,17 @@ fn ml_transform_and_task_run() {
         .unwrap(),
     );
     let task = run["TaskRunId"].as_str().unwrap().to_string();
+    // First read reports RUNNING (matching AWS).
+    let running = body_of(
+        svc.get_ml_task_run(&req(
+            "GetMLTaskRun",
+            json!({"TransformId": tid, "TaskRunId": task}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(running["Status"], "RUNNING");
+    // A subsequent read settles the task run to a terminal state instead of
+    // hanging in RUNNING forever.
     let got = body_of(
         svc.get_ml_task_run(&req(
             "GetMLTaskRun",
@@ -372,8 +394,6 @@ fn ml_transform_and_task_run() {
         ))
         .unwrap(),
     );
-    // The task run settles to a terminal state on read instead of hanging in
-    // RUNNING forever.
     assert_eq!(got["Status"], "SUCCEEDED");
 }
 
@@ -670,7 +690,18 @@ fn resume_workflow_run_returns_observable_run_id() {
     );
     let new_id = resumed["RunId"].as_str().unwrap().to_string();
     assert_ne!(new_id, "");
-    // The resumed run must be persisted and readable.
+    // The resumed run must be persisted and readable; the first read reports
+    // RUNNING (matching AWS).
+    let running = body_of(
+        svc.get_workflow_run(&req(
+            "GetWorkflowRun",
+            json!({"Name": "wf", "RunId": new_id}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(running["Run"]["WorkflowRunId"], new_id);
+    assert_eq!(running["Run"]["Status"], "RUNNING");
+    // A subsequent GetWorkflowRun settles the run to a terminal state.
     let got = body_of(
         svc.get_workflow_run(&req(
             "GetWorkflowRun",
@@ -678,8 +709,6 @@ fn resume_workflow_run_returns_observable_run_id() {
         ))
         .unwrap(),
     );
-    assert_eq!(got["Run"]["WorkflowRunId"], new_id);
-    // GetWorkflowRun settles the run to a terminal state on read.
     assert_eq!(got["Run"]["Status"], "COMPLETED");
 }
 
@@ -958,6 +987,16 @@ fn data_quality_ruleset_run_settles_and_publishes_result() {
         .unwrap(),
     );
     let run_id = started["RunId"].as_str().unwrap().to_string();
+    // First read reports the run as still RUNNING (matching AWS).
+    let running = body_of(
+        svc.get_data_quality_ruleset_evaluation_run(&req(
+            "GetDataQualityRulesetEvaluationRun",
+            json!({"RunId": run_id}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(running["Status"], "RUNNING");
+    // A subsequent read settles it to SUCCEEDED and publishes the result.
     let got = body_of(
         svc.get_data_quality_ruleset_evaluation_run(&req(
             "GetDataQualityRulesetEvaluationRun",
@@ -992,6 +1031,15 @@ fn blueprint_run_settles_to_terminal_on_read() {
         .unwrap(),
     );
     let run_id = started["RunId"].as_str().unwrap().to_string();
+    // First read reports RUNNING (matching AWS); a subsequent read settles it.
+    let running = body_of(
+        svc.get_blueprint_run(&req(
+            "GetBlueprintRun",
+            json!({"BlueprintName": "bp", "RunId": run_id}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(running["BlueprintRun"]["State"], "RUNNING");
     let got = body_of(
         svc.get_blueprint_run(&req(
             "GetBlueprintRun",

--- a/crates/fakecloud-glue/src/tests.rs
+++ b/crates/fakecloud-glue/src/tests.rs
@@ -57,28 +57,32 @@ fn crawler_state_transitions() {
 
     svc.start_crawler(&req("StartCrawler", json!({"Name": "c"})))
         .unwrap();
-    let got = body_of(
-        svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
-            .unwrap(),
-    );
-    assert_eq!(got["Crawler"]["State"], "RUNNING");
-    // double-start is rejected
+    // A back-to-back start (before the crawl is polled) is still rejected: the
+    // crawler is RUNNING in storage until the first read settles it.
     assert!(svc
         .start_crawler(&req("StartCrawler", json!({"Name": "c"})))
         .is_err());
 
-    svc.stop_crawler(&req("StopCrawler", json!({"Name": "c"})))
-        .unwrap();
+    // Reading the crawler settles the finished crawl to READY with a LastCrawl
+    // summary. Before the fix it stayed RUNNING forever, hanging poll loops.
     let got = body_of(
         svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
             .unwrap(),
     );
     assert_eq!(got["Crawler"]["State"], "READY");
+    assert_eq!(got["Crawler"]["LastCrawl"]["Status"], "SUCCEEDED");
+
     // stop-when-idle is rejected
     assert!(svc
         .stop_crawler(&req("StopCrawler", json!({"Name": "c"})))
         .is_err());
 
+    // A second start after completion now succeeds.
+    svc.start_crawler(&req("StartCrawler", json!({"Name": "c"})))
+        .unwrap();
+    // Poll again to settle, then delete is no longer permanently blocked.
+    svc.get_crawler(&req("GetCrawler", json!({"Name": "c"})))
+        .unwrap();
     svc.delete_crawler(&req("DeleteCrawler", json!({"Name": "c"})))
         .unwrap();
     assert!(svc
@@ -368,7 +372,9 @@ fn ml_transform_and_task_run() {
         ))
         .unwrap(),
     );
-    assert_eq!(got["Status"], "RUNNING");
+    // The task run settles to a terminal state on read instead of hanging in
+    // RUNNING forever.
+    assert_eq!(got["Status"], "SUCCEEDED");
 }
 
 #[test]
@@ -673,7 +679,8 @@ fn resume_workflow_run_returns_observable_run_id() {
         .unwrap(),
     );
     assert_eq!(got["Run"]["WorkflowRunId"], new_id);
-    assert_eq!(got["Run"]["Status"], "RUNNING");
+    // GetWorkflowRun settles the run to a terminal state on read.
+    assert_eq!(got["Run"]["Status"], "COMPLETED");
 }
 
 #[test]
@@ -870,4 +877,127 @@ fn update_classifier_bumps_version_and_preserves_creation_time() {
         "CreationTime preserved across update"
     );
     assert!(!updated["LastUpdated"].is_null());
+}
+
+#[test]
+fn schema_versions_diff_reflects_stored_definitions() {
+    // Regression: GetSchemaVersionsDiff validated inputs then returned a constant
+    // {"Diff": ""} without reading the two stored schema versions.
+    let svc = GlueService::default();
+    svc.create_schema(&req(
+        "CreateSchema",
+        json!({
+            "SchemaName": "s",
+            "DataFormat": "JSON",
+            "Compatibility": "NONE",
+            "SchemaDefinition": "{\"type\":\"record\",\"a\":1}"
+        }),
+    ))
+    .unwrap();
+    svc.register_schema_version(&req(
+        "RegisterSchemaVersion",
+        json!({
+            "SchemaId": {"SchemaName": "s"},
+            "SchemaDefinition": "{\"type\":\"record\",\"a\":2,\"b\":3}"
+        }),
+    ))
+    .unwrap();
+
+    // Two different versions produce a non-empty diff.
+    let diff = body_of(
+        svc.get_schema_versions_diff(&req(
+            "GetSchemaVersionsDiff",
+            json!({
+                "SchemaId": {"SchemaName": "s"},
+                "FirstSchemaVersionNumber": {"VersionNumber": 1},
+                "SecondSchemaVersionNumber": {"VersionNumber": 2},
+                "SchemaDiffType": "SYNTAX_DIFF"
+            }),
+        ))
+        .unwrap(),
+    );
+    let diff_str = diff["Diff"].as_str().unwrap();
+    assert!(
+        !diff_str.is_empty(),
+        "expected a non-empty diff, got {diff_str:?}"
+    );
+    assert!(
+        diff_str.contains('b'),
+        "diff should mention the added field: {diff_str}"
+    );
+
+    // Identical versions produce an empty diff.
+    let same = body_of(
+        svc.get_schema_versions_diff(&req(
+            "GetSchemaVersionsDiff",
+            json!({
+                "SchemaId": {"SchemaName": "s"},
+                "FirstSchemaVersionNumber": {"VersionNumber": 2},
+                "SecondSchemaVersionNumber": {"VersionNumber": 2},
+                "SchemaDiffType": "SYNTAX_DIFF"
+            }),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(same["Diff"], "");
+}
+
+#[test]
+fn data_quality_ruleset_run_settles_and_publishes_result() {
+    // Regression: a DataQuality ruleset evaluation run stayed RUNNING forever.
+    let svc = GlueService::default();
+    let started = body_of(
+        svc.start_data_quality_ruleset_evaluation_run(&req(
+            "StartDataQualityRulesetEvaluationRun",
+            json!({
+                "DataSource": {"GlueTable": {"DatabaseName": "db", "TableName": "t"}},
+                "Role": "r",
+                "RulesetNames": ["rs1"]
+            }),
+        ))
+        .unwrap(),
+    );
+    let run_id = started["RunId"].as_str().unwrap().to_string();
+    let got = body_of(
+        svc.get_data_quality_ruleset_evaluation_run(&req(
+            "GetDataQualityRulesetEvaluationRun",
+            json!({"RunId": run_id}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(got["Status"], "SUCCEEDED");
+    let result_id = got["ResultIds"][0].as_str().unwrap().to_string();
+    // The published result resolves via GetDataQualityResult.
+    let result = body_of(
+        svc.get_data_quality_result(&req("GetDataQualityResult", json!({"ResultId": result_id})))
+            .unwrap(),
+    );
+    assert_eq!(result["ResultId"], got["ResultIds"][0]);
+    assert_eq!(result["RulesetName"], "rs1");
+}
+
+#[test]
+fn blueprint_run_settles_to_terminal_on_read() {
+    let svc = GlueService::default();
+    svc.create_blueprint(&req(
+        "CreateBlueprint",
+        json!({"Name": "bp", "BlueprintLocation": "s3://b/bp.zip"}),
+    ))
+    .unwrap();
+    let started = body_of(
+        svc.start_blueprint_run(&req(
+            "StartBlueprintRun",
+            json!({"BlueprintName": "bp", "RoleArn": "arn:aws:iam::123456789012:role/r"}),
+        ))
+        .unwrap(),
+    );
+    let run_id = started["RunId"].as_str().unwrap().to_string();
+    let got = body_of(
+        svc.get_blueprint_run(&req(
+            "GetBlueprintRun",
+            json!({"BlueprintName": "bp", "RunId": run_id}),
+        ))
+        .unwrap(),
+    );
+    assert_eq!(got["BlueprintRun"]["State"], "SUCCEEDED");
 }

--- a/crates/fakecloud-glue/src/triggers.rs
+++ b/crates/fakecloud-glue/src/triggers.rs
@@ -4,7 +4,9 @@ use serde_json::{json, Value};
 
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
-use crate::common::{entity, entity_not_found, new_id, now_ts, req_present, req_str};
+use crate::common::{
+    entity, entity_not_found, new_id, now_ts, req_present, req_str, settle_run_status,
+};
 use crate::generic;
 use crate::service::GlueService;
 
@@ -302,12 +304,15 @@ impl GlueService {
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
         req_str(&body, "Name")?;
-        let run_id = req_str(&body, "RunId")?;
-        let accounts = self.state.read();
-        let run = accounts
-            .get(&req.account_id)
-            .and_then(|s| s.workflow_runs.get(run_id))
+        let run_id = req_str(&body, "RunId")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let run = st
+            .workflow_runs
+            .get_mut(&run_id)
             .ok_or_else(|| entity_not_found(format!("WorkflowRun {run_id} not found")))?;
+        settle_run_status(run, "Status", "COMPLETED", Some("CompletedOn"));
+        let run = run.clone();
         Ok(AwsResponse::ok_json(json!({ "Run": run })))
     }
 
@@ -316,18 +321,18 @@ impl GlueService {
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         let body = req.json_body();
-        let name = req_str(&body, "Name")?;
-        let accounts = self.state.read();
-        let runs: Vec<Value> = accounts
-            .get(&req.account_id)
-            .map(|s| {
-                s.workflow_runs
-                    .values()
-                    .filter(|r| r.get("Name").and_then(|n| n.as_str()) == Some(name))
-                    .cloned()
-                    .collect()
+        let name = req_str(&body, "Name")?.to_string();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id, &req.region);
+        let runs: Vec<Value> = st
+            .workflow_runs
+            .values_mut()
+            .filter(|r| r.get("Name").and_then(|n| n.as_str()) == Some(name.as_str()))
+            .map(|r| {
+                settle_run_status(r, "Status", "COMPLETED", Some("CompletedOn"));
+                r.clone()
             })
-            .unwrap_or_default();
+            .collect();
         Ok(AwsResponse::ok_json(json!({ "Runs": runs })))
     }
 

--- a/crates/fakecloud-glue/src/triggers.rs
+++ b/crates/fakecloud-glue/src/triggers.rs
@@ -326,12 +326,9 @@ impl GlueService {
         let st = accounts.get_or_create(&req.account_id, &req.region);
         let runs: Vec<Value> = st
             .workflow_runs
-            .values_mut()
+            .values()
             .filter(|r| r.get("Name").and_then(|n| n.as_str()) == Some(name.as_str()))
-            .map(|r| {
-                settle_run_status(r, "Status", "COMPLETED", Some("CompletedOn"));
-                r.clone()
-            })
+            .cloned()
             .collect();
         Ok(AwsResponse::ok_json(json!({ "Runs": runs })))
     }


### PR DESCRIPTION
## Summary
Six fabricated-success / write-read-loss bugs from the 2026-07-22 bug hunt, replaced with real behavior (no stubs). Each confirmed against write + read paths, each with a regression test.

**AppSync**
- `StartDataSourceIntrospection` persisted nothing → `GetDataSourceIntrospection` permanently 404'd. Now mints an id and persists a retrievable SUCCESS record with a well-formed `IntrospectionResult`; unknown ids still 404.
- `StartSchemaMerge` never merged and `ListTypesByAssociation` was hardcoded empty. Merge now copies the source API's types into the merged API + a per-association map, sets `MERGE_SUCCESS`, and List returns them.

**Athena**
- `StartQueryExecution` hardcoded `EngineVersion` (AUTO/v3), ignoring the workgroup's pinned version. Now resolved from the workgroup Configuration.
- `StartCalculationExecution` fabricated `COMPLETED` with a dangling `ResultS3Uri` and constant Statistics. Now writes a real result object to S3 when a result location + store are available, otherwise advertises no `Result` block; Statistics are stored per-calculation (DpuExecutionInMillis truthfully 0, no real Spark compute).

**Glue**
- `GetSchemaVersionsDiff` returned a hardcoded empty diff. Now computes a real structural/line diff of the two stored definitions (empty iff identical).
- `StartCrawler` + 7 async `Start*Run` ops (ML task/DQ ruleset+recommendation/column-stats/MV-refresh/blueprint/workflow) hung every waiter at `RUNNING` forever. They now settle to a terminal state on read (crawler → READY with a LastCrawl; DQ runs publish `ResultIds` + a resolvable result), so poll-until-done loops complete, a second crawler start after completion succeeds, and delete is no longer permanently blocked.

## Test plan
- New tests for each fix; 3 existing tests that asserted the buggy stuck-`RUNNING` behavior updated to the correct settle-on-read semantics.
- `cargo nextest run -p fakecloud-appsync -p fakecloud-athena -p fakecloud-glue`: 97 passed. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

Fidelity notes: AppSync IntrospectionResult is empty-but-well-formed (no live RDS); Glue diff is a self-consistent JSON diff, not AWS's exact jsondiffpatch format; run settle is synchronous-on-read (no background worker).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces stubbed behavior with real flows in `fakecloud-appsync`, `fakecloud-athena`, and `fakecloud-glue` to match AWS, prevent dangling outputs, and let polling finish. Glue now returns RUNNING on the first Get after a Start, then settles on later single-item reads.

- **Bug Fixes**
  - `fakecloud-appsync`
    - `StartDataSourceIntrospection` persists a SUCCESS record with an empty-but-valid `IntrospectionResult`; `GetDataSourceIntrospection` returns it (unknown ids still 404).
    - `StartSchemaMerge` copies source API types into the merged API and association map; marks `MERGE_SUCCESS`. `ListTypesByAssociation` returns merged types.
  - `fakecloud-athena`
    - `StartQueryExecution` records the workgroup’s configured engine version (falls back to `AUTO`/v3 when unset).
    - `StartCalculationExecution` writes a real JSON result to S3 when a result location and bucket exist; otherwise omits the `Result` block. Statistics are per-calculation (`DpuExecutionInMillis` 0; `Progress` 100%).
  - `fakecloud-glue`
    - `GetSchemaVersionsDiff` computes a real diff from stored definitions (empty only if identical).
    - `StartCrawler` and async `Start*Run` ops now settle on single-item reads: the first `Get*` after a start reports `RUNNING` (matching AWS); a subsequent `Get*` moves to terminal and stamps completion fields. Crawler transitions to `READY` with `LastCrawl`; DQ runs publish `ResultIds` with a resolvable result. List ops do not settle, so `Stop*` still finds a `RUNNING` run; subsequent starts and deletes no longer hang.

<sup>Written for commit 8a6f522b8848061dbf11cc88b53caf0d80888796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

