### PR TITLE
fix(apigateway): guard VTL quote-strip against lone-quote slice panic

### DIFF
--- a/crates/fakecloud-apigateway/src/vtl.rs
+++ b/crates/fakecloud-apigateway/src/vtl.rs
@@ -384,9 +384,13 @@ fn eval_expr(expr: &str, ctx: &mut Context) -> Value {
     if expr.is_empty() {
         return Value::Null;
     }
-    // String literal
-    if (expr.starts_with('\'') && expr.ends_with('\''))
-        || (expr.starts_with('"') && expr.ends_with('"'))
+    // String literal. The `len() >= 2` guard is load-bearing: a lone `'` or `"`
+    // satisfies both `starts_with` and `ends_with` (the single char is
+    // simultaneously first and last), which would make `expr[1..expr.len() - 1]`
+    // slice `[1..0]` and panic, dropping the connection.
+    if expr.len() >= 2
+        && ((expr.starts_with('\'') && expr.ends_with('\''))
+            || (expr.starts_with('"') && expr.ends_with('"')))
     {
         return Value::String(expr[1..expr.len() - 1].to_string());
     }
@@ -565,8 +569,9 @@ fn access_property(val: &Value, prop: &str) -> Value {
     } else {
         prop
     };
-    let prop = if (prop.starts_with('\'') && prop.ends_with('\''))
-        || (prop.starts_with('"') && prop.ends_with('"'))
+    let prop = if prop.len() >= 2
+        && ((prop.starts_with('\'') && prop.ends_with('\''))
+            || (prop.starts_with('"') && prop.ends_with('"')))
     {
         &prop[1..prop.len() - 1]
     } else {
@@ -1080,5 +1085,40 @@ mod tests {
         let mut ctx = Context::new().with_var("util", json!({"_type":"util"}));
         let out = render(r#"$util.base64Encode('hello')"#, &mut ctx);
         assert_eq!(out, "aGVsbG8=");
+    }
+
+    #[test]
+    fn eval_expr_lone_quote_does_not_panic() {
+        // A lone `'` or `"` satisfies both starts_with and ends_with; without the
+        // len>=2 guard `expr[1..expr.len()-1]` slices [1..0] and panics, dropping
+        // the connection. Treat it as a plain one-char string instead.
+        let mut ctx = Context::new();
+        assert_eq!(eval_expr("'", &mut ctx), Value::String("'".to_string()));
+        assert_eq!(eval_expr("\"", &mut ctx), Value::String("\"".to_string()));
+        // Balanced literals still strip.
+        assert_eq!(eval_expr("'hi'", &mut ctx), Value::String("hi".to_string()));
+        assert_eq!(eval_expr("''", &mut ctx), Value::String(String::new()));
+    }
+
+    #[test]
+    fn access_property_lone_quote_does_not_panic() {
+        // Same guard on access_property's quote-strip: a bare-quote property
+        // segment must not panic.
+        let obj = json!({"'": "v", "k": "w"});
+        assert_eq!(access_property(&obj, "'"), Value::String("v".to_string()));
+        assert_eq!(access_property(&obj, "\""), Value::Null);
+        // Balanced-quoted key still resolves.
+        assert_eq!(access_property(&obj, "'k'"), Value::String("w".to_string()));
+    }
+
+    #[test]
+    fn lone_quote_template_renders_without_crash() {
+        // End-to-end: the exact template from the bug report must render without
+        // unwinding (pre-fix it panicked and dropped the connection). The rendered
+        // value itself is incidental; not crashing is the contract under test.
+        let mut ctx = Context::new();
+        let _ = render("#set($x = ')$x", &mut ctx);
+        let mut ctx2 = Context::new().with_var("obj", json!({"a": 1}));
+        let _ = render("$obj.'", &mut ctx2);
     }
 }


### PR DESCRIPTION
## Summary
A reachable request-path panic in the API Gateway VTL engine. `eval_expr`'s string-literal strip (`vtl.rs`) and `access_property`'s quote-strip both tested `starts_with(q) && ends_with(q)` on the same quote character with **no length guard**. A lone `'` or `"` satisfies both conditions (the single char is simultaneously first and last), so `expr[1..expr.len()-1]` sliced `[1..0]` and panicked ("slice index starts at 1 but ends at 0"). With `panic=unwind` and no `catch_unwind` in the request path, the task unwinds and hyper drops the connection — the #1539 "connection closed before we received a valid response" symptom class — rather than returning a clean error.

Trigger: any integration mapping template such as `#set(\$x = ')` or a property reference ending in a bare quote (`\$context.'`), then any request routed through that integration.

Fix: add a `len() >= 2` guard to both strip sites, matching the sibling strip sites that already carry it (`partiql.rs:1307`, `execute.rs:658`). A lone quote is now treated as a plain one-char string; balanced 2+char quoted literals still strip as before.

Found by the 2026-07-23 bug-hunt (Tier 2, class: panics).

## Test plan
- `eval_expr_lone_quote_does_not_panic` — direct call on `'`/`"` returns the char as a string; balanced `'hi'`/`''` still strip.
- `access_property_lone_quote_does_not_panic` — bare-quote property segment resolves without panic; balanced-quoted key still resolves.
- `lone_quote_template_renders_without_crash` — end-to-end render of the reported template unwinds no longer.
- `cargo test -p fakecloud-apigateway vtl::` (23 passed), `cargo clippy -p fakecloud-apigateway --all-targets -D warnings` clean.

## Surface impact
No API surface, flag, endpoint, field, or count change — internal robustness fix. No docs/SDK/website/metadata update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a slice panic in the API Gateway VTL engine when parsing a lone `'` or `"`, which could drop the connection. Templates like `#set($x = ')` and property refs ending with a bare quote now render without crashing.

- **Bug Fixes**
  - Add `len() >= 2` guard before stripping quotes in `vtl.rs` (`eval_expr`, `access_property`); lone quotes return as a one-char string, balanced quotes still strip.
  - Add regression tests for lone quotes and end-to-end rendering of `#set($x = ')` and `$obj.'`.

<sup>Written for commit 9c04864271bf5310a765a07e422a98bac435534a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

