### PR TITLE
fix(ec2,sns): Describe NotFound guards + real filters + pagination; count attributes in SNS Publish size

### DIFF
--- a/crates/fakecloud-ec2/src/service/eni.rs
+++ b/crates/fakecloud-ec2/src/service/eni.rs
@@ -200,11 +200,21 @@ pub(crate) fn describe_network_interfaces(
     let accounts = svc.state.read();
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+    // An explicitly-requested NetworkInterfaceId that does not exist is a hard
+    // error on AWS (InvalidNetworkInterfaceID.NotFound), not a silently-empty
+    // result. Matches the sibling Describe ops (subnets/volumes/instances/...).
+    for id in &wanted {
+        if !state.network_interfaces.contains_key(id) {
+            return Err(eni_not_found(id));
+        }
+    }
+
     let mut items: Vec<String> = state
         .network_interfaces
         .values()
         .filter(|n| wanted.is_empty() || wanted.contains(&n.network_interface_id))
-        .filter(|n| eni_match(n, state.tags_for(&n.network_interface_id), &filters))
+        .filter(|n| eni_match(n, state.tags_for(&n.network_interface_id), &filters, &owner))
         .map(|n| eni_xml(n, state.tags_for(&n.network_interface_id), &owner))
         .collect();
     items.sort();
@@ -227,7 +237,7 @@ pub(crate) fn describe_network_interfaces(
     ))
 }
 
-fn eni_match(n: &NetworkInterface, tags: &[Tag], filters: &[Filter]) -> bool {
+fn eni_match(n: &NetworkInterface, tags: &[Tag], filters: &[Filter], owner: &str) -> bool {
     filters.iter().all(|f| {
         let candidates: Vec<String> = match f.name.as_str() {
             "network-interface-id" => vec![n.network_interface_id.clone()],
@@ -235,8 +245,44 @@ fn eni_match(n: &NetworkInterface, tags: &[Tag], filters: &[Filter]) -> bool {
             "vpc-id" => vec![n.vpc_id.clone()],
             "status" => vec![n.status.clone()],
             "mac-address" => vec![n.mac_address.clone()],
-            "private-ip-address" => vec![n.private_ip_address.clone()],
+            "private-ip-address" => {
+                // Match the primary private IP plus any secondary addresses.
+                let mut ips = vec![n.private_ip_address.clone()];
+                ips.extend(n.private_ips.iter().cloned());
+                ips
+            }
+            "addresses.private-ip-address" => {
+                let mut ips = vec![n.private_ip_address.clone()];
+                ips.extend(n.private_ips.iter().cloned());
+                ips
+            }
             "interface-type" => vec![n.interface_type.clone()],
+            "availability-zone" => vec![n.availability_zone.clone()],
+            "description" => vec![n.description.clone()],
+            "owner-id" => vec![owner.to_string()],
+            // AWS accepts both `group-id` and `groups.group-id` for the ENI's
+            // attached security groups (Terraform data sources use `group-id`).
+            "group-id" | "groups.group-id" => n.group_ids.clone(),
+            "attachment.instance-id" => n
+                .attachment
+                .as_ref()
+                .map(|a| vec![a.instance_id.clone()])
+                .unwrap_or_default(),
+            "attachment.attachment-id" => n
+                .attachment
+                .as_ref()
+                .map(|a| vec![a.attachment_id.clone()])
+                .unwrap_or_default(),
+            "attachment.status" => n
+                .attachment
+                .as_ref()
+                .map(|a| vec![a.status.clone()])
+                .unwrap_or_default(),
+            "attachment.device-index" => n
+                .attachment
+                .as_ref()
+                .map(|a| vec![a.device_index.to_string()])
+                .unwrap_or_default(),
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -915,6 +961,119 @@ mod tests {
         let accounts = svc.state.read();
         assert!(
             accounts.get("000000000000").unwrap().network_interfaces["eni-1"].source_dest_check
+        );
+    }
+
+    fn describe_enis(svc: &Ec2Service, query: &[(&str, &str)]) -> AwsResponse {
+        describe_network_interfaces(svc, &req(query)).unwrap()
+    }
+
+    #[test]
+    fn describe_network_interfaces_unknown_id_errors() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        let err = crate::test_support::err_of(describe_network_interfaces(
+            &svc,
+            &req(&[("NetworkInterfaceId.1", "eni-doesnotexist000000000")]),
+        ));
+        assert_eq!(err.code(), "InvalidNetworkInterfaceID.NotFound");
+    }
+
+    #[test]
+    fn describe_network_interfaces_known_id_ok() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        let resp = describe_enis(&svc, &[("NetworkInterfaceId.1", "eni-1")]);
+        let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        assert!(
+            body.contains("<networkInterfaceId>eni-1</networkInterfaceId>"),
+            "{body}"
+        );
+    }
+
+    #[test]
+    fn describe_network_interfaces_group_id_filter() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.network_interfaces.insert(
+                "eni-1".to_string(),
+                NetworkInterface {
+                    network_interface_id: "eni-1".into(),
+                    subnet_id: "subnet-1".into(),
+                    vpc_id: "vpc-1".into(),
+                    availability_zone: "us-east-1a".into(),
+                    description: "primary".into(),
+                    mac_address: "02:00:00:00:00:01".into(),
+                    private_ip_address: "10.0.0.5".into(),
+                    status: "in-use".into(),
+                    interface_type: "interface".into(),
+                    source_dest_check: true,
+                    group_ids: vec!["sg-web".into()],
+                    private_ips: vec![],
+                    ipv6_addresses: vec![],
+                    attachment: Some(crate::state::EniAttachment {
+                        attachment_id: "eni-attach-1".into(),
+                        instance_id: "i-123".into(),
+                        device_index: 0,
+                        status: "attached".into(),
+                    }),
+                    public_ip_dns_hostname_type: None,
+                },
+            );
+        }
+        let body = String::from_utf8_lossy(
+            describe_enis(
+                &svc,
+                &[
+                    ("Filter.1.Name", "group-id"),
+                    ("Filter.1.Value.1", "sg-web"),
+                ],
+            )
+            .body
+            .expect_bytes(),
+        )
+        .to_string();
+        assert!(
+            body.contains("<networkInterfaceId>eni-1</networkInterfaceId>"),
+            "{body}"
+        );
+
+        // attachment.instance-id also resolves the ENI.
+        let body = String::from_utf8_lossy(
+            describe_enis(
+                &svc,
+                &[
+                    ("Filter.1.Name", "attachment.instance-id"),
+                    ("Filter.1.Value.1", "i-123"),
+                ],
+            )
+            .body
+            .expect_bytes(),
+        )
+        .to_string();
+        assert!(
+            body.contains("<networkInterfaceId>eni-1</networkInterfaceId>"),
+            "{body}"
+        );
+
+        // A genuinely-unknown filter still matches nothing.
+        let body = String::from_utf8_lossy(
+            describe_enis(
+                &svc,
+                &[
+                    ("Filter.1.Name", "group-id"),
+                    ("Filter.1.Value.1", "sg-absent"),
+                ],
+            )
+            .body
+            .expect_bytes(),
+        )
+        .to_string();
+        assert!(
+            !body.contains("<networkInterfaceId>eni-1</networkInterfaceId>"),
+            "{body}"
         );
     }
 }

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -1294,6 +1294,21 @@ pub(crate) fn describe_instances(
         }
     }
 
+    // Resolve group id -> name up front so both the `group-name` filter and the
+    // response rendering can use it. Build the per-instance block-device
+    // mappings (from attached volumes) so `block-device-mapping.*` filters work.
+    let sg_names = sg_name_map(state);
+    let mut bdm_by_instance: HashMap<String, Vec<&crate::state::VolumeAttachment>> = HashMap::new();
+    for vol in state.volumes.values() {
+        for att in &vol.attachments {
+            bdm_by_instance
+                .entry(att.instance_id.clone())
+                .or_default()
+                .push(att);
+        }
+    }
+    let no_bdm: Vec<&crate::state::VolumeAttachment> = Vec::new();
+
     // Flatten matching instances into a stable order (by reservation, then id),
     // then paginate over the flat instance list — AWS counts instances, not
     // reservations, against MaxResults.
@@ -1307,6 +1322,8 @@ pub(crate) fn describe_instances(
                 state.tags_for(&i.instance_id),
                 &filters,
                 &arch_for(state, &i.image_id),
+                &sg_names,
+                bdm_by_instance.get(&i.instance_id).unwrap_or(&no_bdm),
             )
         })
         .collect();
@@ -1318,7 +1335,6 @@ pub(crate) fn describe_instances(
     let (page, token) = crate::service_helpers::paginate(&matching, next_token, max_results);
 
     // Group the page back into reservations, preserving the sorted order.
-    let sg_names = sg_name_map(state);
     let mut by_res: HashMap<String, Vec<String>> = HashMap::new();
     let mut order: Vec<String> = Vec::new();
     for i in page {
@@ -1365,7 +1381,14 @@ fn parse_max_results(params: &HashMap<String, String>) -> Option<usize> {
         .and_then(|v| v.parse::<usize>().ok())
 }
 
-fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter], architecture: &str) -> bool {
+fn inst_match(
+    i: &Instance,
+    tags: &[Tag],
+    filters: &[Filter],
+    architecture: &str,
+    sg_names: &HashMap<String, String>,
+    block_devices: &[&crate::state::VolumeAttachment],
+) -> bool {
     use crate::service_helpers::filter_value_matches;
     filters.iter().all(|f| {
         let candidates: Vec<String> = match f.name.as_str() {
@@ -1381,6 +1404,53 @@ fn inst_match(i: &Instance, tags: &[Tag], filters: &[Filter], architecture: &str
             "ip-address" => i.public_ip.clone().into_iter().collect(),
             "key-name" => i.key_name.clone().into_iter().collect(),
             "architecture" => vec![architecture.to_string()],
+            "launch-time" => vec![i.launch_time.clone()],
+            // The instance's security groups. AWS exposes them under `group-id`
+            // (default-VPC form), `instance.group-id`, and `group-name`; the
+            // primary ENI mirrors them for `network-interface.group-id`.
+            "group-id" | "instance.group-id" | "network-interface.group-id" => {
+                i.security_group_ids.clone()
+            }
+            "group-name" | "instance.group-name" => i
+                .security_group_ids
+                .iter()
+                .map(|g| sg_names.get(g).cloned().unwrap_or_else(|| g.clone()))
+                .collect(),
+            // Public DNS name derived from the public IP (see `instance_xml`).
+            "dns-name" => i
+                .public_ip
+                .as_ref()
+                .map(|ip| {
+                    vec![format!(
+                        "ec2-{}.compute.amazonaws.com",
+                        ip.replace('.', "-")
+                    )]
+                })
+                .unwrap_or_default(),
+            "private-dns-name" => {
+                vec![format!(
+                    "ip-{}.ec2.internal",
+                    i.private_ip.replace('.', "-")
+                )]
+            }
+            // The primary network interface mirrors the instance's placement.
+            "network-interface.subnet-id" => i.subnet_id.clone().into_iter().collect(),
+            "network-interface.vpc-id" => i.vpc_id.clone().into_iter().collect(),
+            "network-interface.availability-zone" => vec![i.az.clone()],
+            "network-interface.addresses.private-ip-address" => vec![i.private_ip.clone()],
+            "block-device-mapping.volume-id" => {
+                block_devices.iter().map(|a| a.volume_id.clone()).collect()
+            }
+            "block-device-mapping.device-name" => {
+                block_devices.iter().map(|a| a.device.clone()).collect()
+            }
+            "block-device-mapping.status" => {
+                block_devices.iter().map(|a| a.status.clone()).collect()
+            }
+            "block-device-mapping.delete-on-termination" => block_devices
+                .iter()
+                .map(|a| a.delete_on_termination.to_string())
+                .collect(),
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
@@ -1420,6 +1490,17 @@ pub(crate) fn describe_instance_status(
     let accounts = svc.state.read();
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
+    let sg_names = sg_name_map(state);
+    let mut bdm_by_instance: HashMap<String, Vec<&crate::state::VolumeAttachment>> = HashMap::new();
+    for vol in state.volumes.values() {
+        for att in &vol.attachments {
+            bdm_by_instance
+                .entry(att.instance_id.clone())
+                .or_default()
+                .push(att);
+        }
+    }
+    let no_bdm: Vec<&crate::state::VolumeAttachment> = Vec::new();
     let mut matching: Vec<&Instance> = state
         .instances
         .values()
@@ -1431,6 +1512,8 @@ pub(crate) fn describe_instance_status(
                 state.tags_for(&i.instance_id),
                 &filters,
                 &arch_for(state, &i.image_id),
+                &sg_names,
+                bdm_by_instance.get(&i.instance_id).unwrap_or(&no_bdm),
             )
         })
         .collect();
@@ -2517,6 +2600,80 @@ mod modify_tests {
                 .unwrap(),
         );
         assert!(out.contains("<instanceId>i-1</instanceId>"), "got: {out}");
+    }
+
+    #[test]
+    fn describe_instances_group_and_attachment_filters() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-1");
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.instances.get_mut("i-1").unwrap().security_group_ids = vec!["sg-web".into()];
+            // A security group so `group-name` can resolve.
+            state.security_groups.insert(
+                "sg-web".into(),
+                crate::state::SecurityGroup {
+                    group_id: "sg-web".into(),
+                    group_name: "web".into(),
+                    description: "d".into(),
+                    vpc_id: "vpc-1".into(),
+                    rules: vec![],
+                },
+            );
+            // A volume attached to the instance for block-device-mapping filters.
+            state.volumes.insert(
+                "vol-1".into(),
+                crate::state::Volume {
+                    volume_id: "vol-1".into(),
+                    size: 8,
+                    snapshot_id: None,
+                    availability_zone: "us-east-1a".into(),
+                    state: "in-use".into(),
+                    volume_type: "gp3".into(),
+                    iops: None,
+                    throughput: None,
+                    encrypted: false,
+                    kms_key_id: None,
+                    multi_attach_enabled: false,
+                    auto_enable_io: false,
+                    attachments: vec![crate::state::VolumeAttachment {
+                        volume_id: "vol-1".into(),
+                        instance_id: "i-1".into(),
+                        device: "/dev/sdf".into(),
+                        status: "attached".into(),
+                        delete_on_termination: true,
+                    }],
+                    in_recycle_bin: false,
+                    modification: None,
+                },
+            );
+        }
+        let matches = |name: &str, value: &str| -> bool {
+            body(
+                describe_instances(
+                    &svc,
+                    &req(
+                        "DescribeInstances",
+                        &[("Filter.1.Name", name), ("Filter.1.Value.1", value)],
+                    ),
+                )
+                .unwrap(),
+            )
+            .contains("<instanceId>i-1</instanceId>")
+        };
+        assert!(matches("instance.group-id", "sg-web"));
+        assert!(matches("group-id", "sg-web"));
+        assert!(matches("group-name", "web"));
+        assert!(matches("network-interface.group-id", "sg-web"));
+        assert!(matches("launch-time", "2024-01-01T00:00:00.000Z"));
+        assert!(matches("network-interface.subnet-id", "subnet-1"));
+        assert!(matches("block-device-mapping.volume-id", "vol-1"));
+        assert!(matches("block-device-mapping.device-name", "/dev/sdf"));
+        // A group that the instance is not in does not match.
+        assert!(!matches("instance.group-id", "sg-other"));
+        // A genuinely-unknown filter still matches nothing.
+        assert!(!matches("bogus-filter-name", "sg-web"));
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/sg.rs
+++ b/crates/fakecloud-ec2/src/service/sg.rs
@@ -502,7 +502,7 @@ pub(crate) fn describe_security_groups(
         .values()
         .filter(|g| wanted_ids.is_empty() || wanted_ids.contains(&g.group_id))
         .filter(|g| wanted_names.is_empty() || wanted_names.contains(&g.group_name))
-        .filter(|g| sg_matches(g, state.tags_for(&g.group_id), &filters))
+        .filter(|g| sg_matches(g, state.tags_for(&g.group_id), &filters, &owner))
         .map(|g| sg_xml(g, state.tags_for(&g.group_id), &owner, &region))
         .collect();
     items.sort();
@@ -525,13 +525,25 @@ pub(crate) fn describe_security_groups(
     ))
 }
 
-fn sg_matches(g: &SecurityGroup, tags: &[Tag], filters: &[Filter]) -> bool {
+fn sg_matches(g: &SecurityGroup, tags: &[Tag], filters: &[Filter], owner: &str) -> bool {
+    // `ip-permission.*` filters match against the group's ingress rules on AWS
+    // (egress rules are matched by the separate `egress.ip-permission.*` family).
+    let ingress = || g.rules.iter().filter(|r| !r.is_egress);
     filters.iter().all(|f| {
         let candidates: Vec<String> = match f.name.as_str() {
             "group-id" => vec![g.group_id.clone()],
             "group-name" => vec![g.group_name.clone()],
             "vpc-id" => vec![g.vpc_id.clone()],
             "description" => vec![g.description.clone()],
+            "owner-id" => vec![owner.to_string()],
+            "ip-permission.cidr" => ingress().filter_map(|r| r.cidr_ipv4.clone()).collect(),
+            "ip-permission.ipv6-cidr" => ingress().filter_map(|r| r.cidr_ipv6.clone()).collect(),
+            "ip-permission.protocol" => ingress().map(|r| r.ip_protocol.clone()).collect(),
+            "ip-permission.from-port" => ingress().map(|r| r.from_port.to_string()).collect(),
+            "ip-permission.to-port" => ingress().map(|r| r.to_port.to_string()).collect(),
+            "ip-permission.group-id" => ingress()
+                .filter_map(|r| r.referenced_group_id.clone())
+                .collect(),
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
@@ -1649,5 +1661,89 @@ mod modify_tests {
         .unwrap();
         let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
         assert!(body.contains("<groupId>sg-1</groupId>"), "{body}");
+    }
+
+    fn sg_describe_body(svc: &Ec2Service, query: &[(&str, &str)]) -> String {
+        let resp = describe_security_groups(svc, &req("DescribeSecurityGroups", query)).unwrap();
+        String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
+    }
+
+    #[test]
+    fn describe_security_groups_owner_id_filter() {
+        let svc = Ec2Service::new();
+        seed_group(&svc, base_rule());
+        // owner-id matches the requesting account.
+        assert!(sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "owner-id"),
+                ("Filter.1.Value.1", "000000000000")
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
+        // A different account filters it out.
+        assert!(!sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "owner-id"),
+                ("Filter.1.Value.1", "999999999999")
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
+    }
+
+    #[test]
+    fn describe_security_groups_ip_permission_filters() {
+        let svc = Ec2Service::new();
+        // Ingress tcp/22 from 10.0.0.0/8, plus a referenced-group rule.
+        let mut ref_rule = ingress_rule("sgr-ref", 443, "0.0.0.0/0");
+        ref_rule.cidr_ipv4 = None;
+        ref_rule.referenced_group_id = Some("sg-peer".into());
+        seed_group_rules(
+            &svc,
+            vec![ingress_rule("sgr-a", 22, "10.0.0.0/8"), ref_rule],
+        );
+
+        assert!(sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "ip-permission.cidr"),
+                ("Filter.1.Value.1", "10.0.0.0/8"),
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
+        assert!(sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "ip-permission.from-port"),
+                ("Filter.1.Value.1", "22"),
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
+        assert!(sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "ip-permission.protocol"),
+                ("Filter.1.Value.1", "tcp"),
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
+        assert!(sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "ip-permission.group-id"),
+                ("Filter.1.Value.1", "sg-peer"),
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
+        // A CIDR not present in any rule filters the group out.
+        assert!(!sg_describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "ip-permission.cidr"),
+                ("Filter.1.Value.1", "192.168.0.0/16"),
+            ],
+        )
+        .contains("<groupId>sg-1</groupId>"));
     }
 }

--- a/crates/fakecloud-ec2/src/service/snapshot.rs
+++ b/crates/fakecloud-ec2/src/service/snapshot.rs
@@ -6,8 +6,9 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    filter_value_matches, gen_id, indexed_list, invalid_parameter_value, not_found, parse_filters,
-    require, require_struct, validate_enum, validate_int_range, validate_max_results, Filter,
+    filter_value_matches, gen_id, indexed_list, invalid_parameter_value, not_found, paginate,
+    parse_filters, require, require_struct, validate_enum, validate_int_range,
+    validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Snapshot, Tag};
 
@@ -151,35 +152,70 @@ pub(crate) fn describe_snapshots(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    validate_max_results(&req.query_params, 5, 1000)?;
     let filters = parse_filters(&req.query_params);
     let wanted = indexed_list(&req.query_params, "SnapshotId");
     let owner = req.account_id.clone();
     let accounts = svc.state.read();
     let empty = Ec2State::new(&req.account_id, &req.region);
     let state = accounts.get(&req.account_id).unwrap_or(&empty);
+
+    // An explicitly-requested SnapshotId that does not exist (or is in the
+    // recycle bin) is a hard error on AWS (InvalidSnapshot.NotFound), not a
+    // silently-empty result. Matches the sibling Describe ops.
+    for id in &wanted {
+        if !state.snapshots.get(id).is_some_and(|s| !s.in_recycle_bin) {
+            return Err(not_found("InvalidSnapshot.NotFound", id));
+        }
+    }
+
     let mut items: Vec<String> = state
         .snapshots
         .values()
         .filter(|s| !s.in_recycle_bin)
         .filter(|s| wanted.is_empty() || wanted.contains(&s.snapshot_id))
-        .filter(|s| snap_match(s, state.tags_for(&s.snapshot_id), &filters))
+        .filter(|s| snap_match(s, state.tags_for(&s.snapshot_id), &filters, &owner))
         .map(|s| snapshot_xml(s, state.tags_for(&s.snapshot_id), &owner))
         .collect();
     items.sort();
+
+    // DescribeSnapshots is `paginated` in the model; honor MaxResults +
+    // NextToken instead of always returning the full set.
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("snapshotSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeSnapshots",
         &req.request_id,
-        &ec2_list("snapshotSet", &items),
+        &body,
     ))
 }
 
-fn snap_match(s: &Snapshot, tags: &[Tag], filters: &[Filter]) -> bool {
+fn snap_match(s: &Snapshot, tags: &[Tag], filters: &[Filter], owner: &str) -> bool {
     filters.iter().all(|f| {
         let candidates: Vec<String> = match f.name.as_str() {
             "snapshot-id" => vec![s.snapshot_id.clone()],
             "volume-id" => vec![s.volume_id.clone()],
             "status" => vec![s.state.clone()],
             "storage-tier" => vec![s.storage_tier.clone()],
+            "owner-id" => vec![owner.to_string()],
+            // Self-owned snapshots have no owner alias on AWS.
+            "owner-alias" => vec![String::new()],
+            // Snapshots are rendered as fully complete (see `snapshot_xml`).
+            "progress" => vec!["100%".to_string()],
+            "start-time" => vec![FIXED_TIME.to_string()],
+            "encrypted" => vec![s.encrypted.to_string()],
+            "volume-size" => vec![s.volume_size.to_string()],
+            "description" => vec![s.description.clone()],
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             name => {
                 if let Some(key) = name.strip_prefix("tag:") {
@@ -1028,5 +1064,110 @@ mod modify_tests {
             ],
         );
         assert!(format!("{err:?}").contains("InvalidParameterValue"));
+    }
+
+    fn describe_body(svc: &Ec2Service, query: &[(&str, &str)]) -> String {
+        let resp = describe_snapshots(svc, &req("DescribeSnapshots", query)).unwrap();
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn describe_snapshots_unknown_id_errors() {
+        let svc = Ec2Service::new();
+        seed_snapshot(&svc);
+        let err = crate::test_support::err_of(describe_snapshots(
+            &svc,
+            &req("DescribeSnapshots", &[("SnapshotId.1", "snap-missing")]),
+        ));
+        assert_eq!(err.code(), "InvalidSnapshot.NotFound");
+    }
+
+    #[test]
+    fn describe_snapshots_rejects_below_min_max_results() {
+        let svc = Ec2Service::new();
+        let err = crate::test_support::err_of(describe_snapshots(
+            &svc,
+            &req("DescribeSnapshots", &[("MaxResults", "3")]),
+        ));
+        assert_eq!(err.code(), "InvalidParameterValue");
+    }
+
+    #[test]
+    fn describe_snapshots_paginates() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            for i in 0..8 {
+                let mut s = build_snapshot("vol-x".into(), format!("d{i}"));
+                s.snapshot_id = format!("snap-{i:02}");
+                state.snapshots.insert(s.snapshot_id.clone(), s);
+            }
+        }
+        let body = describe_body(&svc, &[("MaxResults", "5")]);
+        assert!(body.contains("<nextToken>"), "expected a NextToken: {body}");
+        // The token round-trips to the next page.
+        let token = body
+            .split("<nextToken>")
+            .nth(1)
+            .and_then(|s| s.split("</nextToken>").next())
+            .unwrap()
+            .to_string();
+        let page2 = describe_body(&svc, &[("MaxResults", "5"), ("NextToken", &token)]);
+        assert!(
+            page2.contains("<snapshotId>snap-07</snapshotId>"),
+            "{page2}"
+        );
+    }
+
+    #[test]
+    fn describe_snapshots_owner_and_field_filters() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            let mut s = build_snapshot("vol-9".into(), "backup-nightly".into());
+            s.snapshot_id = "snap-9".into();
+            s.encrypted = true;
+            s.volume_size = 20;
+            state.snapshots.insert("snap-9".into(), s);
+        }
+        // owner-id matches the requesting account.
+        assert!(describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "owner-id"),
+                ("Filter.1.Value.1", "000000000000")
+            ],
+        )
+        .contains("<snapshotId>snap-9</snapshotId>"));
+        // volume-size, encrypted and description filters resolve.
+        assert!(describe_body(
+            &svc,
+            &[("Filter.1.Name", "volume-size"), ("Filter.1.Value.1", "20")],
+        )
+        .contains("<snapshotId>snap-9</snapshotId>"));
+        assert!(describe_body(
+            &svc,
+            &[("Filter.1.Name", "encrypted"), ("Filter.1.Value.1", "true")],
+        )
+        .contains("<snapshotId>snap-9</snapshotId>"));
+        assert!(describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "description"),
+                ("Filter.1.Value.1", "backup-nightly")
+            ],
+        )
+        .contains("<snapshotId>snap-9</snapshotId>"));
+        // A non-matching owner-id filters it out.
+        assert!(!describe_body(
+            &svc,
+            &[
+                ("Filter.1.Name", "owner-id"),
+                ("Filter.1.Value.1", "999999999999")
+            ],
+        )
+        .contains("<snapshotId>snap-9</snapshotId>"));
     }
 }

--- a/crates/fakecloud-ec2/src/service/tags.rs
+++ b/crates/fakecloud-ec2/src/service/tags.rs
@@ -8,7 +8,9 @@ use fakecloud_aws::ec2query::{ec2_elem, ec2_list, ec2_return};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
-use crate::service_helpers::{indexed_list, parse_filters, parse_tag_pairs, Filter};
+use crate::service_helpers::{
+    indexed_list, paginate, parse_filters, parse_tag_pairs, validate_max_results, Filter,
+};
 use crate::state::{Ec2State, Tag};
 
 /// Render a `<tagSet>` from a resource's stored tags (lowerCamel wire shape).
@@ -192,6 +194,8 @@ pub(crate) fn describe_tags(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    // DescribeTags caps MaxResults at [5, 1000] like the other paginated ops.
+    validate_max_results(&req.query_params, 5, 1000)?;
     let filters = parse_filters(&req.query_params);
 
     let accounts = svc.state.read();
@@ -216,7 +220,19 @@ pub(crate) fn describe_tags(
     // Stable ordering so responses are deterministic.
     items.sort();
 
-    let body = ec2_list("tagSet", &items);
+    // DescribeTags is `paginated`; honor MaxResults + NextToken.
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("tagSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond("DescribeTags", &req.request_id, &body))
 }
 

--- a/crates/fakecloud-ec2/src/service/volume.rs
+++ b/crates/fakecloud-ec2/src/service/volume.rs
@@ -210,6 +210,18 @@ fn vol_match(v: &Volume, tags: &[Tag], filters: &[Filter]) -> bool {
             "snapshot-id" => v.snapshot_id.clone().into_iter().collect(),
             "encrypted" => vec![v.encrypted.to_string()],
             "size" => vec![v.size.to_string()],
+            "attachment.instance-id" => v
+                .attachments
+                .iter()
+                .map(|a| a.instance_id.clone())
+                .collect(),
+            "attachment.status" => v.attachments.iter().map(|a| a.status.clone()).collect(),
+            "attachment.device" => v.attachments.iter().map(|a| a.device.clone()).collect(),
+            "attachment.delete-on-termination" => v
+                .attachments
+                .iter()
+                .map(|a| a.delete_on_termination.to_string())
+                .collect(),
             "tag-key" => tags.iter().map(|t| t.key.clone()).collect(),
             "tag-value" => tags.iter().map(|t| t.value.clone()).collect(),
             name => {
@@ -918,5 +930,61 @@ mod tests {
             ),
         ));
         assert_eq!(err.code(), "InvalidVolume.NotFound");
+    }
+
+    #[test]
+    fn describe_volumes_attachment_filters() {
+        let svc = Ec2Service::new();
+        seed_volume(&svc, "vol-1", "in-use", true);
+        seed_volume(&svc, "vol-2", "available", false);
+
+        // attachment.instance-id matches only the attached volume.
+        let body = body_of(
+            describe_volumes(
+                &svc,
+                &req(
+                    "DescribeVolumes",
+                    &[
+                        ("Filter.1.Name", "attachment.instance-id"),
+                        ("Filter.1.Value.1", "i-1"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(body.contains("<volumeId>vol-1</volumeId>"), "{body}");
+        assert!(!body.contains("<volumeId>vol-2</volumeId>"), "{body}");
+
+        // attachment.device and attachment.status also resolve.
+        let body = body_of(
+            describe_volumes(
+                &svc,
+                &req(
+                    "DescribeVolumes",
+                    &[
+                        ("Filter.1.Name", "attachment.device"),
+                        ("Filter.1.Value.1", "/dev/sdf"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(body.contains("<volumeId>vol-1</volumeId>"), "{body}");
+
+        // A device that matches nothing filters out both volumes.
+        let body = body_of(
+            describe_volumes(
+                &svc,
+                &req(
+                    "DescribeVolumes",
+                    &[
+                        ("Filter.1.Name", "attachment.status"),
+                        ("Filter.1.Value.1", "detached"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        assert!(!body.contains("<volumeId>vol-1</volumeId>"), "{body}");
     }
 }

--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -561,6 +561,21 @@ pub(crate) fn build_envelope_attrs(
     envelope_attrs
 }
 
+/// Size (in bytes) a set of message attributes contributes toward the 256 KiB
+/// Publish/PublishBatch limit: the name, the data type, and the value bytes of
+/// each attribute. AWS counts attributes against the same limit as the body.
+pub(crate) fn message_attributes_size(attrs: &BTreeMap<String, MessageAttribute>) -> usize {
+    attrs
+        .iter()
+        .map(|(name, attr)| {
+            name.len()
+                + attr.data_type.len()
+                + attr.string_value.as_ref().map_or(0, |s| s.len())
+                + attr.binary_value.as_ref().map_or(0, |b| b.len())
+        })
+        .sum()
+}
+
 pub(crate) fn parse_message_attributes(req: &AwsRequest) -> BTreeMap<String, MessageAttribute> {
     let mut attrs = BTreeMap::new();
     for n in 1..=10 {

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -48,8 +48,14 @@ impl SnsService {
             }
         }
 
-        // Validate message length (256KB)
-        if message.len() > 262144 {
+        // Parse MessageAttributes from query params
+        let message_attributes = parse_message_attributes(req);
+
+        // Validate total size (256 KiB). AWS counts the message body PLUS all
+        // message attributes (name + data type + value) against the limit, the
+        // same way PublishBatch does — not just the body length.
+        let total_size = message.len() + message_attributes_size(&message_attributes);
+        if total_size > 262144 {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameter",
@@ -61,9 +67,6 @@ impl SnsService {
         if message_structure.as_deref() == Some("json") {
             validate_message_structure_json(&message)?;
         }
-
-        // Parse MessageAttributes from query params
-        let message_attributes = parse_message_attributes(req);
 
         if let Some(ref phone) = phone_number {
             return self.publish_to_phone_number(
@@ -407,16 +410,7 @@ impl SnsService {
             .enumerate()
             .map(|(idx, e)| {
                 let attrs = parse_batch_message_attributes(req, idx + 1);
-                let attr_size: usize = attrs
-                    .iter()
-                    .map(|(name, attr)| {
-                        name.len()
-                            + attr.data_type.len()
-                            + attr.string_value.as_ref().map_or(0, |s| s.len())
-                            + attr.binary_value.as_ref().map_or(0, |b| b.len())
-                    })
-                    .sum();
-                e.1.len() + attr_size
+                e.1.len() + message_attributes_size(&attrs)
             })
             .sum();
         if total_batch_size > 262_144 {

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -815,6 +815,42 @@ fn publish_validates_subject_length() {
 }
 
 #[test]
+fn publish_size_limit_counts_message_attributes() {
+    let (svc, _state) = make_sns();
+    assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "size-topic")])));
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:size-topic";
+
+    // A ~250 KB body plus a large attribute value pushes the total over the
+    // 256 KiB (262144-byte) limit; the whole publish must be rejected. Before
+    // the fix, only the body length was measured so this incorrectly succeeded.
+    let body = "x".repeat(250_000);
+    let attr_value = "y".repeat(20_000);
+    let req = sns_request(
+        "Publish",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Message", &body),
+            ("MessageAttributes.entry.1.Name", "big"),
+            ("MessageAttributes.entry.1.Value.DataType", "String"),
+            ("MessageAttributes.entry.1.Value.StringValue", &attr_value),
+        ],
+    );
+    let err = svc
+        .publish(&req)
+        .err()
+        .expect("body + attributes over 256 KiB must be rejected");
+    assert_eq!(err.code(), "InvalidParameter");
+
+    // A body-only message just under the limit still succeeds.
+    let ok_body = "z".repeat(262_144);
+    let ok_req = sns_request(
+        "Publish",
+        vec![("TopicArn", topic_arn), ("Message", &ok_body)],
+    );
+    assert_ok(&svc.publish(&ok_req));
+}
+
+#[test]
 fn publish_to_sms_phone_number() {
     let (svc, state) = make_sns();
     let req = sns_request(


### PR DESCRIPTION
## Summary
Correctness bugs from the 2026-07-22 bug hunt in EC2 Describe ops and SNS Publish. Each confirmed against the handler, each with tests.

**EC2**
- **`DescribeNetworkInterfaces`/`DescribeSnapshots` returned empty for an explicitly-requested unknown id** instead of `InvalidNetworkInterfaceID.NotFound` / `InvalidSnapshot.NotFound` (every sibling Describe op has the guard). Added. DescribeSnapshots also gained `MaxResults` (5-1000, below-range → `InvalidParameterValue`) + `NextToken` pagination.
- **AWS-documented filters silently matched nothing** (each match fn's fall-through returned false, swallowing real filters). Implemented the common Terraform-data-source filters per op: DescribeInstances `group-id`/`instance.group-id`/`group-name`/`dns-name`/`launch-time`/`network-interface.*`/`block-device-mapping.*`; DescribeVolumes `attachment.*`; DescribeSecurityGroups `owner-id`/`ip-permission.*`; DescribeSnapshots `owner-id`/`owner-alias`/`progress`/`encrypted`/`volume-size`/`description`/`start-time`; DescribeNetworkInterfaces `owner-id`/`group-id`/`attachment.*`/etc. Unknown filter names still return no match.
- LOW: `DescribeTags` gained MaxResults/NextToken pagination.

**SNS**
- **Single `Publish` 256 KiB size check counted only the body**, ignoring message attributes; `PublishBatch` correctly summed both. Now shares a `message_attributes_size` helper so single Publish enforces body+attributes like AWS (and like PublishBatch).

## Test plan
- New per-op tests: unknown-id NotFound (eni/snapshot), below-min MaxResults + pagination round-trip (snapshot), and representative filter matches + negatives across instances/volumes/security-groups/network-interfaces/snapshots; SNS over-limit body+attributes rejected, body-only under-limit ok.
- `cargo nextest run -p fakecloud-ec2 -p fakecloud-sns`: 422 passed, existing describe/sg/snapshot suites green. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- EC2/SNS conformance needs Docker (not runnable in the sandbox); relying on CI's conformance shard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix EC2 Describe correctness and parity: unknown IDs now return proper NotFound errors, real AWS filters work, and pagination is supported. Also enforce SNS `Publish` 256 KiB limit by counting message attributes with the body.

- **Bug Fixes**
  - EC2: `DescribeNetworkInterfaces`/`DescribeSnapshots` now return `InvalidNetworkInterfaceID.NotFound` / `InvalidSnapshot.NotFound` for explicitly requested unknown IDs; documented filters now evaluate correctly across Instances, Volumes, Security Groups, ENIs, and Snapshots (e.g., `group-id`/`group-name`, `ip-permission.*`, `attachment.*`, `network-interface.*`, `block-device-mapping.*`, `owner-id`, `encrypted`).
  - SNS: single `Publish` counts message attributes toward the 256 KiB limit (matches `PublishBatch` and AWS).

- **New Features**
  - EC2: `DescribeSnapshots` and `DescribeTags` now support pagination with `MaxResults` (5–1000) and `NextToken`; below-min `MaxResults` returns `InvalidParameterValue`.

<sup>Written for commit 10f131ff8b7203c98da975d941fbea7bfdb7dc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

