### PR TITLE
fix(rds): accept any minor of a supported engine major version

### DIFF
--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -415,7 +415,18 @@ pub(crate) fn validate_create_request(
         _ => vec![],
     };
 
-    if !supported_versions.contains(&engine_version) {
+    // Accept any version whose major (or major.minor) prefix is supported: the
+    // runtime resolves the prebuilt image by MAJOR version
+    // (`ensure_postgres_image(engine_version.split('.').next())`, and the
+    // equivalent for mysql/mariadb), so every minor/patch of a supported major
+    // runs the same container. Enumerating every AWS minor in the allowlist is
+    // futile and rots the moment AWS ships a new one (e.g. rejecting the valid
+    // `postgres 17.9`, issue #2391). Matching on a `<prefix>.`/exact boundary
+    // means `17` accepts `17`, `17.4`, `17.9` but never `170.x` or `16.*`.
+    let version_supported = supported_versions
+        .iter()
+        .any(|v| engine_version == *v || engine_version.starts_with(&format!("{v}.")));
+    if !version_supported {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
             "InsufficientDBInstanceCapacity",
@@ -2217,6 +2228,45 @@ pub(crate) fn default_parameter_group(engine: &str, engine_version: &str) -> Str
             format!("default.{engine}-{major}.{minor}")
         }
         _ => "default.postgres16".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod engine_version_tests {
+    use super::*;
+
+    fn create(engine: &str, version: &str) -> Result<(), AwsServiceError> {
+        validate_create_request("db-1", 20, "db.t3.micro", engine, version, 5432)
+    }
+
+    #[test]
+    fn accepts_any_minor_of_a_supported_major() {
+        // Regression for #2391: postgres 17.9 is a valid AWS minor whose major
+        // (17) is image-backed, but the old exact-minor allowlist rejected it.
+        for v in ["17", "17.4", "17.9", "16.5", "15.8", "14.13", "13.16"] {
+            assert!(
+                create("postgres", v).is_ok(),
+                "postgres {v} should be accepted"
+            );
+        }
+        // Other engines' minors of a supported major also pass.
+        assert!(create("mysql", "8.0.40").is_ok());
+        assert!(create("mariadb", "10.11.9").is_ok());
+    }
+
+    #[test]
+    fn rejects_unsupported_major() {
+        // A major with no image mapping is still rejected (not a prefix of any
+        // supported version), and prefix matching respects the dot boundary so
+        // `17` never accepts `170.x` or a different major.
+        assert!(create("postgres", "9.6").is_err());
+        assert!(create("postgres", "170.1").is_err());
+        assert!(create("postgres", "18.0").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_engine() {
+        assert!(create("cockroachdb", "1.0").is_err());
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #2391. `CreateDBInstance`/`ModifyDBInstance` validated `EngineVersion` against an **exact-minor allowlist** (`"17", "17.4", ...`), so a perfectly valid AWS minor whose major is image-backed was rejected — e.g. `postgres 17.9` — with `EngineVersion '17.9' is not available for the requested engine.`

The runtime resolves the prebuilt container image by **major** version (`ensure_postgres_image(engine_version.split('.').next())`, and the mysql/mariadb equivalents), so every minor/patch of a supported major runs the *same* image. Enumerating each AWS minor is futile and rots on every upstream release (this is the engine-version half of the reject-valid class from the 2026-07-23 bug-hunt, now with a concrete user report).

## Fix
Accept a version when its major (or major.minor) prefix is supported, matching on a `<prefix>.`/exact boundary — so `17` accepts `17`, `17.4`, `17.9` but never `170.x` or a different major. Unknown engines and unsupported majors still fail with the declared error shape. No image work needed (the major images already exist).

## Test plan
- `accepts_any_minor_of_a_supported_major` — postgres 17.9/16.5/15.8/…, mysql 8.0.40, mariadb 10.11.9 all accepted.
- `rejects_unsupported_major` — 9.6 / 170.1 / 18.0 rejected (dot-boundary respected).
- `rejects_unknown_engine`. `cargo test -p fakecloud-rds` green; clippy clean.
- Conformance unaffected (validation is strictly more permissive; probes use accepted versions).

## Surface impact
No API/flag/count change — validation correctness. No docs/SDK update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes engine version validation in the RDS emulator to accept any minor/patch of a supported major (e.g., Postgres 17.9). Applies to `CreateDBInstance` and `ModifyDBInstance` validation only; images are resolved by major.

- **Bug Fixes**
  - Match versions by major (or major.minor) prefix with a dot/exact boundary (e.g., 17 → 17, 17.4, 17.9; never 170.x).
  - Unsupported majors and unknown engines still return the same errors.
  - No API or image changes.

<sup>Written for commit 0de394d45cb1cbb963425664003fdfb068cf226a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

