### PR TITLE
fix(iam,core): match IAM action names case-insensitively + fail closed on unmapped anonymous actions

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -826,6 +826,30 @@ pub async fn dispatch(
                         }
                         // Soft mode: audit log emitted; fall through to the handler.
                     }
+                } else {
+                    // Anonymous request to an iam_enforceable service whose
+                    // operation has no IamAction mapping. Mirror the signed
+                    // branch above: an operation we cannot map to an IAM action
+                    // cannot be authorized, so serving it would be a fail-open
+                    // bypass of `--iam strict`. Deny by default under strict;
+                    // soft mode warns and falls through.
+                    tracing::warn!(
+                        target: "fakecloud::iam::audit",
+                        service = %detected.service,
+                        action = %aws_request.action,
+                        mode = %config.iam_mode,
+                        request_id = %request_id,
+                        "anonymous request to iam_enforceable service has no IamAction mapping; denying under strict, allowing under soft"
+                    );
+                    if config.iam_mode.is_strict() {
+                        return build_error_response(
+                            StatusCode::FORBIDDEN,
+                            "AccessDenied",
+                            "Access Denied",
+                            &request_id,
+                            detected.protocol,
+                        );
+                    }
                 }
             }
         }

--- a/crates/fakecloud-iam/src/evaluator.rs
+++ b/crates/fakecloud-iam/src/evaluator.rs
@@ -937,19 +937,24 @@ fn resource_matches(resource: &ResourceMatch, request_resource: &str) -> bool {
 }
 
 /// IAM-style glob match supporting `*` (any sequence) and `?` (single
-/// character). When `case_insensitive_service_prefix` is true and the
-/// pattern looks like an action (`service:Action`), the service prefix is
-/// matched case-insensitively while the action name is matched as-is —
-/// matches how AWS evaluates Action patterns.
-fn iam_glob_match(pattern: &str, value: &str, case_insensitive_service_prefix: bool) -> bool {
-    if case_insensitive_service_prefix {
+/// character). When `is_action` is true the pattern is an Action element
+/// (`service:Action`), which AWS evaluates **case-insensitively** for BOTH the
+/// service prefix and the action name — so `s3:deleteobject` and
+/// `s3:DeleteObject` match. Resource (ARN) patterns pass `false` and are
+/// matched case-sensitively.
+fn iam_glob_match(pattern: &str, value: &str, is_action: bool) -> bool {
+    if is_action {
         if let (Some((p_svc, p_act)), Some((v_svc, v_act))) =
             (pattern.split_once(':'), value.split_once(':'))
         {
             if !glob_match(&p_svc.to_ascii_lowercase(), &v_svc.to_ascii_lowercase()) {
                 return false;
             }
-            return glob_match(p_act, v_act);
+            // AWS matches the action NAME case-insensitively too. Comparing it
+            // verbatim let a mixed-case explicit Deny (e.g. `s3:deleteobject`)
+            // silently miss `s3:DeleteObject` and become a no-op, so the
+            // request fell through to an Allow.
+            return glob_match(&p_act.to_ascii_lowercase(), &v_act.to_ascii_lowercase());
         }
     }
     glob_match(pattern, value)

--- a/crates/fakecloud-iam/src/evaluator_tests.rs
+++ b/crates/fakecloud-iam/src/evaluator_tests.rs
@@ -66,10 +66,14 @@ fn iam_action_service_prefix_is_case_insensitive() {
 }
 
 #[test]
-fn iam_action_name_is_case_sensitive() {
-    // Action name is case-sensitive in AWS.
-    assert!(!iam_glob_match("s3:getobject", "s3:GetObject", true));
+fn iam_action_name_is_case_insensitive() {
+    // AWS matches the Action element case-insensitively for BOTH the service
+    // prefix and the action name. A differently-cased action must still match.
+    assert!(iam_glob_match("s3:getobject", "s3:GetObject", true));
+    assert!(iam_glob_match("S3:GETOBJECT", "s3:GetObject", true));
     assert!(iam_glob_match("s3:GetObject", "s3:GetObject", true));
+    // Different action entirely still does not match.
+    assert!(!iam_glob_match("s3:putobject", "s3:GetObject", true));
 }
 
 #[test]
@@ -139,6 +143,29 @@ fn deny_takes_precedence_over_allow() {
     assert_eq!(
         evaluate(
             &[deny, allow],
+            &req(&p, "s3:DeleteObject", "arn:aws:s3:::bucket/key")
+        ),
+        Decision::ExplicitDeny
+    );
+}
+
+#[test]
+fn mixed_case_explicit_deny_still_wins() {
+    // Regression: a Deny written with a non-canonical action case (as a user
+    // copying a real AWS policy or typing lowercase easily does) must still
+    // deny the canonically-cased request. Pre-fix the action name was matched
+    // verbatim, so this Deny silently became a no-op and the request was
+    // allowed.
+    let p = principal_user("arn:aws:iam::123456789012:user/alice");
+    let allow = doc(json!({
+        "Statement": [{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}]
+    }));
+    let deny = doc(json!({
+        "Statement": [{"Effect": "Deny", "Action": "s3:deleteobject", "Resource": "*"}]
+    }));
+    assert_eq!(
+        evaluate(
+            &[allow, deny],
             &req(&p, "s3:DeleteObject", "arn:aws:s3:::bucket/key")
         ),
         Decision::ExplicitDeny


### PR DESCRIPTION
## Summary
Two auth-when-enabled correctness bugs (only reachable with `--iam` / `--verify-sigv4`).

**1. IAM Action matched case-sensitively (MED wrong-allow).** `iam_glob_match` lowercased only the service prefix and compared the action **name** verbatim. AWS evaluates the whole Action element case-insensitively, so a principal with `Allow s3:*` plus an explicit `{"Effect":"Deny","Action":"s3:deleteobject"}` (non-canonical case — exactly what a user copying a real policy or typing lowercase produces) had the Deny silently miss `s3:DeleteObject` and become a no-op → the request fell through to the Allow. An explicit Deny becoming a no-op is a wrong-allow that undermines a user verifying their security posture. Fix: lower-case both the service prefix and the action name. Resource/ARN patterns stay case-sensitive (correct for AWS). Renamed the now-misleading `case_insensitive_service_prefix` flag to `is_action`.

**2. Anonymous unmapped action served under `--iam strict` (LOW fail-open).** The signed-principal branch fails closed when a service is `iam_enforceable` but `iam_action_for` returns `None`; the anonymous branch skipped the check entirely and fell through to the handler. Mirror the signed branch: warn always, deny under strict.

Found by the 2026-07-23 bug-hunt (Tier 5, class: auth).

## Test plan
- `mixed_case_explicit_deny_still_wins`: `Allow s3:*` + `Deny s3:deleteobject` → `ExplicitDeny` for `s3:DeleteObject`.
- `iam_action_name_is_case_insensitive` (replaces the test that had encoded the buggy behavior) + wildcard/prefix cases.
- Full `fakecloud-iam` unit suite (540) green; `iam_enforcement` + `sigv4_verification` + `iam_enforcement_scheduler` e2e green (incl. `strict_mode_denies_unmapped_enforceable_action`).
- `cargo clippy -p fakecloud-iam -p fakecloud-core --all-targets -D warnings` clean.

## Surface impact
No API surface / flag / field / count change — enforcement-correctness fix, only active when `--iam`/`--verify-sigv4` is opted in. No docs/SDK/metadata update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make IAM Action matching case-insensitive and close a strict-mode bypass for anonymous requests. Aligns with AWS behavior and prevents wrong-allow when an explicit Deny uses different casing.

- **Bug Fixes**
  - Action matching: Both the service prefix and action name are matched case-insensitively in `fakecloud-iam`; resource/ARN patterns remain case-sensitive.
  - Anonymous unmapped actions: In `fakecloud-core` dispatch, deny under strict when an enforceable action has no IAM mapping; warn and allow in soft mode.

<sup>Written for commit a7b3ab11843b162078c5c17b6dfc5ac9f302936d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

