### PR TITLE
fix(route53,kms,cloudwatch,dynamodb): error codes, alias DELETE match, asymmetric decrypt algo check, GetMetricStatistics validation, atomic transact idempotency

### DIFF
--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -1073,10 +1073,22 @@ impl CloudWatchService {
         if period <= 0 {
             return Err(invalid_param("Period must be positive"));
         }
+        // AWS requires Period to be 1, 5, 10, 30, or any positive multiple of
+        // 60 (high-resolution values below one minute plus per-minute buckets).
+        if !matches!(period, 1 | 5 | 10 | 30) && period % 60 != 0 {
+            return Err(invalid_param(
+                "The parameter Period must be a positive multiple of 60, or one of 1, 5, 10, 30.",
+            ));
+        }
         let start_ts = parse_input_timestamp(&start)
             .ok_or_else(|| invalid_param("StartTime must be ISO 8601 or epoch seconds"))?;
         let end_ts = parse_input_timestamp(&end)
             .ok_or_else(|| invalid_param("EndTime must be ISO 8601 or epoch seconds"))?;
+        if start_ts >= end_ts {
+            return Err(invalid_param(
+                "The parameter StartTime must be less than the parameter EndTime.",
+            ));
+        }
 
         let mut statistics: Vec<String> = Vec::new();
         let mut extended_statistics: Vec<String> = Vec::new();

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -1028,6 +1028,68 @@ async fn get_metric_statistics_json_roundtrip() {
 }
 
 #[tokio::test]
+async fn get_metric_statistics_rejects_start_ge_end() {
+    // AWS rejects StartTime >= EndTime with InvalidParameterValue.
+    let svc = service();
+    let err = call_err(
+        &svc,
+        "GetMetricStatistics",
+        &[
+            ("Namespace", "MyApp"),
+            ("MetricName", "Latency"),
+            ("StartTime", "2020-06-01T12:00:00Z"),
+            ("EndTime", "2020-06-01T12:00:00Z"),
+            ("Period", "60"),
+            ("Statistics.member.1", "Average"),
+        ],
+    )
+    .await;
+    assert_eq!(err.code(), "InvalidParameterValue");
+}
+
+#[tokio::test]
+async fn get_metric_statistics_rejects_non_multiple_of_60_period() {
+    // Period must be 1/5/10/30 or a positive multiple of 60; 7 is invalid.
+    let svc = service();
+    let err = call_err(
+        &svc,
+        "GetMetricStatistics",
+        &[
+            ("Namespace", "MyApp"),
+            ("MetricName", "Latency"),
+            ("StartTime", "2020-06-01T12:00:00Z"),
+            ("EndTime", "2020-06-01T13:00:00Z"),
+            ("Period", "7"),
+            ("Statistics.member.1", "Average"),
+        ],
+    )
+    .await;
+    assert_eq!(err.code(), "InvalidParameterValue");
+}
+
+#[tokio::test]
+async fn get_metric_statistics_accepts_valid_range_and_period() {
+    // A valid StartTime<EndTime with a 60s Period (and a high-resolution 10s
+    // value) succeeds.
+    let svc = service();
+    for period in ["60", "10"] {
+        call(
+            &svc,
+            "GetMetricStatistics",
+            &[
+                ("Namespace", "MyApp"),
+                ("MetricName", "Latency"),
+                ("StartTime", "2020-06-01T12:00:00Z"),
+                ("EndTime", "2020-06-01T13:00:00Z"),
+                ("Period", period),
+                ("Statistics.member.1", "Average"),
+            ],
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
 async fn put_metric_alarm_json_roundtrip() {
     let svc = service();
     let resp = call_json(

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -487,7 +487,10 @@ impl DynamoDbService {
         // (within the window) must be applied at most once and replay the
         // original result. Reusing a token with a different body is rejected.
         // The hash covers the whole request body, so the token field itself is
-        // part of the identity — only an identical retry replays.
+        // part of the identity — only an identical retry replays. The actual
+        // check-and-reserve happens under the state write lock below so that a
+        // concurrent same-token retry serializes with (and replays) the apply
+        // instead of double-applying across the lock gap.
         let client_token = body["ClientRequestToken"].as_str().map(str::to_string);
         let request_hash = {
             use std::hash::{Hash, Hasher};
@@ -495,13 +498,6 @@ impl DynamoDbService {
             req.body.hash(&mut h);
             h.finish()
         };
-        if let Some(token) = client_token.as_deref() {
-            if let Some(cached) =
-                self.transact_idempotency_lookup(&req.account_id, token, request_hash)?
-            {
-                return Ok(cached);
-            }
-        }
 
         validate_optional_enum_value(
             "returnConsumedCapacity",
@@ -583,6 +579,21 @@ impl DynamoDbService {
         }
 
         let mut accounts = self.state.write();
+
+        // Idempotency check-and-reserve under the same write lock that guards
+        // the apply below. Doing the lookup here (rather than before taking the
+        // lock) means two concurrent retries carrying the same token serialize
+        // on this lock: the first applies and stores its result while holding
+        // the lock, so the second observes the cached outcome and replays it
+        // instead of applying the transaction a second time.
+        if let Some(token) = client_token.as_deref() {
+            if let Some(cached) =
+                self.transact_idempotency_lookup(&req.account_id, token, request_hash)?
+            {
+                return Ok(cached);
+            }
+        }
+
         let state = accounts.get_or_create(&req.account_id);
 
         // Validate every referenced table exists up-front. Without this
@@ -1063,6 +1074,13 @@ impl DynamoDbService {
             result["ItemCollectionMetrics"] = json!(icm);
         }
 
+        // Cache the committed outcome while still holding the state write lock
+        // so the store is atomic with the apply: an identical retry with the
+        // same ClientRequestToken replays this result rather than re-applying.
+        if let Some(token) = client_token.as_deref() {
+            self.transact_idempotency_store(&req.account_id, token, request_hash, &result);
+        }
+
         // Drop the write lock before firing kinesis deliveries so the
         // delivery bus (which may take a read lock to look up the target
         // stream) doesn't deadlock against us.
@@ -1075,12 +1093,6 @@ impl DynamoDbService {
                 old_image.as_ref(),
                 new_image.as_ref(),
             );
-        }
-
-        // Cache the committed outcome so an identical retry with the same
-        // ClientRequestToken replays this result instead of re-applying.
-        if let Some(token) = client_token.as_deref() {
-            self.transact_idempotency_store(&req.account_id, token, request_hash, &result);
         }
 
         Self::ok_json(result)
@@ -1315,12 +1327,34 @@ impl DynamoDbService {
             )
         })?;
 
+        // Idempotency: like TransactWriteItems, a retried ExecuteTransaction
+        // carrying the same ClientRequestToken (within the window) is applied
+        // at most once and replays the original result. The check-and-reserve
+        // and the store both happen under the state write lock below so a
+        // concurrent same-token retry serializes with the apply.
+        let client_token = body["ClientRequestToken"].as_str().map(str::to_string);
+        let request_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            req.body.hash(&mut h);
+            h.finish()
+        };
+
         // Acquire the write lock once for the whole batch — DDB
         // ExecuteTransaction is all-or-nothing so we cannot release
         // the lock between phases or another writer could observe
         // partial state. Use the caller's account_id so cross-account
         // STS callers don't accidentally write to the default account.
         let mut accounts = self.state.write();
+
+        if let Some(token) = client_token.as_deref() {
+            if let Some(cached) =
+                self.transact_idempotency_lookup(&req.account_id, token, request_hash)?
+            {
+                return Ok(cached);
+            }
+        }
+
         let state = accounts.get_or_create(&req.account_id);
 
         let region = req.region.clone();
@@ -1488,6 +1522,15 @@ impl DynamoDbService {
             }
         }
 
+        let result = json!({ "Responses": applied_responses });
+
+        // Cache the committed outcome while still holding the write lock so the
+        // store is atomic with the apply: an identical retry with the same
+        // ClientRequestToken replays this result rather than re-applying.
+        if let Some(token) = client_token.as_deref() {
+            self.transact_idempotency_store(&req.account_id, token, request_hash, &result);
+        }
+
         // Drop the write lock before firing kinesis deliveries so
         // the delivery bus (which may take a read lock to look up
         // the target stream) doesn't deadlock against us.
@@ -1502,7 +1545,7 @@ impl DynamoDbService {
             );
         }
 
-        Self::ok_json(json!({ "Responses": applied_responses }))
+        Self::ok_json(result)
     }
 }
 
@@ -1994,6 +2037,124 @@ mod tests {
         let records = table.stream_records.read();
         assert_eq!(records.len(), 2, "one stream record per Put");
         assert!(records.iter().all(|r| r.event_name == "INSERT"));
+    }
+
+    #[tokio::test]
+    async fn transact_write_same_client_token_applies_once() {
+        // A retried TransactWriteItems carrying the same ClientRequestToken must
+        // be applied at most once (idempotent replay), not double-applied. An
+        // ADD that increments a counter must move it by exactly 1 across two
+        // identical calls, and the second call must still return success.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        let body = json!({
+            "ClientRequestToken": "tok-fixed-1",
+            "TransactItems": [
+                {"Update": {
+                    "TableName": "Widgets",
+                    "Key": {"pk": {"S": "counter"}},
+                    "UpdateExpression": "ADD #c :inc",
+                    "ExpressionAttributeNames": {"#c": "count"},
+                    "ExpressionAttributeValues": {":inc": {"N": "1"}}
+                }}
+            ]
+        });
+
+        svc.transact_write_items(&req_for("TransactWriteItems", body.clone()))
+            .unwrap();
+        // Second call with the same token + body: replays, does not re-apply.
+        let resp = svc
+            .transact_write_items(&req_for("TransactWriteItems", body))
+            .unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        let item = table
+            .items
+            .iter()
+            .find(|i| i["pk"]["S"] == json!("counter"))
+            .expect("counter item");
+        assert_eq!(
+            item["count"]["N"],
+            json!("1"),
+            "counter must be incremented exactly once for a replayed token"
+        );
+    }
+
+    #[tokio::test]
+    async fn transact_write_distinct_tokens_apply_each_time() {
+        // Control for the idempotency test: two calls with DIFFERENT tokens are
+        // two separate transactions, so the ADD increments the counter twice.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        for tok in ["tok-a", "tok-b"] {
+            let body = json!({
+                "ClientRequestToken": tok,
+                "TransactItems": [
+                    {"Update": {
+                        "TableName": "Widgets",
+                        "Key": {"pk": {"S": "counter"}},
+                        "UpdateExpression": "ADD #c :inc",
+                        "ExpressionAttributeNames": {"#c": "count"},
+                        "ExpressionAttributeValues": {":inc": {"N": "1"}}
+                    }}
+                ]
+            });
+            svc.transact_write_items(&req_for("TransactWriteItems", body))
+                .unwrap();
+        }
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        let item = table
+            .items
+            .iter()
+            .find(|i| i["pk"]["S"] == json!("counter"))
+            .expect("counter item");
+        assert_eq!(item["count"]["N"], json!("2"));
+    }
+
+    #[tokio::test]
+    async fn execute_transaction_same_client_token_applies_once() {
+        // ExecuteTransaction shares the same idempotency machinery: a retried
+        // INSERT with the same ClientRequestToken replays success instead of
+        // re-applying (which would otherwise cancel with a DuplicateItem).
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state.clone());
+
+        let body = json!({
+            "ClientRequestToken": "tok-exec-1",
+            "TransactStatements": [
+                {"Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}"},
+            ]
+        });
+
+        let resp = svc
+            .execute_transaction(&req_for("ExecuteTransaction", body.clone()))
+            .unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+        // Replay: same token + body must succeed and not insert a duplicate.
+        let resp = svc
+            .execute_transaction(&req_for("ExecuteTransaction", body))
+            .unwrap();
+        assert_eq!(resp.status, http::StatusCode::OK);
+
+        let accts = state.read();
+        let s = accts.get("123456789012").unwrap();
+        let table = s.tables.get("Widgets").unwrap();
+        assert_eq!(
+            table.items.len(),
+            1,
+            "a replayed ExecuteTransaction must not apply the INSERT twice"
+        );
     }
 
     #[tokio::test]

--- a/crates/fakecloud-kms/src/service_crypto.rs
+++ b/crates/fakecloud-kms/src/service_crypto.rs
@@ -164,6 +164,25 @@ impl KmsService {
         let ec_aad = canonical_encryption_context(&body["EncryptionContext"])?;
         let decoded = decode_ciphertext_envelope(state, ciphertext_b64, &ec_aad)?;
 
+        // For ciphertext produced by an asymmetric (RSA) KMS key, AWS requires
+        // the caller to supply the EncryptionAlgorithm and it must match the
+        // algorithm recorded in the ciphertext envelope. An omitted algorithm
+        // defaults to SYMMETRIC_DEFAULT, which never matches an RSA envelope,
+        // so both an omitted and a mismatched algorithm surface as
+        // InvalidCiphertextException. Symmetric decrypt is unaffected.
+        if decoded.encryption_algorithm != "SYMMETRIC_DEFAULT" {
+            let requested = body["EncryptionAlgorithm"]
+                .as_str()
+                .unwrap_or("SYMMETRIC_DEFAULT");
+            if requested != decoded.encryption_algorithm {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidCiphertextException",
+                    "The specified EncryptionAlgorithm does not match the algorithm used to produce the ciphertext.",
+                ));
+            }
+        }
+
         // When the caller supplies KeyId for a symmetric decrypt, AWS
         // validates it identifies the same CMK that produced the blob and
         // returns IncorrectKeyException otherwise (1.5). For symmetric keys

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -3143,10 +3143,15 @@ fn encrypt_rsa_key_uses_real_oaep_and_roundtrips() {
         "RSA key must use the RSA envelope, got {env}"
     );
 
+    // AWS requires the caller to supply EncryptionAlgorithm when decrypting
+    // ciphertext produced by an asymmetric KMS key.
     let resp = svc
         .decrypt(&make_request(
             "Decrypt",
-            json!({ "CiphertextBlob": ciphertext }),
+            json!({
+                "CiphertextBlob": ciphertext,
+                "EncryptionAlgorithm": "RSAES_OAEP_SHA_256",
+            }),
         ))
         .unwrap();
     let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
@@ -3155,6 +3160,70 @@ fn encrypt_rsa_key_uses_real_oaep_and_roundtrips() {
         .decode(body["Plaintext"].as_str().unwrap())
         .unwrap();
     assert_eq!(decrypted, plaintext);
+}
+
+#[test]
+fn asymmetric_decrypt_wrong_algorithm_is_rejected() {
+    // Ciphertext produced by an RSA ENCRYPT_DECRYPT key records the algorithm
+    // used (RSAES_OAEP_SHA_256). AWS rejects a Decrypt that supplies a
+    // different EncryptionAlgorithm with InvalidCiphertextException, and
+    // requires the algorithm to be present for asymmetric ciphertext (an
+    // omitted algorithm defaults to SYMMETRIC_DEFAULT, which never matches).
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({ "KeyUsage": "ENCRYPT_DECRYPT", "KeySpec": "RSA_2048" }),
+    );
+    let pt_b64 = base64::engine::general_purpose::STANDARD.encode(b"asymmetric hello");
+    let resp = svc
+        .encrypt(&make_request(
+            "Encrypt",
+            json!({
+                "KeyId": key_id,
+                "Plaintext": pt_b64,
+                "EncryptionAlgorithm": "RSAES_OAEP_SHA_256",
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let ciphertext = body["CiphertextBlob"].as_str().unwrap().to_string();
+
+    // Wrong algorithm -> rejected.
+    match svc.decrypt(&make_request(
+        "Decrypt",
+        json!({
+            "CiphertextBlob": ciphertext.clone(),
+            "EncryptionAlgorithm": "RSAES_OAEP_SHA_1",
+        }),
+    )) {
+        Err(e) => assert_eq!(e.code(), "InvalidCiphertextException"),
+        Ok(_) => panic!("a wrong EncryptionAlgorithm must be rejected"),
+    }
+
+    // Omitted algorithm (defaults to SYMMETRIC_DEFAULT) -> also rejected.
+    match svc.decrypt(&make_request(
+        "Decrypt",
+        json!({ "CiphertextBlob": ciphertext.clone() }),
+    )) {
+        Err(e) => assert_eq!(e.code(), "InvalidCiphertextException"),
+        Ok(_) => panic!("an omitted EncryptionAlgorithm must be rejected for asymmetric"),
+    }
+
+    // Correct algorithm -> succeeds.
+    let resp = svc
+        .decrypt(&make_request(
+            "Decrypt",
+            json!({
+                "CiphertextBlob": ciphertext,
+                "EncryptionAlgorithm": "RSAES_OAEP_SHA_256",
+            }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let decrypted = base64::engine::general_purpose::STANDARD
+        .decode(body["Plaintext"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(decrypted, b"asymmetric hello");
 }
 
 #[test]

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -93,7 +93,13 @@ fn rrset_value_key(r: &ResourceRecordSet) -> Vec<String> {
         .map(|rr| rr.resource_record.iter().map(|x| x.value.clone()).collect())
         .unwrap_or_default();
     if let Some(at) = &r.alias_target {
-        vals.push(format!("ALIAS {}:{}", at.hosted_zone_id, at.dns_name));
+        // The alias `EvaluateTargetHealth` flag is part of the record set's
+        // current values: a DELETE must submit it exactly, so include it in the
+        // value key rather than matching on hosted-zone-id + dns-name alone.
+        vals.push(format!(
+            "ALIAS {}:{}:{}",
+            at.hosted_zone_id, at.dns_name, at.evaluate_target_health
+        ));
     }
     vals.sort();
     vals

--- a/crates/fakecloud-route53/src/service/mod.rs
+++ b/crates/fakecloud-route53/src/service/mod.rs
@@ -1952,4 +1952,118 @@ mod tests {
             data[0]
         );
     }
+
+    // ─── ChangeResourceRecordSets error-code + alias DELETE match tests ───
+
+    fn change_rrset_req(zone_id: &str, body_xml: &str) -> AwsRequest {
+        let raw_path = format!("/2013-04-01/hostedzone/{zone_id}/rrset");
+        let segs: Vec<String> = raw_path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        AwsRequest {
+            service: "route53".to_string(),
+            action: "ChangeResourceRecordSets".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: DEFAULT_ACCOUNT.to_string(),
+            request_id: "test".to_string(),
+            headers: HeaderMap::new(),
+            query_params: std::collections::HashMap::new(),
+            body: Bytes::from(body_xml.to_string()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: segs,
+            raw_path,
+            raw_query: String::new(),
+            method: http::Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn alias_rrset(evaluate_target_health: bool) -> crate::model::ResourceRecordSet {
+        crate::model::ResourceRecordSet {
+            name: "alias.example.com.".to_string(),
+            record_type: "A".to_string(),
+            ttl: None,
+            resource_records: None,
+            alias_target: Some(crate::model::AliasTarget {
+                hosted_zone_id: "Z2FDTNDATAQYW2".to_string(),
+                dns_name: "target.example.com.".to_string(),
+                evaluate_target_health,
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn alias_delete_body(evaluate_target_health: bool) -> String {
+        format!(
+            "<?xml version=\"1.0\"?><ChangeResourceRecordSetsRequest xmlns=\"https://route53.amazonaws.com/doc/2013-04-01/\">\
+             <ChangeBatch><Changes><Change><Action>DELETE</Action>\
+             <ResourceRecordSet><Name>alias.example.com.</Name><Type>A</Type>\
+             <AliasTarget><HostedZoneId>Z2FDTNDATAQYW2</HostedZoneId>\
+             <DNSName>target.example.com.</DNSName>\
+             <EvaluateTargetHealth>{evaluate_target_health}</EvaluateTargetHealth>\
+             </AliasTarget></ResourceRecordSet></Change></Changes></ChangeBatch>\
+             </ChangeResourceRecordSetsRequest>"
+        )
+    }
+
+    #[tokio::test]
+    async fn change_rrsets_empty_batch_returns_invalid_change_batch() {
+        // AWS models `ChangeBatch.Changes` as a list with `@length(min:1)` and
+        // surfaces an empty batch as `InvalidChangeBatch`, not `InvalidInput`.
+        let (svc, zid) = svc_with_zone(vec![]);
+        let body = "<?xml version=\"1.0\"?><ChangeResourceRecordSetsRequest \
+                    xmlns=\"https://route53.amazonaws.com/doc/2013-04-01/\">\
+                    <ChangeBatch><Changes></Changes></ChangeBatch>\
+                    </ChangeResourceRecordSetsRequest>";
+        let resp = svc.handle(change_rrset_req(&zid, body)).await.unwrap();
+        assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+        let out = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(
+            out.contains("<Code>InvalidChangeBatch</Code>"),
+            "expected InvalidChangeBatch, got {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alias_delete_with_flipped_evaluate_target_health_is_rejected() {
+        // Seed an alias record with EvaluateTargetHealth=false; a DELETE that
+        // submits true does not match the current values and must be rejected.
+        let (svc, zid) = svc_with_zone(vec![alias_rrset(false)]);
+        let resp = svc
+            .handle(change_rrset_req(&zid, &alias_delete_body(true)))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+        let out = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+        assert!(
+            out.contains("<Code>InvalidChangeBatch</Code>"),
+            "expected InvalidChangeBatch, got {out}"
+        );
+        // The record is still present (DELETE did not apply).
+        let st = svc.state.read();
+        let zone = &st.accounts.get(DEFAULT_ACCOUNT).unwrap().hosted_zones[&zid];
+        assert_eq!(zone.resource_record_sets.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn alias_delete_with_matching_evaluate_target_health_succeeds() {
+        // The same DELETE with the correct EvaluateTargetHealth flag applies.
+        let (svc, zid) = svc_with_zone(vec![alias_rrset(false)]);
+        let resp = svc
+            .handle(change_rrset_req(&zid, &alias_delete_body(false)))
+            .await
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::OK, "expected DELETE to succeed");
+        let st = svc.state.read();
+        let zone = &st.accounts.get(DEFAULT_ACCOUNT).unwrap().hosted_zones[&zid];
+        assert!(
+            zone.resource_record_sets.is_empty(),
+            "alias record should have been deleted"
+        );
+    }
 }

--- a/crates/fakecloud-route53/src/service/records.rs
+++ b/crates/fakecloud-route53/src/service/records.rs
@@ -15,7 +15,10 @@ impl Route53Service {
                 invalid_argument(format!("invalid ChangeResourceRecordSetsRequest XML: {e}"))
             })?;
         if cfg.change_batch.changes.change.is_empty() {
-            return Err(invalid_argument("ChangeBatch.Changes is empty"));
+            // AWS models `ChangeBatch.Changes` as a list with `@length(min:1)`
+            // and surfaces an empty batch as `InvalidChangeBatch`, not the
+            // generic `InvalidInput`.
+            return Err(invalid_change_batch("ChangeBatch.Changes is empty"));
         }
         let mut state = self.state.write();
         let account = state


### PR DESCRIPTION
## Summary
LOW-severity correctness fixes from the 2026-07-22 bug hunt. Each confirmed against the handler, each with a regression test; conformance verified locally (110/110 across the four services).

- **route53**: empty `ChangeBatch.Changes` now returns `InvalidChangeBatch` (not `InvalidInput`), matching the `@length(min:1)` contract; alias-record DELETE value-match now includes `EvaluateTargetHealth` so a DELETE with a flipped flag is rejected.
- **kms**: asymmetric (RSA) `Decrypt` now validates the request's `EncryptionAlgorithm` against the ciphertext envelope's recorded algorithm, returning `InvalidCiphertextException` on mismatch (symmetric decrypt unchanged).
- **cloudwatch**: `GetMetricStatistics` rejects `StartTime >= EndTime` and a `Period` that isn't 1/5/10/30 or a positive multiple of 60 (`InvalidParameterValue`).
- **dynamodb**: `TransactWriteItems` idempotency token is now checked-and-reserved under the same `state.write()` guard as the apply (was check-then-act across a lock gap → concurrent same-token retries double-applied); same handling added to `ExecuteTransaction`, which previously had no idempotency replay.

## Test plan
- New tests per fix (empty-batch code, alias flipped-flag reject/retain, wrong-algorithm decrypt reject, StartTime/Period validation, same-token transact single-apply).
- `cargo nextest` on the four crates: 757 passed. Conformance (route53/kms/cloudwatch/dynamodb): 110/110. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- One pre-existing kms unit test that omitted `EncryptionAlgorithm` on an asymmetric decrypt (non-AWS-faithful) updated to supply it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS correctness gaps across `fakecloud-route53`, `fakecloud-kms`, `fakecloud-cloudwatch`, and `fakecloud-dynamodb`, and makes transactional writes idempotent under contention. Adds precise validations and error codes to match AWS.

- **Bug Fixes**
  - `fakecloud-route53`: Empty `ChangeBatch.Changes` now returns `InvalidChangeBatch`; alias DELETE must match `EvaluateTargetHealth`.
  - `fakecloud-kms`: Asymmetric `Decrypt` enforces `EncryptionAlgorithm` matching the ciphertext; mismatch or omission returns `InvalidCiphertextException` (symmetric unchanged).
  - `fakecloud-cloudwatch`: `GetMetricStatistics` rejects `StartTime >= EndTime` and invalid `Period` (only 1/5/10/30 or a positive multiple of 60).
  - `fakecloud-dynamodb`: `TransactWriteItems` idempotency token is checked and stored under the same write lock as the apply to prevent double-apply; `ExecuteTransaction` now uses the same idempotency handling.

<sup>Written for commit 6cefb00c84f6ddc23d6add72cb9a83cdaf1f5559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

