### PR TITLE
chore(release): bump workspace to v0.44.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acmpca"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-amplify"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appsync"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4725,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4947,7 +4947,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-comprehend"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-config"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-docdb"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-efs"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticbeanstalk"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-emr"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-fis"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5853,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5873,7 +5873,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iot"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iotdata"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iotwireless"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kafka"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesisanalyticsv2"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-managedblockchain"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6142,7 +6142,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mediaconvert"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mq"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6204,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mwaa"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-neptune"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6284,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6303,7 +6303,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pinpoint"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6340,7 +6340,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6357,7 +6357,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6465,7 +6465,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6511,7 +6511,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53resolver"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sagemaker"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6630,7 +6630,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6662,7 +6662,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-serverlessrepo"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-shield"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-support"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-swf"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6977,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-textract"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -7004,7 +7004,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-timestream"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transcribe"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7065,7 +7065,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-translate"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7109,7 +7109,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-xray"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -118,387 +118,387 @@ features = [ "json", "multipart",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-shield]
 path = "crates/fakecloud-shield"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-docdb]
 path = "crates/fakecloud-docdb"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-neptune]
 path = "crates/fakecloud-neptune"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-textract]
 path = "crates/fakecloud-textract"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-transcribe]
 path = "crates/fakecloud-transcribe"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-translate]
 path = "crates/fakecloud-translate"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-swf]
 path = "crates/fakecloud-swf"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-pinpoint]
 path = "crates/fakecloud-pinpoint"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-timestream]
 path = "crates/fakecloud-timestream"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-elasticbeanstalk]
 path = "crates/fakecloud-elasticbeanstalk"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-efs]
 path = "crates/fakecloud-efs"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-mq]
 path = "crates/fakecloud-mq"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-kafka]
 path = "crates/fakecloud-kafka"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-fis]
 path = "crates/fakecloud-fis"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-emr]
 path = "crates/fakecloud-emr"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-mwaa]
 path = "crates/fakecloud-mwaa"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-kinesisanalyticsv2]
 path = "crates/fakecloud-kinesisanalyticsv2"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-route53resolver]
 path = "crates/fakecloud-route53resolver"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-acmpca]
 path = "crates/fakecloud-acmpca"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-config]
 path = "crates/fakecloud-config"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.kube]
 version = "0.95"
@@ -511,49 +511,49 @@ features = ["latest"]
 
 [workspace.dependencies.fakecloud-xray]
 path = "crates/fakecloud-xray"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-amplify]
 path = "crates/fakecloud-amplify"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-appsync]
 path = "crates/fakecloud-appsync"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-mediaconvert]
 path = "crates/fakecloud-mediaconvert"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-serverlessrepo]
 path = "crates/fakecloud-serverlessrepo"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-iot]
 path = "crates/fakecloud-iot"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-iotdata]
 path = "crates/fakecloud-iotdata"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-iotwireless]
 path = "crates/fakecloud-iotwireless"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-sagemaker]
 path = "crates/fakecloud-sagemaker"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-managedblockchain]
 path = "crates/fakecloud-managedblockchain"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-comprehend]
 path = "crates/fakecloud-comprehend"
-version = "0.43.0"
+version = "0.44.0"
 
 [workspace.dependencies.fakecloud-support]
 path = "crates/fakecloud-support"
-version = "0.43.0"
+version = "0.44.0"
 

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.43.0")
+    testImplementation("dev.fakecloud:fakecloud:0.44.0")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.43.0</version>
+    <version>0.44.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -394,7 +394,7 @@ import dev.fakecloud.Types.BedrockResponseRule;
 import java.util.List;
 
 FakeCloud fc = new FakeCloud();
-String modelId = "anthropic.claude-3-haiku-20.43.07-v1:0";
+String modelId = "anthropic.claude-3-haiku-20.44.07-v1:0";
 
 // beforeEach
 fc.reset();

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.43.0"
+version = "0.44.0"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.43.0"
+version = "0.44.0"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.44.0. Bumps the workspace + all SDK versions (0.43.0 -> 0.44.0).

Since v0.43.0: the 2026-07-22 bug-hunt (13 fix PRs across Tier 0-5 + LOW tail — region-in-ARN family, CFN UpdateStack/SAM transforms, SSM/EventBridge->Logs persistence, ACM PEM panic, ECR OCI blocking, Kafka UPDATING restart, DynamoDB set/transact validation, and a wide write/read-asymmetry + fabricated-success cleanup), plus feat(dynamodb) multi-table import and feat(rds) postgres 17.x.

## Files
- `Cargo.toml` (workspace.package version + all fakecloud-* dep pins), `Cargo.lock`
- `sdks/typescript/package.json`, `sdks/python/pyproject.toml`, `sdks/java/build.gradle.kts` + `README.md`

No new crates -> release.yml publish list unchanged. Mechanical bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.44.0. Bumps the Rust workspace and all SDKs from 0.43.0 to 0.44.0 to publish the latest fixes and features.

- **Dependencies**
  - Set all workspace crates to `0.44.0` in `Cargo.toml` and `Cargo.lock`.
  - Updated SDKs: `sdks/typescript/package.json` (`fakecloud@0.44.0`), `sdks/python/pyproject.toml` (`fakecloud==0.44.0`), `sdks/java` (`version` and README to `0.44.0`).
  - No new crates; release workflow unchanged.

- **Migration**
  - Upgrade to `fakecloud@0.44.0` (npm), `fakecloud==0.44.0` (pip), or `dev.fakecloud:fakecloud:0.44.0` (Maven/Gradle). No code changes in this PR.

<sup>Written for commit 14aebc827f6fcacba5066989b1f3b7bb3f84bed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

