### PR TITLE
fix(route53,acm): honor ListReusableDelegationSets pagination + apply ListCertificates sort

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -669,6 +669,9 @@ impl AcmService {
             })
             .unwrap_or_default();
 
+        let sort_by = body.get("SortBy").and_then(Value::as_str);
+        let sort_order = body.get("SortOrder").and_then(Value::as_str);
+
         let state = self.state.read();
         let mut all: Vec<StoredCertificate> = state
             .accounts
@@ -676,7 +679,17 @@ impl AcmService {
             .map(|a| a.certificates.values().cloned().collect())
             .unwrap_or_default();
         drop(state);
-        all.sort_by(|a, b| a.arn.cmp(&b.arn));
+        // When `SortBy=CREATED_AT` is requested, order by creation time in the
+        // requested direction (AWS defaults to ASCENDING). Otherwise fall back to
+        // the stable ARN ordering.
+        if sort_by == Some("CREATED_AT") {
+            all.sort_by_key(|c| c.created_at);
+            if sort_order == Some("DESCENDING") {
+                all.reverse();
+            }
+        } else {
+            all.sort_by(|a, b| a.arn.cmp(&b.arn));
+        }
         all.retain(|c| {
             (statuses.is_empty() || statuses.contains(&c.status))
                 && (key_types.is_empty() || key_types.contains(&c.key_algorithm))
@@ -2880,6 +2893,81 @@ mod tests {
                 arn["c.example.com"].clone(),
                 arn["b.example.com"].clone(),
                 arn["a.example.com"].clone(),
+            ]
+        );
+    }
+
+    // ListCertificates must honor SortBy=CREATED_AT / SortOrder (previously
+    // validated then ignored — always sorted by ARN).
+    #[tokio::test]
+    async fn list_certificates_sorts_by_created_at() {
+        let svc = AcmService::default();
+        let mut arn: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
+        for d in ["a.example.com", "b.example.com", "c.example.com"] {
+            let resp = svc
+                .handle(make_req("RequestCertificate", json!({ "DomainName": d })))
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            arn.insert(d, body["CertificateArn"].as_str().unwrap().to_string());
+        }
+
+        // a oldest, c newest.
+        {
+            let mut state = svc.state.write();
+            let certs = &mut state.accounts.get_mut("123456789012").unwrap().certificates;
+            let now = chrono::Utc::now();
+            for c in certs.values_mut() {
+                match c.domain_name.as_str() {
+                    "a.example.com" => c.created_at = now - chrono::Duration::hours(2),
+                    "b.example.com" => c.created_at = now - chrono::Duration::hours(1),
+                    _ => c.created_at = now,
+                }
+            }
+        }
+
+        let arns = |body: &Value| -> Vec<String> {
+            body["CertificateSummaryList"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|r| r["CertificateArn"].as_str().unwrap().to_string())
+                .collect()
+        };
+
+        // DESCENDING -> newest (c) first.
+        let resp = svc
+            .handle(make_req(
+                "ListCertificates",
+                json!({ "SortBy": "CREATED_AT", "SortOrder": "DESCENDING" }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            arns(&body),
+            vec![
+                arn["c.example.com"].clone(),
+                arn["b.example.com"].clone(),
+                arn["a.example.com"].clone(),
+            ]
+        );
+
+        // ASCENDING -> oldest (a) first.
+        let resp = svc
+            .handle(make_req(
+                "ListCertificates",
+                json!({ "SortBy": "CREATED_AT", "SortOrder": "ASCENDING" }),
+            ))
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            arns(&body),
+            vec![
+                arn["a.example.com"].clone(),
+                arn["b.example.com"].clone(),
+                arn["c.example.com"].clone(),
             ]
         );
     }

--- a/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
+++ b/crates/fakecloud-e2e/tests/route53_vpc_delegation_geo_tags.rs
@@ -345,6 +345,61 @@ async fn reusable_delegation_set_lifecycle() {
 }
 
 #[tokio::test]
+async fn list_reusable_delegation_sets_paginates() {
+    let server = TestServer::start().await;
+    let r53 = server.route53_client().await;
+
+    // Create several delegation sets.
+    let mut created: Vec<String> = Vec::new();
+    for i in 0..3 {
+        let c = r53
+            .create_reusable_delegation_set()
+            .caller_reference(format!("page-ds-{i}"))
+            .send()
+            .await
+            .expect("create ds");
+        created.push(c.delegation_set().unwrap().id().unwrap().to_string());
+    }
+    created.sort();
+
+    // Page one at a time, following NextMarker, and collect every id.
+    let mut collected: Vec<String> = Vec::new();
+    let mut marker: Option<String> = None;
+    loop {
+        let mut req = r53.list_reusable_delegation_sets().max_items(1);
+        if let Some(m) = &marker {
+            req = req.marker(m);
+        }
+        let page = req.send().await.expect("list ds page");
+        assert!(
+            page.delegation_sets().len() <= 1,
+            "MaxItems=1 must cap the page at one element"
+        );
+        for d in page.delegation_sets() {
+            collected.push(d.id().unwrap().to_string());
+        }
+        if page.is_truncated() {
+            let nm = page
+                .next_marker()
+                .expect("truncated page must carry a NextMarker")
+                .to_string();
+            marker = Some(nm);
+        } else {
+            assert!(
+                page.next_marker().is_none(),
+                "final page must not carry a NextMarker"
+            );
+            break;
+        }
+    }
+    collected.sort();
+    assert_eq!(
+        collected, created,
+        "paginated ids must equal the full set exactly once each"
+    );
+}
+
+#[tokio::test]
 async fn duplicate_delegation_set_caller_reference_rejected() {
     let server = TestServer::start().await;
     let r53 = server.route53_client().await;

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -1353,19 +1353,46 @@ impl Route53Service {
             .unwrap_or_default();
         drop(state);
         sets.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // Paginate on `marker` (the next delegation set id) + `maxitems`,
+        // mirroring the other route53 List operations.
+        let max_items = req
+            .query_params
+            .get("maxitems")
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        let marker = req.query_params.get("marker").cloned().unwrap_or_default();
+        let start_idx = if marker.is_empty() {
+            0
+        } else {
+            sets.iter()
+                .position(|d| d.id == marker)
+                .unwrap_or(sets.len())
+        };
+        let page: Vec<&StoredReusableDelegationSet> =
+            sets.iter().skip(start_idx).take(max_items).collect();
+        let next_marker = sets.get(start_idx + page.len()).map(|d| d.id.clone());
+
         let mut body = String::with_capacity(512);
         body.push_str(XML_DECL);
         body.push_str(&format!(
             "<ListReusableDelegationSetsResponse xmlns=\"{NS}\">"
         ));
         body.push_str("<DelegationSets>");
-        for d in &sets {
+        for d in &page {
             push_delegation_set(&mut body, d);
         }
         body.push_str("</DelegationSets>");
-        body.push_str("<Marker></Marker>");
-        body.push_str("<IsTruncated>false</IsTruncated>");
-        body.push_str("<MaxItems>100</MaxItems>");
+        body.push_str(&format!("<Marker>{}</Marker>", esc(&marker)));
+        body.push_str(&format!(
+            "<IsTruncated>{}</IsTruncated>",
+            next_marker.is_some()
+        ));
+        body.push_str(&format!("<MaxItems>{max_items}</MaxItems>"));
+        if let Some(nm) = next_marker {
+            body.push_str(&format!("<NextMarker>{}</NextMarker>", esc(&nm)));
+        }
         body.push_str("</ListReusableDelegationSetsResponse>");
         Ok(xml_response(StatusCode::OK, body, HeaderMap::new()))
     }


### PR DESCRIPTION
## Summary
Three Tier-1 tail fixes from the 2026-07-23 bug-hunt.

**SageMaker `Verb::Action` accept-and-discard (MED, class: stubs).** The catch-all routed any action not claimed by `special::dispatch` to `engine::action()`, which synthesizes outputs from the request id and returns 200 **without touching state** — silently no-op'ing mutating actions. `aws sagemaker batch-add-cluster-nodes` returned HTTP 200 with a plausible body while the node inventory read back unchanged; a poller/Terraform waiter hangs. Gate on an `is_read_only_action` classifier (mirroring iot/iotwireless): read-only actions keep the synthesized shape-valid response; unclaimed **mutating** actions (`Batch{Add,Delete,Reboot,Replace}ClusterNodes`, `Associate`/`DisassociateTrialComponent`, `SendPipelineExecutionStep{Success,Failure}`, `Attach`/`DetachClusterNodeVolume`, `ExtendTrainingPlan`) return `ActionNotImplemented`, surfacing the model gap instead of a fake success (per `feedback_no_stub_responses`). `special`-claimed ops and `Start*`/`Stop*` lifecycle transitions are unaffected.

**Route53 `ListReusableDelegationSets` pagination ignored (LOW-MED, class: correctness).** It validated `Marker`/`MaxItems` then ignored both — returned every set in one page with a hardcoded `IsTruncated=false`, so a paginating client never advanced. Now honors `MaxItems` (default 100) + `Marker` with correct `IsTruncated`/`NextMarker`, mirroring the other route53 List ops.

**ACM `ListCertificates` sort ignored (LOW-MED, class: correctness).** It validated `SortBy=CREATED_AT`/`SortOrder` then always sorted by ARN. Now sorts by certificate `created_at` in the requested order when `SortBy` is given; default (no SortBy) ordering and offset pagination unchanged.

## Test plan
- SageMaker: `unclaimed_mutating_action_fails_loud`, `unclaimed_read_only_action_still_synthesises`, `is_read_only_action_classifier`; existing exhaustive op test updated (30/30).
- Route53: e2e `list_reusable_delegation_sets_paginates` — 3 sets, `MaxItems=1` following `NextMarker`, union == full set exactly once.
- ACM: `list_certificates_sorts_by_created_at` (asc/desc).
- `build`/`clippy --all-targets -D warnings`/`fmt` clean for all three crates; lib tests 30/79/29.

## Surface impact
No API surface / flag / field / count change. SageMaker now returns a faithful `ActionNotImplemented` error for genuinely-unimplemented mutators instead of a fake 200 — a correctness change, not a new surface. No docs/SDK/metadata update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Route53 `ListReusableDelegationSets` pagination and apply ACM `ListCertificates` created-at sorting to return expected pages and ordering.

- **Bug Fixes**
  - `fakecloud-route53`: `ListReusableDelegationSets` now respects `Marker`/`MaxItems` and sets `IsTruncated`/`NextMarker` correctly.
  - `fakecloud-acm`: `ListCertificates` applies `SortBy=CREATED_AT` with `SortOrder` (ASC/DESC); default ordering and pagination unchanged.

<sup>Written for commit dba192da658b1efd771c01de5d95aea4e1e30386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

