### PR TITLE
fix(sagemaker): scope ListClusterNodes/PipelineExecutionSteps/PipelineExecutions by parent

### DIFF
--- a/crates/fakecloud-sagemaker/src/service/special.rs
+++ b/crates/fakecloud-sagemaker/src/service/special.rs
@@ -67,6 +67,9 @@ pub(super) fn dispatch(
             Ok(Some(disassociate_trial_component(svc, ctx, meta, body)))
         }
         "ListTrialComponents" => Ok(list_trial_components(svc, ctx, meta, body)),
+        "ListClusterNodes" => Ok(Some(list_cluster_nodes(svc, ctx, meta, body))),
+        "ListPipelineExecutionSteps" => Ok(list_pipeline_execution_steps(svc, ctx, meta, body)),
+        "ListPipelineExecutions" => Ok(list_pipeline_executions(svc, ctx, meta, body)),
         "SendPipelineExecutionStepSuccess" => Ok(Some(send_pipeline_execution_step(
             svc, ctx, meta, body, true,
         ))),
@@ -727,6 +730,33 @@ fn batch_replace_cluster_nodes(
     (engine::action(ctx, meta, &aug), mutated)
 }
 
+/// Scoped `ListClusterNodes`: the operation carries a **required** `ClusterName`,
+/// but the generic list engine ignores it and would return every account node
+/// across all clusters. Filter the `ClusterNode` family to the requested
+/// cluster (reusing the `node_in_cluster` scoping the batch mutators apply),
+/// then project via the shared list response builder for shape parity.
+fn list_cluster_nodes(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> (AwsResponse, bool) {
+    let cluster = str_member(body, "ClusterName");
+    let g = svc.state.read();
+    let entries = g
+        .get(&ctx.account)
+        .map(|d| d.list_resource_entries(CLUSTER_NODE_FAMILY))
+        .unwrap_or_default();
+    let filtered: Vec<(String, Value)> = entries
+        .into_iter()
+        .filter(|(_k, rec)| node_in_cluster(rec, &cluster))
+        .collect();
+    (
+        engine::list_entries_response(ctx, meta, body, filtered),
+        false,
+    )
+}
+
 // ── Trial ⇄ trial-component association ───────────────────────────────────
 //
 // `AssociateTrialComponent` / `DisassociateTrialComponent` are Action verbs the
@@ -845,6 +875,15 @@ fn send_pipeline_execution_step(
     success: bool,
 ) -> (AwsResponse, bool) {
     let token = str_member(body, "CallbackToken");
+    // The callback token is the only handle the caller holds (the execution arn
+    // is embedded in it on real AWS); with no minted-token registry we derive a
+    // stable execution arn from the token. It is stored on the step record so
+    // `ListPipelineExecutionSteps(PipelineExecutionArn=…)` can scope to it, and
+    // echoed in the response's required `PipelineExecutionArn`.
+    let exec_arn = format!(
+        "arn:aws:sagemaker:{}:{}:pipeline/callback/execution/{}",
+        ctx.region, ctx.account, token
+    );
     {
         let mut g = svc.state.write();
         let data = g.get_or_create(&ctx.account);
@@ -860,6 +899,12 @@ fn send_pipeline_execution_step(
             "StepStatus".to_string(),
             Value::String(if success { "Succeeded" } else { "Failed" }.to_string()),
         );
+        // `PipelineExecutionArn` is an internal scoping member (not a
+        // `PipelineExecutionStep` output field, so the list projection drops it).
+        record.insert(
+            "PipelineExecutionArn".to_string(),
+            Value::String(exec_arn.clone()),
+        );
         if success {
             record.remove("FailureReason");
         } else if let Some(reason) = body.get("FailureReason") {
@@ -867,19 +912,75 @@ fn send_pipeline_execution_step(
         }
         data.put_resource(PIPELINE_STEP_FAMILY, &token, Value::Object(record));
     }
-    // Echo the execution the callback belongs to. The callback token is the
-    // only handle the caller holds (the execution arn is embedded in it on real
-    // AWS); with no minted-token registry we derive a stable execution arn from
-    // the token so the required-shape `PipelineExecutionArn` is populated.
     let mut aug = body.clone();
-    aug.insert(
-        "PipelineExecutionArn".to_string(),
-        Value::String(format!(
-            "arn:aws:sagemaker:{}:{}:pipeline/callback/execution/{}",
-            ctx.region, ctx.account, token
-        )),
-    );
+    aug.insert("PipelineExecutionArn".to_string(), Value::String(exec_arn));
     (engine::action(ctx, meta, &aug), true)
+}
+
+/// Scoped `ListPipelineExecutionSteps`: when the request carries a
+/// `PipelineExecutionArn`, return only the callback steps stored for that
+/// execution (the internal `PipelineExecutionArn` member
+/// `send_pipeline_execution_step` records). Returns `None` when the filter is
+/// absent so the caller falls through to the generic, unscoped list engine
+/// (unchanged behaviour).
+fn list_pipeline_execution_steps(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> Option<(AwsResponse, bool)> {
+    let arn = body.get("PipelineExecutionArn").and_then(Value::as_str)?;
+    let g = svc.state.read();
+    let entries = g
+        .get(&ctx.account)
+        .map(|d| d.list_resource_entries(PIPELINE_STEP_FAMILY))
+        .unwrap_or_default();
+    let filtered: Vec<(String, Value)> = entries
+        .into_iter()
+        .filter(|(_k, rec)| {
+            rec.as_object()
+                .and_then(|o| o.get("PipelineExecutionArn"))
+                .and_then(Value::as_str)
+                == Some(arn)
+        })
+        .collect();
+    Some((
+        engine::list_entries_response(ctx, meta, body, filtered),
+        false,
+    ))
+}
+
+/// Scoped `ListPipelineExecutions`: the operation carries a **required**
+/// `PipelineName`, but the generic list engine ignores it and would return
+/// every execution across all pipelines. Filter the `PipelineExecution` family
+/// to the stored `PipelineName` (`StartPipelineExecution` records it). Returns
+/// `None` when the filter is absent so the caller falls through to the generic
+/// list engine (unchanged behaviour).
+fn list_pipeline_executions(
+    svc: &SageMakerService,
+    ctx: &Ctx,
+    meta: &OpMeta,
+    body: &Map<String, Value>,
+) -> Option<(AwsResponse, bool)> {
+    let name = body.get("PipelineName").and_then(Value::as_str)?;
+    let g = svc.state.read();
+    let entries = g
+        .get(&ctx.account)
+        .map(|d| d.list_resource_entries("PipelineExecution"))
+        .unwrap_or_default();
+    let filtered: Vec<(String, Value)> = entries
+        .into_iter()
+        .filter(|(_k, rec)| {
+            rec.as_object()
+                .and_then(|o| o.get("PipelineName"))
+                .and_then(Value::as_str)
+                == Some(name)
+        })
+        .collect();
+    Some((
+        engine::list_entries_response(ctx, meta, body, filtered),
+        false,
+    ))
 }
 
 fn tags_to_array(tags: &std::collections::BTreeMap<String, String>) -> Value {

--- a/crates/fakecloud-sagemaker/src/service/tests.rs
+++ b/crates/fakecloud-sagemaker/src/service/tests.rs
@@ -241,10 +241,18 @@ fn list_elements_carry_required_fields() {
             continue;
         }
         let s = svc();
+        // Seed the record carrying the operation's required request members, so
+        // resource-scoped list handlers (e.g. ListClusterNodes filtered by the
+        // required ClusterName, ListPipelineExecutions by PipelineName) still
+        // resolve the seeded record instead of filtering it out.
+        let seed = match build_success_body(meta) {
+            Value::Object(m) => Value::Object(m),
+            _ => Value::Object(Map::new()),
+        };
         {
             let mut g = s.state.write();
             let data = g.get_or_create("000000000000");
-            data.put_resource(meta.family, "seed", Value::Object(Map::new()));
+            data.put_resource(meta.family, "seed", seed);
         }
         let listed = resp_json(&run(&s, meta.op, build_success_body(meta)).unwrap());
         let field = meta
@@ -923,6 +931,114 @@ fn list_trial_components_unscoped_returns_all() {
     .unwrap();
     let all = resp_json(&run(&s, "ListTrialComponents", Value::Null).unwrap());
     assert_eq!(all["TrialComponentSummaries"].as_array().unwrap().len(), 2);
+}
+
+// ListClusterNodes must scope to the request's required ClusterName: nodes added
+// to cluster A must not leak into a ListClusterNodes(B) call (regression 0.2).
+#[test]
+fn list_cluster_nodes_scoped_by_cluster_name() {
+    let s = svc();
+    run(
+        &s,
+        "BatchAddClusterNodes",
+        json!({"ClusterName": "cluster-a", "NodesToAdd": [{"InstanceGroupName": "g", "IncrementTargetCountBy": 2}]}),
+    )
+    .unwrap();
+    run(
+        &s,
+        "BatchAddClusterNodes",
+        json!({"ClusterName": "cluster-b", "NodesToAdd": [{"InstanceGroupName": "g", "IncrementTargetCountBy": 3}]}),
+    )
+    .unwrap();
+
+    let a = resp_json(&run(&s, "ListClusterNodes", json!({"ClusterName": "cluster-a"})).unwrap());
+    assert_eq!(
+        a["ClusterNodeSummaries"].as_array().unwrap().len(),
+        2,
+        "cluster-a sees only its own nodes: {a}"
+    );
+    let b = resp_json(&run(&s, "ListClusterNodes", json!({"ClusterName": "cluster-b"})).unwrap());
+    assert_eq!(
+        b["ClusterNodeSummaries"].as_array().unwrap().len(),
+        3,
+        "cluster-b sees only its own nodes: {b}"
+    );
+    // An unknown cluster sees nothing.
+    let none =
+        resp_json(&run(&s, "ListClusterNodes", json!({"ClusterName": "cluster-x"})).unwrap());
+    assert!(none["ClusterNodeSummaries"].as_array().unwrap().is_empty());
+}
+
+// ListPipelineExecutionSteps must scope to the request's PipelineExecutionArn:
+// callback steps sent for execution X must not leak into a query for Y (0.3).
+#[test]
+fn list_pipeline_execution_steps_scoped_by_execution_arn() {
+    let s = svc();
+    // Two distinct callback tokens -> two distinct derived execution arns.
+    let sent_x = resp_json(
+        &run(
+            &s,
+            "SendPipelineExecutionStepSuccess",
+            json!({"CallbackToken": "tokenaaaa1"}),
+        )
+        .unwrap(),
+    );
+    let arn_x = sent_x["PipelineExecutionArn"].as_str().unwrap().to_string();
+    run(
+        &s,
+        "SendPipelineExecutionStepSuccess",
+        json!({"CallbackToken": "tokenaaaa2"}),
+    )
+    .unwrap();
+
+    // Scoped to X returns exactly the one step for X.
+    let scoped = resp_json(
+        &run(
+            &s,
+            "ListPipelineExecutionSteps",
+            json!({"PipelineExecutionArn": arn_x}),
+        )
+        .unwrap(),
+    );
+    let steps = scoped["PipelineExecutionSteps"].as_array().unwrap();
+    assert_eq!(steps.len(), 1, "only X's step: {scoped}");
+    assert_eq!(steps[0]["StepStatus"], "Succeeded");
+    // The internal scoping member is not projected onto the summary.
+    assert!(steps[0].get("PipelineExecutionArn").is_none());
+
+    // Unscoped (no filter) keeps the generic behaviour: both steps.
+    let all = resp_json(&run(&s, "ListPipelineExecutionSteps", json!({})).unwrap());
+    assert_eq!(all["PipelineExecutionSteps"].as_array().unwrap().len(), 2);
+}
+
+// ListPipelineExecutions must scope to the request's required PipelineName:
+// executions of pipeline p1 must not leak into a query for p2 (0.3 LOW).
+#[test]
+fn list_pipeline_executions_scoped_by_pipeline_name() {
+    let s = svc();
+    for (name, count) in [("p1", 2), ("p2", 1)] {
+        for i in 0..count {
+            run(
+                &s,
+                "StartPipelineExecution",
+                json!({"PipelineName": name, "ClientRequestToken": format!("{name}-{i}-{}", "a".repeat(32))}),
+            )
+            .unwrap();
+        }
+    }
+    let p1 = resp_json(&run(&s, "ListPipelineExecutions", json!({"PipelineName": "p1"})).unwrap());
+    let sums = p1["PipelineExecutionSummaries"].as_array().unwrap();
+    assert_eq!(sums.len(), 2, "p1 sees only its own executions: {p1}");
+    assert!(sums
+        .iter()
+        .all(|x| x["PipelineExecutionArn"].as_str().unwrap().contains("/p1/")));
+
+    let p2 = resp_json(&run(&s, "ListPipelineExecutions", json!({"PipelineName": "p2"})).unwrap());
+    assert_eq!(
+        p2["PipelineExecutionSummaries"].as_array().unwrap().len(),
+        1,
+        "p2 sees only its own executions: {p2}"
+    );
 }
 
 // SendPipelineExecutionStepSuccess advances a waiting callback step to Succeeded;


### PR DESCRIPTION
## Summary
Regression from the #2387 real-state work. Three list ops routed to the generic `engine::list` (which applies only NameContains/CreationTime/StatusEquals) and **ignored their required parent-scope member** → cross-parent leaks:
- `ListClusterNodes(ClusterName=B)` returned cluster **A**'s nodes.
- `ListPipelineExecutionSteps(PipelineExecutionArn=X)` returned **every** callback step in the account (the step record never stored its execution ARN).
- `ListPipelineExecutions(PipelineName=B)` returned pipeline **A**'s executions.

## Fix
Claim each in `special.rs` and filter the family by the stored parent id — reusing `node_in_cluster` for `ClusterName`; storing `PipelineExecutionArn` on the step in `send_pipeline_execution_step`; using the `PipelineName` that `StartPipelineExecution` already persists — projecting through the **same** `engine::list_entries_response` so response shapes are identical (conformance-safe). `PipelineExecutionArn` is an internal record member, dropped by the summary projection.

`BatchDescribeModelPackage` + `Attach`/`DetachClusterNodeVolume`/`ExtendTrainingPlan` are left on the synthesized path: their outputs are opaque maps with no engine field metadata and no Describe/List sibling projects the state, so a real/error response risks dropping conformance variants with no local way to verify (loopback-blocked sandbox). Documented.

Found by the 2026-07-24 bug-hunt (class: stubs/scoping).

## Test plan
- `list_cluster_nodes_scoped_by_cluster_name`, `list_pipeline_execution_steps_scoped_by_execution_arn`, `list_pipeline_executions_scoped_by_pipeline_name` — each returns only its own parent's children; unscoped still returns all.
- `cargo test -p fakecloud-sagemaker` 35 pass; `clippy --all-targets -D warnings` clean. Shapes unchanged → conformance-safe (CI shard verifies; loopback blocked locally).

## Surface impact
No API/count change — list ops now honor their required scope. No docs/SDK update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes SageMaker list operations to their parent inputs so they only return records from the requested parent. Prevents cross-parent leaks; response shapes and behavior remain the same.

- **Bug Fixes**
  - `ListClusterNodes` filters nodes by `ClusterName` (reuses `node_in_cluster`).
  - `SendPipelineExecutionStep{Success,Failure}` now store an internal `PipelineExecutionArn`; `ListPipelineExecutionSteps` filters by it. ARN is echoed in send responses but not in step summaries.
  - `ListPipelineExecutions` filters by the `PipelineName` persisted by `StartPipelineExecution`.
  - Uses `engine::list_entries_response` for identical list response shapes; added scoped/unscoped tests.

<sup>Written for commit 1c023f8f47ad5fc8a5f7ca7027dfe2270b97d942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

