### PR TITLE
fix(kms,cloudformation): CFN-provisioned KMS ARNs use the request region + accept ML-DSA key specs

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/kms.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/kms.rs
@@ -24,8 +24,12 @@ impl ResourceProvisioner {
         resource: &ResourceDefinition,
     ) -> Result<ProvisionResult, String> {
         let input = parse_kms_key_input(&resource.properties);
-        let (key_id, arn) =
-            kms_provisioner::provision_key(&self.kms_state, &self.account_id, &input)?;
+        let (key_id, arn) = kms_provisioner::provision_key(
+            &self.kms_state,
+            &self.account_id,
+            &self.region,
+            &input,
+        )?;
         Ok(ProvisionResult::new(key_id.clone())
             .with("Arn", arn)
             .with("KeyId", key_id))
@@ -113,6 +117,7 @@ impl ResourceProvisioner {
         let (replica_key_id, replica_arn) = kms_provisioner::provision_replica_key(
             &self.kms_state,
             &self.account_id,
+            &self.region,
             &primary_arn,
             description,
             enabled,
@@ -219,6 +224,7 @@ impl ResourceProvisioner {
         let alias = kms_provisioner::provision_alias(
             &self.kms_state,
             &self.account_id,
+            &self.region,
             &alias_name,
             &target_input,
         )?;

--- a/crates/fakecloud-kms/src/helpers.rs
+++ b/crates/fakecloud-kms/src/helpers.rs
@@ -315,6 +315,8 @@ pub(crate) fn signing_algorithms_for_key_spec(key_spec: &str) -> Option<Vec<Stri
         "ECC_NIST_P256" | "ECC_SECG_P256K1" => Some(vec!["ECDSA_SHA_256".into()]),
         "ECC_NIST_P384" => Some(vec!["ECDSA_SHA_384".into()]),
         "ECC_NIST_P521" => Some(vec!["ECDSA_SHA_512".into()]),
+        // ML-DSA post-quantum specs share a single SHAKE-256 signing algorithm.
+        "ML_DSA_44" | "ML_DSA_65" | "ML_DSA_87" => Some(vec!["ML_DSA_SHAKE_256".into()]),
         _ => None,
     }
 }
@@ -553,6 +555,8 @@ fn allowed_usages_for_key_spec(key_spec: &str) -> &'static [&'static str] {
         "ECC_SECG_P256K1" => &["SIGN_VERIFY"],
         // SM2 (China regions) supports all three.
         "SM2" => &["SIGN_VERIFY", "ENCRYPT_DECRYPT", "KEY_AGREEMENT"],
+        // ML-DSA post-quantum specs are signing-only.
+        s if s.starts_with("ML_DSA_") => &["SIGN_VERIFY"],
         _ => &[],
     }
 }

--- a/crates/fakecloud-kms/src/provisioner.rs
+++ b/crates/fakecloud-kms/src/provisioner.rs
@@ -76,6 +76,9 @@ pub const VALID_KEY_SPECS: &[&str] = &[
     "HMAC_384",
     "HMAC_512",
     "SM2",
+    "ML_DSA_44",
+    "ML_DSA_65",
+    "ML_DSA_87",
 ];
 
 /// AWS KMS key usages accepted across `CreateKey` / CFN.
@@ -102,6 +105,8 @@ pub fn validate_key_usage_for_spec(key_usage: &str, key_spec: &str) -> Result<()
     let is_rsa = key_spec.starts_with("RSA_");
     let is_ecc = key_spec.starts_with("ECC_");
     let is_sm2 = key_spec == "SM2";
+    // ML-DSA post-quantum specs are signing-only, like ECC secp256k1.
+    let is_ml_dsa = key_spec.starts_with("ML_DSA_");
     match key_usage {
         "ENCRYPT_DECRYPT" => {
             if !(is_symmetric || is_rsa || is_sm2) {
@@ -111,7 +116,7 @@ pub fn validate_key_usage_for_spec(key_usage: &str, key_spec: &str) -> Result<()
             }
         }
         "SIGN_VERIFY" => {
-            if !(is_rsa || is_ecc || is_sm2) {
+            if !(is_rsa || is_ecc || is_sm2 || is_ml_dsa) {
                 return Err(format!(
                     "KeySpec {key_spec} does not support KeyUsage SIGN_VERIFY"
                 ));
@@ -227,12 +232,12 @@ pub fn build_kms_key(
 pub fn provision_key(
     state: &SharedKmsState,
     account_id: &str,
+    region: &str,
     input: &KeyCreationInput,
 ) -> Result<(String, String), String> {
     let mut accounts = state.write();
     let s = accounts.get_or_create(account_id);
-    let region = s.region.clone();
-    let key = build_kms_key(&region, account_id, input)?;
+    let key = build_kms_key(region, account_id, input)?;
     let key_id = key.key_id.clone();
     let arn = key.arn.clone();
     s.keys.insert(key_id.clone(), key);
@@ -245,9 +250,11 @@ pub fn provision_key(
 /// single-region so colliding IDs would overwrite the primary), and
 /// inserts the replica with `primary_region` set so `DescribeKey`
 /// reports `MultiRegionKeyType=REPLICA`.
+#[allow(clippy::too_many_arguments)]
 pub fn provision_replica_key(
     state: &SharedKmsState,
     account_id: &str,
+    region: &str,
     primary_arn: &str,
     description: Option<String>,
     enabled: bool,
@@ -266,7 +273,6 @@ pub fn provision_replica_key(
 
     let mut accounts = state.write();
     let s = accounts.get_or_create(account_id);
-    let region = s.region.clone();
     // Source must be a multi-region key in the primary account; look
     // it up either by raw key_id (when the primary lives in this
     // state's region) or via the region-keyed slot.
@@ -283,7 +289,7 @@ pub fn provision_replica_key(
 
     let replica_key_id = format!("mrk-replica-{}", Uuid::new_v4().as_simple());
     let replica_arn =
-        Arn::new("kms", &region, account_id, &format!("key/{replica_key_id}")).to_string();
+        Arn::new("kms", region, account_id, &format!("key/{replica_key_id}")).to_string();
     let mut replica = source;
     replica.key_id = replica_key_id.clone();
     replica.arn = replica_arn.clone();
@@ -321,6 +327,7 @@ pub fn provision_replica_key(
 pub fn provision_alias(
     state: &SharedKmsState,
     account_id: &str,
+    region: &str,
     alias_name: &str,
     target_input: &str,
 ) -> Result<String, String> {
@@ -345,7 +352,7 @@ pub fn provision_alias(
     } else {
         return Err(format!("KMS key '{target_input}' does not exist"));
     };
-    let alias_arn = Arn::new("kms", &s.region, &s.account_id, alias_name).to_string();
+    let alias_arn = Arn::new("kms", region, &s.account_id, alias_name).to_string();
     let alias = KmsAlias {
         alias_name: alias_name.to_string(),
         alias_arn,
@@ -438,4 +445,103 @@ pub fn update_alias_target(
         .ok_or_else(|| format!("Alias '{alias_name}' does not exist"))?;
     alias.target_key_id = target_key_id;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    fn make_state() -> SharedKmsState {
+        Arc::new(RwLock::new(
+            fakecloud_core::multi_account::MultiAccountState::new(
+                "123456789012",
+                "us-east-1",
+                "http://localhost:4566",
+            ),
+        ))
+    }
+
+    #[test]
+    fn provisioned_key_arn_carries_request_region_not_server_default() {
+        // The server-frozen region is us-east-1; a stack signed for
+        // eu-central-1 must mint an eu-central-1 key ARN.
+        let state = make_state();
+        let input = KeyCreationInput::default();
+        let (key_id, arn) = provision_key(&state, "123456789012", "eu-central-1", &input).unwrap();
+        assert_eq!(
+            arn,
+            format!("arn:aws:kms:eu-central-1:123456789012:key/{key_id}")
+        );
+    }
+
+    #[test]
+    fn provisioned_alias_arn_carries_request_region() {
+        let state = make_state();
+        let input = KeyCreationInput::default();
+        let (key_id, _) = provision_key(&state, "123456789012", "eu-central-1", &input).unwrap();
+        provision_alias(
+            &state,
+            "123456789012",
+            "eu-central-1",
+            "alias/region-test",
+            &key_id,
+        )
+        .unwrap();
+        let mut accounts = state.write();
+        let s = accounts.get_or_create("123456789012");
+        let alias = s.aliases.get("alias/region-test").unwrap();
+        assert_eq!(
+            alias.alias_arn,
+            "arn:aws:kms:eu-central-1:123456789012:alias/region-test"
+        );
+    }
+
+    #[test]
+    fn provisioned_replica_key_arn_carries_request_region() {
+        let state = make_state();
+        let input = KeyCreationInput {
+            multi_region: true,
+            ..Default::default()
+        };
+        let (_, primary_arn) = provision_key(&state, "123456789012", "us-east-1", &input).unwrap();
+        let (_, replica_arn) = provision_replica_key(
+            &state,
+            "123456789012",
+            "eu-central-1",
+            &primary_arn,
+            None,
+            true,
+            None,
+            BTreeMap::new(),
+        )
+        .unwrap();
+        assert!(
+            replica_arn.starts_with("arn:aws:kms:eu-central-1:123456789012:key/"),
+            "replica ARN must carry the request region, got {replica_arn}"
+        );
+    }
+
+    #[test]
+    fn build_kms_key_accepts_ml_dsa_sign_verify() {
+        let input = KeyCreationInput {
+            key_usage: "SIGN_VERIFY".to_string(),
+            key_spec: "ML_DSA_65".to_string(),
+            ..Default::default()
+        };
+        let key = build_kms_key("us-east-1", "123456789012", &input).unwrap();
+        assert_eq!(key.key_spec, "ML_DSA_65");
+        assert_eq!(key.key_usage, "SIGN_VERIFY");
+        assert_eq!(
+            key.signing_algorithms.as_deref(),
+            Some(&["ML_DSA_SHAKE_256".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn validate_key_usage_rejects_ml_dsa_encrypt_decrypt() {
+        assert!(validate_key_usage_for_spec("SIGN_VERIFY", "ML_DSA_87").is_ok());
+        assert!(validate_key_usage_for_spec("ENCRYPT_DECRYPT", "ML_DSA_87").is_err());
+    }
 }

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -45,6 +45,9 @@ const VALID_KEY_SPECS: &[&str] = &[
     "HMAC_256",
     "HMAC_384",
     "HMAC_512",
+    "ML_DSA_44",
+    "ML_DSA_65",
+    "ML_DSA_87",
     "RSA_2048",
     "RSA_3072",
     "RSA_4096",
@@ -62,6 +65,7 @@ const VALID_SIGNING_ALGORITHMS: &[&str] = &[
     "ECDSA_SHA_256",
     "ECDSA_SHA_384",
     "ECDSA_SHA_512",
+    "ML_DSA_SHAKE_256",
 ];
 
 /// Single source of truth for supported KMS actions. Referenced by both

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -1781,6 +1781,44 @@ fn describe_key_returns_metadata_for_new_key() {
 }
 
 #[test]
+fn create_key_accepts_ml_dsa_post_quantum_spec() {
+    // ML-DSA (post-quantum) signing keys must be accepted at CreateKey and
+    // echoed back verbatim by DescribeKey, even though the backend does not
+    // implement real ML-DSA signing crypto.
+    let svc = make_service();
+    let key_id = create_key_with_opts(
+        &svc,
+        json!({
+            "KeyUsage": "SIGN_VERIFY",
+            "KeySpec": "ML_DSA_65"
+        }),
+    );
+
+    let resp = svc
+        .describe_key(&make_request("DescribeKey", json!({ "KeyId": &key_id })))
+        .unwrap();
+    let body = body_json(resp);
+    assert_eq!(body["KeyMetadata"]["KeySpec"], json!("ML_DSA_65"));
+    assert_eq!(body["KeyMetadata"]["KeyUsage"], json!("SIGN_VERIFY"));
+    assert_eq!(
+        body["KeyMetadata"]["SigningAlgorithms"],
+        json!(["ML_DSA_SHAKE_256"])
+    );
+}
+
+#[test]
+fn create_key_rejects_ml_dsa_with_encrypt_decrypt() {
+    // ML-DSA is signing-only; ENCRYPT_DECRYPT must still be rejected.
+    let svc = make_service();
+    let req = make_request(
+        "CreateKey",
+        json!({ "KeyUsage": "ENCRYPT_DECRYPT", "KeySpec": "ML_DSA_65" }),
+    );
+    let err = svc.create_key(&req).err().expect("expected error");
+    assert_eq!(err.code(), "ValidationException");
+}
+
+#[test]
 fn describe_key_requires_key_id() {
     let svc = make_service();
     let err = svc


### PR DESCRIPTION
## Summary
Two KMS fixes from the 2026-07-24 bug-hunt.

**Region-in-ARN (MED, identity).** CFN-provisioned `AWS::KMS::Key`/`ReplicaKey`/`Alias` minted their ARNs from the frozen `MultiAccountState` region (`s.region`) instead of the stack region — a `CreateStack` signed `eu-central-1` returned a `us-east-1` `!GetAtt Key.Arn`, breaking IAM key policies / S3 `SSEKMSKeyId` / `kms:*` conditions. The CFN provisioner already holds `req.region` in `self.region`; thread it into `provision_key`/`provision_replica_key`/`provision_alias` (`build_kms_key` already takes a region param). Matches the direct `CreateKey` handler. This is the region-ARN sibling (#2361/#2363/#2381) missed in the CFN delegation path. Keying is by `key_id` (region-agnostic) — unaffected.

**ML-DSA key specs (LOW-MED, stale-enum).** `VALID_KEY_SPECS` stopped at SM2 and rejected AWS's ML-DSA post-quantum specs. Add `ML_DSA_44/65/87` (both `service.rs` + `provisioner.rs` lists), `ML_DSA_SHAKE_256` to `VALID_SIGNING_ALGORITHMS`, and an ML-DSA → `SIGN_VERIFY`-only usage pairing. Metadata-only: `CreateKey`/`DescribeKey` accept + store + echo the spec; no fake ML-DSA signing is claimed (no backend).

## Test plan
- CFN key/alias/replica ARNs carry a non-default request region (us-east-1 server, eu-central-1 request).
- `CreateKey ML_DSA_65` succeeds + `DescribeKey` echoes KeySpec/KeyUsage/SigningAlgorithms; ML-DSA+`ENCRYPT_DECRYPT` rejected.
- `cargo test`: 222 kms + 303 cloudformation pass; `clippy --all-targets -D warnings` clean. More-permissive + shape-unchanged → conformance-safe.

## Surface impact
No count change. KMS now accepts current AWS post-quantum specs; CFN KMS ARNs are region-correct. No docs/SDK update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CFN KMS ARNs to use the request region and adds support for ML-DSA post-quantum key specs. This unblocks region-scoped IAM/S3 conditions and allows creating ML-DSA signing keys.

- **Bug Fixes**
  - CFN-provisioned `AWS::KMS::Key`, `ReplicaKey`, and `Alias` now mint ARNs with the request region (not the server default).
  - Threads `region` from `fakecloud-cloudformation` into `fakecloud-kms` `provision_key`/`provision_replica_key`/`provision_alias`, matching direct `CreateKey`.

- **New Features**
  - Accepts `ML_DSA_44`, `ML_DSA_65`, and `ML_DSA_87`; advertises `ML_DSA_SHAKE_256`.
  - ML-DSA keys are `SIGN_VERIFY`-only; `ENCRYPT_DECRYPT` is rejected.
  - `DescribeKey` echoes ML-DSA spec and signing algorithm.

<sup>Written for commit 9325db53d29dea5406231691867dfa084acef0cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

