### PR TITLE
fix(ec2): boot a fresh container when StartInstances resumes a stopped instance after restart

### DIFF
--- a/crates/fakecloud-ec2/src/runtime/mod.rs
+++ b/crates/fakecloud-ec2/src/runtime/mod.rs
@@ -588,6 +588,19 @@ impl Ec2Runtime {
         }
     }
 
+    /// Whether the runtime holds an in-memory backing record for this instance.
+    /// After a fakecloud restart the registry is rebuilt only for instances that
+    /// persisted as `running`/`pending` (see `recover_persisted_containers`), so
+    /// an instance that persisted as `stopped` has no record here. `StartInstances`
+    /// uses this to distinguish "reattach the existing container" (`start_instance`)
+    /// from "the registry was lost across a restart, boot a fresh container"
+    /// (`run_instance`) — without it, starting a stopped-then-restarted instance
+    /// flips it to `running` with no backing container (the EC2 analogue of the
+    /// RDS restart-recovery bug).
+    pub fn is_registered(&self, instance_id: &str) -> bool {
+        self.instances.read().contains_key(instance_id)
+    }
+
     fn handle_of(&self, instance_id: &str) -> Option<String> {
         self.instances
             .read()

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -611,6 +611,50 @@ fn reconcile_started(
     }
 }
 
+/// The inputs [`crate::runtime::Ec2Runtime::run_instance`] needs to boot a
+/// backing container, reconstituted from a persisted instance: base64
+/// user-data, the tag map (carries `fakecloud-k8s/*` Pod scheduling tags), and
+/// the subnet network placement.
+type RunInstanceInputs = (
+    Option<String>,
+    std::collections::BTreeMap<String, String>,
+    Option<crate::runtime::InstanceNetwork>,
+);
+
+/// Gather the inputs needed to boot a fresh backing container for an already
+/// persisted instance (`user_data`, the tag map, and the subnet network
+/// placement), reading them from the persisted instance metadata. Mirrors the
+/// per-instance derivation in
+/// [`recover_persisted_containers`](crate::service::Ec2Service::recover_persisted_containers)
+/// so a container reconstituted here rejoins the same VPC/subnet (and re-runs
+/// the same user-data) as one recovered on restart. Returns `None` if the
+/// instance no longer exists.
+fn run_instance_inputs(
+    state: &crate::state::SharedEc2State,
+    account_id: &str,
+    id: &str,
+) -> Option<RunInstanceInputs> {
+    let accounts = state.read();
+    let s = accounts.get(account_id)?;
+    let inst = s.instances.get(id)?;
+    let user_data = inst.user_data.clone();
+    // A subnet with no `0.0.0.0/0 -> igw` route is private -> `internal`
+    // network, matching RunInstances / recover_persisted_containers.
+    let network = inst
+        .subnet_id
+        .clone()
+        .map(|sid| crate::runtime::InstanceNetwork {
+            internal: !crate::defaults::subnet_is_public(s, &sid),
+            subnet_id: sid,
+        });
+    let tags = s
+        .tags_for(id)
+        .iter()
+        .map(|t| (t.key.clone(), t.value.clone()))
+        .collect();
+    Some((user_data, tags, network))
+}
+
 /// Build a [`MetadataOptions`](crate::state::MetadataOptions) from launch-time
 /// `MetadataOptions.*` request params, defaulting each unset field to the AWS
 /// default. Shared by RunInstances (the CFN provisioner parses its own JSON
@@ -1094,7 +1138,39 @@ async fn change_state(
                 match new_code {
                     16 => {
                         let running = match &runtime {
-                            Some(rt) => rt.start_instance(id).await,
+                            // The runtime holds a backing record for this
+                            // instance: reattach/restart the existing container.
+                            Some(rt) if rt.is_registered(id) => rt.start_instance(id).await,
+                            // No backing record: the instance persisted as
+                            // `stopped` and fakecloud restarted, so its runtime
+                            // registry entry was never rebuilt (recovery only
+                            // reconstitutes running/pending instances). `start_instance`
+                            // would return `None` and `reconcile_started` would
+                            // flip the instance to `running` with no live
+                            // container — a phantom-running instance where every
+                            // later container-backed op silently no-ops (the EC2
+                            // analogue of the RDS restart-recovery bug). Boot a
+                            // fresh container from the persisted metadata instead,
+                            // mirroring `recover_persisted_containers`.
+                            Some(rt) => match run_instance_inputs(&svc_state, &account_id, id) {
+                                Some((user_data, tags, network)) => match rt
+                                    .run_instance(
+                                        &account_id,
+                                        id,
+                                        user_data.as_deref(),
+                                        &tags,
+                                        network.as_ref(),
+                                    )
+                                    .await
+                                {
+                                    Ok(r) => Some(r),
+                                    Err(e) => {
+                                        tracing::warn!(instance_id = %id, error = %e, "EC2 instance container failed to start after restart; serving metadata-only");
+                                        None
+                                    }
+                                },
+                                None => None,
+                            },
                             None => None,
                         };
                         reconcile_started(&svc_state, &account_id, id, running);
@@ -2403,6 +2479,80 @@ mod modify_tests {
             enable_resource_name_dns_aaaa_record: false,
         };
         state.instances.insert(id.to_string(), inst);
+    }
+
+    // Docker-free coverage of the metadata threading the StartInstances
+    // stopped-then-restart fallback relies on: after a restart the runtime
+    // registry has no handle for a `stopped` instance, so the boot task must
+    // reconstitute a fresh container via `run_instance`, feeding it the same
+    // user-data / tags / subnet placement as `recover_persisted_containers`
+    // would. This asserts `run_instance_inputs` extracts exactly those from the
+    // persisted instance (the container spawn itself needs Docker and is not
+    // exercised here).
+    #[test]
+    fn run_instance_inputs_mirror_persisted_metadata() {
+        let svc = Ec2Service::new();
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            let inst = crate::state::Instance {
+                instance_id: "i-1".into(),
+                image_id: "ami-1".into(),
+                instance_type: "t3.micro".into(),
+                state_code: 80,
+                state_name: "stopped".into(),
+                private_ip: "10.0.0.5".into(),
+                public_ip: None,
+                subnet_id: Some("subnet-1".into()),
+                vpc_id: Some("vpc-1".into()),
+                key_name: None,
+                security_group_ids: vec![],
+                reservation_id: "r-1".into(),
+                ami_launch_index: 0,
+                monitoring: false,
+                az: "us-east-1a".into(),
+                launch_time: "2024-01-01T00:00:00.000Z".into(),
+                container_id: None,
+                disable_api_termination: false,
+                disable_api_stop: false,
+                source_dest_check: true,
+                ebs_optimized: false,
+                instance_initiated_shutdown_behavior: "stop".into(),
+                user_data: Some("Zm9v".into()),
+                metadata_options: Default::default(),
+                cpu_options: None,
+                bandwidth_weighting: None,
+                maintenance_options: Default::default(),
+                placement_tenancy: None,
+                placement_affinity: None,
+                placement_group_name: None,
+                private_dns_hostname_type: None,
+                enable_resource_name_dns_a_record: false,
+                enable_resource_name_dns_aaaa_record: false,
+            };
+            state.instances.insert("i-1".into(), inst);
+            state.upsert_tags(
+                "i-1",
+                &[Tag {
+                    key: "Name".into(),
+                    value: "web".into(),
+                }],
+            );
+        }
+
+        let (user_data, tags, network) =
+            run_instance_inputs(&svc.state, "000000000000", "i-1").expect("instance exists");
+        assert_eq!(user_data.as_deref(), Some("Zm9v"), "user-data is threaded");
+        assert_eq!(
+            tags.get("Name").map(String::as_str),
+            Some("web"),
+            "tags threaded"
+        );
+        let net = network.expect("subnet-bound instance gets a network placement");
+        assert_eq!(net.subnet_id, "subnet-1", "rejoins the same subnet");
+
+        // A missing instance yields None (mirrors a concurrent terminate).
+        assert!(run_instance_inputs(&svc.state, "000000000000", "i-missing").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
MED restart-recovery bug — the EC2 analogue of the RDS #1338/#914 "restored `available` but backing container dead" class. `recover_persisted_containers` rebuilds the runtime handle registry only for `running`/`pending` instances, so a `stopped` instance has no registry entry after a server restart. `StartInstances` then spawned a boot task that called `runtime.start_instance(id)`, which returned `None` (no handle) — yet `reconcile_started` flipped the instance to `running` **unconditionally**. Result: DescribeInstances reports `running` with no live container, and every later container-backed op (console output, networking, later Stop/Reboot) silently no-ops.

## Fix
In the boot task, distinguish reattach from recreate with a new `runtime.is_registered(id)`:
- **registered** (handle survived) → `start_instance` as before.
- **unregistered** (lost across restart) → boot a genuinely fresh container via `run_instance`, threading user-data, tags, and the subnet `InstanceNetwork` from the persisted instance metadata **exactly like `recover_persisted_containers`** (private subnets get the `--internal` network; the durable data volume reattaches under `FAKECLOUD_PERSIST_EC2_VOLUMES`). `reconcile_started` then populates `container_id`/`private_ip` from the real handle.

Metadata-only mode (no runtime wired) returns `None` and flips to `running` exactly as before — no regression. The container spawn stays off the request path (inside the existing spawned boot task); no ephemeral handle is persisted.

Found by the 2026-07-23 bug-hunt (Tier 4, class: concurrency/persistence/restart-recovery).

## Test plan
- `run_instance_inputs_mirror_persisted_metadata` (Docker-free): seeds a `stopped` instance with user-data/subnet/tag and asserts the fallback's metadata threading (base64 user-data, tag map, subnet placement; `None` for a missing id). The actual container boot needs Docker and runs in CI; the registry-branch decision is a trivial HashMap lookup.
- `cargo build -p fakecloud-ec2 --tests` + `clippy --all-targets -D warnings` clean.

## Surface impact
No API surface / flag / field / count change — restart-recovery correctness. No docs/SDK/metadata update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an EC2 restart-recovery bug where starting a previously stopped instance after a server restart could report running with no backing container. We now check for a missing runtime handle and, if absent, boot a fresh container from persisted metadata.

- **Bug Fixes**
  - Added `Ec2Runtime::is_registered` to detect if a runtime handle exists.
  - Updated `StartInstances` boot task: if unregistered, rebuild user-data, tags, and subnet placement from persisted state and call `run_instance`; then reconcile real `container_id`/`private_ip` (warn and serve metadata-only if boot fails).
  - Kept metadata-only mode unchanged and added `run_instance_inputs_mirror_persisted_metadata` test; no API changes.

<sup>Written for commit 746b9cf722213a3596288111832791acc4c87334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

