### PR TITLE
fix(sdks/python): reformat README for ruff 0.16 + cap ruff <0.17 (unblock CI)

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -18,6 +18,7 @@ pip install fakecloud
 import asyncio
 from fakecloud import FakeCloud
 
+
 async def main():
     async with FakeCloud("http://localhost:4566") as fc:
         # Check server health
@@ -41,6 +42,7 @@ async def main():
 
         # Reset all state between tests
         await fc.reset()
+
 
 asyncio.run(main())
 ```
@@ -389,7 +391,7 @@ def test_classifier_branches_on_spam_vs_ham():
         ],
     )
 
-    classify("hello friend")           # user code that calls Bedrock
+    classify("hello friend")  # user code that calls Bedrock
     classify("buy now cheap pills")
 
     invocations = fc.bedrock.get_invocations().invocations
@@ -436,12 +438,14 @@ except FakeCloudError as e:
 import pytest
 from fakecloud import FakeCloudSync
 
+
 @pytest.fixture(autouse=True)
 def reset_fakecloud():
     fc = FakeCloudSync()
     fc.reset()
     yield fc
     fc.close()
+
 
 def test_email_sent(reset_fakecloud):
     # ... your code that sends an email via SES ...

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.9"
 dependencies = ["httpx>=0.24"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "boto3>=1.28", "ruff>=0.4", "mypy>=1.10"]
+dev = ["pytest>=7", "pytest-asyncio>=0.21", "boto3>=1.28", "ruff>=0.4,<0.17", "mypy>=1.10"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/fakecloud"]


### PR DESCRIPTION
## Summary
The `python-lint` CI job (`working-directory: sdks/python`) installs an **unpinned** `ruff>=0.4` and picked up 0.16.0, whose formatter reflows the async example in `sdks/python/README.md` (blank lines + comment spacing + a wrapped f-string assignment). `ruff format --check .` then failed on **every** PR regardless of its content — a systemic red on main (observed failing identically on two unrelated Rust-only PRs, #2383 and #2384, in <30s).

## Fix
- Reformat `sdks/python/README.md` with ruff 0.16.0 — `ruff check .` and `ruff format --check .` are both clean now, and only `README.md` changed.
- Cap the dev dependency at `ruff>=0.4,<0.17` so the next formatter-changing minor can't silently red every PR again.

## Test plan
- `ruff 0.16.0 format --check .` in `sdks/python` → `6 files already formatted`.
- `ruff 0.16.0 check .` → `All checks passed!`.

## Surface impact
Docs-only reformat of an SDK README + a dev-dependency version cap. No API/behavior/count change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformatted `sdks/python/README.md` to match `ruff` 0.16 formatting and capped the dev dependency to `ruff>=0.4,<0.17` to prevent formatter-induced CI failures. This unblocks python-lint on main; no runtime or API changes.

<sup>Written for commit e0ac568879e8fd8a285792a4b1016226a1815804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

