### PR TITLE
fix(cloudformation): skip unchanged resources on UpdateStack instead of reprovisioning them

### DIFF
--- a/crates/fakecloud-cloudformation/src/service.rs
+++ b/crates/fakecloud-cloudformation/src/service.rs
@@ -2968,6 +2968,50 @@ pub(crate) fn apply_resource_updates(
         .map(|r| (r.logical_id.clone(), r.attributes.clone()))
         .collect();
 
+    // Resolve the OLD template's properties per logical id so an existing
+    // resource whose effective (resolved) definition is unchanged can be left
+    // completely untouched. Without this, every resource present in both
+    // templates was fed to `update_resource` on every deploy — and for any
+    // type lacking a dedicated in-place `update_*` arm that routes to
+    // `reprovision_resource` (delete + recreate). A single unrelated change
+    // (or an identical re-deploy) therefore tore down and recreated every
+    // co-existing ElastiCache/EC2/OpenSearch container and cascaded Glue
+    // database deletes, flushing their data while reporting UPDATE_COMPLETE.
+    // `stack.template`/`stack.parameters` still hold the pre-update values here
+    // (both callers overwrite them only after this function returns), and the
+    // `physical_ids`/`attributes` maps built above are the old stack's, so
+    // resolving against them yields the previous effective definition. Using
+    // the RESOLVED form (not the raw authored properties) means a resource
+    // whose `Ref`/`GetAtt` target was replaced still resolves to a new value
+    // and is correctly updated.
+    let old_resolved: BTreeMap<String, serde_json::Value> = {
+        let old_template = stack.template.clone();
+        let old_parameters = stack.parameters.clone();
+        let old_physical_ids = physical_ids.clone();
+        let old_attributes = attributes.clone();
+        match template::parse_template(&old_template, &old_parameters) {
+            Ok(parsed_old) => parsed_old
+                .resources
+                .iter()
+                .filter_map(|def| {
+                    template::resolve_resource_properties_with_attrs(
+                        def,
+                        &old_template,
+                        &old_parameters,
+                        &old_physical_ids,
+                        &old_attributes,
+                        imports,
+                    )
+                    .ok()
+                    .map(|resolved| (def.logical_id.clone(), resolved.properties))
+                })
+                .collect(),
+            // If the old template no longer parses, fall back to always
+            // attempting the update (prior behavior) rather than skipping.
+            Err(_) => BTreeMap::new(),
+        }
+    };
+
     // Create new resources / update resources that already exist. Provision in
     // dependency order so a `Ref`/`GetAtt`/`Fn::Sub`/`DependsOn` to another
     // resource resolves to that resource's physical id rather than its bare
@@ -3027,6 +3071,18 @@ pub(crate) fn apply_resource_updates(
             // resource types that don't support updates yet; in that case
             // the existing resource stays as-is so the rest of the stack
             // continues to validate.
+            // Skip resources whose resolved definition is unchanged: real
+            // CloudFormation performs no action and records no `ResourceChange`
+            // for an untouched resource. Critically, this prevents the
+            // replacement fallback (`reprovision_resource`) from destroying and
+            // recreating a stateful backing resource (cache/db/instance) or
+            // cascading a Glue-database delete on an unrelated stack update.
+            if old_resolved
+                .get(&resource_def.logical_id)
+                .is_some_and(|old_props| *old_props == resolved_def.properties)
+            {
+                continue;
+            }
             let existing = stack
                 .resources
                 .iter()

--- a/crates/fakecloud-e2e/tests/cloudformation_update_preserves_unchanged.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_update_preserves_unchanged.rs
@@ -1,0 +1,130 @@
+//! Regression coverage for the CloudFormation `UpdateStack` /
+//! `ExecuteChangeSet` "reprovision-unchanged" data-loss bug.
+//!
+//! `apply_resource_updates` used to feed EVERY resource present in both the old
+//! and new template to `update_resource`, regardless of whether its properties
+//! changed. For any resource type without a dedicated in-place `update_*` arm
+//! (e.g. `AWS::Glue::Database`), that routed to `reprovision_resource`, which
+//! deletes and recreates the backing resource. So a single UNRELATED change to
+//! a stack (here: adding an SNS topic) tore down and recreated every unchanged
+//! resource — cascading a Glue database delete that wiped any table created in
+//! it, while the stack still reported `UPDATE_COMPLETE`.
+//!
+//! After the fix, a resource whose resolved definition is unchanged is left
+//! completely untouched: the table created in the Glue database survives the
+//! unrelated update.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "GlueDb": {
+      "Type": "AWS::Glue::Database",
+      "Properties": {
+        "DatabaseInput": {"Name": "cfn-preserve-db", "Description": "keep me"}
+      }
+    }
+  }
+}"#;
+
+// Identical Glue database, plus one unrelated new resource (an SNS topic).
+const TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "GlueDb": {
+      "Type": "AWS::Glue::Database",
+      "Properties": {
+        "DatabaseInput": {"Name": "cfn-preserve-db", "Description": "keep me"}
+      }
+    },
+    "UnrelatedTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {"TopicName": "cfn-preserve-unrelated"}
+    }
+  }
+}"#;
+
+async fn wait_for_status(server: &TestServer, stack: &str, want: &str) {
+    let cfn = server.cloudformation_client().await;
+    let got = helpers::wait_until(std::time::Duration::from_secs(10), || {
+        let cfn = cfn.clone();
+        async move {
+            let out = cfn.describe_stacks().stack_name(stack).send().await.ok()?;
+            let status = out.stacks().first()?.stack_status()?;
+            (status.as_str() == want).then_some(())
+        }
+    })
+    .await;
+    assert!(got.is_some(), "stack {stack} never reached {want}");
+}
+
+#[tokio::test]
+async fn cfn_update_leaves_unchanged_resource_untouched() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+
+    cfn.create_stack()
+        .stack_name("preserve")
+        .template_body(TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "preserve", "CREATE_COMPLETE").await;
+
+    // Create a table in the Glue database out-of-band (the way real usage adds
+    // data the CFN provisioner never sees).
+    let glue = server.glue_client().await;
+    glue.create_table()
+        .database_name("cfn-preserve-db")
+        .table_input(
+            aws_sdk_glue::types::TableInput::builder()
+                .name("keep-me")
+                .build()
+                .expect("table_input"),
+        )
+        .send()
+        .await
+        .expect("create_table");
+
+    // Sanity: the table exists before the update.
+    glue.get_table()
+        .database_name("cfn-preserve-db")
+        .name("keep-me")
+        .send()
+        .await
+        .expect("get_table before update");
+
+    // Apply an UNRELATED change (add an SNS topic). The Glue database is
+    // identical between the two templates and must not be reprovisioned.
+    cfn.update_stack()
+        .stack_name("preserve")
+        .template_body(TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "preserve", "UPDATE_COMPLETE").await;
+
+    // The out-of-band table must survive: pre-fix, the database was
+    // delete+recreated and this 404s.
+    let table = glue
+        .get_table()
+        .database_name("cfn-preserve-db")
+        .name("keep-me")
+        .send()
+        .await
+        .expect("table must survive an unrelated stack update");
+    assert_eq!(table.table().map(|t| t.name()), Some("keep-me"));
+
+    // The unrelated resource was actually added.
+    let sns = server.sns_client().await;
+    let topics = sns.list_topics().send().await.expect("list_topics");
+    assert!(
+        topics.topics().iter().any(|t| t
+            .topic_arn()
+            .is_some_and(|a| a.ends_with(":cfn-preserve-unrelated"))),
+        "the unrelated SNS topic should have been provisioned by the update"
+    );
+}


### PR DESCRIPTION
## Summary
**HIGH data-loss / downtime on routine redeploys.** `apply_resource_updates` diffed resources only by logical-id **set membership** — it fed *every* resource present in both the old and new template to `update_resource`, with no property comparison. For any resource type without a dedicated in-place `update_*` arm, `update_resource` routes to `reprovision_resource` (delete + recreate). So the 2nd `sam deploy` / `cdk deploy` / `aws cloudformation deploy` of **any** stack — or even an identical re-deploy — tore down and recreated every co-existing resource whose type lacks an update arm:

- `AWS::ElastiCache::CacheCluster`/`ReplicationGroup`, `AWS::EC2::Instance`, `AWS::OpenSearchService::Domain` — backing container **destroyed and recreated empty** (cache/data loss + connection downtime).
- `AWS::Glue::Database` — delete **cascades its tables/partitions**; Timestream/EMR/Redshift similar.

The stack still reported `UPDATE_COMPLETE`, so it failed silently as success. Introduced by the #2366 `reprovision_resource` fallback (which correctly replaced the earlier silent "UpdateStack no-op", but over-applied it to *unchanged* resources).

## Fix
Gate `update_resource` on an actual **resolved-property diff**. `apply_resource_updates` resolves the old template's properties per logical id (`stack.template`/`stack.parameters` still hold the pre-update values at call time — both callers overwrite them only after it returns) against the old physical-id/attribute maps, and skips any resource whose resolved definition equals the new one — leaving it untouched and recording no `ResourceChange`, exactly as real CloudFormation does for an unmodified resource. Using the **resolved** form (not raw authored properties) means a resource whose `Ref`/`GetAtt` target was replaced still resolves to a new value and is correctly updated. Also closes the sibling dangling-reference issue (reprovision regenerated a physical id that already-processed dependents had captured).

Both `UpdateStack` and `ExecuteChangeSet` (CDK / `aws cloudformation deploy`) inherit the fix, since it lives inside `apply_resource_updates`. If the old template no longer parses, it falls back to the prior always-attempt-update behavior.

Found by the 2026-07-23 bug-hunt (Tier 1, headline; class: orchestration).

## Test plan
- New `cloudformation_update_preserves_unchanged`: create a stack with a Glue `Database`, create a table in it out-of-band, then `UpdateStack` adding an unrelated SNS topic — the table **survives** (pre-fix the database was delete+recreated and the table 404'd), and the unrelated topic is provisioned.
- `cloudformation_execute_change_set` (modify-only / add-and-remove / events) + `cloudformation_update_stack` pass unchanged (nextest).
- `cargo clippy -p fakecloud-cloudformation --all-targets -D warnings` clean.
- (`cloudformation_custom_resource_invokes_lambda` is Docker/Lambda-backed and only runs green in CI's Docker environment.)

## Surface impact
No API surface / flag / field / count change — provisioner-behavior correctness fix. No docs/SDK/website/metadata update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip unchanged resources during CloudFormation updates to stop accidental reprovisioning of stateful resources, preventing data loss and downtime. Applies to both `UpdateStack` and `ExecuteChangeSet`.

- **Bug Fixes**
  - Gate updates on a resolved-property diff between old and new definitions; unchanged resources are skipped with no `ResourceChange`.
  - Use resolved values to detect `Ref`/`GetAtt` target changes, so dependent resources update when needed.
  - Prevent fallback `reprovision_resource` from deleting/recreating stateful resources on identical or unrelated redeploys (e.g., `AWS::Glue::Database`, `AWS::ElastiCache::*`, `AWS::EC2::Instance`, `AWS::OpenSearchService::Domain`).
  - If the old template cannot be parsed, fall back to the previous attempt-update behavior.
  - Add regression test `cloudformation_update_preserves_unchanged` that preserves a Glue table while adding an unrelated SNS topic.

<sup>Written for commit ebeeec390afa67834cbdc778c04c1f5725f72eac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

