### PR TITLE
fix(elbv2,ecr,ce,appconfig): non-persisted target health, serialized layer-part appends, nested tag-status validation, ValidateConfiguration validators

### DIFF
--- a/crates/fakecloud-appconfig/src/handlers.rs
+++ b/crates/fakecloud-appconfig/src/handlers.rs
@@ -56,6 +56,131 @@ fn bad_request(msg: impl Into<String>) -> AwsServiceError {
     aws_err("BadRequestException", StatusCode::BAD_REQUEST, msg)
 }
 
+/// Validate `instance` against a JSON Schema `schema`. Supports the keyword
+/// subset AppConfig configurations exercise in practice: `type`, `enum`,
+/// `const`, `required`, `properties`, `additionalProperties: false`, `items`,
+/// `minLength`/`maxLength`, `minimum`/`maximum`, and `minItems`/`maxItems`.
+/// Unknown keywords are ignored (lenient), so the check only ever rejects a
+/// definite violation and never a valid document. `path` is the JSON pointer
+/// of `instance` used in error messages.
+fn json_schema_check(schema: &Value, instance: &Value, path: &str) -> Result<(), String> {
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        // A non-object schema (`true`/`false` or malformed) imposes no
+        // enforceable constraint here.
+        None => return Ok(()),
+    };
+    let at = |p: &str| if p.is_empty() { "(root)".to_string() } else { p.to_string() };
+
+    if let Some(ty) = obj.get("type") {
+        let ok = match ty.as_str() {
+            Some("object") => instance.is_object(),
+            Some("array") => instance.is_array(),
+            Some("string") => instance.is_string(),
+            Some("boolean") => instance.is_boolean(),
+            Some("null") => instance.is_null(),
+            Some("integer") => instance.as_i64().is_some() || instance.as_u64().is_some(),
+            Some("number") => instance.is_number(),
+            // Union `type` array or unrecognised type keyword: accept.
+            _ => true,
+        };
+        if !ok {
+            return Err(format!(
+                "{} is not of type {}",
+                at(path),
+                ty.as_str().unwrap_or("<type>")
+            ));
+        }
+    }
+
+    if let Some(Value::Array(allowed)) = obj.get("enum") {
+        if !allowed.iter().any(|a| a == instance) {
+            return Err(format!("{} is not one of the enum values", at(path)));
+        }
+    }
+    if let Some(expected) = obj.get("const") {
+        if expected != instance {
+            return Err(format!("{} does not equal the const value", at(path)));
+        }
+    }
+
+    if let Some(s) = instance.as_str() {
+        if let Some(min) = obj.get("minLength").and_then(Value::as_u64) {
+            if (s.chars().count() as u64) < min {
+                return Err(format!("{} is shorter than minLength {min}", at(path)));
+            }
+        }
+        if let Some(max) = obj.get("maxLength").and_then(Value::as_u64) {
+            if (s.chars().count() as u64) > max {
+                return Err(format!("{} is longer than maxLength {max}", at(path)));
+            }
+        }
+    }
+
+    if let Some(n) = instance.as_f64() {
+        if let Some(min) = obj.get("minimum").and_then(Value::as_f64) {
+            if n < min {
+                return Err(format!("{} is less than minimum {min}", at(path)));
+            }
+        }
+        if let Some(max) = obj.get("maximum").and_then(Value::as_f64) {
+            if n > max {
+                return Err(format!("{} is greater than maximum {max}", at(path)));
+            }
+        }
+    }
+
+    if let Some(arr) = instance.as_array() {
+        if let Some(min) = obj.get("minItems").and_then(Value::as_u64) {
+            if (arr.len() as u64) < min {
+                return Err(format!("{} has fewer than minItems {min}", at(path)));
+            }
+        }
+        if let Some(max) = obj.get("maxItems").and_then(Value::as_u64) {
+            if (arr.len() as u64) > max {
+                return Err(format!("{} has more than maxItems {max}", at(path)));
+            }
+        }
+        if let Some(items) = obj.get("items") {
+            for (i, elem) in arr.iter().enumerate() {
+                json_schema_check(items, elem, &format!("{path}/{i}"))?;
+            }
+        }
+    }
+
+    if let Some(map) = instance.as_object() {
+        if let Some(Value::Array(required)) = obj.get("required") {
+            for key in required.iter().filter_map(Value::as_str) {
+                if !map.contains_key(key) {
+                    return Err(format!("{} is missing required property '{key}'", at(path)));
+                }
+            }
+        }
+        let properties = obj.get("properties").and_then(Value::as_object);
+        if let Some(props) = properties {
+            for (key, subschema) in props {
+                if let Some(child) = map.get(key) {
+                    json_schema_check(subschema, child, &format!("{path}/{key}"))?;
+                }
+            }
+        }
+        // `additionalProperties: false` rejects keys not named in `properties`.
+        if obj.get("additionalProperties") == Some(&Value::Bool(false)) {
+            for key in map.keys() {
+                let known = properties.map(|p| p.contains_key(key)).unwrap_or(false);
+                if !known {
+                    return Err(format!(
+                        "{} has property '{key}' not allowed by additionalProperties:false",
+                        at(path)
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn req_body(req: &AwsRequest) -> Value {
     serde_json::from_slice(&req.body).unwrap_or(Value::Null)
 }
@@ -566,8 +691,63 @@ impl AppConfigService {
             .get(&req.account_id)
             .and_then(|st| st.applications.get(app_id))
             .ok_or_else(|| not_found(format!("Application not found: {app_id}")))?;
-        if !app.profiles.contains_key(id) {
-            return Err(not_found(format!("ConfigurationProfile not found: {id}")));
+        let profile = app
+            .profiles
+            .get(id)
+            .ok_or_else(|| not_found(format!("ConfigurationProfile not found: {id}")))?;
+
+        // Collect the profile's JSON_SCHEMA validators. LAMBDA validators run a
+        // customer function on the real service; there is no Lambda in scope
+        // here, so we accept them rather than fabricate a pass/fail verdict.
+        let schemas: Vec<&str> = profile
+            .validators
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter(|v| {
+                        v.get("Type").and_then(Value::as_str) == Some("JSON_SCHEMA")
+                    })
+                    .filter_map(|v| v.get("Content").and_then(Value::as_str))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if schemas.is_empty() {
+            // Nothing enforceable to validate against.
+            return Ok(empty(204));
+        }
+
+        // Resolve the configuration content to validate: the requested
+        // `configuration_version`, falling back to the latest hosted version.
+        let requested = req
+            .query_params
+            .get("configuration_version")
+            .and_then(|v| v.parse::<i64>().ok());
+        let record = match requested {
+            Some(ver) => profile.hosted_versions.get(&ver),
+            None => profile.hosted_versions.values().next_back(),
+        };
+        let Some(record) = record else {
+            // No hosted content to validate; a JSON_SCHEMA validator has
+            // nothing to reject.
+            return Ok(empty(204));
+        };
+
+        // A JSON_SCHEMA validator requires the content to be JSON.
+        let content: Value = serde_json::from_slice(&record.content).map_err(|e| {
+            bad_request(format!("Configuration content is not valid JSON: {e}"))
+        })?;
+
+        for schema_str in &schemas {
+            // A validator whose schema itself is not valid JSON can't be
+            // applied; skip it rather than reject otherwise-valid content.
+            let Ok(schema) = serde_json::from_str::<Value>(schema_str) else {
+                continue;
+            };
+            if let Err(msg) = json_schema_check(&schema, &content, "") {
+                return Err(bad_request(format!(
+                    "Configuration failed JSON schema validation: {msg}"
+                )));
+            }
         }
         Ok(empty(204))
     }

--- a/crates/fakecloud-appconfig/tests/service_tests.rs
+++ b/crates/fakecloud-appconfig/tests/service_tests.rs
@@ -1027,3 +1027,104 @@ async fn missing_and_invalid_inputs_error() {
     .await;
     assert_eq!(code, 400);
 }
+
+/// Create a configuration profile carrying an explicit `Validators` list.
+async fn make_profile_with_validators(
+    svc: &AppConfigService,
+    app: &str,
+    name: &str,
+    validators: Value,
+) -> String {
+    let resp = call(
+        svc,
+        req(
+            Method::POST,
+            &format!("/applications/{app}/configurationprofiles"),
+            json!({ "Name": name, "LocationUri": "hosted", "Validators": validators }),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status.as_u16(), 201);
+    id_of(&body_of(&resp))
+}
+
+#[tokio::test]
+async fn validate_configuration_runs_json_schema_validator() {
+    let svc = service();
+    let app = make_app(&svc, "cfg-app").await;
+    let schema = json!({
+        "type": "object",
+        "required": ["name"],
+        "properties": { "name": { "type": "string" } },
+        "additionalProperties": false
+    })
+    .to_string();
+    let profile = make_profile_with_validators(
+        &svc,
+        &app,
+        "cfg-profile",
+        json!([{ "Type": "JSON_SCHEMA", "Content": schema }]),
+    )
+    .await;
+
+    // Invalid content (missing required `name`) is rejected with
+    // BadRequestException.
+    make_hosted_version(&svc, &app, &profile, br#"{"other": 1}"#, "application/json").await;
+    let (code, name) = call_err(
+        &svc,
+        req(
+            Method::POST,
+            &format!(
+                "/applications/{app}/configurationprofiles/{profile}/validators?configuration_version=1"
+            ),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(code, 400);
+    assert_eq!(name, "BadRequestException");
+
+    // Valid content passes and returns 204.
+    make_hosted_version(
+        &svc,
+        &app,
+        &profile,
+        br#"{"name": "ok"}"#,
+        "application/json",
+    )
+    .await;
+    let resp = call(
+        &svc,
+        req(
+            Method::POST,
+            &format!(
+                "/applications/{app}/configurationprofiles/{profile}/validators?configuration_version=2"
+            ),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status.as_u16(), 204);
+}
+
+#[tokio::test]
+async fn validate_configuration_with_no_validators_succeeds() {
+    let svc = service();
+    let app = make_app(&svc, "novalidators-app").await;
+    let profile = make_profile(&svc, &app, "plain-profile").await;
+    make_hosted_version(&svc, &app, &profile, br#"not even json"#, "text/plain").await;
+    // No JSON_SCHEMA validators means nothing to enforce; ValidateConfiguration
+    // returns 204 regardless of content.
+    let resp = call(
+        &svc,
+        req(
+            Method::POST,
+            &format!(
+                "/applications/{app}/configurationprofiles/{profile}/validators?configuration_version=1"
+            ),
+            Value::Null,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status.as_u16(), 204);
+}

--- a/crates/fakecloud-ce/src/service/tests.rs
+++ b/crates/fakecloud-ce/src/service/tests.rs
@@ -170,3 +170,37 @@ fn invalid_enum_is_rejected() {
         "ValidationException"
     );
 }
+
+#[test]
+fn update_cost_allocation_tags_status_rejects_invalid_nested_status() {
+    let s = svc();
+    assert_eq!(
+        err_code(
+            &s,
+            "UpdateCostAllocationTagsStatus",
+            json!({
+                "CostAllocationTagsStatus": [
+                    { "TagKey": "team", "Status": "Bogus" }
+                ]
+            })
+        ),
+        "ValidationException"
+    );
+}
+
+#[test]
+fn update_cost_allocation_tags_status_accepts_valid_nested_status() {
+    let s = svc();
+    let out = call(
+        &s,
+        "UpdateCostAllocationTagsStatus",
+        json!({
+            "CostAllocationTagsStatus": [
+                { "TagKey": "team", "Status": "Active" },
+                { "TagKey": "env", "Status": "Inactive" }
+            ]
+        }),
+    );
+    // No per-key failures for a well-formed request.
+    assert_eq!(out["Errors"].as_array().map(|a| a.len()), Some(0));
+}

--- a/crates/fakecloud-ce/src/validate.rs
+++ b/crates/fakecloud-ce/src/validate.rs
@@ -121,6 +121,36 @@ pub(crate) fn validate_input(action: &str, body: &Value) -> Result<(), AwsServic
             }
         }
     }
+    validate_nested(action, body)?;
+    Ok(())
+}
+
+/// Validate constrained members nested inside list/structure inputs that the
+/// flat top-level rule table can't express. The Smithy model constrains these
+/// (e.g. `CostAllocationTagStatusEntry.Status` is the `CostAllocationTagStatus`
+/// enum), so a garbage value is a `ValidationException` on the real service.
+/// Only fires when the offending value is actually present, so a well-formed
+/// request (including the conformance probe's valid-enum fill) still succeeds.
+fn validate_nested(action: &str, body: &Value) -> Result<(), AwsServiceError> {
+    if action == "UpdateCostAllocationTagsStatus" {
+        if let Some(entries) = body
+            .get("CostAllocationTagsStatus")
+            .and_then(Value::as_array)
+        {
+            for entry in entries {
+                if let Some(status) = entry.get("Status").and_then(Value::as_str) {
+                    if !TAG_STATUS.contains(&status) {
+                        return Err(invalid(format!(
+                            "CostAllocationTagsStatus.Status '{}' is not a valid value. \
+                             Valid values are: {}.",
+                            status,
+                            TAG_STATUS.join(", ")
+                        )));
+                    }
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -703,6 +703,7 @@ fn blob_upload_start(
             created_at: Utc::now(),
             spool_path: spool.to_string_lossy().to_string(),
             last_byte_received: 0,
+            append_in_flight: false,
         },
     );
     let mut resp = base_response(StatusCode::ACCEPTED, "application/json", Vec::new());
@@ -735,37 +736,50 @@ async fn blob_upload_patch(
     name: &str,
     upload_id: &str,
 ) -> Result<AwsResponse, AwsServiceError> {
-    // Resolve the upload + spool path under a short-lived read guard
-    // so the streaming append below doesn't hold a Send-unfriendly
-    // `parking_lot::RwLockWriteGuard` across `.await`.
-    let (spool, expected_start) = {
-        let accounts = service.state_handle().read();
+    // Parse the optional Content-Range start once so we can validate it
+    // under the same lock that reserves the append below.
+    let range_start = request
+        .headers
+        .get("content-range")
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_content_range_start);
+
+    // Resolve the upload + spool path under a short-lived write guard,
+    // validating the offset and RESERVING the append (marking the upload
+    // in-flight) before the lock is released. The streaming append below
+    // never holds the `parking_lot` write guard across `.await`, but the
+    // reservation guarantees a concurrent PATCH for the same upload is
+    // rejected before it can append into the spool and corrupt the blob.
+    let spool = {
+        let mut accounts = service.state_handle().write();
         let state = accounts
-            .get(&request.account_id)
+            .get_mut(&request.account_id)
             .ok_or_else(|| repo_not_found(name))?;
         let upload = state
             .layer_uploads
-            .get(upload_id)
+            .get_mut(upload_id)
             .ok_or_else(|| upload_unknown(upload_id))?;
         if upload.repository_name != name {
             return Err(upload_unknown(upload_id));
         }
-        (PathBuf::from(&upload.spool_path), upload.last_byte_received)
-    };
-
-    // A chunked PATCH carries a Content-Range whose start must equal the
-    // number of bytes already received. Docker retries a failed chunk by
-    // re-sending the same range; without this check the retry appends the
-    // chunk a second time and silently corrupts the blob (detected only at
-    // the finishing digest). Reject a non-contiguous range with 416 so the
-    // client resumes from the right offset instead of double-appending.
-    if let Some(cr) = request
-        .headers
-        .get("content-range")
-        .and_then(|v| v.to_str().ok())
-    {
-        if let Some(start) = parse_content_range_start(cr) {
-            if start != expected_start {
+        // Another PATCH for this upload is already appending. Reject before
+        // touching the spool so two chunks can't interleave into corruption.
+        if upload.append_in_flight {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "another blob upload PATCH for this upload is already in progress",
+            ));
+        }
+        // A chunked PATCH carries a Content-Range whose start must equal the
+        // number of bytes already received. Docker retries a failed chunk by
+        // re-sending the same range; without this check the retry appends the
+        // chunk a second time and silently corrupts the blob (detected only
+        // at the finishing digest). Reject a non-contiguous range with 416 so
+        // the client resumes from the right offset instead of double-appending.
+        if let Some(start) = range_start {
+            if start != upload.last_byte_received {
+                let expected_start = upload.last_byte_received;
                 return Err(AwsServiceError::aws_error(
                     StatusCode::RANGE_NOT_SATISFIABLE,
                     "BLOB_UPLOAD_INVALID",
@@ -776,19 +790,44 @@ async fn blob_upload_patch(
                 ));
             }
         }
-    }
+        upload.append_in_flight = true;
+        PathBuf::from(&upload.spool_path)
+    };
+
+    // Clear the in-flight reservation. Called on every early-return after the
+    // reservation is taken so a failed append doesn't wedge the upload as
+    // permanently in-flight (the success path clears the flag inline while it
+    // advances the cursor below).
+    let clear_in_flight = || {
+        let mut accounts = service.state_handle().write();
+        if let Some(state) = accounts.get_mut(&request.account_id) {
+            if let Some(upload) = state.layer_uploads.get_mut(upload_id) {
+                upload.append_in_flight = false;
+            }
+        }
+    };
 
     // Streaming-only: dispatch flags blob-upload PATCH/PUT to keep
     // `body_stream` populated, so we always consume it here. A 1 GiB
     // push lands in constant memory.
-    let stream = request.take_body_stream().ok_or_else(|| {
-        AwsServiceError::aws_error(
-            StatusCode::BAD_REQUEST,
-            "BLOB_UPLOAD_INVALID",
-            "blob upload PATCH requires a streaming request body",
-        )
-    })?;
-    let appended = append_stream(&spool, stream).await?;
+    let stream = match request.take_body_stream() {
+        Some(s) => s,
+        None => {
+            clear_in_flight();
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "BLOB_UPLOAD_INVALID",
+                "blob upload PATCH requires a streaming request body",
+            ));
+        }
+    };
+    let appended = match append_stream(&spool, stream).await {
+        Ok(n) => n,
+        Err(e) => {
+            clear_in_flight();
+            return Err(e);
+        }
+    };
 
     let mut accounts = service.state_handle().write();
     let state = accounts
@@ -801,11 +840,11 @@ async fn blob_upload_patch(
     if upload.repository_name != name {
         return Err(upload_unknown(upload_id));
     }
-    // Increment the live counter under the write lock instead of from a
-    // pre-append snapshot — concurrent PATCH calls are serialized by
-    // append order on the spool file, so adding `appended` here is the
+    // Advance the live counter and release the reservation. The reservation
+    // blocked any concurrent append, so adding `appended` here is the
     // race-free progress update.
     upload.last_byte_received = upload.last_byte_received.saturating_add(appended);
+    upload.append_in_flight = false;
     let range_end = upload.last_byte_received.saturating_sub(1);
     let mut resp = base_response(StatusCode::ACCEPTED, "application/json", Vec::new());
     resp.headers.insert(
@@ -1332,6 +1371,7 @@ mod immutability_tests {
                     created_at: chrono::Utc::now(),
                     spool_path: spool.to_string_lossy().into_owned(),
                     last_byte_received: 0,
+                    append_in_flight: false,
                 },
             );
         }

--- a/crates/fakecloud-ecr/src/service/layers.rs
+++ b/crates/fakecloud-ecr/src/service/layers.rs
@@ -170,6 +170,7 @@ impl EcrService {
                 created_at: Utc::now(),
                 spool_path: spool.to_string_lossy().to_string(),
                 last_byte_received: 0,
+                append_in_flight: false,
             },
         );
         Ok(AwsResponse::ok_json(json!({
@@ -221,10 +222,19 @@ impl EcrService {
             )?;
             let upload = state
                 .layer_uploads
-                .get(&upload_id)
+                .get_mut(&upload_id)
                 .ok_or_else(|| upload_not_found(&upload_id))?;
             if upload.repository_name != name {
                 return Err(upload_not_found(&upload_id));
+            }
+            // A part for this upload is already being appended (validated and
+            // reserved here, appended with the lock released below). Reject a
+            // concurrent second part BEFORE it appends so two parts racing on
+            // the same start offset can't both write into the spool.
+            if upload.append_in_flight {
+                return Err(invalid_layer(
+                    "Layer part upload out of order: another part is already being appended",
+                ));
             }
             if first_byte != upload.last_byte_received {
                 return Err(invalid_layer(format!(
@@ -242,7 +252,23 @@ impl EcrService {
                     part_bytes.len()
                 )));
             }
+            // Reserve the append. The flag is cleared once the append
+            // completes (below) or fails (the map entry is left intact but
+            // unreserved so the client can retry the same offset).
+            upload.append_in_flight = true;
             std::path::PathBuf::from(&upload.spool_path)
+        };
+
+        // Helper: clear the in-flight reservation. Used on the append-failure
+        // path so a failed append doesn't wedge the upload as permanently
+        // "in flight" and block later retries at the same offset.
+        let clear_reservation = || {
+            let mut accounts = self.state.write();
+            if let Some(state) = accounts.get_mut(&account) {
+                if let Some(upload) = state.layer_uploads.get_mut(&upload_id) {
+                    upload.append_in_flight = false;
+                }
+            }
         };
 
         // Append the (potentially multi-hundred-MB) chunk on a blocking
@@ -250,29 +276,33 @@ impl EcrService {
         // worker (bug-audit 2026-06-13, 3.2). The OCI `docker push` path
         // already streams asynchronously.
         let append_spool = spool.clone();
-        tokio::task::spawn_blocking(move || {
+        let append_result = tokio::task::spawn_blocking(move || {
             crate::oci::append_bytes_sync(&append_spool, &part_bytes)
         })
-        .await
-        .map_err(|e| {
-            AwsServiceError::aws_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "InternalError",
-                format!("layer part append task failed: {e}"),
-            )
-        })?
-        .map_err(|e| {
-            AwsServiceError::aws_error(
+        .await;
+        let append_result = match append_result {
+            Ok(inner) => inner,
+            Err(e) => {
+                clear_reservation();
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalError",
+                    format!("layer part append task failed: {e}"),
+                ));
+            }
+        };
+        if let Err(e) = append_result {
+            clear_reservation();
+            return Err(AwsServiceError::aws_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "InternalError",
                 format!("failed to append upload chunk: {e}"),
-            )
-        })?;
+            ));
+        }
 
-        // Re-acquire the lock to advance the received-byte cursor. Re-check
-        // the upload still exists and the cursor is where we left it; if a
-        // concurrent part raced in we surface an out-of-order error rather
-        // than corrupting the cursor.
+        // Re-acquire the lock to advance the received-byte cursor and clear
+        // the reservation. Because the reservation blocked any concurrent
+        // append, the cursor is exactly where we left it.
         let mut accounts = self.state.write();
         let state = accounts
             .get_mut(&account)
@@ -282,13 +312,8 @@ impl EcrService {
                 .layer_uploads
                 .get_mut(&upload_id)
                 .ok_or_else(|| upload_not_found(&upload_id))?;
-            if upload.last_byte_received != first_byte {
-                return Err(invalid_layer(format!(
-                    "Layer part upload out of order: expected partFirstByte {} got {}",
-                    upload.last_byte_received, first_byte,
-                )));
-            }
             upload.last_byte_received = last_byte + 1;
+            upload.append_in_flight = false;
         }
         let registry_id = state.registry_id();
         Ok(AwsResponse::ok_json(json!({
@@ -433,5 +458,133 @@ impl EcrService {
             "uploadId": upload_id,
             "layerDigest": computed,
         })))
+    }
+}
+
+#[cfg(test)]
+mod concurrency_tests {
+    use crate::service::EcrService;
+    use crate::state::{EcrState, Repository, SharedEcrState};
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine;
+    use bytes::Bytes;
+    use fakecloud_core::multi_account::MultiAccountState;
+    use fakecloud_core::service::AwsRequest;
+    use http::{HeaderMap, Method};
+    use parking_lot::RwLock;
+    use serde_json::{json, Value};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const ACCOUNT: &str = "111111111111";
+
+    fn make_request(body: Value) -> AwsRequest {
+        AwsRequest {
+            service: "ecr".into(),
+            action: "UploadLayerPart".into(),
+            region: "us-east-1".into(),
+            account_id: ACCOUNT.into(),
+            request_id: "req-1".into(),
+            headers: HeaderMap::new(),
+            query_params: HashMap::new(),
+            body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec![],
+            raw_path: "/".into(),
+            raw_query: String::new(),
+            method: Method::POST,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn fixture() -> (EcrService, SharedEcrState) {
+        let mut mas: MultiAccountState<EcrState> =
+            MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
+        let state = mas.get_or_create(ACCOUNT);
+        let arn = state.repository_arn("app");
+        let repo = Repository::new("app", arn, ACCOUNT, "fakecloud:4566");
+        state.repositories.insert("app".to_string(), repo);
+        let shared: SharedEcrState = Arc::new(RwLock::new(mas));
+        let svc = EcrService::new(shared.clone());
+        (svc, shared)
+    }
+
+    fn initiate(svc: &EcrService) -> String {
+        let req = make_request(json!({ "repositoryName": "app" }));
+        let resp = svc
+            .initiate_layer_upload(&req)
+            .expect("initiate should succeed");
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        body["uploadId"].as_str().unwrap().to_string()
+    }
+
+    fn part(upload_id: &str, first: u64, last: u64, bytes: &[u8]) -> AwsRequest {
+        make_request(json!({
+            "repositoryName": "app",
+            "uploadId": upload_id,
+            "partFirstByte": first,
+            "partLastByte": last,
+            "layerPartBlob": B64.encode(bytes),
+        }))
+    }
+
+    #[tokio::test]
+    async fn second_same_offset_part_is_rejected() {
+        let (svc, _shared) = fixture();
+        let upload_id = initiate(&svc);
+
+        // First part at offset 0 succeeds and advances the cursor.
+        let ok = svc
+            .upload_layer_part(&part(&upload_id, 0, 3, b"test"))
+            .await
+            .expect("first part should succeed");
+        let ok_body: Value = serde_json::from_slice(ok.body.expect_bytes()).unwrap();
+        assert_eq!(ok_body["lastByteReceived"].as_u64(), Some(3));
+
+        // A second part starting at the same offset 0 is now out of order and
+        // must be rejected, rather than appended into the spool.
+        let err = svc
+            .upload_layer_part(&part(&upload_id, 0, 3, b"test"))
+            .await
+            .err()
+            .expect("second same-offset part should be rejected");
+        assert!(
+            format!("{err:?}").contains("out of order"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_reservation_rejects_concurrent_part() {
+        let (svc, shared) = fixture();
+        let upload_id = initiate(&svc);
+
+        // Simulate a first part that has passed validation and is mid-append:
+        // the reservation flag is set while its file append runs with the
+        // state lock released.
+        {
+            let mut guard = shared.write();
+            let state = guard.get_mut(ACCOUNT).unwrap();
+            state
+                .layer_uploads
+                .get_mut(&upload_id)
+                .unwrap()
+                .append_in_flight = true;
+        }
+
+        // A concurrent part for the same upload -- even at the correct next
+        // offset -- must be rejected before it appends, so two parts can't both
+        // write into the spool and corrupt it.
+        let err = svc
+            .upload_layer_part(&part(&upload_id, 0, 3, b"test"))
+            .await
+            .err()
+            .expect("in-flight upload should reject a concurrent part");
+        assert!(
+            format!("{err:?}").contains("already being appended"),
+            "unexpected error: {err:?}"
+        );
     }
 }

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -349,6 +349,15 @@ pub struct LayerUpload {
     #[serde(default)]
     pub spool_path: String,
     pub last_byte_received: u64,
+    /// True while a layer-part / blob-`PATCH` append for this upload is
+    /// in flight (validated + reserved under the state lock, but the
+    /// actual file append runs with the lock released so a multi-hundred-
+    /// MB chunk doesn't stall a worker). A second concurrent append that
+    /// observes this flag set is rejected BEFORE it appends, so two parts
+    /// racing on the same start offset can't both write into the spool and
+    /// corrupt it. Runtime-only, never persisted.
+    #[serde(default, skip)]
+    pub append_in_flight: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -438,6 +447,7 @@ mod tests {
                 created_at: Utc::now(),
                 spool_path: "/tmp/fakecloud-ecr-upload-upload-1".to_string(),
                 last_byte_received: 42,
+                append_in_flight: false,
             },
         );
 

--- a/crates/fakecloud-elbv2/src/state.rs
+++ b/crates/fakecloud-elbv2/src/state.rs
@@ -161,6 +161,14 @@ pub struct TargetDescription {
     pub id: String,
     pub port: Option<i32>,
     pub availability_zone: Option<String>,
+    // Per-target health is runtime-only and must NOT persist across a
+    // restart. If it did, a stale "unhealthy" would load and, since the
+    // data plane filters non-healthy targets out of routing, an ALB could
+    // drop that target for up to one health-check interval until the prober
+    // re-probes it. Skipping it means a restored target starts at the
+    // default (healthy) state and participates in routing until the prober
+    // re-derives its real health.
+    #[serde(skip, default)]
     pub health: TargetHealth,
     #[serde(default)]
     pub consecutive_success: u32,
@@ -324,4 +332,46 @@ pub struct TrustStoreRevocation {
     pub revocation_type: String,
     pub number_of_revoked_entries: i64,
     pub content: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_health_does_not_persist_across_snapshot() {
+        // A target marked unhealthy at runtime must NOT round-trip through a
+        // serialize/deserialize of the state. If it did, a restart would load
+        // the stale "unhealthy" and, because the data plane filters non-healthy
+        // targets out of routing, silently drop the target until the prober
+        // re-probes it.
+        let target = TargetDescription {
+            id: "i-abc".to_string(),
+            port: Some(8080),
+            availability_zone: None,
+            health: TargetHealth {
+                state: "unhealthy".to_string(),
+                reason: Some("Target.FailedHealthChecks".to_string()),
+                description: Some("stale".to_string()),
+            },
+            consecutive_success: 0,
+            consecutive_failure: 3,
+            last_probe_at: None,
+        };
+
+        let json = serde_json::to_string(&target).expect("serialize");
+        assert!(
+            !json.contains("unhealthy"),
+            "target health must not be serialized, got: {json}"
+        );
+
+        let restored: TargetDescription = serde_json::from_str(&json).expect("deserialize");
+        // Restores to the default (healthy) state so the target participates in
+        // routing until the prober re-derives its real health.
+        assert_eq!(restored.health.state, TargetHealth::default().state);
+        assert_ne!(restored.health.state, "unhealthy");
+        // The rest of the target survives the round-trip.
+        assert_eq!(restored.id, "i-abc");
+        assert_eq!(restored.port, Some(8080));
+    }
 }


### PR DESCRIPTION
## Summary
LOW-severity fixes from the 2026-07-22 bug hunt. Each confirmed against the handler, each with tests; conformance verified locally (208/208 across the five services).

- **elbv2**: per-target `health` is now `#[serde(skip, default)]` so it does not persist across restart. A restore starts targets at the default (healthy) and re-probes, instead of loading a stale `unhealthy` that `forward_action` would drop from routing for a health-check interval.
- **ecr**: `UploadLayerPart` (JSON + OCI `docker push`) now sets an `append_in_flight` reservation under the state lock before releasing it for the append, so a concurrent same-offset part is rejected before it appends rather than both appending and corrupting the spool (previously caught only by the final SHA-256 as `LayerDigestMismatch`). The state lock is still never held across the append.
- **ce**: `UpdateCostAllocationTagsStatus` now validates each nested `CostAllocationTagsStatus[].Status` against `{Active, Inactive}` (`ValidationException`).
- **appconfig**: `ValidateConfiguration` now runs the profile's `JSON_SCHEMA` validators against the resolved hosted content and returns `BadRequestException` on failure (LAMBDA validators accepted; no-validators/valid content → 204).

### Left unchanged (documented false-positives)
- **ce `ProvideAnomalyFeedback`**: the Smithy model declares only `LimitExceededException` for this op, so there is no modeled "unknown anomaly" error, and the conformance probe expects success on a synthetic id against the (always-empty) anomaly store. Returning an error would break the probe with an undeclared code.
- **config `DescribePendingAggregationRequests`/`DeletePendingAggregationRequest` + org detailed-status**: cross-account artifacts a single-account emulator can't originate; no state to reflect, and the org-status ops already validate existence and return an empty member-account list. No fake data invented.

## Test plan
- 6 new tests (target-health non-persistence, ecr same-offset rejection ×2, ce nested-status ±, appconfig JSON_SCHEMA ±).
- `cargo nextest` on the five crates: 190 passed. Conformance (elbv2/ecr/ce/config/appconfig): 208/208. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes across ELBv2, ECR, CE, and AppConfig to avoid stale state, prevent layer corruption, and enforce input validation. Improves correctness without behavior changes for valid requests.

- **Bug Fixes**
  - ELBv2: Per-target `health` is now runtime-only (not persisted). Restarts begin healthy and re-probe before routing decisions.
  - ECR: `UploadLayerPart` and OCI blob `PATCH` reserve an in-flight append under the state lock; concurrent same-offset parts are rejected before writing, preventing spool corruption.
  - CE: `UpdateCostAllocationTagsStatus` validates each entry’s `Status` against `{Active, Inactive}` and returns `ValidationException` for invalid values.
  - AppConfig: `ValidateConfiguration` runs `JSON_SCHEMA` validators against hosted content; invalid documents return `BadRequestException`. `LAMBDA` validators are accepted; no validators or valid content return 204.

<sup>Written for commit 98c927543e297ab595544ae2a88baa1b95ba6771. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

