### PR TITLE
fix(ses,sdks/python): xml-escape SendBounce user fields + cap mypy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6717,6 +6717,7 @@ dependencies = [
  "http 1.4.0",
  "parking_lot",
  "percent-encoding",
+ "quick-xml",
  "rand 0.8.5",
  "rsa",
  "serde",

--- a/crates/fakecloud-eventbridge/src/state.rs
+++ b/crates/fakecloud-eventbridge/src/state.rs
@@ -304,11 +304,11 @@ impl EventBridgeState {
         self.log_deliveries.clear();
         self.step_function_executions.clear();
         // Re-create default bus. NOTE: the default bus is seeded here (and at
-        // init) before any request exists, so its ARN carries the frozen server
-        // region rather than the request's credential-scope region. Custom buses
-        // created via CreateEventBus already use req.region; a matching fix for
-        // the default bus would need a read-time restamp in DescribeEventBus/
-        // ListEventBuses and is intentionally left as an init-time limitation.
+        // init) before any request exists, so this stored ARN carries the frozen
+        // server region rather than the request's credential-scope region. This
+        // seed remains the storage key/existence record; handlers that RETURN the
+        // default-bus ARN (DescribeEventBus / ListEventBuses / etc.) restamp the
+        // region from req.region at read time via `arn_with_request_region`.
         let default_bus_arn = format!(
             "arn:aws:events:{}:{}:event-bus/default",
             self.region, self.account_id

--- a/crates/fakecloud-ses/Cargo.toml
+++ b/crates/fakecloud-ses/Cargo.toml
@@ -29,4 +29,5 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }
+quick-xml = { workspace = true }
 tokio = { workspace = true }

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -1850,12 +1850,17 @@ pub(crate) fn send_bounce(
             .unwrap_or_else(|| "smtp; 550 5.1.1 user unknown".to_string());
         recipient_xml.push_str(&format!(
             "<member>\
-             <Recipient>{recipient}</Recipient>\
-             <StatusCode>{status}</StatusCode>\
-             <Action>{action}</Action>\
-             <DiagnosticCode>{diagnostic}</DiagnosticCode>\
-             <BounceType>{bounce_type}</BounceType>\
-             </member>"
+             <Recipient>{}</Recipient>\
+             <StatusCode>{}</StatusCode>\
+             <Action>{}</Action>\
+             <DiagnosticCode>{}</DiagnosticCode>\
+             <BounceType>{}</BounceType>\
+             </member>",
+            xml_escape(&recipient),
+            xml_escape(&status),
+            xml_escape(&action),
+            xml_escape(&diagnostic),
+            xml_escape(&bounce_type),
         ));
         recipient_info.push(crate::state::BouncedRecipientInfo {
             recipient: recipient.clone(),

--- a/crates/fakecloud-ses/src/v1_tests.rs
+++ b/crates/fakecloud-ses/src/v1_tests.rs
@@ -2102,6 +2102,53 @@ fn test_send_bounce_v1_custom_dsn_fields() {
 }
 
 #[test]
+fn test_send_bounce_v1_xml_escapes_user_fields() {
+    // BouncedRecipientInfoList fields are user-controlled and were interpolated
+    // into the response XML unescaped. A DiagnosticCode containing `<`, `>` and
+    // `&` (as real SMTP diagnostics carry, e.g. the rejected recipient in angle
+    // brackets) would break the SDK XML deserializer. They must be escaped.
+    let state = make_state();
+    let req = make_v1_request(
+        "SendBounce",
+        vec![
+            ("BounceSender", "postmaster@example.com"),
+            ("OriginalMessageId", "abc-def"),
+            (
+                "BouncedRecipientInfoList.member.1.Recipient",
+                "user@example.com",
+            ),
+            (
+                "BouncedRecipientInfoList.member.1.RecipientDsnFields.DiagnosticCode",
+                "smtp; 550 5.1.1 <bob@example.com>: rejected & dropped",
+            ),
+        ],
+    );
+    let resp = handle_v1_action(&state, &req).unwrap();
+    let body = String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap();
+
+    // The raw injected `<...>` / `&` must not appear verbatim inside the body.
+    assert!(
+        !body.contains("<bob@example.com>"),
+        "raw angle brackets leaked into XML: {body}"
+    );
+    // The escaped form must be present.
+    assert!(
+        body.contains("&lt;bob@example.com&gt;: rejected &amp; dropped"),
+        "diagnostic code not escaped: {body}"
+    );
+
+    // And the response must still parse as well-formed XML.
+    let mut reader = quick_xml::Reader::from_str(&body);
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Eof) => break,
+            Ok(_) => {}
+            Err(e) => panic!("response is not well-formed XML: {e}\n{body}"),
+        }
+    }
+}
+
+#[test]
 fn test_send_bounce_v1_missing_recipient() {
     let state = make_state();
     let req = make_v1_request(

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.9"
 dependencies = ["httpx>=0.24"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "pytest-asyncio>=0.21", "boto3>=1.28", "ruff>=0.4,<0.17", "mypy>=1.10"]
+dev = ["pytest>=7,<9", "pytest-asyncio>=0.21,<0.25", "boto3>=1.28", "ruff>=0.4,<0.17", "mypy>=1.10,<1.19"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/fakecloud"]


### PR DESCRIPTION
## Summary
Two fixes from the 2026-07-24 bug-hunt (+ a stale-comment cleanup).

**SES SendBounce XML injection (MED, encoding).** `SendBounce` interpolated five user-controlled request fields — `Recipient`, `StatusCode`, `Action`, `DiagnosticCode`, `BounceType` — into the response XML **unescaped**. SMTP diagnostics routinely wrap the address in angle brackets (`smtp; 550 5.1.1 <bob@example.com>: rejected`), injecting raw `<...>` into the body and breaking the SDK's XML deserializer. Now each is wrapped in `xml_escape` (already used 57× in the same file). Response shape unchanged.

**mypy uncapped (MED, distribution).** ruff was pinned `<0.17` (#2385) but its sibling `mypy>=1.10` was left uncapped — a future mypy tightening a `strict`-mode default would red **every** PR (the `python-typecheck` job pip-installs fresh each run). Capped `mypy>=1.10,<1.19` (+ pytest/pytest-asyncio), matching the ruff discipline.

**EventBridge (no-op):** the default-bus ARN already restamps the region at read time (`arn_with_request_region`) — the hunt flagged it off a stale `state.rs` comment, now corrected. No behavior change.

## Test plan
- `test_send_bounce_v1_xml_escapes_user_fields` — a `DiagnosticCode` with `<>&` is escaped in the response and the whole body parses as well-formed XML (quick-xml).
- Existing `default_bus_arn_uses_request_region_not_server_default` still passes.
- `cargo build/clippy -p fakecloud-ses -p fakecloud-eventbridge --all-targets -D warnings` clean; pyproject parses.

## Surface impact
No API/count change. SES response is now well-formed for special-char inputs; python dev-dep pins tightened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes user-controlled fields in SES `SendBounce` to prevent XML injection and fix XML parsing. Also pins Python SDK dev deps to avoid CI drift; EventBridge comment cleanup only.

- **Bug Fixes**
  - Escape `Recipient`, `StatusCode`, `Action`, `DiagnosticCode`, `BounceType` in `SendBounce` XML.
  - Add test to verify `<`, `>`, `&` are escaped and response parses as XML using `quick-xml`.
  - Correct stale comment on EventBridge default-bus ARN region restamp; no behavior change.

- **Dependencies**
  - Add `quick-xml` to SES dev-deps for tests.
  - Cap `mypy>=1.10,<1.19`, `pytest>=7,<9`, `pytest-asyncio>=0.21,<0.25` in `sdks/python`, aligning with `ruff` pin.

<sup>Written for commit 0b1705728d5dae586ec26bc2503ba3d80def499b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

