### PR TITLE
fix(rds): validate DB instance class by format instead of a 7-entry allowlist

### DIFF
--- a/crates/fakecloud-conformance/tests/rds.rs
+++ b/crates/fakecloud-conformance/tests/rds.rs
@@ -39,10 +39,24 @@ async fn rds_describe_orderable_db_instance_options() {
         .unwrap();
 
     let options = response.orderable_db_instance_options();
-    assert_eq!(options.len(), 7); // 7 instance classes per engine/version
-    assert_eq!(options[0].engine(), Some("postgres"));
-    assert_eq!(options[0].engine_version(), Some("16.3"));
-    assert_eq!(options[0].db_instance_class(), Some("db.t3.micro"));
+    // One option per instance class in the orderable catalog for this
+    // engine/version. The catalog is a realistic set of current-generation
+    // classes (not a fixed handful), so assert on its contents rather than an
+    // exact count/order.
+    assert!(
+        options.len() >= 7,
+        "expected a realistic orderable catalog, got {}",
+        options.len()
+    );
+    assert!(options
+        .iter()
+        .all(|o| o.engine() == Some("postgres") && o.engine_version() == Some("16.3")));
+    assert!(options
+        .iter()
+        .any(|o| o.db_instance_class() == Some("db.t3.micro")));
+    assert!(options
+        .iter()
+        .any(|o| o.db_instance_class() == Some("db.m6i.large")));
 }
 
 #[test_action("rds", "CreateDBInstance", checksum = "66cdd119")]

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -426,15 +426,56 @@ pub(crate) fn validate_create_request(
     Ok(())
 }
 
+/// Known AWS instance-size suffixes. The `<n>xlarge` sizes are matched
+/// structurally (any positive integer prefix) rather than enumerated, so
+/// future large sizes validate without a code change.
+const INSTANCE_SIZE_SUFFIXES: &[&str] = &["micro", "small", "medium", "large", "xlarge", "metal"];
+
+/// Returns true when `class` has the shape `db.<family>.<size>` that AWS
+/// uses for every DB instance class:
+///   * starts with `db.`
+///   * exactly three dot-separated, non-empty segments
+///   * family segment is alphanumeric (e.g. `t3`, `m6i`, `r6gd`)
+///   * size segment is a known suffix (`micro`/`small`/`medium`/`large`/
+///     `xlarge`/`metal`) or an `<n>xlarge` form (`2xlarge`, `24xlarge`, ...)
+///
+/// This mirrors what AWS actually accepts: it only rejects genuinely
+/// malformed values with `InvalidParameterValue`, not merely-uncommon
+/// (but well-formed) classes. The class is stored as metadata only and
+/// never influences the container runtime, so there is no need to gate on
+/// a fixed allowlist.
+pub(crate) fn is_valid_db_instance_class(class: &str) -> bool {
+    let Some(rest) = class.strip_prefix("db.") else {
+        return false;
+    };
+    let mut segments = rest.split('.');
+    let (Some(family), Some(size), None) = (segments.next(), segments.next(), segments.next())
+    else {
+        return false;
+    };
+    if family.is_empty() || !family.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return false;
+    }
+    is_valid_instance_size(size)
+}
+
+fn is_valid_instance_size(size: &str) -> bool {
+    if INSTANCE_SIZE_SUFFIXES.contains(&size) {
+        return true;
+    }
+    // `<n>xlarge` where <n> is a positive integer (2xlarge, 24xlarge, ...).
+    if let Some(prefix) = size.strip_suffix("xlarge") {
+        return !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit());
+    }
+    false
+}
+
 pub(crate) fn validate_db_instance_class(db_instance_class: &str) -> Result<(), AwsServiceError> {
-    if !crate::state::SUPPORTED_INSTANCE_CLASSES.contains(&db_instance_class) {
+    if !is_valid_db_instance_class(db_instance_class) {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
-            "InsufficientDBInstanceCapacity",
-            format!(
-                "DBInstanceClass '{}' is not available in the requested Availability Zone.",
-                db_instance_class
-            ),
+            "InvalidParameterValue",
+            format!("Invalid DB Instance class: {db_instance_class}"),
         ));
     }
     Ok(())
@@ -2198,5 +2239,92 @@ pub(crate) fn runtime_error_to_service_error(error: RuntimeError) -> AwsServiceE
             "InternalFailure",
             message,
         ),
+    }
+}
+
+#[cfg(test)]
+mod instance_class_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_common_current_generation_classes() {
+        // Classes the old 7-entry allowlist rejected but AWS accepts.
+        for class in [
+            "db.t4g.medium",
+            "db.t3.xlarge",
+            "db.t3.2xlarge",
+            "db.m6i.large",
+            "db.m6g.large",
+            "db.r6g.large",
+            "db.r5.large",
+            "db.m5.xlarge",
+            "db.t2.micro",
+            "db.r7g.16xlarge",
+            "db.m7g.48xlarge",
+            "db.x2idn.metal",
+        ] {
+            assert!(
+                is_valid_db_instance_class(class),
+                "expected {class} to be accepted"
+            );
+            assert!(
+                validate_db_instance_class(class).is_ok(),
+                "expected validate_db_instance_class to accept {class}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_classes_with_invalid_parameter_value() {
+        for class in [
+            "notaclass",         // no `db.` prefix, no segments
+            "db.foo",            // only two segments
+            "db.t3",             // missing size
+            "db.t3.",            // empty size
+            "db..large",         // empty family
+            "t3.micro",          // missing `db.` prefix
+            "db.t3.gigantic",    // unknown size suffix
+            "db.t3.micro.extra", // too many segments
+            "db.t-3.large",      // non-alphanumeric family
+            "",
+        ] {
+            assert!(
+                !is_valid_db_instance_class(class),
+                "expected {class:?} to be rejected"
+            );
+            let err = validate_db_instance_class(class).unwrap_err();
+            assert_eq!(err.code(), "InvalidParameterValue", "for {class:?}");
+        }
+    }
+
+    #[test]
+    fn orderable_catalog_is_realistic_and_non_empty() {
+        let options = crate::state::default_orderable_options();
+        assert!(
+            options.len() >= 100,
+            "orderable options should be a realistic catalog, got {}",
+            options.len()
+        );
+        // Every enumerated class must itself validate.
+        for opt in &options {
+            assert!(
+                is_valid_db_instance_class(&opt.db_instance_class),
+                "catalog class {} should validate",
+                opt.db_instance_class
+            );
+        }
+        // The seed catalog exposes the burstable/general/memory families.
+        let classes: std::collections::HashSet<&str> = crate::state::SUPPORTED_INSTANCE_CLASSES
+            .iter()
+            .copied()
+            .collect();
+        for expected in [
+            "db.t4g.medium",
+            "db.m6i.large",
+            "db.r6g.large",
+            "db.t3.2xlarge",
+        ] {
+            assert!(classes.contains(expected), "catalog missing {expected}");
+        }
     }
 }

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -15,15 +15,89 @@ impl fakecloud_core::multi_account::AccountState for RdsState {
     }
 }
 
-/// Supported DB instance classes — single source of truth.
+/// Representative catalog of current DB instance classes used to
+/// enumerate `DescribeOrderableDBInstanceOptions`. This is NOT an
+/// allowlist — `CreateDBInstance`/`ModifyDBInstance` accept ANY
+/// well-formed AWS instance class (see
+/// `service_helpers::validate_db_instance_class`), because the class is
+/// stored purely as metadata and never reaches the container runtime.
+/// The list below just gives `DescribeOrderableDBInstanceOptions` a
+/// realistic, non-empty set of common current-generation classes to
+/// return across the burstable (t*), general-purpose (m*), and
+/// memory-optimized (r*) families.
 pub const SUPPORTED_INSTANCE_CLASSES: &[&str] = &[
+    // Burstable — t2 / t3 / t4g
+    "db.t2.micro",
+    "db.t2.small",
+    "db.t2.medium",
+    "db.t2.large",
     "db.t3.micro",
     "db.t3.small",
     "db.t3.medium",
     "db.t3.large",
+    "db.t3.xlarge",
+    "db.t3.2xlarge",
     "db.t4g.micro",
     "db.t4g.small",
+    "db.t4g.medium",
+    "db.t4g.large",
+    "db.t4g.xlarge",
+    "db.t4g.2xlarge",
+    // General purpose — m5 / m6i / m6g / m7g
     "db.m5.large",
+    "db.m5.xlarge",
+    "db.m5.2xlarge",
+    "db.m5.4xlarge",
+    "db.m5.8xlarge",
+    "db.m5.12xlarge",
+    "db.m5.16xlarge",
+    "db.m5.24xlarge",
+    "db.m6i.large",
+    "db.m6i.xlarge",
+    "db.m6i.2xlarge",
+    "db.m6i.4xlarge",
+    "db.m6i.8xlarge",
+    "db.m6i.12xlarge",
+    "db.m6i.16xlarge",
+    "db.m6i.24xlarge",
+    "db.m6i.32xlarge",
+    "db.m6g.large",
+    "db.m6g.xlarge",
+    "db.m6g.2xlarge",
+    "db.m6g.4xlarge",
+    "db.m6g.8xlarge",
+    "db.m6g.12xlarge",
+    "db.m6g.16xlarge",
+    "db.m7g.large",
+    "db.m7g.xlarge",
+    "db.m7g.2xlarge",
+    "db.m7g.4xlarge",
+    "db.m7g.8xlarge",
+    "db.m7g.12xlarge",
+    "db.m7g.16xlarge",
+    // Memory optimized — r5 / r6g / r7g
+    "db.r5.large",
+    "db.r5.xlarge",
+    "db.r5.2xlarge",
+    "db.r5.4xlarge",
+    "db.r5.8xlarge",
+    "db.r5.12xlarge",
+    "db.r5.16xlarge",
+    "db.r5.24xlarge",
+    "db.r6g.large",
+    "db.r6g.xlarge",
+    "db.r6g.2xlarge",
+    "db.r6g.4xlarge",
+    "db.r6g.8xlarge",
+    "db.r6g.12xlarge",
+    "db.r6g.16xlarge",
+    "db.r7g.large",
+    "db.r7g.xlarge",
+    "db.r7g.2xlarge",
+    "db.r7g.4xlarge",
+    "db.r7g.8xlarge",
+    "db.r7g.12xlarge",
+    "db.r7g.16xlarge",
 ];
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -939,7 +1013,7 @@ mod tests {
 
     use super::{
         default_engine_versions, default_orderable_options, default_parameter_groups, Arn,
-        DbInstance, RdsState,
+        DbInstance, RdsState, SUPPORTED_INSTANCE_CLASSES,
     };
 
     #[test]
@@ -1048,8 +1122,9 @@ mod tests {
         let versions = default_engine_versions();
         let options = default_orderable_options();
 
-        assert_eq!(options.len(), 77); // 11 versions * 7 instance classes
-                                       // Verify all engines and versions have orderable options
+        // 11 engine versions * every representative instance class.
+        assert_eq!(options.len(), 11 * SUPPORTED_INSTANCE_CLASSES.len());
+        // Verify all engines and versions have orderable options
         for version in &versions {
             assert!(options.iter().any(|opt| {
                 opt.engine == version.engine && opt.engine_version == version.engine_version


### PR DESCRIPTION
## Summary
HIGH reject-valid-input bug. `SUPPORTED_INSTANCE_CLASSES` was a **7-entry** array (`db.t3.micro`..`db.m5.large`) gating `validate_db_instance_class` on **CreateDBInstance and ModifyDBInstance**, so RDS rejected extremely common real classes — `db.t4g.medium`, `db.t3.xlarge`, `db.t3.2xlarge`, `db.m6i.large`, `db.m6g.large`, `db.r6g.large`, `db.r5.large`, `db.m5.xlarge`, `db.t2.micro`, … — that AWS accepts, wedging `terraform apply`/`destroy` the same way #2107 did. The instance class is stored as **pure metadata** and never reaches the container runtime, so the allowlist had zero runtime justification.

## Fix
Split the overloaded const into two roles:
1. A representative **69-class enumeration catalog** (t2/t3/t4g burstable, m5/m6i/m6g/m7g general-purpose, r5/r6g/r7g memory-optimized × common sizes) that `DescribeOrderableDBInstanceOptions` loops → now **759 options**, non-empty and realistic.
2. A **format-check validator** `is_valid_db_instance_class` — `db.<family>.<size>`, 3 non-empty dot segments, alphanumeric family, size ∈ {micro/small/medium/large/xlarge/metal} or `<n>xlarge`. Any current AWS class validates on create/modify; malformed input (`notaclass`, `db.foo`, `db.t3.gigantic`) errors with AWS-faithful `InvalidParameterValue` (previously the wrong `InsufficientDBInstanceCapacity`/AZ message).

Engine-version lists (mysql 8.4 / mariadb 11.8 / postgres 18) are intentionally **not** extended here: their major images aren't wired in the runtime, so adding them would just move the failure to container start — that needs image work first.

Found by the 2026-07-23 bug-hunt (Tier 1, class: stale-enum / reject-valid).

## Test plan
- `accepts_common_current_generation_classes` (12 previously-rejected real classes now accepted on create+modify), `rejects_malformed_classes_with_invalid_parameter_value` (10 malformed → `InvalidParameterValue`), `orderable_catalog_is_realistic_and_non_empty`.
- `cargo test -p fakecloud-rds` 261 passed; `clippy --all-targets -D warnings` clean. Conformance unaffected (validation is strictly more permissive; response shapes unchanged).

## Surface impact
No public API/flag change. `DescribeOrderableDBInstanceOptions` now returns a realistic catalog. RDS instance classes appear in docs only as generic CLI snippets (still valid) — no documented enumerated list to sync (checked).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch RDS instance class validation to a format check instead of a 7-item allowlist, so real AWS classes (e.g. `db.t4g.medium`, `db.m6i.large`) are accepted on create/modify. DescribeOrderableDBInstanceOptions now returns a realistic catalog.

- **Bug Fixes**
  - Accept any well-formed `db.<family>.<size>` (family is alphanumeric; size in `micro|small|medium|large|xlarge|metal` or `<n>xlarge`); malformed values now return `InvalidParameterValue` instead of `InsufficientDBInstanceCapacity`.
  - `SUPPORTED_INSTANCE_CLASSES` is used only to seed the orderable catalog; catalog expanded across `t*`, `m*`, and `r*` families (~69 classes → 759 options).
  - Updated conformance test to assert catalog by contents (>=7, includes `db.t3.micro` and `db.m6i.large`) instead of a fixed count/order; response shapes unchanged; no migration needed.

<sup>Written for commit 5bae74cbc2a566f92cb71a93f6f9aeef32124735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

