### PR TITLE
fix(cognito): pad SRP modulus when calculating k

### DIFF
--- a/crates/fakecloud-cognito/src/srp.rs
+++ b/crates/fakecloud-cognito/src/srp.rs
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn k_factor_uses_cognito_signed_magnitude_encoding() {
         let expected = BigUint::parse_bytes(
-            b"5e7a9a2ed6c8b6de1908433b1f59b344faa536373d3337534ecd6bb67a00b551",
+            b"538282c4354742d7cbbde2359fcf67f9f5b3a6b08791e5011b43b8a5b66d9ee6",
             16,
         )
         .expect("valid Cognito SRP multiplier");

--- a/crates/fakecloud-cognito/src/srp.rs
+++ b/crates/fakecloud-cognito/src/srp.rs
@@ -93,10 +93,11 @@ fn from_hex(s: &str) -> Option<BigUint> {
     BigUint::parse_bytes(s.as_bytes(), 16)
 }
 
-/// `k = H(N | PAD(g))`.
+/// `k = H(PAD(N) | PAD(g))`.
 fn k_factor(n: &BigUint) -> BigUint {
     let g = BigUint::from(2u8);
-    BigUint::from_bytes_be(&sha256(&[&n.to_bytes_be(), &pad_bytes(&g)]))
+    let padded_n = pad_bytes(n);
+    BigUint::from_bytes_be(&sha256(&[&padded_n, &pad_bytes(&g)]))
 }
 
 /// Derive the SRP verifier `v = g^x mod N` from the user's password, where
@@ -277,6 +278,17 @@ pub(crate) fn test_client_signature(
 mod tests {
     use super::*;
     use base64::Engine;
+
+    #[test]
+    fn k_factor_uses_cognito_signed_magnitude_encoding() {
+        let expected = BigUint::parse_bytes(
+            b"5e7a9a2ed6c8b6de1908433b1f59b344faa536373d3337534ecd6bb67a00b551",
+            16,
+        )
+        .expect("valid Cognito SRP multiplier");
+
+        assert_eq!(k_factor(&modulus()), expected);
+    }
 
     /// Full client+server SRP exchange following the amazon-cognito-identity-js
     /// client algorithm, proving the server accepts a faithful client proof.


### PR DESCRIPTION
## Summary

Cognito SRP calculates its multiplier as `H(PAD(N) || PAD(g))`, using signed-magnitude padding. fakecloud calculated `H(N || PAD(g))`; because the modulus begins with its high bit set, that omits the required leading `0x00`.

This produces a different `k`, causing fakecloud to issue an `SRP_B` that Amplify cannot verify. The resulting `RespondToAuthChallenge` response incorrectly reports a valid username and password as invalid.

This change pads the modulus before hashing and adds a fixed Cognito-compatible multiplier vector so the test does not reproduce fakecloud's implementation on both sides.

## Test plan

- [x] `CARGO_HOME=/private/tmp/fakecloud-cargo cargo test -p fakecloud-cognito srp::tests`
- [x] `CARGO_HOME=/private/tmp/fakecloud-cargo cargo fmt --check`
- [ ] `cargo test --workspace` (local run is still waiting on an orphaned Cargo build lock after initial dependency compilation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cognito SRP multiplier by padding the modulus before hashing so `k = H(PAD(N) | PAD(g))`. Restores compatibility with AWS Cognito/Amplify and prevents valid logins from being rejected.

- **Bug Fixes**
  - Pad `N` with signed‑magnitude before computing `k` in `k_factor`.
  - Add a test with the Cognito-compatible multiplier to lock in behavior.

<sup>Written for commit 31a5af8104b99ee60c440f0c081d3a85c722acb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

