### PR TITLE
fix(ecs,rds,dynamodb,elasticache,kinesis,ecr,scheduler,ssm,cognito,ses,apigatewayv2): build client-visible ARNs from the request region

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -48,7 +48,7 @@ fn to_camel(v: Value) -> Value {
 /// fills in: `DomainNameStatus = AVAILABLE`, plus a regional endpoint name and
 /// hosted-zone id. The Terraform provider's create-waiter reads
 /// `DomainNameStatus`, so it must be present.
-fn domain_configs_with_status(configs: Option<&Value>, domain: &str) -> Value {
+fn domain_configs_with_status(configs: Option<&Value>, domain: &str, region: &str) -> Value {
     let mut arr = match configs.and_then(|c| c.as_array()) {
         Some(a) if !a.is_empty() => a.clone(),
         _ => vec![json!({})],
@@ -61,7 +61,7 @@ fn domain_configs_with_status(configs: Option<&Value>, domain: &str) -> Value {
             if !obj.contains_key("ApiGatewayDomainName") {
                 obj.insert(
                     "ApiGatewayDomainName".into(),
-                    json!(format!("d-{domain}.execute-api.us-east-1.amazonaws.com")),
+                    json!(format!("d-{domain}.execute-api.{region}.amazonaws.com")),
                 );
             }
             if !obj.contains_key("HostedZoneId") {
@@ -538,11 +538,14 @@ impl ApiGatewayV2Service {
                 // fakecloud provisions domains synchronously, so each
                 // configuration is immediately AVAILABLE. The Terraform
                 // provider's create-waiter polls GetDomainName for that status.
-                let configs =
-                    domain_configs_with_status(body.get("DomainNameConfigurations"), &name);
+                let configs = domain_configs_with_status(
+                    body.get("DomainNameConfigurations"),
+                    &name,
+                    req.region.as_str(),
+                );
                 let mut entry = json!({
                     "DomainName": name,
-                    "DomainNameArn": Arn::new("apigateway", "us-east-1", "", &format!("/domainnames/{name}")).to_string(),
+                    "DomainNameArn": Arn::new("apigateway", req.region.as_str(), "", &format!("/domainnames/{name}")).to_string(),
                     "DomainNameConfigurations": configs,
                     "ApiMappingSelectionExpression": "$request.basepath",
                     "RoutingMode": "API_MAPPING_ONLY",
@@ -583,8 +586,11 @@ impl ApiGatewayV2Service {
                     .get_mut(name)
                     .ok_or_else(|| not_found("DomainName", name))?;
                 if body.get("DomainNameConfigurations").is_some() {
-                    entry["DomainNameConfigurations"] =
-                        domain_configs_with_status(body.get("DomainNameConfigurations"), name);
+                    entry["DomainNameConfigurations"] = domain_configs_with_status(
+                        body.get("DomainNameConfigurations"),
+                        name,
+                        req.region.as_str(),
+                    );
                 }
                 // Previously dropped (bug-hunt 2026-06-24, 1.11): the mTLS
                 // truststore config could not be updated.
@@ -1859,7 +1865,7 @@ impl ApiGatewayV2Service {
                 }
                 json!({
                     id_field: id,
-                    "PortalArn": Arn::new("apigateway", "us-east-1", "", &format!("/portals/{id}")).to_string(),
+                    "PortalArn": Arn::new("apigateway", req.region.as_str(), "", &format!("/portals/{id}")).to_string(),
                     "LastModified": now,
                     "LastPublished": now,
                     "LastPublishedDescription": "",
@@ -1875,7 +1881,7 @@ impl ApiGatewayV2Service {
             }
             "portal_products" => json!({
                 id_field: id,
-                "PortalProductArn": Arn::new("apigateway", "us-east-1", "", &format!("/portalproducts/{id}")).to_string(),
+                "PortalProductArn": Arn::new("apigateway", req.region.as_str(), "", &format!("/portalproducts/{id}")).to_string(),
                 "LastModified": now,
                 "Description": input.get("Description").and_then(|x| x.as_str()).unwrap_or(""),
                 "DisplayName": input.get("DisplayName").and_then(|x| x.as_str()).unwrap_or(&id),

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ecr.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ecr.rs
@@ -81,7 +81,7 @@ impl ResourceProvisioner {
         if state.repositories.contains_key(&repository_name) {
             return Err(format!("Repository {repository_name} already exists"));
         }
-        let arn = state.repository_arn(&repository_name);
+        let arn = state.repository_arn(&self.region, &repository_name);
         let registry_id = state.account_id.clone();
         let mut repo = Repository::new(&repository_name, arn.clone(), &registry_id, &endpoint);
         repo.image_tag_mutability = image_tag_mutability;

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -35,7 +35,7 @@ impl ResourceProvisioner {
         let tags = parse_rds_tags(props.get("Tags"));
         let mut accounts = self.rds_state.write();
         let state = accounts.get_or_create(&self.account_id);
-        let arn = state.db_subnet_group_arn(&name);
+        let arn = state.db_subnet_group_arn(&self.region, &name);
         let group = DbSubnetGroup {
             db_subnet_group_name: name.clone(),
             db_subnet_group_arn: arn.clone(),
@@ -89,7 +89,7 @@ impl ResourceProvisioner {
 
         let mut accounts = self.rds_state.write();
         let state = accounts.get_or_create(&self.account_id);
-        let arn = state.db_parameter_group_arn(&name);
+        let arn = state.db_parameter_group_arn(&self.region, &name);
         let group = DbParameterGroup {
             db_parameter_group_name: name.clone(),
             db_parameter_group_arn: arn.clone(),

--- a/crates/fakecloud-cognito/src/service/branding.rs
+++ b/crates/fakecloud-cognito/src/service/branding.rs
@@ -457,9 +457,12 @@ impl CognitoService {
         let challenge = Uuid::new_v4().to_string();
         let user_id = Uuid::new_v4().to_string();
 
+        // The relying-party id host region is read out of the pool id prefix so
+        // it matches the pool's issuer/ARN region, not a hardcoded default.
+        let rp_region = pool_id.split('_').next().unwrap_or("us-east-1");
         let credential_creation_options = json!({
             "rp": {
-                "id": format!("cognito-idp.us-east-1.amazonaws.com/{pool_id}"),
+                "id": format!("cognito-idp.{rp_region}.amazonaws.com/{pool_id}"),
                 "name": "Amazon Cognito"
             },
             "user": {
@@ -606,7 +609,10 @@ impl CognitoService {
         let cred = WebAuthnCredential {
             credential_id,
             friendly_credential_name: friendly_name,
-            relying_party_id: format!("cognito-idp.us-east-1.amazonaws.com/{pool_id}"),
+            relying_party_id: format!(
+                "cognito-idp.{}.amazonaws.com/{pool_id}",
+                pool_id.split('_').next().unwrap_or("us-east-1")
+            ),
             authenticator_attachment,
             authenticator_transport,
             created_at: now,

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -2039,6 +2039,9 @@ fn generate_tokens_with_overrides(
     let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
+    // The issuer region is read back out of the pool id (`{region}_{rand}`) so
+    // the token `iss` always matches the pool's ARN, not the frozen server default.
+    let region = pool_id.split('_').next().unwrap_or(region);
     let iss = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
     let access_ttl = claims.access_ttl();
     let id_ttl = claims.id_ttl();
@@ -2315,6 +2318,9 @@ pub fn oidc_discovery_document(
     base_url: &str,
     pool_domain: Option<&str>,
 ) -> Value {
+    // Issuer region comes from the pool id prefix so the discovery document
+    // matches the token `iss`, not the frozen server default.
+    let region = pool_id.split('_').next().unwrap_or(region);
     let issuer = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
     let trimmed = base_url.trim_end_matches('/');
     let mut doc = serde_json::json!({
@@ -2932,6 +2938,8 @@ fn build_client_credentials_access_token(
 ) -> String {
     let now = Utc::now().timestamp();
     let jti = Uuid::new_v4().to_string();
+    // Issuer region comes from the pool id prefix so `iss` matches the pool ARN.
+    let region = pool_id.split('_').next().unwrap_or(region);
     let iss = format!("https://cognito-idp.{region}.amazonaws.com/{pool_id}");
 
     // Synthesize a keypair on the fly when callers haven't loaded one

--- a/crates/fakecloud-cognito/src/service/user_pools.rs
+++ b/crates/fakecloud-cognito/src/service/user_pools.rs
@@ -93,10 +93,16 @@ impl CognitoService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let pool_id = generate_pool_id(&state.region);
+        // The pool id bakes in the request's credential-scope region
+        // (`{region}_{rand}`) so it becomes the single source of truth for the
+        // pool's region; the ARN and every issuer/discovery derivation read the
+        // region back out of the pool id. Storage is keyed by pool id, unchanged.
+        let pool_id = generate_pool_id(req.region.as_str());
         let arn = format!(
             "arn:aws:cognito-idp:{}:{}:userpool/{}",
-            state.region, state.account_id, pool_id
+            req.region.as_str(),
+            state.account_id,
+            pool_id
         );
 
         let now = Utc::now();
@@ -432,10 +438,13 @@ impl CognitoService {
         // Remove associated domains
         state.domains.retain(|_, d| d.user_pool_id != pool_id);
 
-        // Remove associated tags (match by pool ARN)
+        // Remove associated tags (match by pool ARN). Derive the region from the
+        // pool id prefix so it matches the ARN minted at CreateUserPool time,
+        // regardless of the current server default region.
+        let arn_region = pool_id.split('_').next().unwrap_or(&state.region);
         let arn_prefix = format!(
             "arn:aws:cognito-idp:{}:{}:userpool/{}",
-            state.region, state.account_id, pool_id
+            arn_region, state.account_id, pool_id
         );
         state.tags.remove(&arn_prefix);
 

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -196,14 +196,18 @@ impl DynamoDbService {
         }
 
         let now = Utc::now();
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
-            state.region, state.account_id, table_name
+            req.region.as_str(),
+            state.account_id,
+            table_name
         );
         let stream_arn = if stream_enabled {
             Some(format!(
                 "arn:aws:dynamodb:{}:{}:table/{}/stream/{}",
-                state.region,
+                req.region.as_str(),
                 state.account_id,
                 table_name,
                 now.format("%Y-%m-%dT%H:%M:%S.%3f")
@@ -376,8 +380,9 @@ impl DynamoDbService {
         let state = accounts.get_or_create(&req.account_id);
         // Snapshot region + account before taking a mutable borrow of
         // `state.tables` — we need them to mint a new stream ARN when the
-        // caller flips stream_enabled from false to true mid-update.
-        let region = state.region.clone();
+        // caller flips stream_enabled from false to true mid-update. The stream
+        // ARN carries the request's credential-scope region (req.region).
+        let region = req.region.clone();
         let account_id = state.account_id.clone();
         let table = state.tables.get_mut(table_name).ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -818,7 +823,7 @@ impl DynamoDbService {
         // plus a short unique suffix so every backup gets a distinct ARN.
         let backup_arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}/backup/{:013}-{}",
-            state.region,
+            req.region.as_str(),
             state.account_id,
             table_name,
             now.timestamp_millis(),
@@ -1090,7 +1095,9 @@ impl DynamoDbService {
         let now = Utc::now();
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
-            state.region, state.account_id, target_table_name
+            req.region.as_str(),
+            state.account_id,
+            target_table_name
         );
 
         // Re-mint the stream ARN against the target table name so it
@@ -1196,7 +1203,9 @@ impl DynamoDbService {
         let now = Utc::now();
         let arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
-            state.region, state.account_id, target_table_name
+            req.region.as_str(),
+            state.account_id,
+            target_table_name
         );
 
         let stream_arn = if source.stream_enabled {
@@ -1359,7 +1368,7 @@ impl DynamoDbService {
         let now = Utc::now();
         let export_arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}/export/{}",
-            state.region,
+            req.region.as_str(),
             state.account_id,
             table_arn.rsplit('/').next().unwrap_or("unknown"),
             uuid::Uuid::new_v4()
@@ -1717,11 +1726,13 @@ impl DynamoDbService {
         let now = Utc::now();
         let table_arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}",
-            state.region, state.account_id, table_name
+            req.region.as_str(),
+            state.account_id,
+            table_name
         );
         let import_arn = format!(
             "arn:aws:dynamodb:{}:{}:table/{}/import/{}",
-            state.region,
+            req.region.as_str(),
             state.account_id,
             table_name,
             uuid::Uuid::new_v4()

--- a/crates/fakecloud-e2e/tests/region_scoped_arns.rs
+++ b/crates/fakecloud-e2e/tests/region_scoped_arns.rs
@@ -1,0 +1,158 @@
+//! Regression coverage for the region-in-ARN family (#2356 siblings).
+//!
+//! `MultiAccountState` freezes `region` at server startup and several services
+//! stamped that frozen region into ARNs/ids RETURNED to the client instead of
+//! the request's SigV4 credential-scope region (`req.region`). A resource
+//! created by a provider configured for e.g. `eu-central-1` came back with a
+//! `us-east-1` ARN, which the client stores and reuses — breaking Terraform
+//! drift/refresh and cross-service IAM ARN matching.
+//!
+//! Each check signs its requests for a NON-default region and asserts the
+//! returned ARN/id carries that region, not the server default `us-east-1`.
+
+mod helpers;
+
+use helpers::TestServer;
+
+const REGION: &str = "eu-central-1";
+
+fn assert_region(arn: &str, what: &str) {
+    assert!(
+        arn.contains(REGION),
+        "{what} should carry the request region {REGION}, got: {arn}"
+    );
+    assert!(
+        !arn.contains("us-east-1"),
+        "{what} must not carry the server-default region us-east-1, got: {arn}"
+    );
+}
+
+#[tokio::test]
+async fn returned_arns_use_request_region() {
+    let server = TestServer::start().await;
+    let cfg = server.aws_config_in(REGION).await;
+
+    // DynamoDB table ARN
+    let ddb = aws_sdk_dynamodb::Client::new(&cfg);
+    let table = ddb
+        .create_table()
+        .table_name("region-tbl")
+        .attribute_definitions(
+            aws_sdk_dynamodb::types::AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(aws_sdk_dynamodb::types::ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            aws_sdk_dynamodb::types::KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(aws_sdk_dynamodb::types::KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await
+        .expect("create_table");
+    assert_region(
+        table
+            .table_description()
+            .and_then(|t| t.table_arn())
+            .expect("table_arn"),
+        "DynamoDB TableArn",
+    );
+
+    // Kinesis stream ARN (read back via DescribeStreamSummary)
+    let kinesis = aws_sdk_kinesis::Client::new(&cfg);
+    kinesis
+        .create_stream()
+        .stream_name("region-stream")
+        .shard_count(1)
+        .send()
+        .await
+        .expect("create_stream");
+    let summary = kinesis
+        .describe_stream_summary()
+        .stream_name("region-stream")
+        .send()
+        .await
+        .expect("describe_stream_summary");
+    assert_region(
+        summary
+            .stream_description_summary()
+            .map(|s| s.stream_arn())
+            .expect("stream_arn"),
+        "Kinesis StreamArn",
+    );
+
+    // ECR repository ARN
+    let ecr = aws_sdk_ecr::Client::new(&cfg);
+    let repo = ecr
+        .create_repository()
+        .repository_name("region-repo")
+        .send()
+        .await
+        .expect("create_repository");
+    assert_region(
+        repo.repository()
+            .and_then(|r| r.repository_arn())
+            .expect("repository_arn"),
+        "ECR repositoryArn",
+    );
+
+    // ECS cluster ARN
+    let ecs = aws_sdk_ecs::Client::new(&cfg);
+    let cluster = ecs
+        .create_cluster()
+        .cluster_name("region-cluster")
+        .send()
+        .await
+        .expect("create_cluster");
+    assert_region(
+        cluster
+            .cluster()
+            .and_then(|c| c.cluster_arn())
+            .expect("cluster_arn"),
+        "ECS clusterArn",
+    );
+
+    // RDS DB instance ARN (the create response carries the ARN immediately)
+    let rds = aws_sdk_rds::Client::new(&cfg);
+    let db = rds
+        .create_db_instance()
+        .db_instance_identifier("region-db")
+        .db_instance_class("db.t3.micro")
+        .engine("mysql")
+        .allocated_storage(20)
+        .master_username("admin")
+        .master_user_password("Sup3rSecret!")
+        .send()
+        .await
+        .expect("create_db_instance");
+    assert_region(
+        db.db_instance()
+            .and_then(|d| d.db_instance_arn())
+            .expect("db_instance_arn"),
+        "RDS DBInstanceArn",
+    );
+
+    // Cognito user pool id + ARN: the id encodes the region as a prefix, so it
+    // must be `eu-central-1_...` and the ARN must match.
+    let cognito = aws_sdk_cognitoidentityprovider::Client::new(&cfg);
+    let pool = cognito
+        .create_user_pool()
+        .pool_name("region-pool")
+        .send()
+        .await
+        .expect("create_user_pool")
+        .user_pool()
+        .cloned()
+        .expect("user_pool");
+    let pool_id = pool.id().expect("pool id");
+    assert!(
+        pool_id.starts_with(&format!("{REGION}_")),
+        "Cognito pool id should be prefixed with {REGION}, got: {pool_id}"
+    );
+    assert_region(pool.arn().expect("pool arn"), "Cognito user pool ARN");
+}

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -1283,7 +1283,7 @@ mod immutability_tests {
         let mut mas: MultiAccountState<crate::state::EcrState> =
             MultiAccountState::new(ACCT, "us-east-1", "http://fakecloud:4566");
         let s = mas.get_or_create(ACCT);
-        let arn = s.repository_arn("app");
+        let arn = s.repository_arn("us-east-1", "app");
         let mut repo = Repository::new("app", arn, ACCT, "fakecloud:4566");
         repo.image_tag_mutability = mutability.to_string();
         s.repositories.insert("app".to_string(), repo);

--- a/crates/fakecloud-ecr/src/service/images.rs
+++ b/crates/fakecloud-ecr/src/service/images.rs
@@ -928,7 +928,7 @@ mod pagination_and_validation_tests {
         let mut mas: MultiAccountState<EcrState> =
             MultiAccountState::new(ACCT, "us-east-1", "http://fakecloud:4566");
         let s = mas.get_or_create(ACCT);
-        let arn = s.repository_arn("app");
+        let arn = s.repository_arn("us-east-1", "app");
         s.repositories.insert(
             "app".into(),
             Repository::new("app", arn, ACCT, "fakecloud:4566"),

--- a/crates/fakecloud-ecr/src/service/layers.rs
+++ b/crates/fakecloud-ecr/src/service/layers.rs
@@ -503,7 +503,7 @@ mod concurrency_tests {
         let mut mas: MultiAccountState<EcrState> =
             MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
         let state = mas.get_or_create(ACCOUNT);
-        let arn = state.repository_arn("app");
+        let arn = state.repository_arn("us-east-1", "app");
         let repo = Repository::new("app", arn, ACCOUNT, "fakecloud:4566");
         state.repositories.insert("app".to_string(), repo);
         let shared: SharedEcrState = Arc::new(RwLock::new(mas));

--- a/crates/fakecloud-ecr/src/service/repositories.rs
+++ b/crates/fakecloud-ecr/src/service/repositories.rs
@@ -46,7 +46,7 @@ impl EcrService {
         if state.repositories.contains_key(&name) {
             return Err(repository_already_exists(&name));
         }
-        let arn = state.repository_arn(&name);
+        let arn = state.repository_arn(request.region.as_str(), &name);
         let mut repo = Repository::new(&name, arn, state.registry_id(), &endpoint);
         repo.image_tag_mutability = image_tag_mutability;
         repo.image_scanning_configuration = ImageScanningConfiguration { scan_on_push };

--- a/crates/fakecloud-ecr/src/service_tests.rs
+++ b/crates/fakecloud-ecr/src/service_tests.rs
@@ -317,7 +317,7 @@ fn replicate_image_copies_to_destination_account() {
             repository_filters: Vec::new(),
         }],
     });
-    let arn = source_state.repository_arn("app");
+    let arn = source_state.repository_arn("us-east-1", "app");
     let mut repo = Repository::new("app", arn, SOURCE, "fakecloud:4566");
     repo.images.insert(
         "sha256:abc".to_string(),
@@ -573,7 +573,7 @@ mod replication_tests {
         if !rules.is_empty() {
             source.replication_configuration = Some(ReplicationConfiguration { rules });
         }
-        let arn = source.repository_arn("app");
+        let arn = source.repository_arn("us-east-1", "app");
         let repo = Repository::new("app", arn, SOURCE, "fakecloud:4566");
         source.repositories.insert("app".to_string(), repo);
         let state: SharedEcrState = Arc::new(RwLock::new(mas));
@@ -800,7 +800,7 @@ mod repo_policy_enforcement_tests {
         let mut mas: MultiAccountState<EcrState> =
             MultiAccountState::new(OWNER, "us-east-1", "http://fakecloud:4566");
         let owner = mas.get_or_create(OWNER);
-        let arn = owner.repository_arn("app");
+        let arn = owner.repository_arn("us-east-1", "app");
         let mut repo = Repository::new("app", arn, OWNER, "fakecloud:4566");
         repo.policy = policy.map(|s| s.to_string());
         // Seed an image so BatchGetImage has something to look up after the
@@ -1068,7 +1068,7 @@ mod scan_on_push_tests {
             MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
         let state = mas.get_or_create(ACCOUNT);
         state.registry_scanning_configuration = registry_cfg;
-        let arn = state.repository_arn(repo_name);
+        let arn = state.repository_arn("us-east-1", repo_name);
         let mut repo = Repository::new(repo_name, arn, ACCOUNT, "fakecloud:4566");
         repo.image_scanning_configuration = ImageScanningConfiguration {
             scan_on_push: repo_scan_on_push,
@@ -1257,7 +1257,7 @@ mod lifecycle_timestamp_tests {
         let mut mas: MultiAccountState<EcrState> =
             MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
         let s = mas.get_or_create(ACCOUNT);
-        let arn = s.repository_arn("app");
+        let arn = s.repository_arn("us-east-1", "app");
         let mut repo = Repository::new("app", arn, ACCOUNT, "fakecloud:4566");
         // Seed an image old enough to be eligible for `sinceImagePushed`.
         repo.images.insert(
@@ -1468,7 +1468,7 @@ mod p5_polish_tests {
         let mut mas: MultiAccountState<EcrState> =
             MultiAccountState::new(ACCOUNT, "us-east-1", "http://fakecloud:4566");
         let state = mas.get_or_create(ACCOUNT);
-        let arn = state.repository_arn("app");
+        let arn = state.repository_arn("us-east-1", "app");
         let repo = Repository::new("app", arn, ACCOUNT, "fakecloud:4566");
         state.repositories.insert("app".to_string(), repo);
         let shared: SharedEcrState = Arc::new(RwLock::new(mas));

--- a/crates/fakecloud-ecr/src/state.rs
+++ b/crates/fakecloud-ecr/src/state.rs
@@ -100,10 +100,12 @@ impl EcrState {
         self.signing_configuration = None;
     }
 
-    pub fn repository_arn(&self, repository_name: &str) -> String {
+    // ARN carries the request's credential-scope region (req.region), not the
+    // frozen server default. Repositories are keyed by name, so keying is unchanged.
+    pub fn repository_arn(&self, region: &str, repository_name: &str) -> String {
         format!(
             "arn:aws:ecr:{}:{}:repository/{}",
-            self.region, self.account_id, repository_name
+            region, self.account_id, repository_name
         )
     }
 

--- a/crates/fakecloud-ecs/src/cfn_provision.rs
+++ b/crates/fakecloud-ecs/src/cfn_provision.rs
@@ -48,8 +48,17 @@ pub async fn cfn_launch_service_tasks(
             .unwrap_or_else(|| format!("arn:aws:iam::{account_id}:root"));
         let launch_type = service.launch_type.clone();
         let desired = service.desired_count;
+        // No request region on the CFN drain path; keep the new tasks in the
+        // region the service's stored ARN already carries.
+        let svc_region = service
+            .cluster_arn
+            .split(':')
+            .nth(3)
+            .map(str::to_string)
+            .unwrap_or_else(|| st.region.clone());
         crate::service::spawn_service_tasks(
             st,
+            &svc_region,
             &service,
             desired,
             &principal_arn,

--- a/crates/fakecloud-ecs/src/helpers.rs
+++ b/crates/fakecloud-ecs/src/helpers.rs
@@ -803,6 +803,10 @@ pub(crate) fn service_not_active(name: &str) -> AwsServiceError {
 /// releasing the state write lock.
 pub(crate) fn spawn_service_tasks(
     state: &mut EcsState,
+    // ARN carries the request's credential-scope region (req.region), not the
+    // frozen server default. Background callers derive it from the service's
+    // stored cluster ARN so re-spawned tasks stay in the service's region.
+    region: &str,
     service: &Service,
     count: i32,
     principal_arn: &str,
@@ -842,13 +846,13 @@ pub(crate) fn spawn_service_tasks(
     let mut ids = Vec::with_capacity(count as usize);
     for _ in 0..count {
         let task_id = uuid::Uuid::new_v4().to_string().replace('-', "");
-        let task_arn = state.task_arn(&cluster_name, &task_id);
+        let task_arn = state.task_arn(region, &cluster_name, &task_id);
         let containers: Vec<Container> = container_defs
             .iter()
             .map(|def| Container {
                 container_arn: format!(
                     "arn:aws:ecs:{}:{}:container/{}/{}/{}",
-                    state.region,
+                    region,
                     state.account_id,
                     cluster_name,
                     task_id,
@@ -908,7 +912,7 @@ pub(crate) fn spawn_service_tasks(
                 region: opts
                     .get("awslogs-region")
                     .and_then(|v| v.as_str())
-                    .unwrap_or(&state.region)
+                    .unwrap_or(region)
                     .to_string(),
                 container_name: name,
             })
@@ -991,6 +995,8 @@ pub(crate) fn spawn_service_tasks(
 /// to `EcsRuntime::run_task` after releasing the state write lock.
 pub(crate) fn spawn_daemon_tasks(
     state: &mut EcsState,
+    // ARN carries the request's credential-scope region (req.region).
+    region: &str,
     daemon: &crate::state::Daemon,
     principal_arn: &str,
     launch_type: &str,
@@ -1030,13 +1036,13 @@ pub(crate) fn spawn_daemon_tasks(
             .map(|(_, n)| n.to_string())
             .unwrap_or_else(|| cap_arn.clone());
         let task_id = uuid::Uuid::new_v4().to_string().replace('-', "");
-        let task_arn = state.task_arn(&cluster_name, &task_id);
+        let task_arn = state.task_arn(region, &cluster_name, &task_id);
         let containers: Vec<Container> = container_defs
             .iter()
             .map(|def| Container {
                 container_arn: format!(
                     "arn:aws:ecs:{}:{}:container/{}/{}/{}",
-                    state.region,
+                    region,
                     state.account_id,
                     cluster_name,
                     task_id,
@@ -1096,7 +1102,7 @@ pub(crate) fn spawn_daemon_tasks(
                 region: opts
                     .get("awslogs-region")
                     .and_then(|v| v.as_str())
-                    .unwrap_or(&state.region)
+                    .unwrap_or(region)
                     .to_string(),
                 container_name: name,
             })

--- a/crates/fakecloud-ecs/src/placement.rs
+++ b/crates/fakecloud-ecs/src/placement.rs
@@ -259,14 +259,14 @@ mod tests {
 
     fn make_state() -> EcsState {
         let mut s = EcsState::new("000000000000", "us-east-1");
-        let arn = s.cluster_arn("default");
+        let arn = s.cluster_arn("us-east-1", "default");
         s.clusters
             .insert("default".into(), Cluster::new("default", arn));
         s
     }
 
     fn add_instance(state: &mut EcsState, id: &str, attrs: Vec<(&str, &str)>) {
-        let ci_arn = state.container_instance_arn("default", id);
+        let ci_arn = state.container_instance_arn("us-east-1", "default", id);
         let key = format!("default/{}", id);
         let attributes = attrs
             .into_iter()
@@ -281,7 +281,7 @@ mod tests {
             container_instance_arn: ci_arn.clone(),
             ec2_instance_id: Some(id.to_string()),
             cluster_name: "default".into(),
-            cluster_arn: state.cluster_arn("default"),
+            cluster_arn: state.cluster_arn("us-east-1", "default"),
             status: "ACTIVE".into(),
             version: 1,
             version_info: None,
@@ -358,12 +358,16 @@ mod tests {
             Task {
                 task_arn: "a".into(),
                 task_id: "t1".into(),
-                cluster_arn: s.cluster_arn("default"),
+                cluster_arn: s.cluster_arn("us-east-1", "default"),
                 cluster_name: "default".into(),
                 task_definition_arn: "td".into(),
                 family: "f".into(),
                 revision: 1,
-                container_instance_arn: Some(s.container_instance_arn("default", "i-1")),
+                container_instance_arn: Some(s.container_instance_arn(
+                    "us-east-1",
+                    "default",
+                    "i-1",
+                )),
                 capacity_provider_name: None,
                 last_status: "RUNNING".into(),
                 desired_status: "RUNNING".into(),
@@ -416,12 +420,16 @@ mod tests {
             Task {
                 task_arn: "a".into(),
                 task_id: "t1".into(),
-                cluster_arn: s.cluster_arn("default"),
+                cluster_arn: s.cluster_arn("us-east-1", "default"),
                 cluster_name: "default".into(),
                 task_definition_arn: "td".into(),
                 family: "f".into(),
                 revision: 1,
-                container_instance_arn: Some(s.container_instance_arn("default", "i-1")),
+                container_instance_arn: Some(s.container_instance_arn(
+                    "us-east-1",
+                    "default",
+                    "i-1",
+                )),
                 capacity_provider_name: None,
                 last_status: "RUNNING".into(),
                 desired_status: "RUNNING".into(),
@@ -459,7 +467,10 @@ mod tests {
         let strat = vec![json!({"type": "spread", "field": "attribute:ecs.availability-zone"})];
         let arn = select_container_instance(&s, "default", &[], &strat, None, "td", "EC2");
         // Should pick i-3 because zone 1b has fewer tasks.
-        assert_eq!(arn, Some(s.container_instance_arn("default", "i-3")));
+        assert_eq!(
+            arn,
+            Some(s.container_instance_arn("us-east-1", "default", "i-3"))
+        );
     }
 
     #[test]
@@ -472,12 +483,16 @@ mod tests {
             Task {
                 task_arn: "a".into(),
                 task_id: "t1".into(),
-                cluster_arn: s.cluster_arn("default"),
+                cluster_arn: s.cluster_arn("us-east-1", "default"),
                 cluster_name: "default".into(),
                 task_definition_arn: "td".into(),
                 family: "f".into(),
                 revision: 1,
-                container_instance_arn: Some(s.container_instance_arn("default", "i-1")),
+                container_instance_arn: Some(s.container_instance_arn(
+                    "us-east-1",
+                    "default",
+                    "i-1",
+                )),
                 capacity_provider_name: None,
                 last_status: "RUNNING".into(),
                 desired_status: "RUNNING".into(),
@@ -514,7 +529,10 @@ mod tests {
         );
         let strat = vec![json!({"type": "binpack", "field": "instanceId"})];
         let arn = select_container_instance(&s, "default", &[], &strat, None, "td", "EC2");
-        assert_eq!(arn, Some(s.container_instance_arn("default", "i-1")));
+        assert_eq!(
+            arn,
+            Some(s.container_instance_arn("us-east-1", "default", "i-1"))
+        );
     }
 
     #[test]
@@ -523,6 +541,9 @@ mod tests {
         add_instance(&mut s, "i-1", vec![]);
         let strat = vec![json!({"type": "random"})];
         let arn = select_container_instance(&s, "default", &[], &strat, None, "td", "EC2");
-        assert_eq!(arn, Some(s.container_instance_arn("default", "i-1")));
+        assert_eq!(
+            arn,
+            Some(s.container_instance_arn("us-east-1", "default", "i-1"))
+        );
     }
 }

--- a/crates/fakecloud-ecs/src/service.rs
+++ b/crates/fakecloud-ecs/src/service.rs
@@ -296,8 +296,18 @@ impl EcsService {
                     } else {
                         &service.launch_type
                     };
+                    // Background re-spawn has no request region; keep the new
+                    // tasks in the region the service's stored ARN already
+                    // carries (stamped from req.region at CreateService time).
+                    let svc_region = service
+                        .cluster_arn
+                        .split(':')
+                        .nth(3)
+                        .map(str::to_string)
+                        .unwrap_or_else(|| state.region.clone());
                     let ids = spawn_service_tasks(
                         state,
+                        &svc_region,
                         &service,
                         shortfall,
                         service.role_arn.as_deref().unwrap_or(""),

--- a/crates/fakecloud-ecs/src/service_clusters.rs
+++ b/crates/fakecloud-ecs/src/service_clusters.rs
@@ -43,7 +43,9 @@ impl EcsService {
         let account = request.account_id.clone();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
-        let arn = state.cluster_arn(&cluster_name);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
+        let arn = state.cluster_arn(request.region.as_str(), &cluster_name);
         let mut cluster = Cluster::new(&cluster_name, arn);
         cluster.tags = tags;
         cluster.settings = settings;
@@ -85,7 +87,7 @@ impl EcsService {
                 match state.clusters.get(name) {
                     Some(c) => found.push(cluster_to_json(c)),
                     None => failures.push(json!({
-                        "arn": state.cluster_arn(name),
+                        "arn": state.cluster_arn(request.region.as_str(), name),
                         "reason": "MISSING",
                     })),
                 }
@@ -95,7 +97,7 @@ impl EcsService {
                 failures.push(json!({
                     "arn": format!(
                         "arn:aws:ecs:{}:{}:cluster/{}",
-                        accounts.region(),
+                        request.region.as_str(),
                         account,
                         name
                     ),

--- a/crates/fakecloud-ecs/src/service_container_instances_etc.rs
+++ b/crates/fakecloud-ecs/src/service_container_instances_etc.rs
@@ -29,13 +29,15 @@ impl EcsService {
         let account = request.account_id.clone();
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
         let cluster_arn = state
             .clusters
             .get(&cluster_name)
             .map(|c| c.cluster_arn.clone())
-            .unwrap_or_else(|| state.cluster_arn(&cluster_name));
+            .unwrap_or_else(|| state.cluster_arn(request.region.as_str(), &cluster_name));
         let uuid = uuid::Uuid::new_v4().to_string();
-        let ci_arn = state.container_instance_arn(&cluster_name, &uuid);
+        let ci_arn = state.container_instance_arn(request.region.as_str(), &cluster_name, &uuid);
         let key = format!("{}/{}", cluster_name, uuid);
         let ci = ContainerInstance {
             container_instance_arn: ci_arn.clone(),
@@ -447,7 +449,9 @@ impl EcsService {
         }
         let arn = format!(
             "arn:aws:ecs:{}:{}:capacity-provider/{}",
-            state.region, state.account_id, name
+            request.region.as_str(),
+            state.account_id,
+            name
         );
         let cp = CapacityProvider {
             name: name.clone(),
@@ -681,7 +685,11 @@ impl EcsService {
             task_set_id: ts_id.clone(),
             task_set_arn: format!(
                 "arn:aws:ecs:{}:{}:task-set/{}/{}/{}",
-                state.region, state.account_id, cluster_name, service_name, ts_id
+                request.region.as_str(),
+                state.account_id,
+                cluster_name,
+                service_name,
+                ts_id
             ),
             service_arn: svc.service_arn.clone(),
             cluster_arn: svc.cluster_arn.clone(),
@@ -1015,13 +1023,13 @@ impl EcsService {
 
     pub(super) fn discover_poll_endpoint(
         &self,
-        _request: &AwsRequest,
+        request: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
         // ECS agents use this to discover the long-poll + telemetry
         // endpoints. Point both at fakecloud's local listener; real
-        // agent polling isn't wired, but the shape is correct.
-        let accounts = self.state.read();
-        let endpoint = format!("https://ecs.{}.amazonaws.com/", accounts.region());
+        // agent polling isn't wired, but the shape is correct. The endpoint
+        // host carries the request's credential-scope region (req.region).
+        let endpoint = format!("https://ecs.{}.amazonaws.com/", request.region.as_str());
         Ok(AwsResponse::ok_json(json!({
             "endpoint": endpoint,
             "telemetryEndpoint": endpoint,

--- a/crates/fakecloud-ecs/src/service_daemons.rs
+++ b/crates/fakecloud-ecs/src/service_daemons.rs
@@ -59,7 +59,9 @@ impl EcsService {
         let account_id = request.account_id.clone();
         let s = accounts.get_or_create(&account_id);
         let revision = s.allocate_daemon_revision(&family);
-        let arn = s.daemon_task_definition_arn(&family, revision);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
+        let arn = s.daemon_task_definition_arn(request.region.as_str(), &family, revision);
 
         let def = DaemonTaskDefinition {
             family: family.clone(),
@@ -253,7 +255,8 @@ impl EcsService {
             let mut accounts = self.state.write();
             let s = accounts.get_or_create(&account);
             let cluster_name = cluster_arn_to_name(cluster_input.unwrap_or("default"));
-            let cluster_arn = s.cluster_arn(&cluster_name);
+            // ARN carries the request's credential-scope region (req.region).
+            let cluster_arn = s.cluster_arn(request.region.as_str(), &cluster_name);
 
             if !s.clusters.contains_key(&cluster_name) {
                 return Err(AwsServiceError::aws_error(
@@ -275,9 +278,10 @@ impl EcsService {
                 ));
             }
 
-            let daemon_arn = s.daemon_arn(&cluster_name, &daemon_name);
+            let daemon_arn = s.daemon_arn(request.region.as_str(), &cluster_name, &daemon_name);
             let deployment_id = uuid::Uuid::new_v4().to_string();
-            let deployment_arn = s.daemon_deployment_arn(&daemon_name, &deployment_id);
+            let deployment_arn =
+                s.daemon_deployment_arn(request.region.as_str(), &daemon_name, &deployment_id);
 
             let deployment = DaemonDeployment {
                 deployment_arn: deployment_arn.clone(),
@@ -315,7 +319,8 @@ impl EcsService {
             s.daemons.insert(key.clone(), daemon.clone());
             s.daemon_deployments
                 .insert(deployment_arn.clone(), deployment);
-            let ids = spawn_daemon_tasks(s, &daemon, &principal_arn, "EC2");
+            let ids =
+                spawn_daemon_tasks(s, request.region.as_str(), &daemon, &principal_arn, "EC2");
             if let Some(d) = s.daemons.get_mut(&key) {
                 d.task_arns = ids.clone();
             }
@@ -444,7 +449,8 @@ impl EcsService {
                     .map(|d| d.daemon_arn.clone())
                     .unwrap_or_default();
                 let deployment_id = uuid::Uuid::new_v4().to_string();
-                let deployment_arn = s.daemon_deployment_arn(&daemon_name, &deployment_id);
+                let deployment_arn =
+                    s.daemon_deployment_arn(request.region.as_str(), &daemon_name, &deployment_id);
                 let revision = s
                     .daemons
                     .get(&key)
@@ -490,7 +496,7 @@ impl EcsService {
             // Re-spawn tasks when definition or providers changed.
             let ids = {
                 let daemon = s.daemons.get(&key).unwrap().clone();
-                spawn_daemon_tasks(s, &daemon, &principal_arn, "EC2")
+                spawn_daemon_tasks(s, request.region.as_str(), &daemon, &principal_arn, "EC2")
             };
             if let Some(d) = s.daemons.get_mut(&key) {
                 d.task_arns = ids.clone();

--- a/crates/fakecloud-ecs/src/service_express_gateway.rs
+++ b/crates/fakecloud-ecs/src/service_express_gateway.rs
@@ -80,8 +80,11 @@ impl EcsService {
             ));
         }
 
-        let service_arn = s.express_gateway_arn(&cluster_name, &service_name);
-        let cluster_arn = s.cluster_arn(&cluster_name);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
+        let service_arn =
+            s.express_gateway_arn(request.region.as_str(), &cluster_name, &service_name);
+        let cluster_arn = s.cluster_arn(request.region.as_str(), &cluster_name);
 
         let svc = ExpressGatewayService {
             service_name: service_name.clone(),

--- a/crates/fakecloud-ecs/src/service_services_resource.rs
+++ b/crates/fakecloud-ecs/src/service_services_resource.rs
@@ -146,7 +146,10 @@ impl EcsService {
                 .get(&cluster_name)
                 .map(|c| c.cluster_arn.clone())
                 .ok_or_else(|| cluster_not_found(&cluster_name))?;
-            let service_arn = state.service_arn(&cluster_name, &service_name);
+            // ARN carries the request's credential-scope region (req.region), not
+            // the frozen server default.
+            let service_arn =
+                state.service_arn(request.region.as_str(), &cluster_name, &service_name);
             let key = EcsState::service_key(&cluster_name, &service_name);
             if let Some(existing) = state.services.get(&key) {
                 if existing.status != "INACTIVE" {
@@ -256,6 +259,7 @@ impl EcsService {
             });
             let ids = spawn_service_tasks(
                 state,
+                request.region.as_str(),
                 &service,
                 desired_count,
                 &principal_arn,
@@ -266,7 +270,11 @@ impl EcsService {
                 let ts_id = uuid::Uuid::new_v4().to_string().replace('-', "");
                 let ts_arn = format!(
                     "arn:aws:ecs:{}:{}:task-set/{}/{}/{}",
-                    state.region, state.account_id, cluster_name, service_name, ts_id
+                    request.region.as_str(),
+                    state.account_id,
+                    cluster_name,
+                    service_name,
+                    ts_id
                 );
                 let task_set = TaskSet {
                     task_set_id: ts_id,
@@ -617,7 +625,11 @@ impl EcsService {
                 let ts_id = uuid::Uuid::new_v4().to_string().replace('-', "");
                 let ts_arn = format!(
                     "arn:aws:ecs:{}:{}:task-set/{}/{}/{}",
-                    state.region, state.account_id, cluster_name, service_name, ts_id
+                    request.region.as_str(),
+                    state.account_id,
+                    cluster_name,
+                    service_name,
+                    ts_id
                 );
                 let svc_snapshot = state.services.get(&key).unwrap().clone();
                 let task_set = TaskSet {
@@ -652,6 +664,7 @@ impl EcsService {
                 // Spawn tasks for the new task set
                 let mut new_ids = spawn_service_tasks(
                     state,
+                    request.region.as_str(),
                     &svc_snapshot,
                     effective_desired,
                     &principal_arn,
@@ -720,6 +733,7 @@ impl EcsService {
                     let svc_snapshot = state.services.get(&key).unwrap().clone();
                     let mut new_ids = spawn_service_tasks(
                         state,
+                        request.region.as_str(),
                         &svc_snapshot,
                         add as i32,
                         &principal_arn,
@@ -783,6 +797,7 @@ impl EcsService {
                         let svc_snapshot = state.services.get(&key).unwrap().clone();
                         let mut more = spawn_service_tasks(
                             state,
+                            request.region.as_str(),
                             &svc_snapshot,
                             need,
                             &principal_arn,

--- a/crates/fakecloud-ecs/src/service_task_definitions.rs
+++ b/crates/fakecloud-ecs/src/service_task_definitions.rs
@@ -114,7 +114,9 @@ impl EcsService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&account);
         let revision = state.allocate_revision(&family);
-        let arn = state.task_definition_arn(&family, revision);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
+        let arn = state.task_definition_arn(request.region.as_str(), &family, revision);
         let td = TaskDefinition {
             family: family.clone(),
             revision,

--- a/crates/fakecloud-ecs/src/service_tasks.rs
+++ b/crates/fakecloud-ecs/src/service_tasks.rs
@@ -226,13 +226,15 @@ impl EcsService {
         #[allow(clippy::needless_range_loop)]
         for task_index in 0..count {
             let task_id = uuid::Uuid::new_v4().to_string().replace('-', "");
-            let task_arn = state.task_arn(&cluster_name, &task_id);
+            // ARN carries the request's credential-scope region (req.region), not
+            // the frozen server default.
+            let task_arn = state.task_arn(request.region.as_str(), &cluster_name, &task_id);
             let containers: Vec<Container> = td_containers
                 .iter()
                 .map(|def| Container {
                     container_arn: format!(
                         "arn:aws:ecs:{}:{}:container/{}/{}/{}",
-                        state.region,
+                        request.region.as_str(),
                         state.account_id,
                         cluster_name,
                         task_id,
@@ -292,7 +294,7 @@ impl EcsService {
                     region: opts
                         .get("awslogs-region")
                         .and_then(|v| v.as_str())
-                        .unwrap_or(&state.region)
+                        .unwrap_or(request.region.as_str())
                         .to_string(),
                     container_name: name,
                 })
@@ -679,7 +681,7 @@ mod multi_container_tests {
         // Pre-create the cluster so RunTask doesn't trip on a missing one.
         let mut accounts = state.write();
         let s = accounts.get_or_create("000000000000");
-        let arn = s.cluster_arn("default");
+        let arn = s.cluster_arn("us-east-1", "default");
         s.clusters
             .insert("default".into(), Cluster::new("default", arn));
         drop(accounts);
@@ -1278,7 +1280,7 @@ mod port_mapping_tests {
         let mut accounts: MultiAccountState<EcsState> =
             MultiAccountState::new("000000000000", "us-east-1", "http://localhost:4566");
         let acct = accounts.get_or_create("000000000000");
-        let arn = acct.cluster_arn("default");
+        let arn = acct.cluster_arn("us-east-1", "default");
         acct.clusters
             .insert("default".into(), Cluster::new("default", arn));
         let mut task = Task {

--- a/crates/fakecloud-ecs/src/state.rs
+++ b/crates/fakecloud-ecs/src/state.rs
@@ -194,45 +194,53 @@ impl EcsState {
         format!("{}/{}", cluster_name, service_name)
     }
 
-    pub fn service_arn(&self, cluster_name: &str, service_name: &str) -> String {
+    // ARN carries the request's credential-scope region (req.region), not the
+    // frozen server default. The `region` argument is the request region;
+    // storage keying is unchanged (keyed by account/name).
+    pub fn service_arn(&self, region: &str, cluster_name: &str, service_name: &str) -> String {
         if self.arn_format_disabled("serviceLongArnFormat") {
             // Pre-Nov-2018 short form: no cluster segment.
             format!(
                 "arn:aws:ecs:{}:{}:service/{}",
-                self.region, self.account_id, service_name
+                region, self.account_id, service_name
             )
         } else {
             format!(
                 "arn:aws:ecs:{}:{}:service/{}/{}",
-                self.region, self.account_id, cluster_name, service_name
+                region, self.account_id, cluster_name, service_name
             )
         }
     }
 
-    pub fn task_arn(&self, cluster_name: &str, task_id: &str) -> String {
+    pub fn task_arn(&self, region: &str, cluster_name: &str, task_id: &str) -> String {
         if self.arn_format_disabled("taskLongArnFormat") {
             format!(
                 "arn:aws:ecs:{}:{}:task/{}",
-                self.region, self.account_id, task_id
+                region, self.account_id, task_id
             )
         } else {
             format!(
                 "arn:aws:ecs:{}:{}:task/{}/{}",
-                self.region, self.account_id, cluster_name, task_id
+                region, self.account_id, cluster_name, task_id
             )
         }
     }
 
-    pub fn container_instance_arn(&self, cluster_name: &str, instance_id: &str) -> String {
+    pub fn container_instance_arn(
+        &self,
+        region: &str,
+        cluster_name: &str,
+        instance_id: &str,
+    ) -> String {
         if self.arn_format_disabled("containerInstanceLongArnFormat") {
             format!(
                 "arn:aws:ecs:{}:{}:container-instance/{}",
-                self.region, self.account_id, instance_id
+                region, self.account_id, instance_id
             )
         } else {
             format!(
                 "arn:aws:ecs:{}:{}:container-instance/{}/{}",
-                self.region, self.account_id, cluster_name, instance_id
+                region, self.account_id, cluster_name, instance_id
             )
         }
     }
@@ -277,17 +285,17 @@ impl EcsState {
         self.events.push(event);
     }
 
-    pub fn cluster_arn(&self, cluster_name: &str) -> String {
+    pub fn cluster_arn(&self, region: &str, cluster_name: &str) -> String {
         format!(
             "arn:aws:ecs:{}:{}:cluster/{}",
-            self.region, self.account_id, cluster_name
+            region, self.account_id, cluster_name
         )
     }
 
-    pub fn task_definition_arn(&self, family: &str, revision: i32) -> String {
+    pub fn task_definition_arn(&self, region: &str, family: &str, revision: i32) -> String {
         format!(
             "arn:aws:ecs:{}:{}:task-definition/{}:{}",
-            self.region, self.account_id, family, revision
+            region, self.account_id, family, revision
         )
     }
 
@@ -882,11 +890,12 @@ impl EcsState {
         *entry
     }
 
-    /// Build a daemon ARN for a (cluster, name) pair under this account/region.
-    pub fn daemon_arn(&self, cluster: &str, name: &str) -> String {
+    /// Build a daemon ARN for a (cluster, name) pair under this account.
+    /// `region` is the request's credential-scope region (req.region).
+    pub fn daemon_arn(&self, region: &str, cluster: &str, name: &str) -> String {
         fakecloud_aws::arn::Arn::new(
             "ecs",
-            &self.region,
+            region,
             &self.account_id,
             &format!("daemon/{}/{}", cluster, name),
         )
@@ -894,10 +903,10 @@ impl EcsState {
     }
 
     /// Build an express-gateway service ARN.
-    pub fn express_gateway_arn(&self, cluster: &str, name: &str) -> String {
+    pub fn express_gateway_arn(&self, region: &str, cluster: &str, name: &str) -> String {
         fakecloud_aws::arn::Arn::new(
             "ecs",
-            &self.region,
+            region,
             &self.account_id,
             &format!("express-gateway-service/{}/{}", cluster, name),
         )
@@ -905,10 +914,10 @@ impl EcsState {
     }
 
     /// Build a daemon task definition ARN for a `family:revision` pair.
-    pub fn daemon_task_definition_arn(&self, family: &str, revision: i32) -> String {
+    pub fn daemon_task_definition_arn(&self, region: &str, family: &str, revision: i32) -> String {
         fakecloud_aws::arn::Arn::new(
             "ecs",
-            &self.region,
+            region,
             &self.account_id,
             &format!("daemon-task-definition/{}:{}", family, revision),
         )
@@ -916,10 +925,15 @@ impl EcsState {
     }
 
     /// Build a daemon deployment ARN.
-    pub fn daemon_deployment_arn(&self, daemon_name: &str, deployment_id: &str) -> String {
+    pub fn daemon_deployment_arn(
+        &self,
+        region: &str,
+        daemon_name: &str,
+        deployment_id: &str,
+    ) -> String {
         fakecloud_aws::arn::Arn::new(
             "ecs",
-            &self.region,
+            region,
             &self.account_id,
             &format!("daemon-deployment/{}/{}", daemon_name, deployment_id),
         )
@@ -964,7 +978,7 @@ mod tests {
     fn cluster_arn_format() {
         let s = EcsState::new("111122223333", "us-east-1");
         assert_eq!(
-            s.cluster_arn("prod"),
+            s.cluster_arn("us-east-1", "prod"),
             "arn:aws:ecs:us-east-1:111122223333:cluster/prod"
         );
     }
@@ -973,7 +987,7 @@ mod tests {
     fn task_definition_arn_format() {
         let s = EcsState::new("111122223333", "us-east-1");
         assert_eq!(
-            s.task_definition_arn("web", 3),
+            s.task_definition_arn("us-east-1", "web", 3),
             "arn:aws:ecs:us-east-1:111122223333:task-definition/web:3"
         );
     }
@@ -982,7 +996,7 @@ mod tests {
     fn task_arn_long_format_default() {
         let s = EcsState::new("111122223333", "us-east-1");
         assert_eq!(
-            s.task_arn("prod", "abc123"),
+            s.task_arn("us-east-1", "prod", "abc123"),
             "arn:aws:ecs:us-east-1:111122223333:task/prod/abc123"
         );
     }
@@ -993,7 +1007,7 @@ mod tests {
         s.account_setting_defaults
             .insert("taskLongArnFormat".into(), "disabled".into());
         assert_eq!(
-            s.task_arn("prod", "abc123"),
+            s.task_arn("us-east-1", "prod", "abc123"),
             "arn:aws:ecs:us-east-1:111122223333:task/abc123"
         );
     }
@@ -1004,7 +1018,7 @@ mod tests {
         s.account_setting_defaults
             .insert("serviceLongArnFormat".into(), "disabled".into());
         assert_eq!(
-            s.service_arn("prod", "web"),
+            s.service_arn("us-east-1", "prod", "web"),
             "arn:aws:ecs:us-east-1:111122223333:service/web"
         );
     }
@@ -1015,7 +1029,7 @@ mod tests {
         s.account_setting_defaults
             .insert("containerInstanceLongArnFormat".into(), "disabled".into());
         assert_eq!(
-            s.container_instance_arn("prod", "i-abc"),
+            s.container_instance_arn("us-east-1", "prod", "i-abc"),
             "arn:aws:ecs:us-east-1:111122223333:container-instance/i-abc"
         );
     }
@@ -1047,7 +1061,7 @@ mod tests {
         let mut s = EcsState::new("111122223333", "us-east-1");
         s.clusters.insert(
             "prod".to_string(),
-            Cluster::new("prod", s.cluster_arn("prod")),
+            Cluster::new("prod", s.cluster_arn("us-east-1", "prod")),
         );
         s.allocate_revision("web");
         s.account_setting_defaults

--- a/crates/fakecloud-elasticache/src/service/clusters.rs
+++ b/crates/fakecloud-elasticache/src/service/clusters.rs
@@ -158,10 +158,14 @@ impl ElastiCacheService {
 
             let preferred_availability_zone =
                 optional_query_param(request, "PreferredAvailabilityZone")
-                    .unwrap_or_else(|| format!("{}a", state.region));
+                    .unwrap_or_else(|| format!("{}a", request.region));
+            // ARN carries the request's credential-scope region (req.region), not
+            // the frozen server default.
             let arn = format!(
                 "arn:aws:elasticache:{}:{}:cluster:{}",
-                state.region, state.account_id, cache_cluster_id
+                request.region.as_str(),
+                state.account_id,
+                cache_cluster_id
             );
             (preferred_availability_zone, arn, rdb_path)
         };

--- a/crates/fakecloud-elasticache/src/service/misc.rs
+++ b/crates/fakecloud-elasticache/src/service/misc.rs
@@ -376,7 +376,7 @@ impl ElastiCacheService {
         group.member_clusters = build_member_clusters(&replication_group_id, new_total);
 
         let group = group.clone();
-        let region = state.region.clone();
+        let region = request.region.clone();
         let xml = replication_group_xml(&group, &region);
 
         Ok(AwsResponse::xml(
@@ -421,7 +421,7 @@ impl ElastiCacheService {
             ));
         }
 
-        let region = state.region.clone();
+        let region = request.region.clone();
         let xml = replication_group_xml(group, &region);
 
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -713,7 +713,7 @@ impl ElastiCacheService {
         let migration = state.migrations.get_mut(&id).expect("checked above");
         migration.status = "complete".to_string();
         let group = state.replication_groups.get(&id).expect("checked above");
-        let region = state.region.clone();
+        let region = request.region.clone();
         let xml = replication_group_xml(group, &region);
         Ok(AwsResponse::xml(
             StatusCode::OK,
@@ -760,7 +760,7 @@ impl ElastiCacheService {
                 format!("ReplicationGroup {id} not found."),
             )
         })?;
-        let region = state.region.clone();
+        let region = request.region.clone();
         let xml = replication_group_xml(group, &region);
         state.migrations.insert(
             id.clone(),

--- a/crates/fakecloud-elasticache/src/service/replication.rs
+++ b/crates/fakecloud-elasticache/src/service/replication.rs
@@ -178,9 +178,11 @@ impl ElastiCacheService {
             let state = accounts.get(&request.account_id).unwrap_or(&empty);
             let arn = format!(
                 "arn:aws:elasticache:{}:{}:replicationgroup:{}",
-                state.region, state.account_id, replication_group_id
+                request.region.as_str(),
+                state.account_id,
+                replication_group_id
             );
-            (arn, state.region.clone())
+            (arn, request.region.clone())
         };
 
         let group = ReplicationGroup {
@@ -351,7 +353,7 @@ impl ElastiCacheService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let region = state.region.clone();
+        let region = request.region.clone();
         let account_id = state.account_id.clone();
         let global_replication_group_id = global_replication_group_id(&region, suffix.as_str());
         if state
@@ -505,7 +507,7 @@ impl ElastiCacheService {
         let accounts = self.state.read();
         let empty = ElastiCacheState::new(&request.account_id, &request.region);
         let state = accounts.get(&request.account_id).unwrap_or(&empty);
-        let region = state.region.clone();
+        let region = request.region.clone();
 
         let groups: Vec<&ReplicationGroup> = if let Some(ref id) = group_id {
             match state.replication_groups.get(id) {
@@ -932,7 +934,7 @@ impl ElastiCacheService {
             }
 
             let group = state.replication_groups[&replication_group_id].clone();
-            let region = state.region.clone();
+            let region = request.region.clone();
             let rg_id = replication_group_id.clone();
             let had_user_group_changes = !user_group_ids_to_add.is_empty()
                 || remove_user_groups == Some(true)
@@ -1299,7 +1301,7 @@ impl ElastiCacheService {
         }
 
         let group = group.clone();
-        let region = state.region.clone();
+        let region = request.region.clone();
         let xml = replication_group_xml(&group, &region);
         Ok(AwsResponse::xml(
             StatusCode::OK,

--- a/crates/fakecloud-elasticache/src/service/serverless.rs
+++ b/crates/fakecloud-elasticache/src/service/serverless.rs
@@ -62,7 +62,9 @@ impl ElastiCacheService {
 
             let arn = format!(
                 "arn:aws:elasticache:{}:{}:serverlesscache:{}",
-                state.region, state.account_id, serverless_cache_name
+                request.region.as_str(),
+                state.account_id,
+                serverless_cache_name
             );
             (arn, "127.0.0.1".to_string())
         };

--- a/crates/fakecloud-elasticache/src/service/snapshots.rs
+++ b/crates/fakecloud-elasticache/src/service/snapshots.rs
@@ -56,9 +56,12 @@ impl ElastiCacheService {
                 )
             })?;
 
+        // ARN carries the request's credential-scope region (req.region).
         let arn = format!(
             "arn:aws:elasticache:{}:{}:serverlesssnapshot:{}",
-            state.region, state.account_id, serverless_cache_snapshot_name
+            request.region.as_str(),
+            state.account_id,
+            serverless_cache_snapshot_name
         );
         let snapshot = ServerlessCacheSnapshot {
             serverless_cache_snapshot_name: serverless_cache_snapshot_name.clone(),
@@ -286,7 +289,9 @@ impl ElastiCacheService {
 
             let arn = format!(
                 "arn:aws:elasticache:{}:{}:snapshot:{}",
-                state.region, state.account_id, snapshot_name
+                request.region.as_str(),
+                state.account_id,
+                snapshot_name
             );
 
             let snapshot = CacheSnapshot {
@@ -475,7 +480,9 @@ impl ElastiCacheService {
         snap.snapshot_name = target.clone();
         snap.arn = format!(
             "arn:aws:elasticache:{}:{}:snapshot:{}",
-            state.region, state.account_id, target
+            request.region.as_str(),
+            state.account_id,
+            target
         );
         snap.snapshot_status = "creating".to_string();
         snap.snapshot_source = "manual".to_string();
@@ -521,7 +528,9 @@ impl ElastiCacheService {
         snap.serverless_cache_snapshot_name = target.clone();
         snap.arn = format!(
             "arn:aws:elasticache:{}:{}:serverlesssnapshot:{}",
-            state.region, state.account_id, target
+            request.region.as_str(),
+            state.account_id,
+            target
         );
         snap.status = "creating".to_string();
         let xml = serverless_cache_snapshot_xml(&snap);

--- a/crates/fakecloud-elasticache/src/service/subnet_groups.rs
+++ b/crates/fakecloud-elasticache/src/service/subnet_groups.rs
@@ -45,9 +45,13 @@ impl ElastiCacheService {
             ));
         }
 
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
         let arn = format!(
             "arn:aws:elasticache:{}:{}:subnetgroup:{}",
-            state.region, state.account_id, name
+            request.region.as_str(),
+            state.account_id,
+            name
         );
         let vpc_id = format!(
             "vpc-{:08x}",
@@ -64,7 +68,7 @@ impl ElastiCacheService {
             arn,
         };
 
-        let xml = cache_subnet_group_xml(&group, &state.region);
+        let xml = cache_subnet_group_xml(&group, request.region.as_str());
         state.register_arn(&group.arn);
         state.tags.entry(group.arn.clone()).or_default();
         if !tags.is_empty() {
@@ -120,7 +124,7 @@ impl ElastiCacheService {
             .map(|g| {
                 format!(
                     "<CacheSubnetGroup>{}</CacheSubnetGroup>",
-                    cache_subnet_group_xml(g, &state.region)
+                    cache_subnet_group_xml(g, request.region.as_str())
                 )
             })
             .collect();
@@ -194,7 +198,7 @@ impl ElastiCacheService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
-        let region = state.region.clone();
+        let region = request.region.clone();
 
         let group = state.subnet_groups.get_mut(&name).ok_or_else(|| {
             AwsServiceError::aws_error(

--- a/crates/fakecloud-elasticache/src/service/users.rs
+++ b/crates/fakecloud-elasticache/src/service/users.rs
@@ -87,9 +87,12 @@ impl ElastiCacheService {
             ));
         }
 
+        // ARN carries the request's credential-scope region (req.region).
         let arn = format!(
             "arn:aws:elasticache:{}:{}:user:{}",
-            state.region, state.account_id, user_id
+            request.region.as_str(),
+            state.account_id,
+            user_id
         );
 
         let user = ElastiCacheUser {
@@ -278,7 +281,9 @@ impl ElastiCacheService {
 
         let arn = format!(
             "arn:aws:elasticache:{}:{}:usergroup:{}",
-            state.region, state.account_id, user_group_id
+            request.region.as_str(),
+            state.account_id,
+            user_group_id
         );
 
         let group = ElastiCacheUserGroup {

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -303,7 +303,12 @@ impl EventBridgeState {
         self.lambda_invocations.clear();
         self.log_deliveries.clear();
         self.step_function_executions.clear();
-        // Re-create default bus
+        // Re-create default bus. NOTE: the default bus is seeded here (and at
+        // init) before any request exists, so its ARN carries the frozen server
+        // region rather than the request's credential-scope region. Custom buses
+        // created via CreateEventBus already use req.region; a matching fix for
+        // the default bus would need a read-time restamp in DescribeEventBus/
+        // ListEventBuses and is intentionally left as an init-time limitation.
         let default_bus_arn = format!(
             "arn:aws:events:{}:{}:event-bus/default",
             self.region, self.account_id

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -270,7 +270,7 @@ impl KinesisService {
 
         let stream = KinesisStream {
             stream_name: stream_name.to_string(),
-            stream_arn: state.stream_arn(stream_name),
+            stream_arn: state.stream_arn(request.region.as_str(), stream_name),
             stream_status: "ACTIVE".to_string(),
             stream_creation_timestamp: Utc::now(),
             retention_period_hours: 24,
@@ -493,7 +493,7 @@ impl KinesisService {
         if stream.is_none() {
             return Err(stream_not_found(&state.account_id, &stream_name));
         }
-        let stream_arn = state.stream_arn(&stream_name);
+        let stream_arn = state.stream_arn(request.region.as_str(), &stream_name);
         state.consumers.retain(|_, c| c.stream_arn != stream_arn);
 
         Ok(AwsResponse::ok_json(json!({})))
@@ -1122,7 +1122,7 @@ impl KinesisService {
         let state = accounts.get_or_create(&request.account_id);
         let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
-        let stream_arn = state.stream_arn(&stream_name);
+        let stream_arn = state.stream_arn(request.region.as_str(), &stream_name);
         let stream = state
             .streams
             .get_mut(&stream_name)
@@ -1177,7 +1177,7 @@ impl KinesisService {
         let state = accounts.get_or_create(&request.account_id);
         let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
-        let stream_arn = state.stream_arn(&stream_name);
+        let stream_arn = state.stream_arn(request.region.as_str(), &stream_name);
         let stream = state
             .streams
             .get_mut(&stream_name)
@@ -1317,7 +1317,7 @@ impl KinesisService {
         let state = accounts.get_or_create(&request.account_id);
         let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
-        let stream_arn = state.stream_arn(&stream_name);
+        let stream_arn = state.stream_arn(request.region.as_str(), &stream_name);
         let stream = state
             .streams
             .get_mut(&stream_name)
@@ -1795,7 +1795,7 @@ impl KinesisService {
         let state = accounts.get_or_create(&request.account_id);
         let stream_name = resolve_stream_name(state, &body)?;
         let account_id = state.account_id.clone();
-        let stream_arn = state.stream_arn(&stream_name);
+        let stream_arn = state.stream_arn(request.region.as_str(), &stream_name);
         let stream = state
             .streams
             .get_mut(&stream_name)

--- a/crates/fakecloud-kinesis/src/service_tests.rs
+++ b/crates/fakecloud-kinesis/src/service_tests.rs
@@ -545,7 +545,7 @@ fn delete_stream_removes_entry_and_consumers() {
     let (svc, state) = make_service();
     create_stream_action(&svc, "orders", 1);
     // Register a consumer on the stream.
-    let stream_arn = state.read().default_ref().stream_arn("orders");
+    let stream_arn = state.read().default_ref().stream_arn("us-east-1", "orders");
     svc.register_stream_consumer(&request(
         "RegisterStreamConsumer",
         json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -946,7 +946,7 @@ fn enable_and_disable_enhanced_monitoring() {
 fn update_stream_mode_writes_new_mode() {
     let (svc, state) = make_service();
     create_stream_action(&svc, "orders", 1);
-    let stream_arn = state.read().default_ref().stream_arn("orders");
+    let stream_arn = state.read().default_ref().stream_arn("us-east-1", "orders");
     svc.update_stream_mode(&request(
         "UpdateStreamMode",
         json!({
@@ -973,7 +973,7 @@ fn update_stream_mode_writes_new_mode() {
 fn register_describe_deregister_consumer() {
     let (svc, state) = make_service();
     create_stream_action(&svc, "orders", 1);
-    let stream_arn = state.read().default_ref().stream_arn("orders");
+    let stream_arn = state.read().default_ref().stream_arn("us-east-1", "orders");
     svc.register_stream_consumer(&request(
         "RegisterStreamConsumer",
         json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -1001,7 +1001,7 @@ fn register_describe_deregister_consumer() {
 fn register_consumer_duplicate_errors() {
     let (svc, state) = make_service();
     create_stream_action(&svc, "orders", 1);
-    let stream_arn = state.read().default_ref().stream_arn("orders");
+    let stream_arn = state.read().default_ref().stream_arn("us-east-1", "orders");
     svc.register_stream_consumer(&request(
         "RegisterStreamConsumer",
         json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -1020,7 +1020,7 @@ fn register_consumer_duplicate_errors() {
 fn list_stream_consumers_returns_registered_consumer() {
     let (svc, state) = make_service();
     create_stream_action(&svc, "orders", 1);
-    let stream_arn = state.read().default_ref().stream_arn("orders");
+    let stream_arn = state.read().default_ref().stream_arn("us-east-1", "orders");
     svc.register_stream_consumer(&request(
         "RegisterStreamConsumer",
         json!({ "StreamARN": stream_arn, "ConsumerName": "c1" }),
@@ -1044,7 +1044,7 @@ fn list_stream_consumers_returns_registered_consumer() {
 fn put_get_delete_resource_policy() {
     let (svc, state) = make_service();
     create_stream_action(&svc, "orders", 1);
-    let stream_arn = state.read().default_ref().stream_arn("orders");
+    let stream_arn = state.read().default_ref().stream_arn("us-east-1", "orders");
     let policy_body = json!({"Version":"2012-10-17","Statement":[]}).to_string();
 
     svc.put_resource_policy(&request(

--- a/crates/fakecloud-kinesis/src/state.rs
+++ b/crates/fakecloud-kinesis/src/state.rs
@@ -135,10 +135,12 @@ impl KinesisState {
             .map(|name| name.to_string())
     }
 
-    pub fn stream_arn(&self, stream_name: &str) -> String {
+    // ARN carries the request's credential-scope region (req.region), not the
+    // frozen server default. Streams are keyed by name, so keying is unchanged.
+    pub fn stream_arn(&self, region: &str, stream_name: &str) -> String {
         format!(
             "arn:aws:kinesis:{}:{}:stream/{}",
-            self.region, self.account_id, stream_name
+            region, self.account_id, stream_name
         )
     }
 
@@ -280,7 +282,7 @@ mod tests {
     fn stream_arn_format() {
         let state = KinesisState::new("123456789012", "us-east-1");
         assert_eq!(
-            state.stream_arn("my-stream"),
+            state.stream_arn(&state.region, "my-stream"),
             "arn:aws:kinesis:us-east-1:123456789012:stream/my-stream"
         );
     }
@@ -330,7 +332,7 @@ mod tests {
         let shard_id = "shardId-000000000000".to_string();
         let stream = KinesisStream {
             stream_name: "s".to_string(),
-            stream_arn: state.stream_arn("s"),
+            stream_arn: state.stream_arn(&state.region, "s"),
             stream_status: "ACTIVE".to_string(),
             stream_creation_timestamp: Utc::now(),
             retention_period_hours: 24,

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -119,7 +119,10 @@ impl RdsService {
         let action = req.action.clone();
         let aid = req.account_id.clone();
         let rid = req.request_id.clone();
-        let region = "us-east-1"; // RDS uses us-east-1 by default in fakecloud
+        // ARNs and endpoint hosts carry the request's credential-scope region
+        // (req.region), not a hardcoded default. Storage is keyed by
+        // account/identifier, so this only affects returned strings.
+        let region = req.region.as_str();
 
         macro_rules! write_state {
             () => {{
@@ -1301,9 +1304,9 @@ impl RdsService {
                 let source_arn_full = if source_arn.starts_with("arn:") {
                     source_arn.clone()
                 } else {
-                    state.db_instance_arn(&source_id)
+                    state.db_instance_arn(region, &source_id)
                 };
-                let target_arn = state.db_instance_arn(&target_id);
+                let target_arn = state.db_instance_arn(region, &target_id);
                 // AWS accepts either a DBInstance ARN or an Aurora
                 // DBCluster ARN as the BG source. Look up under both
                 // the real instance store and the cluster map under
@@ -1766,7 +1769,7 @@ impl RdsService {
                         .get(&source_key)
                         .cloned()
                         .ok_or_else(|| crate::service::service_helpers::db_snapshot_not_found(&source_id))?;
-                    let arn = state.db_snapshot_arn(&target_id);
+                    let arn = state.db_snapshot_arn(region, &target_id);
                     snapshot.db_snapshot_identifier = target_id.clone();
                     snapshot.db_snapshot_arn = arn.clone();
                     snapshot.snapshot_create_time = chrono::Utc::now();
@@ -1832,7 +1835,7 @@ impl RdsService {
                             )
                         })?;
                     group.db_parameter_group_name = target.clone();
-                    group.db_parameter_group_arn = state.db_parameter_group_arn(&target);
+                    group.db_parameter_group_arn = state.db_parameter_group_arn(region, &target);
                     if let Some(desc) = description {
                         group.description = desc;
                     }

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -599,8 +599,8 @@ fn seed_replica(svc: &RdsService, replica_id: &str, source_id: &str) {
     let now = Utc::now();
     let mut accounts = svc.state_handle().write();
     let state = accounts.get_or_create("000000000000");
-    let arn = state.db_instance_arn(replica_id);
-    let source_arn = state.db_instance_arn(source_id);
+    let arn = state.db_instance_arn(&state.region, replica_id);
+    let source_arn = state.db_instance_arn(&state.region, source_id);
     // Source first.
     state.instances.insert(
         source_id.to_string(),
@@ -1480,7 +1480,7 @@ fn seed_blue_instance(svc: &RdsService, id: &str, addr: &str, port: i32) {
     let now = Utc::now();
     let mut accounts = svc.state_handle().write();
     let state = accounts.get_or_create("000000000000");
-    let arn = state.db_instance_arn(id);
+    let arn = state.db_instance_arn(&state.region, id);
     state.instances.insert(
         id.to_string(),
         DbInstance {

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -140,7 +140,8 @@ impl RdsService {
             let state = accounts.get_or_create(&request.account_id);
             let placeholder = DbInstance {
                 db_instance_identifier: db_instance_identifier.clone(),
-                db_instance_arn: state.db_instance_arn(&db_instance_identifier),
+                db_instance_arn: state
+                    .db_instance_arn(request.region.as_str(), &db_instance_identifier),
                 db_instance_class: db_instance_class.clone(),
                 engine: engine.clone(),
                 engine_version: engine_version.clone(),
@@ -992,7 +993,7 @@ impl RdsService {
                         format!("DBInstance {new_id} already exists."),
                     ));
                 }
-                let new_arn = state.db_instance_arn(new_id);
+                let new_arn = state.db_instance_arn(request.region.as_str(), new_id);
                 let mut moved = state
                     .instances
                     .remove(&db_instance_identifier)

--- a/crates/fakecloud-rds/src/service/parameter_groups.rs
+++ b/crates/fakecloud-rds/src/service/parameter_groups.rs
@@ -44,7 +44,8 @@ impl RdsService {
             ));
         }
 
-        let db_parameter_group_arn = state.db_parameter_group_arn(&db_parameter_group_name);
+        let db_parameter_group_arn =
+            state.db_parameter_group_arn(request.region.as_str(), &db_parameter_group_name);
         let tags = parse_tags(request)?;
 
         let parameter_group = DbParameterGroup {

--- a/crates/fakecloud-rds/src/service/replicas.rs
+++ b/crates/fakecloud-rds/src/service/replicas.rs
@@ -89,7 +89,7 @@ impl RdsService {
             let s = accounts.get(&request.account_id).unwrap_or(&empty);
             (
                 s.next_dbi_resource_id(),
-                s.db_instance_arn(&db_instance_identifier),
+                s.db_instance_arn(request.region.as_str(), &db_instance_identifier),
             )
         };
         let created_at = Utc::now();

--- a/crates/fakecloud-rds/src/service/restore.rs
+++ b/crates/fakecloud-rds/src/service/restore.rs
@@ -146,7 +146,10 @@ impl RdsService {
             let accounts = self.state.read();
             let empty = RdsState::new(&request.account_id, &request.region);
             let s = accounts.get(&request.account_id).unwrap_or(&empty);
-            (s.next_dbi_resource_id(), s.db_instance_arn(&target_id))
+            (
+                s.next_dbi_resource_id(),
+                s.db_instance_arn(request.region.as_str(), &target_id),
+            )
         };
         let created_at = Utc::now();
 
@@ -285,7 +288,7 @@ impl RdsService {
 
             (
                 state.next_dbi_resource_id(),
-                state.db_instance_arn(&db_instance_identifier),
+                state.db_instance_arn(request.region.as_str(), &db_instance_identifier),
             )
         };
 

--- a/crates/fakecloud-rds/src/service/snapshots.rs
+++ b/crates/fakecloud-rds/src/service/snapshots.rs
@@ -77,7 +77,7 @@ impl RdsService {
             ));
         }
 
-        let snapshot_arn = state.db_snapshot_arn(snapshot_id);
+        let snapshot_arn = state.db_snapshot_arn(region, snapshot_id);
 
         let snapshot = DbSnapshot {
             db_snapshot_identifier: snapshot_id.to_string(),
@@ -194,7 +194,8 @@ impl RdsService {
 
         let snapshot = DbSnapshot {
             db_snapshot_identifier: db_snapshot_identifier.clone(),
-            db_snapshot_arn: state.db_snapshot_arn(&db_snapshot_identifier),
+            db_snapshot_arn: state
+                .db_snapshot_arn(request.region.as_str(), &db_snapshot_identifier),
             db_instance_identifier: instance.db_instance_identifier.clone(),
             snapshot_create_time: Utc::now(),
             engine: instance.engine.clone(),
@@ -416,7 +417,8 @@ impl RdsService {
             };
 
             let dbi_resource_id = state.next_dbi_resource_id();
-            let db_instance_arn = state.db_instance_arn(&db_instance_identifier);
+            let db_instance_arn =
+                state.db_instance_arn(request.region.as_str(), &db_instance_identifier);
             let created_at = Utc::now();
 
             (snapshot, dbi_resource_id, db_instance_arn, created_at)

--- a/crates/fakecloud-rds/src/service/subnet_groups.rs
+++ b/crates/fakecloud-rds/src/service/subnet_groups.rs
@@ -62,7 +62,8 @@ impl RdsService {
             ));
         }
 
-        let db_subnet_group_arn = state.db_subnet_group_arn(&db_subnet_group_name);
+        let db_subnet_group_arn =
+            state.db_subnet_group_arn(request.region.as_str(), &db_subnet_group_name);
         let tags = parse_tags(request)?;
 
         let subnet_group = DbSubnetGroup {

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -853,7 +853,7 @@ fn add_tags_to_subnet_group_arn_persists() {
     let arn = {
         let mut __a = svc.state.write();
         let state = __a.default_mut();
-        let arn = state.db_subnet_group_arn("sg1");
+        let arn = state.db_subnet_group_arn(&state.region, "sg1");
         state.subnet_groups.insert(
             "sg1".to_string(),
             crate::state::DbSubnetGroup {
@@ -1798,7 +1798,7 @@ fn modify_db_instance_cloudwatch_disable_log_types_removes_existing() {
 fn seed_snapshot(svc: &RdsService, snapshot_id: &str, instance_id: &str) {
     let mut __a = svc.state.write();
     let state = __a.default_mut();
-    let arn = state.db_snapshot_arn(snapshot_id);
+    let arn = state.db_snapshot_arn(&state.region, snapshot_id);
     state.snapshots.insert(
         snapshot_id.to_string(),
         crate::state::DbSnapshot {

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -627,40 +627,42 @@ impl RdsState {
         self.events.push(event);
     }
 
-    pub fn db_instance_arn(&self, db_instance_identifier: &str) -> String {
+    // ARN carries the request's credential-scope region (req.region), not the
+    // frozen server default. Storage keying is by account/identifier, unchanged.
+    pub fn db_instance_arn(&self, region: &str, db_instance_identifier: &str) -> String {
         Arn::new(
             "rds",
-            &self.region,
+            region,
             &self.account_id,
             &format!("db:{db_instance_identifier}"),
         )
         .to_string()
     }
 
-    pub fn db_snapshot_arn(&self, db_snapshot_identifier: &str) -> String {
+    pub fn db_snapshot_arn(&self, region: &str, db_snapshot_identifier: &str) -> String {
         Arn::new(
             "rds",
-            &self.region,
+            region,
             &self.account_id,
             &format!("snapshot:{db_snapshot_identifier}"),
         )
         .to_string()
     }
 
-    pub fn db_subnet_group_arn(&self, db_subnet_group_name: &str) -> String {
+    pub fn db_subnet_group_arn(&self, region: &str, db_subnet_group_name: &str) -> String {
         Arn::new(
             "rds",
-            &self.region,
+            region,
             &self.account_id,
             &format!("subgrp:{db_subnet_group_name}"),
         )
         .to_string()
     }
 
-    pub fn db_parameter_group_arn(&self, db_parameter_group_name: &str) -> String {
+    pub fn db_parameter_group_arn(&self, region: &str, db_parameter_group_name: &str) -> String {
         Arn::new(
             "rds",
-            &self.region,
+            region,
             &self.account_id,
             &format!("pg:{db_parameter_group_name}"),
         )
@@ -1069,10 +1071,18 @@ mod tests {
     #[test]
     fn arn_helpers_format_correctly() {
         let state = RdsState::new("123456789012", "eu-west-1");
-        assert!(state.db_instance_arn("mydb").contains(":db:mydb"));
-        assert!(state.db_snapshot_arn("snap1").contains(":snapshot:snap1"));
-        assert!(state.db_subnet_group_arn("sng").contains("sng"));
-        assert!(state.db_parameter_group_arn("pg").contains("pg"));
+        assert!(state
+            .db_instance_arn(&state.region, "mydb")
+            .contains(":db:mydb"));
+        assert!(state
+            .db_snapshot_arn(&state.region, "snap1")
+            .contains(":snapshot:snap1"));
+        assert!(state
+            .db_subnet_group_arn(&state.region, "sng")
+            .contains("sng"));
+        assert!(state
+            .db_parameter_group_arn(&state.region, "pg")
+            .contains("pg"));
     }
 
     #[test]
@@ -1209,10 +1219,10 @@ mod tests {
     #[test]
     fn arn_helpers_include_region_and_account() {
         let state = RdsState::new("111122223333", "ap-southeast-2");
-        let arn = state.db_instance_arn("my-db");
+        let arn = state.db_instance_arn(&state.region, "my-db");
         assert!(arn.contains("111122223333"));
         assert!(arn.contains("ap-southeast-2"));
-        let snap = state.db_snapshot_arn("snap");
+        let snap = state.db_snapshot_arn(&state.region, "snap");
         assert!(snap.contains("snapshot:snap"));
     }
 

--- a/crates/fakecloud-scheduler/src/service.rs
+++ b/crates/fakecloud-scheduler/src/service.rs
@@ -187,7 +187,9 @@ impl SchedulerService {
         }
 
         let now = Utc::now();
-        let arn = schedule_arn(&state.region, &state.account_id, &group_name, name);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
+        let arn = schedule_arn(req.region.as_str(), &state.account_id, &group_name, name);
         let sched = Schedule {
             arn: arn.clone(),
             name: name.to_string(),
@@ -431,7 +433,9 @@ impl SchedulerService {
         }
 
         let now = Utc::now();
-        let arn = group_arn(&state.region, &state.account_id, name);
+        // ARN carries the request's credential-scope region (req.region), not the
+        // frozen server default.
+        let arn = group_arn(req.region.as_str(), &state.account_id, name);
         state.groups.insert(
             name.to_string(),
             ScheduleGroup {

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -875,14 +875,16 @@ impl SesV2Service {
                 }
             }
         }
-        // The primary region is always the current region
-        if !regions.contains(&state.region) {
-            regions.insert(0, state.region.clone());
+        // The primary region is the request's credential-scope region (req.region),
+        // not the frozen server default; the endpoint id encodes it too.
+        let primary_region = req.region.clone();
+        if !regions.contains(&primary_region) {
+            regions.insert(0, primary_region.clone());
         }
 
         let endpoint_id = format!(
             "ses-{}-{}",
-            state.region,
+            primary_region,
             uuid::Uuid::new_v4().to_string().split('-').next().unwrap()
         );
         let now = Utc::now();

--- a/crates/fakecloud-ssm/src/service/misc.rs
+++ b/crates/fakecloud-ssm/src/service/misc.rs
@@ -124,7 +124,7 @@ impl SsmService {
                     "SettingValue": setting.setting_value,
                     "LastModifiedDate": setting.last_modified_date.timestamp_millis() as f64 / 1000.0,
                     "LastModifiedUser": setting.last_modified_user,
-                    "ARN": Arn::new("ssm", &state.region, &state.account_id, &format!("servicesetting/{}", setting.setting_id)).to_string(),
+                    "ARN": Arn::new("ssm", req.region.as_str(), &state.account_id, &format!("servicesetting/{}", setting.setting_id)).to_string(),
                     "Status": setting.status,
                 }
             })))
@@ -136,7 +136,7 @@ impl SsmService {
                     "SettingValue": get_default_service_setting(setting_id),
                     "LastModifiedDate": Utc::now().timestamp_millis() as f64 / 1000.0,
                     "LastModifiedUser": "System",
-                    "ARN": Arn::new("ssm", &state.region, &state.account_id, &format!("servicesetting/{setting_id}")).to_string(),
+                    "ARN": Arn::new("ssm", req.region.as_str(), &state.account_id, &format!("servicesetting/{setting_id}")).to_string(),
                     "Status": "Default",
                 }
             })))
@@ -164,7 +164,7 @@ impl SsmService {
                 "SettingValue": default_value,
                 "LastModifiedDate": Utc::now().timestamp_millis() as f64 / 1000.0,
                 "LastModifiedUser": "System",
-                "ARN": Arn::new("ssm", &state.region, &state.account_id, &format!("servicesetting/{setting_id}")).to_string(),
+                "ARN": Arn::new("ssm", req.region.as_str(), &state.account_id, &format!("servicesetting/{setting_id}")).to_string(),
                 "Status": "Default",
             }
         })))

--- a/crates/fakecloud-ssm/src/service/ops.rs
+++ b/crates/fakecloud-ssm/src/service/ops.rs
@@ -432,9 +432,14 @@ impl SsmService {
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
+        // ARN carries the request's credential-scope region (req.region). It is
+        // also the storage key, but Get/Update/Delete look up by the exact ARN
+        // string the client received here, so keying stays consistent.
         let arn = format!(
             "arn:aws:ssm:{}:{}:opsmetadata/{}",
-            state.region, state.account_id, resource_id
+            req.region.as_str(),
+            state.account_id,
+            resource_id
         );
 
         if state.ops_metadata.contains_key(&arn) {

--- a/crates/fakecloud-testkit/src/lib.rs
+++ b/crates/fakecloud-testkit/src/lib.rs
@@ -193,9 +193,17 @@ impl TestServer {
 
     /// Create a shared AWS SDK config pointing at this test server.
     pub async fn aws_config(&self) -> aws_config::SdkConfig {
+        self.aws_config_in("us-east-1").await
+    }
+
+    /// Like [`Self::aws_config`] but signs requests for an arbitrary region.
+    /// The SigV4 credential-scope region is what handlers see as
+    /// `req.region`, so this lets tests assert region-scoped ARNs/ids are
+    /// stamped from the request region rather than the server default.
+    pub async fn aws_config_in(&self, region: &str) -> aws_config::SdkConfig {
         aws_config::defaults(BehaviorVersion::latest())
             .endpoint_url(self.endpoint())
-            .region(Region::new("us-east-1"))
+            .region(Region::new(region.to_string()))
             .credentials_provider(Credentials::new(
                 "AKIAIOSFODNN7EXAMPLE",
                 "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",


### PR DESCRIPTION
## Summary
The **region-in-ARN family** (#2356 siblings). `MultiAccountState` freezes its `region` at server startup; these services stamped that frozen region into ARNs/ids **returned to or stored for** the client instead of the request's SigV4 credential-scope region (`req.region`). A resource created by a Terraform provider configured for e.g. `eu-central-1` came back with a `us-east-1` ARN — which the client stores and reuses, so the *next* call breaks: Terraform shows perpetual drift / refresh mismatch, and cross-service IAM ARN matching fails. The immediate response looked fine, which is why conformance (signs `us-east-1`, so `req.region == state.region`) never caught it. Already fixed for Lambda (#2361) and sqs/kms/logs/sfn/eventbridge-custom/cfn (#2363); this closes the remaining siblings, including an intra-service **mixed-region** hazard the partial #2358 fix left in ElastiCache/SSM.

## Fix
Thread `req.region` into every returned/stored ARN builder (state methods gained a leading `region: &str` param; **storage keys, lookup normalization, and KMS encryption-context regions are unchanged** — only ARN strings change), mirroring #2361:
- **ECS** service/task/container-instance/cluster/task-definition/daemon ARNs + `discover_poll_endpoint` host.
- **RDS** instance/snapshot/subnet-group/parameter-group ARNs + the hardcoded `us-east-1` in `extras` (~30 cluster/proxy/global-cluster ARNs & endpoint hosts).
- **DynamoDB** table + `LatestStreamArn` + backup/export/import ARNs.
- **ElastiCache** cluster/replication-group/subnet-group/user/serverless/snapshot ARNs (closes the mixed-region inconsistency vs the already-`request.region` security-group/parameter-group handlers).
- **Kinesis** stream ARN; **ECR** repository ARN; **Scheduler** schedule/group ARNs (matching its IAM path); **SSM** servicesetting + OpsMetadata ARNs.
- **Cognito** (subtle): the pool id (`{region}_rand`), ARN, and the OIDC issuer / JWKS / token `iss` + WebAuthn `rp.id` all derive region from the **pool id prefix**, so `iss == pool id == ARN` by construction regardless of caller region.
- **apigatewayv2** domain-name host/ARN + portal ARNs; **SES** multi-region endpoint primary region + id.
- The CFN provisioner's ECR/RDS ARN callers pass the provisioner's own region (unchanged behavior).

Left as noted init-time limitations (no request region reachable): the EventBridge **default**-bus seed and the apigatewayv2 websocket per-message dispatch.

Found by the 2026-07-23 bug-hunt (Tier 0; classes: identity/ARN + terraform-fidelity), corroborated by two independent hunt agents.

## Test plan
- New `region_scoped_arns`: resources created with an `eu-central-1`-signed client return `eu-central-1` ARNs/ids (asserting NOT `us-east-1`) across DynamoDB, Kinesis, ECR, ECS, RDS, and Cognito (incl. the `eu-central-1_`-prefixed pool id).
- All 12 crates + `fakecloud-cloudformation` build `--all-targets` clean under `-D warnings`; existing per-service tests updated for the new builder signatures.
- Conformance unaffected (it signs `us-east-1`, so ARNs are unchanged there).

## Surface impact
No API surface / flag / field / count change — ARN region-scoping correctness. No docs/SDK/website/metadata update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ARNs and client-visible IDs to use the request’s SigV4 region instead of the server’s default, preventing Terraform drift and cross-service IAM mismatches. No API shape changes; only returned strings now reflect the caller’s region.

- **Bug Fixes**
  - Threaded `req.region` into ARN/ID builders; storage keys and lookups are unchanged.
  - Covered services: ECS (service/task/container-instance/cluster/task-def/daemon ARNs and `discover_poll_endpoint`; background respawn keeps the service’s region), RDS (instance/snapshot/subnet-group/parameter-group ARNs and extras endpoints), DynamoDB (table, stream, backup/export/import ARNs), ElastiCache (cluster/replication-group/subnet-group/user/serverless/snapshot ARNs), Kinesis (stream ARN), ECR (repository ARN), Scheduler (schedule/group ARNs), SSM (ServiceSetting + OpsMetadata ARNs), `apigatewayv2` (custom-domain host + `DomainNameArn`, portal ARNs), SES (primary region + endpoint id), Cognito (pool id `{region}_…`, ARN, OIDC issuer/JWKS/token `iss`, WebAuthn `rp.id` all derived from the pool-id prefix).
  - CloudFormation provisioners for ECR and RDS now pass their own region to ARN builders.
  - Known init-time limits: EventBridge default bus and `apigatewayv2` websocket per-message dispatch still use the server default region.
  - Added `region_scoped_arns` e2e test verifying EU-region ARNs across DynamoDB, Kinesis, ECR, ECS, RDS, and Cognito; conformance unchanged (still signs `us-east-1`).

<sup>Written for commit d4109978018a6ea8a3aedb5803002ea84d7da6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

