### PR TITLE
fix(athena,opensearch,redshift,swf,sns,ec2): settle cancelled capacity, real delete-catalog identity, reflect maintenance/aqua status, reject closed-execution mutations, validate Publish Subject, paginate DescribeImages

### DIFF
--- a/crates/fakecloud-athena/src/service/capacity.rs
+++ b/crates/fakecloud-athena/src/service/capacity.rs
@@ -49,8 +49,9 @@ impl AthenaService {
         let account = account_mut(&mut state, &req.account_id);
         let cr = account
             .capacity_reservations
-            .get(&name)
+            .get_mut(&name)
             .ok_or_else(|| invalid_request(format!("CapacityReservation {name} not found")))?;
+        settle_capacity_reservation(cr);
         Ok(AwsResponse::ok_json(json!({
             "CapacityReservation": capacity_reservation_json(cr),
         })))
@@ -70,6 +71,9 @@ impl AthenaService {
             .map(str::to_owned);
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
+        for cr in account.capacity_reservations.values_mut() {
+            settle_capacity_reservation(cr);
+        }
         let mut all: Vec<CapacityReservation> =
             account.capacity_reservations.values().cloned().collect();
         all.sort_by(|a, b| a.name.cmp(&b.name));
@@ -121,7 +125,12 @@ impl AthenaService {
             .capacity_reservations
             .get_mut(&name)
             .ok_or_else(|| invalid_request(format!("CapacityReservation {name} not found")))?;
-        cr.status = "CANCELLING".to_string();
+        // Cancel begins in CANCELLING; the reservation settles to CANCELLED on a
+        // subsequent Get/List read (see settle_capacity_reservation). An already
+        // cancelled/cancelling reservation stays where it is.
+        if cr.status != "CANCELLED" {
+            cr.status = "CANCELLING".to_string();
+        }
         Ok(AwsResponse::ok_json(json!({})))
     }
 
@@ -188,5 +197,16 @@ impl AthenaService {
                 "CapacityAssignments": cfg.capacity_assignments,
             }
         })))
+    }
+}
+
+/// Settle a cancelled capacity reservation on read: `CancelCapacityReservation`
+/// leaves the reservation in `CANCELLING`, and AWS transitions it to `CANCELLED`
+/// shortly after. Mirroring the settle-on-read pattern used elsewhere, the next
+/// Get/List read completes the transition so callers eventually observe
+/// `CANCELLED` instead of a permanently stuck `CANCELLING`.
+fn settle_capacity_reservation(cr: &mut CapacityReservation) {
+    if cr.status == "CANCELLING" {
+        cr.status = "CANCELLED".to_string();
     }
 }

--- a/crates/fakecloud-athena/src/service/data_catalogs.rs
+++ b/crates/fakecloud-athena/src/service/data_catalogs.rs
@@ -151,13 +151,18 @@ impl AthenaService {
         }
         let mut state = self.state.write();
         let account = account_mut(&mut state, &req.account_id);
-        if account.data_catalogs.remove(&name).is_none() {
-            return Err(invalid_request(format!("DataCatalog {name} not found")));
-        }
+        // AWS echoes the deleted catalog's real identity (Name + Type), so capture
+        // them before removing the entry rather than returning empty strings.
+        let cat_type = account
+            .data_catalogs
+            .get(&name)
+            .map(|c| c.cat_type.clone())
+            .ok_or_else(|| invalid_request(format!("DataCatalog {name} not found")))?;
+        account.data_catalogs.remove(&name);
         Ok(AwsResponse::ok_json(json!({
             "DataCatalog": {
-                "Name": "",
-                "Type": "",
+                "Name": name,
+                "Type": cat_type,
                 "Status": "DELETE_COMPLETE",
             }
         })))

--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -1895,6 +1895,70 @@ mod tests {
         .unwrap();
         assert_eq!(find_engine(&svc, "wg3"), "Athena engine version 2");
     }
+
+    #[test]
+    fn cancel_capacity_reservation_settles_to_cancelled() {
+        let (svc, _glue) = test_service();
+        svc.create_capacity_reservation(&req(
+            "CreateCapacityReservation",
+            json!({ "Name": "cr1", "TargetDpus": 24 }),
+        ))
+        .unwrap();
+
+        // Cancel leaves the reservation in CANCELLING immediately after the call.
+        svc.cancel_capacity_reservation(&req(
+            "CancelCapacityReservation",
+            json!({ "Name": "cr1" }),
+        ))
+        .unwrap();
+        {
+            let state = svc.state.read();
+            let cr = state
+                .accounts
+                .values()
+                .next()
+                .unwrap()
+                .capacity_reservations
+                .get("cr1")
+                .unwrap();
+            assert_eq!(cr.status, "CANCELLING");
+        }
+
+        // A subsequent Get settles it to CANCELLED (settle-on-read).
+        let got = parse_json(
+            &svc.get_capacity_reservation(&req("GetCapacityReservation", json!({ "Name": "cr1" })))
+                .unwrap(),
+        );
+        assert_eq!(got["CapacityReservation"]["Status"], "CANCELLED");
+
+        // ListCapacityReservations also reports the settled status.
+        let listed = parse_json(
+            &svc.list_capacity_reservations(&req("ListCapacityReservations", json!({})))
+                .unwrap(),
+        );
+        assert_eq!(
+            listed["CapacityReservations"][0]["Status"], "CANCELLED",
+            "list should report the settled status"
+        );
+    }
+
+    #[test]
+    fn delete_data_catalog_echoes_real_identity() {
+        let (svc, _glue) = test_service();
+        svc.create_data_catalog(&req(
+            "CreateDataCatalog",
+            json!({ "Name": "cat1", "Type": "GLUE" }),
+        ))
+        .unwrap();
+
+        let deleted = parse_json(
+            &svc.delete_data_catalog(&req("DeleteDataCatalog", json!({ "Name": "cat1" })))
+                .unwrap(),
+        );
+        assert_eq!(deleted["DataCatalog"]["Name"], "cat1");
+        assert_eq!(deleted["DataCatalog"]["Type"], "GLUE");
+        assert_eq!(deleted["DataCatalog"]["Status"], "DELETE_COMPLETE");
+    }
 }
 
 #[cfg(test)]

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -7,7 +7,7 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{
-    gen_id, indexed_list, parse_filters, require, validate_enum, validate_length,
+    gen_id, indexed_list, paginate, parse_filters, require, validate_enum, validate_length,
     validate_max_results, Filter,
 };
 use crate::state::{Ec2State, Image, Tag};
@@ -233,6 +233,7 @@ pub(crate) fn describe_images(
     svc: &Ec2Service,
     req: &AwsRequest,
 ) -> Result<AwsResponse, AwsServiceError> {
+    validate_max_results(&req.query_params, 1, 1000)?;
     let filters = parse_filters(&req.query_params);
     let wanted = indexed_list(&req.query_params, "ImageId");
     // A `disabled` image is hidden from a default DescribeImages; it is only
@@ -281,10 +282,25 @@ pub(crate) fn describe_images(
         .map(|i| image_xml(i, state.tags_for(&i.image_id), &owner))
         .collect();
     items.sort();
+    // MaxResults/NextToken pagination, matching the other EC2 Describe ops. The
+    // owner/filter/NotFound logic above is unchanged; only the returned page is
+    // bounded, with a NextToken cursor that round-trips into the next call.
+    let max_results = req
+        .query_params
+        .get("MaxResults")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok());
+    let next_token = req.query_params.get("NextToken").map(String::as_str);
+    let (page, token) = paginate(&items, next_token, max_results);
+    let body = format!(
+        "{}{}",
+        ec2_list("imagesSet", &page),
+        token.map(|t| ec2_elem("nextToken", &t)).unwrap_or_default(),
+    );
     Ok(Ec2Service::respond(
         "DescribeImages",
         &req.request_id,
-        &ec2_list("imagesSet", &items),
+        &body,
     ))
 }
 
@@ -1266,6 +1282,63 @@ mod tests {
             &req("DescribeImages", &[("ImageId.1", "ami-missing")]),
         ));
         assert_eq!(err.code(), "InvalidAMIID.NotFound");
+    }
+
+    #[test]
+    fn describe_images_paginates_with_max_results() {
+        use crate::test_support::ec2_request as req;
+        let svc = crate::service::Ec2Service::new();
+        seed_image(&svc, "ami-a");
+        seed_image(&svc, "ami-b");
+        seed_image(&svc, "ami-c");
+
+        // First page: MaxResults caps the result at 2 and returns a cursor.
+        // Scope to `self` so only the three seeded images count (the default
+        // account also carries a public AMI catalogue owned by other accounts).
+        let page1 = String::from_utf8(
+            super::describe_images(
+                &svc,
+                &req("DescribeImages", &[("MaxResults", "2"), ("Owner.1", "self")]),
+            )
+            .unwrap()
+            .body
+            .expect_bytes()
+            .to_vec(),
+        )
+        .unwrap();
+        assert_eq!(page1.matches("<imageId>").count(), 2, "{page1}");
+        let token_start = page1
+            .find("<nextToken>")
+            .expect("page 1 should carry a nextToken");
+        let content_start = token_start + "<nextToken>".len();
+        let token_end = page1[content_start..].find("</nextToken>").unwrap() + content_start;
+        let token = page1[content_start..token_end].to_string();
+
+        // The cursor round-trips into the next call, yielding the last image and
+        // no further token.
+        let page2 = String::from_utf8(
+            super::describe_images(
+                &svc,
+                &req(
+                    "DescribeImages",
+                    &[
+                        ("MaxResults", "2"),
+                        ("NextToken", &token),
+                        ("Owner.1", "self"),
+                    ],
+                ),
+            )
+            .unwrap()
+            .body
+            .expect_bytes()
+            .to_vec(),
+        )
+        .unwrap();
+        assert_eq!(page2.matches("<imageId>").count(), 1, "{page2}");
+        assert!(
+            !page2.contains("<nextToken>"),
+            "final page must not carry a nextToken: {page2}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -1298,7 +1298,10 @@ mod tests {
         let page1 = String::from_utf8(
             super::describe_images(
                 &svc,
-                &req("DescribeImages", &[("MaxResults", "2"), ("Owner.1", "self")]),
+                &req(
+                    "DescribeImages",
+                    &[("MaxResults", "2"), ("Owner.1", "self")],
+                ),
             )
             .unwrap()
             .body

--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -1117,10 +1117,7 @@ impl OpenSearchService {
             "RollbackServiceSoftwareUpdate" => self.service_software_update(req, "IN_PROGRESS"),
             // ---- Maintenance ----
             "StartDomainMaintenance" => self.start_domain_maintenance(l, req),
-            "GetDomainMaintenanceStatus" => Ok(ok(json!({
-                "Status": "COMPLETED",
-                "StatusMessage": "Maintenance completed"
-            }))),
+            "GetDomainMaintenanceStatus" => self.get_domain_maintenance_status(l, req),
             "ListDomainMaintenances" => self.list_domain_maintenances(l, req),
             "ListScheduledActions" => self.list_scheduled_actions(l, req),
             "UpdateScheduledAction" => self.update_scheduled_action(l, req),
@@ -3029,6 +3026,48 @@ impl OpenSearchService {
             }),
         );
         Ok(ok(json!({ "MaintenanceId": mid })))
+    }
+
+    fn get_domain_maintenance_status(
+        &self,
+        l: &Labels,
+        req: &AwsRequest,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let dom = label(l.domain.as_deref())?;
+        let mid = req
+            .query_params
+            .get("maintenanceId")
+            .cloned()
+            .unwrap_or_default();
+        let accounts = self.state.read();
+        let stored = accounts
+            .get(&req.account_id)
+            .and_then(|st| st.domains.get(&dom))
+            .and_then(|d| d.maintenances.get(&mid));
+        if let Some(m) = stored {
+            // Reflect the stored maintenance keyed by MaintenanceId instead of a
+            // hardcoded constant, so the status/action tracks what Start recorded.
+            let status = m
+                .get("Status")
+                .and_then(Value::as_str)
+                .unwrap_or("COMPLETED");
+            let action = m
+                .get("Action")
+                .cloned()
+                .unwrap_or_else(|| json!("REBOOT_NODE"));
+            return Ok(ok(json!({
+                "Status": status,
+                "StatusMessage": "Maintenance completed",
+                "Action": action,
+            })));
+        }
+        // No stored maintenance for this id (unknown domain or id): fall back to
+        // the default terminal status rather than erroring, so a minimal probe
+        // without prior StartDomainMaintenance still succeeds.
+        Ok(ok(json!({
+            "Status": "COMPLETED",
+            "StatusMessage": "Maintenance completed",
+        })))
     }
 
     fn list_domain_maintenances(

--- a/crates/fakecloud-opensearch/tests/service_tests.rs
+++ b/crates/fakecloud-opensearch/tests/service_tests.rs
@@ -1854,3 +1854,70 @@ async fn attach_data_source_persists_through_list() {
     assert_eq!(attachments.len(), 1, "{listed}");
     assert_eq!(attachments[0]["dataSourceArn"], "arn:aws:s3:::my-bucket");
 }
+
+#[tokio::test]
+async fn get_domain_maintenance_status_reflects_stored_entry() {
+    let svc = service();
+    // Create a domain, then start a maintenance action and capture its id.
+    call(
+        &svc,
+        req(
+            Method::POST,
+            &format!("{OS}/opensearch/domain"),
+            json!({"DomainName": "maint", "EngineVersion": "OpenSearch_2.11"}),
+        ),
+    )
+    .await;
+    let started = json_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("{OS}/opensearch/domain/maint/domainMaintenance"),
+                json!({"Action": "REBOOT_NODE"}),
+            ),
+        )
+        .await,
+    );
+    let mid = started["MaintenanceId"].as_str().unwrap().to_string();
+
+    // GetDomainMaintenanceStatus keyed by that id reflects the stored entry
+    // (the Action it recorded) rather than an id-blind constant.
+    let status = json_of(
+        &call(
+            &svc,
+            with_query(
+                req(
+                    Method::GET,
+                    &format!("{OS}/opensearch/domain/maint/domainMaintenance"),
+                    json!({}),
+                ),
+                "maintenanceId",
+                &mid,
+            ),
+        )
+        .await,
+    );
+    assert_eq!(status["Action"], "REBOOT_NODE");
+    assert_eq!(status["Status"], "COMPLETED");
+
+    // An unknown maintenance id falls back to the default terminal status
+    // instead of erroring.
+    let unknown = json_of(
+        &call(
+            &svc,
+            with_query(
+                req(
+                    Method::GET,
+                    &format!("{OS}/opensearch/domain/maint/domainMaintenance"),
+                    json!({}),
+                ),
+                "maintenanceId",
+                "does-not-exist",
+            ),
+        )
+        .await,
+    );
+    assert_eq!(unknown["Status"], "COMPLETED");
+    assert!(unknown.get("Action").is_none());
+}

--- a/crates/fakecloud-redshift/src/service/access.rs
+++ b/crates/fakecloud-redshift/src/service/access.rs
@@ -693,12 +693,16 @@ impl RedshiftService {
         let key = Self::partner_key(&cluster, &db, &partner);
         let mut guard = self.state.write();
         let acct = guard.account(&req.account_id);
-        if let Some(p) = acct.partners.get_mut(&key) {
-            if let Some(s) = param(req, "Status") {
-                p.status = s;
-            }
-            p.status_message = param(req, "StatusMessage");
+        // AWS returns PartnerNotFoundFault when the partner is not registered,
+        // rather than a silent 200 that pretends the status update succeeded.
+        let p = acct
+            .partners
+            .get_mut(&key)
+            .ok_or_else(|| partner_not_found(&partner))?;
+        if let Some(s) = param(req, "Status") {
+            p.status = s;
         }
+        p.status_message = param(req, "StatusMessage");
         Ok(xml_resp(
             "UpdatePartnerStatus",
             format!(

--- a/crates/fakecloud-redshift/src/service/clusters.rs
+++ b/crates/fakecloud-redshift/src/service/clusters.rs
@@ -537,9 +537,12 @@ impl RedshiftService {
             c.aqua_configuration_status = v;
         }
         let status = xml_escape(&c.aqua_configuration_status);
+        // AquaStatus reflects the requested/stored configuration status rather
+        // than a hardcoded literal (AQUA is deprecated by AWS, but the echo must
+        // still mirror the input).
         Ok(xml_resp(
             "ModifyAquaConfiguration",
-            format!("<AquaConfiguration><AquaStatus>disabled</AquaStatus><AquaConfigurationStatus>{status}</AquaConfigurationStatus></AquaConfiguration>"),
+            format!("<AquaConfiguration><AquaStatus>{status}</AquaStatus><AquaConfigurationStatus>{status}</AquaConfigurationStatus></AquaConfiguration>"),
             &req.request_id,
         ))
     }

--- a/crates/fakecloud-redshift/src/service/helpers.rs
+++ b/crates/fakecloud-redshift/src/service/helpers.rs
@@ -355,6 +355,14 @@ pub(crate) fn scheduled_action_not_found(id: &str) -> AwsServiceError {
     )
 }
 
+pub(crate) fn partner_not_found(partner: &str) -> AwsServiceError {
+    err(
+        404,
+        "PartnerNotFound",
+        format!("Partner {partner} not found."),
+    )
+}
+
 pub(crate) fn scheduled_action_already_exists(id: &str) -> AwsServiceError {
     err(
         400,

--- a/crates/fakecloud-redshift/src/service/tests.rs
+++ b/crates/fakecloud-redshift/src/service/tests.rs
@@ -777,3 +777,96 @@ fn modify_cluster_persists_encryption_kms_and_port() {
     assert!(listed
         .contains("<AvailabilityZoneRelocationStatus>enabled</AvailabilityZoneRelocationStatus>"));
 }
+
+#[test]
+fn modify_aqua_configuration_echoes_requested_status() {
+    let svc = service();
+    ok(
+        &svc,
+        "CreateCluster",
+        &[
+            ("ClusterIdentifier", "aq"),
+            ("NodeType", "ra3.xlplus"),
+            ("MasterUsername", "admin"),
+            ("MasterUserPassword", "Passw0rd123"),
+            ("ClusterType", "single-node"),
+        ],
+    );
+
+    // AquaStatus must reflect the requested/stored status, not a hardcoded
+    // `disabled` literal.
+    let out = ok(
+        &svc,
+        "ModifyAquaConfiguration",
+        &[
+            ("ClusterIdentifier", "aq"),
+            ("AquaConfigurationStatus", "enabled"),
+        ],
+    );
+    assert!(
+        out.contains("<AquaStatus>enabled</AquaStatus>"),
+        "AquaStatus should echo the requested status: {out}"
+    );
+    assert!(out.contains("<AquaConfigurationStatus>enabled</AquaConfigurationStatus>"));
+}
+
+#[test]
+fn update_partner_status_unknown_partner_faults() {
+    let svc = service();
+    // No partner registered: UpdatePartnerStatus must fault instead of a silent
+    // 200 that pretends the update succeeded.
+    assert_eq!(
+        err_code(
+            &svc,
+            "UpdatePartnerStatus",
+            &[
+                ("AccountId", "123456789012"),
+                ("ClusterIdentifier", "c1"),
+                ("DatabaseName", "db1"),
+                ("PartnerName", "ghost"),
+                ("Status", "Active"),
+            ],
+        ),
+        "PartnerNotFound"
+    );
+}
+
+#[test]
+fn update_partner_status_existing_partner_persists() {
+    let svc = service();
+    ok(
+        &svc,
+        "AddPartner",
+        &[
+            ("AccountId", "123456789012"),
+            ("ClusterIdentifier", "c1"),
+            ("DatabaseName", "db1"),
+            ("PartnerName", "datashare"),
+        ],
+    );
+    ok(
+        &svc,
+        "UpdatePartnerStatus",
+        &[
+            ("AccountId", "123456789012"),
+            ("ClusterIdentifier", "c1"),
+            ("DatabaseName", "db1"),
+            ("PartnerName", "datashare"),
+            ("Status", "Inactive"),
+            ("StatusMessage", "paused"),
+        ],
+    );
+    let listed = ok(
+        &svc,
+        "DescribePartners",
+        &[
+            ("AccountId", "123456789012"),
+            ("ClusterIdentifier", "c1"),
+            ("DatabaseName", "db1"),
+        ],
+    );
+    assert!(
+        listed.contains("<Status>Inactive</Status>"),
+        "DescribePartners should reflect the updated status: {listed}"
+    );
+}

--- a/crates/fakecloud-sns/src/service_publish.rs
+++ b/crates/fakecloud-sns/src/service_publish.rs
@@ -46,6 +46,19 @@ impl SnsService {
                     "Subject must be less than 100 characters",
                 ));
             }
+            // AWS also requires the Subject to begin with a letter, number, or
+            // punctuation mark and to contain no line breaks or control
+            // characters. Reject leading whitespace and any control char while
+            // leaving the existing (byte-multibyte) length handling untouched.
+            let starts_with_whitespace = subj.chars().next().is_some_and(char::is_whitespace);
+            let has_control_char = subj.chars().any(char::is_control);
+            if starts_with_whitespace || has_control_char {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameter",
+                    "Invalid parameter: Subject must be ASCII text that begins with a letter, number, or punctuation mark, and must not contain line breaks or control characters",
+                ));
+            }
         }
 
         // Parse MessageAttributes from query params

--- a/crates/fakecloud-sns/src/service_tests.rs
+++ b/crates/fakecloud-sns/src/service_tests.rs
@@ -743,6 +743,53 @@ fn publish_subject_length_counts_characters_not_bytes() {
 }
 
 #[test]
+fn publish_rejects_subject_with_control_chars_or_leading_whitespace() {
+    // AWS requires the Subject to begin with a letter, number, or punctuation
+    // mark and to contain no line breaks or control characters.
+    let (svc, _state) = make_sns();
+    assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "ctrl-topic")])));
+    let topic_arn = "arn:aws:sns:us-east-1:123456789012:ctrl-topic";
+
+    // A normal subject is accepted.
+    assert_ok(&svc.publish(&sns_request(
+        "Publish",
+        vec![
+            ("TopicArn", topic_arn),
+            ("Message", "hi"),
+            ("Subject", "All good 1."),
+        ],
+    )));
+
+    // A newline in the subject is rejected.
+    let err = svc
+        .publish(&sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Message", "hi"),
+                ("Subject", "line one\nline two"),
+            ],
+        ))
+        .err()
+        .expect("newline subject must be rejected");
+    assert_eq!(err.code(), "InvalidParameter");
+
+    // Leading whitespace is rejected.
+    let err = svc
+        .publish(&sns_request(
+            "Publish",
+            vec![
+                ("TopicArn", topic_arn),
+                ("Message", "hi"),
+                ("Subject", " leading space"),
+            ],
+        ))
+        .err()
+        .expect("leading-whitespace subject must be rejected");
+    assert_eq!(err.code(), "InvalidParameter");
+}
+
+#[test]
 fn publish_to_topic_stores_message() {
     let (svc, state) = make_sns();
     assert_ok(&svc.create_topic(&sns_request("CreateTopic", vec![("Name", "pub-topic")])));

--- a/crates/fakecloud-swf/src/service.rs
+++ b/crates/fakecloud-swf/src/service.rs
@@ -1009,6 +1009,14 @@ impl SwfService {
                     "Unknown execution: {workflow_id}"
                 )));
             };
+            // Signal/RequestCancel/Terminate only apply to a running (OPEN)
+            // execution. AWS returns UnknownResourceFault when the resolved
+            // execution is already CLOSED, so do not mutate a closed run.
+            if exec.status != "OPEN" {
+                return Err(unknown_resource(format!(
+                    "Unknown execution: {workflow_id}"
+                )));
+            }
             let mut attrs = Map::new();
             attrs.insert("signalName".into(), json!(signal_name));
             if let Some(i) = &input {
@@ -1044,6 +1052,14 @@ impl SwfService {
                     "Unknown execution: {workflow_id}"
                 )));
             };
+            // Signal/RequestCancel/Terminate only apply to a running (OPEN)
+            // execution. AWS returns UnknownResourceFault when the resolved
+            // execution is already CLOSED, so do not mutate a closed run.
+            if exec.status != "OPEN" {
+                return Err(unknown_resource(format!(
+                    "Unknown execution: {workflow_id}"
+                )));
+            }
             exec.cancel_requested = true;
             push_event(
                 exec,
@@ -1078,6 +1094,14 @@ impl SwfService {
                     "Unknown execution: {workflow_id}"
                 )));
             };
+            // Signal/RequestCancel/Terminate only apply to a running (OPEN)
+            // execution. AWS returns UnknownResourceFault when the resolved
+            // execution is already CLOSED, so do not mutate a closed run.
+            if exec.status != "OPEN" {
+                return Err(unknown_resource(format!(
+                    "Unknown execution: {workflow_id}"
+                )));
+            }
             let mut attrs = Map::new();
             if let Some(r) = &reason {
                 attrs.insert("reason".into(), json!(r));
@@ -2825,5 +2849,60 @@ mod tests {
             child_desc["executionInfo"]["execution"]["workflowId"],
             "w-child"
         );
+    }
+
+    #[test]
+    fn signal_and_terminate_reject_closed_execution() {
+        let svc = service();
+        call(
+            &svc,
+            "RegisterDomain",
+            json!({ "name": "d", "workflowExecutionRetentionPeriodInDays": "1" }),
+        )
+        .unwrap();
+        register_wf(&svc, "wf");
+        let (_run, _dtoken) = start_and_poll(&svc, "w1", "wf");
+
+        // Signalling a running (OPEN) execution still works.
+        call(
+            &svc,
+            "SignalWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1", "signalName": "go" }),
+        )
+        .unwrap();
+
+        // Terminate closes the execution.
+        call(
+            &svc,
+            "TerminateWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1" }),
+        )
+        .unwrap();
+
+        // Now the execution is CLOSED: signal/cancel/terminate must fault rather
+        // than mutate the closed run.
+        let sig_err = call(
+            &svc,
+            "SignalWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1", "signalName": "go" }),
+        )
+        .unwrap_err();
+        assert_eq!(sig_err, "UnknownResourceFault");
+
+        let cancel_err = call(
+            &svc,
+            "RequestCancelWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1" }),
+        )
+        .unwrap_err();
+        assert_eq!(cancel_err, "UnknownResourceFault");
+
+        let term_err = call(
+            &svc,
+            "TerminateWorkflowExecution",
+            json!({ "domain": "d", "workflowId": "w1" }),
+        )
+        .unwrap_err();
+        assert_eq!(term_err, "UnknownResourceFault");
     }
 }


### PR DESCRIPTION
## Summary
The final LOW-severity cluster from the 2026-07-22 bug hunt. Each confirmed against the handler, each with a regression test; per-service conformance verified locally (all green).

- **athena**: `CancelCapacityReservation` now settles `CANCELLING -> CANCELLED` on read instead of hanging; `DeleteDataCatalog` echoes the deleted catalog's real Name+Type instead of empty strings.
- **opensearch**: `GetDomainMaintenanceStatus` reflects the stored maintenance (by `MaintenanceId`) instead of a hardcoded `COMPLETED`.
- **redshift**: `ModifyAquaConfiguration` echoes the requested/stored `AquaStatus` instead of hardcoded `disabled`; `UpdatePartnerStatus` returns `PartnerNotFoundFault` for an unknown partner instead of a silent 200.
- **swf**: Signal/RequestCancel/Terminate now return `UnknownResourceFault` for a CLOSED/absent execution instead of mutating a closed one.
- **sns**: `Publish` rejects a Subject with leading whitespace or control chars (`InvalidParameter`).
- **ec2**: `DescribeImages` now supports `MaxResults`/`NextToken` pagination.

## Test plan
- 9 new tests (one+ per fix).
- `cargo nextest` on the six crates: 562 passed. Conformance: athena 70/70, opensearch 1/1, redshift 10/10, sns 42/42, ec2 image subset 48/48 (swf has no conformance binary). No test weakened.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

This completes the 2026-07-22 bug-hunt report (all tiers shipped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple AWS compatibility gaps across Athena, OpenSearch, Redshift, SWF, SNS, and EC2. Adds correct status handling, input validation, and `DescribeImages` pagination.

- **Bug Fixes**
  - `fakecloud-athena`: `CancelCapacityReservation` now settles CANCELLING to CANCELLED on subsequent Get/List; `DeleteDataCatalog` echoes the deleted catalog’s real Name and Type.
  - `fakecloud-opensearch`: `GetDomainMaintenanceStatus` reflects the stored maintenance for the given `maintenanceId` (including `Action`); unknown IDs return the default COMPLETED status.
  - `fakecloud-redshift`: `ModifyAquaConfiguration` echoes the requested/stored `AquaStatus`; `UpdatePartnerStatus` returns `PartnerNotFound` for an unregistered partner.
  - `fakecloud-swf`: `SignalWorkflowExecution`, `RequestCancelWorkflowExecution`, and `TerminateWorkflowExecution` now return `UnknownResourceFault` for CLOSED or missing executions and do not mutate closed runs.
  - `fakecloud-sns`: `Publish` rejects a `Subject` with leading whitespace or control characters with `InvalidParameter`.
  - `fakecloud-ec2`: `DescribeImages` supports `MaxResults`/`NextToken` pagination.

<sup>Written for commit d7a15c0355612a4cd0fc08e08d3c80ed163ae7e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

