### PR TITLE
fix(rds,elasticache): reconcile in-flight snapshots on restart + background cluster-restore dump + RDS validation

### DIFF
--- a/crates/fakecloud-elasticache/src/service/mod.rs
+++ b/crates/fakecloud-elasticache/src/service/mod.rs
@@ -168,6 +168,15 @@ pub(crate) fn is_recoverable_status(status: &str) -> bool {
     !matches!(status, "deleting" | "deleted")
 }
 
+/// A `creating` cache snapshot whose backing replication group still exists,
+/// so its RDB dump can be re-run on restart. Produced by
+/// `plan_snapshot_recovery`, driven by `reconcile_inflight_snapshots`.
+pub(crate) struct SnapshotRearm {
+    pub(crate) account_id: String,
+    pub(crate) snapshot_name: String,
+    pub(crate) group_id: String,
+}
+
 pub struct ElastiCacheService {
     state: SharedElastiCacheState,
     runtime: Option<Arc<ElastiCacheRuntime>>,
@@ -177,6 +186,11 @@ pub struct ElastiCacheService {
     /// exported artifact into the target bucket, matching AWS. `None` in
     /// unit tests / when S3 isn't wired.
     s3: Option<SharedS3State>,
+    /// Durable data directory (the `<data-path>/elasticache` root) under which
+    /// snapshot RDB artifacts are written so they survive a restart. `None` in
+    /// memory mode / unit tests, where the RDB falls back to the platform temp
+    /// dir (nothing is persisted across a restart in that mode anyway).
+    data_dir: Option<std::path::PathBuf>,
 }
 
 mod clusters;
@@ -197,11 +211,21 @@ impl ElastiCacheService {
             snapshot_store: None,
             snapshot_lock: Arc::new(AsyncMutex::new(())),
             s3: None,
+            data_dir: None,
         }
     }
 
     pub fn with_runtime(mut self, runtime: Arc<ElastiCacheRuntime>) -> Self {
         self.runtime = Some(runtime);
+        self
+    }
+
+    /// Wire the durable data directory (`<data-path>/elasticache`) so snapshot
+    /// RDB artifacts are written under it and survive a restart, rather than
+    /// under the platform temp dir which reboot clears (bug: a persisted
+    /// snapshot pointing into temp restores an empty cache after reboot).
+    pub fn with_data_dir(mut self, data_dir: std::path::PathBuf) -> Self {
+        self.data_dir = Some(data_dir);
         self
     }
 
@@ -504,6 +528,65 @@ impl ElastiCacheService {
                 }
             });
         }
+    }
+
+    /// Reconcile cache snapshots persisted mid-dump (`creating`) after a
+    /// restart. The RDB dump runs in a detached task that flips the row to
+    /// `available`; a crash mid-dump leaves the snapshot `creating` forever
+    /// (never usable, name blocked). The dispatch-level auto-save can persist
+    /// that `creating` row, so on load we reconcile it: if the source
+    /// replication group still exists (and a runtime is wired) re-arm the dump
+    /// finalizer; otherwise mark the snapshot `failed` so the name is reusable
+    /// and Describe shows a terminal state. Mirrors how RDS re-arms in-flight
+    /// snapshots on load.
+    pub async fn reconcile_inflight_snapshots(&self) {
+        let rearm = self.plan_snapshot_recovery(self.runtime.is_some());
+        // Persist any `failed` transitions the planner applied to disk.
+        self.save_snapshot().await;
+        if let Some(runtime) = self.runtime.clone() {
+            for r in rearm {
+                self.spawn_snapshot_dump(
+                    runtime.clone(),
+                    r.account_id,
+                    r.snapshot_name,
+                    r.group_id,
+                );
+            }
+        }
+    }
+
+    /// Pure state reconcile for `creating` snapshots: marks the un-recoverable
+    /// ones `failed` and returns the set to re-arm via the dump finalizer.
+    /// Split out for Docker-free unit testing. A snapshot is re-armed only when
+    /// its replication group still exists AND a runtime is wired
+    /// (`has_runtime`); otherwise it transitions to the terminal `failed`.
+    /// `has_runtime` is passed in so the re-arm branch is exercisable in
+    /// Docker-free unit tests.
+    pub(crate) fn plan_snapshot_recovery(&self, has_runtime: bool) -> Vec<SnapshotRearm> {
+        let mut rearm = Vec::new();
+        let mut accounts = self.state.write();
+        for (_, state) in accounts.iter_mut() {
+            let account_id = state.account_id.clone();
+            // Snapshot the present group ids so the immutable borrow ends
+            // before we mutate `state.snapshots` below.
+            let groups: std::collections::HashSet<String> =
+                state.replication_groups.keys().cloned().collect();
+            for (name, snap) in state.snapshots.iter_mut() {
+                if snap.snapshot_status != "creating" {
+                    continue;
+                }
+                if has_runtime && groups.contains(&snap.replication_group_id) {
+                    rearm.push(SnapshotRearm {
+                        account_id: account_id.clone(),
+                        snapshot_name: name.clone(),
+                        group_id: snap.replication_group_id.clone(),
+                    });
+                } else {
+                    snap.snapshot_status = "failed".to_string();
+                }
+            }
+        }
+        rearm
     }
 }
 

--- a/crates/fakecloud-elasticache/src/service/snapshots.rs
+++ b/crates/fakecloud-elasticache/src/service/snapshots.rs
@@ -6,22 +6,88 @@ use md5::{Digest, Md5};
 
 use super::*;
 
-/// Per-snapshot RDB dump path. Roots under the platform temp dir rather than a
-/// hardcoded `/tmp` (absent on Windows, sometimes non-writable in containers).
+/// Per-snapshot RDB dump path.
+///
+/// When a durable `data_dir` is configured (persistent mode) the RDB is written
+/// under `<data_dir>/snapshots/` so it survives a restart — the path is stored
+/// in the durable snapshot record, and rooting it in temp meant reboot cleared
+/// the file, leaving `RestoreFromSnapshot` reading a missing RDB and silently
+/// yielding an empty cache. In memory mode (`data_dir == None`) nothing is
+/// persisted across a restart anyway, so the RDB falls back to the platform
+/// temp dir (portable across Windows / containers, unlike a hardcoded `/tmp`).
 /// The PID keeps concurrent servers from colliding on the same file.
-fn snapshot_rdb_temp_path(account_id: &str, snapshot_name: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "fakecloud-ec-{}-{}-{}.rdb",
-            account_id,
-            snapshot_name,
-            std::process::id()
-        ))
-        .to_string_lossy()
-        .into_owned()
+fn snapshot_rdb_path(
+    data_dir: Option<&std::path::Path>,
+    account_id: &str,
+    snapshot_name: &str,
+) -> String {
+    let base = match data_dir {
+        Some(dir) => dir.join("snapshots"),
+        None => std::env::temp_dir(),
+    };
+    // Best-effort: create the directory so the runtime's `docker cp` target
+    // exists. Failures surface later when the dump write fails.
+    let _ = std::fs::create_dir_all(&base);
+    base.join(format!(
+        "fakecloud-ec-{}-{}-{}.rdb",
+        account_id,
+        snapshot_name,
+        std::process::id()
+    ))
+    .to_string_lossy()
+    .into_owned()
 }
 
 impl ElastiCacheService {
+    /// Background the redis RDB dump for a `creating` snapshot: run `SAVE` +
+    /// copy the RDB out to a durable path, then flip the snapshot to
+    /// `available` with `rdb_path` set. Shared by `CreateSnapshot` and by
+    /// restart recovery (`reconcile_inflight_snapshots`), which re-arms a
+    /// snapshot persisted mid-dump. A snapshot deleted while the dump was in
+    /// flight has its orphaned RDB file reaped.
+    pub(crate) fn spawn_snapshot_dump(
+        &self,
+        runtime: Arc<ElastiCacheRuntime>,
+        account_id: String,
+        snapshot_name: String,
+        group_id: String,
+    ) {
+        let state_handle = self.state.clone();
+        let snapshot_store = self.snapshot_store.clone();
+        let snapshot_lock = self.snapshot_lock.clone();
+        let tmp_path = snapshot_rdb_path(self.data_dir.as_deref(), &account_id, &snapshot_name);
+        tokio::spawn(async move {
+            let rdb_path = match runtime.dump_rdb(&group_id, &tmp_path).await {
+                Ok(()) => Some(tmp_path),
+                Err(err) => {
+                    tracing::warn!("Failed to dump RDB for snapshot {}: {}", snapshot_name, err);
+                    None
+                }
+            };
+            {
+                let mut accounts = state_handle.write();
+                let state = accounts.get_or_create(&account_id);
+                match state.snapshots.get_mut(&snapshot_name) {
+                    Some(snap) => {
+                        // A dump failure falls back to a metadata-only snapshot
+                        // (rdb_path stays None) rather than blocking the row; the
+                        // established convention flips to `available` either way.
+                        snap.rdb_path = rdb_path;
+                        snap.snapshot_status = "available".to_string();
+                    }
+                    None => {
+                        // Deleted while the dump was in flight: reap the
+                        // orphaned RDB file rather than leaking it.
+                        if let Some(path) = rdb_path {
+                            let _ = std::fs::remove_file(path);
+                        }
+                    }
+                }
+            }
+            save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+        });
+    }
+
     pub(super) fn create_serverless_cache_snapshot(
         &self,
         request: &AwsRequest,
@@ -338,43 +404,12 @@ impl ElastiCacheService {
         }
 
         if let Some(runtime) = self.runtime.clone() {
-            let state_handle = self.state.clone();
-            let snapshot_store = self.snapshot_store.clone();
-            let snapshot_lock = self.snapshot_lock.clone();
-            let account_id = request.account_id.clone();
-            let snapshot_name = snapshot_name.clone();
-            let tmp_path = snapshot_rdb_temp_path(&account_id, &snapshot_name);
-            tokio::spawn(async move {
-                let rdb_path = match runtime.dump_rdb(&group_id, &tmp_path).await {
-                    Ok(()) => Some(tmp_path),
-                    Err(err) => {
-                        tracing::warn!(
-                            "Failed to dump RDB for snapshot {}: {}",
-                            snapshot_name,
-                            err
-                        );
-                        None
-                    }
-                };
-                {
-                    let mut accounts = state_handle.write();
-                    let state = accounts.get_or_create(&account_id);
-                    match state.snapshots.get_mut(&snapshot_name) {
-                        Some(snap) => {
-                            snap.rdb_path = rdb_path;
-                            snap.snapshot_status = "available".to_string();
-                        }
-                        None => {
-                            // Deleted while the dump was in flight: reap the
-                            // orphaned RDB file rather than leaking it.
-                            if let Some(path) = rdb_path {
-                                let _ = std::fs::remove_file(path);
-                            }
-                        }
-                    }
-                }
-                save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
-            });
+            self.spawn_snapshot_dump(
+                runtime,
+                request.account_id.clone(),
+                snapshot_name.clone(),
+                group_id,
+            );
         }
 
         Ok(AwsResponse::xml(
@@ -680,20 +715,36 @@ impl ElastiCacheService {
 
 #[cfg(test)]
 mod snapshot_path_tests {
-    use super::snapshot_rdb_temp_path;
+    use super::snapshot_rdb_path;
+    use std::path::Path;
 
     #[test]
-    fn rdb_temp_path_roots_under_platform_temp_dir() {
-        // Portability (4.4): the RDB dump must live under the platform temp
-        // dir, not a hardcoded `/tmp` that is absent on Windows / some
-        // containers.
-        let path = snapshot_rdb_temp_path("123456789012", "nightly");
+    fn rdb_path_roots_under_platform_temp_dir_in_memory_mode() {
+        // Portability (4.4): with no durable data dir the RDB dump lives under
+        // the platform temp dir, not a hardcoded `/tmp` absent on Windows /
+        // some containers.
+        let path = snapshot_rdb_path(None, "123456789012", "nightly");
         let temp = std::env::temp_dir();
         assert!(
-            std::path::Path::new(&path).starts_with(&temp),
+            Path::new(&path).starts_with(&temp),
             "{path} must root under {}",
             temp.display()
         );
         assert!(path.contains("nightly") && path.ends_with(".rdb"));
+    }
+
+    #[test]
+    fn rdb_path_roots_under_data_dir_when_persistent() {
+        // 4.1: in persistent mode the RDB must live under the durable data dir
+        // (so it survives a reboot), NOT the platform temp dir which reboot
+        // clears — the path is stored in the persisted snapshot record.
+        let data_dir = std::env::temp_dir().join("fakecloud-ec-datadir-test-4-1");
+        let path = snapshot_rdb_path(Some(&data_dir), "123456789012", "nightly");
+        assert!(
+            Path::new(&path).starts_with(data_dir.join("snapshots")),
+            "{path} must root under the data dir's snapshots/ subdir"
+        );
+        assert!(path.contains("nightly") && path.ends_with(".rdb"));
+        let _ = std::fs::remove_dir_all(&data_dir);
     }
 }

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -5363,3 +5363,92 @@ fn recovery_predicate_redrives_transient_states() {
     assert!(!is_recoverable_status("deleting"));
     assert!(!is_recoverable_status("deleted"));
 }
+
+// ── 0.1: reconcile snapshots persisted mid-dump on restart ──────────
+
+fn insert_creating_snapshot(svc: &ElastiCacheService, name: &str, group_id: &str) {
+    let mut a = svc.state.write();
+    let state = a.default_mut();
+    state.snapshots.insert(
+        name.to_string(),
+        crate::state::CacheSnapshot {
+            snapshot_name: name.to_string(),
+            replication_group_id: group_id.to_string(),
+            replication_group_description: "desc".to_string(),
+            snapshot_status: "creating".to_string(),
+            cache_node_type: "cache.t3.micro".to_string(),
+            engine: "redis".to_string(),
+            engine_version: "7.1".to_string(),
+            num_cache_clusters: 1,
+            arn: format!("arn:aws:elasticache:us-east-1:123456789012:snapshot:{name}"),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            snapshot_source: "manual".to_string(),
+            rdb_path: None,
+        },
+    );
+}
+
+fn ec_snapshot_status(svc: &ElastiCacheService, name: &str) -> String {
+    svc.state
+        .read()
+        .default_ref()
+        .snapshots
+        .get(name)
+        .unwrap()
+        .snapshot_status
+        .clone()
+}
+
+#[test]
+fn reconcile_rearms_creating_snapshot_when_group_present() {
+    // A `creating` snapshot whose source replication group still exists is
+    // re-armed (its RDB dump re-run), not lost or marked terminal.
+    let svc = service_with_replication_group("rg-1", 1);
+    insert_creating_snapshot(&svc, "snap1", "rg-1");
+    // has_runtime=true exercises the re-arm branch without Docker.
+    let rearm = svc.plan_snapshot_recovery(true);
+    assert_eq!(rearm.len(), 1);
+    assert_eq!(rearm[0].snapshot_name, "snap1");
+    assert_eq!(rearm[0].group_id, "rg-1");
+    // Left `creating`; the re-armed dump flips it to `available`.
+    assert_eq!(ec_snapshot_status(&svc, "snap1"), "creating");
+}
+
+#[test]
+fn reconcile_fails_creating_snapshot_when_group_gone() {
+    // Source replication group missing: mark the snapshot terminal `failed`
+    // so its name is reusable and Describe shows a terminal state.
+    let svc = service_with_replication_group("rg-1", 1);
+    insert_creating_snapshot(&svc, "orphan", "rg-missing");
+    let rearm = svc.plan_snapshot_recovery(true);
+    assert!(rearm.is_empty());
+    assert_eq!(ec_snapshot_status(&svc, "orphan"), "failed");
+}
+
+#[test]
+fn reconcile_fails_creating_snapshot_without_runtime() {
+    // No runtime on restart: the RDB dump can never complete, so a
+    // source-present `creating` snapshot is failed rather than left stuck.
+    let svc = service_with_replication_group("rg-1", 1);
+    insert_creating_snapshot(&svc, "snap1", "rg-1");
+    let rearm = svc.plan_snapshot_recovery(false);
+    assert!(rearm.is_empty());
+    assert_eq!(ec_snapshot_status(&svc, "snap1"), "failed");
+}
+
+#[test]
+fn reconcile_ignores_available_snapshots() {
+    // Only `creating` rows are reconciled; a completed snapshot is untouched.
+    let svc = service_with_replication_group("rg-1", 1);
+    insert_creating_snapshot(&svc, "snap1", "rg-1");
+    svc.state
+        .write()
+        .default_mut()
+        .snapshots
+        .get_mut("snap1")
+        .unwrap()
+        .snapshot_status = "available".to_string();
+    let rearm = svc.plan_snapshot_recovery(true);
+    assert!(rearm.is_empty());
+    assert_eq!(ec_snapshot_status(&svc, "snap1"), "available");
+}

--- a/crates/fakecloud-rds/src/service/cluster_snapshots.rs
+++ b/crates/fakecloud-rds/src/service/cluster_snapshots.rs
@@ -313,30 +313,14 @@ impl RdsService {
             })
         };
 
-        let pending_dump_b64 = if let Some((wid, eng, user, pass, db)) = writer_info {
-            if let Some(runtime) = self.runtime_ref() {
-                match runtime.dump_database(&wid, &eng, &user, &pass, &db).await {
-                    Ok(data) => {
-                        use base64::Engine;
-                        Some(base64::engine::general_purpose::STANDARD.encode(&data))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            cluster = %source,
-                            writer = %wid,
-                            "cluster PIT dump failed; falling back to metadata-only restore"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
+        // The source writer's dump is unbounded (mysqldump/pg_dump) and easily
+        // past the ~60s client read timeout, so it must NOT run inline in the
+        // request handler (bug: PITR blocked the client). Record the restored
+        // cluster placeholder synchronously below and return promptly; a
+        // detached task (spawned after the response is built) live-dumps the
+        // source writer and stages it as `PendingRestoreDumpB64` on the target
+        // cluster, which the first attached CreateDBInstance replays. Mirrors
+        // the instance-restore path's `spawn_finalize_restored_instance`.
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
         let mut entry = state
@@ -377,9 +361,6 @@ impl RdsService {
             if let Some(latest) = optional_query_param(request, "UseLatestRestorableTime") {
                 obj.insert("UseLatestRestorableTime".to_string(), json!(latest));
             }
-            if let Some(b64) = pending_dump_b64 {
-                obj.insert("PendingRestoreDumpB64".to_string(), json!(b64));
-            }
         }
         state
             .extras
@@ -387,6 +368,51 @@ impl RdsService {
             .or_default()
             .insert(target.clone(), entry);
         drop(accounts);
+
+        // Background the source-writer dump so the request returns promptly.
+        // On success the dump is staged as `PendingRestoreDumpB64` on the
+        // target cluster entry; on failure we fall back to a metadata-only
+        // restore (matching the previous inline behaviour).
+        if let (Some((wid, eng, user, pass, db)), Some(runtime)) =
+            (writer_info, self.runtime_ref().cloned())
+        {
+            let state_handle = self.state.clone();
+            let snapshot_store = self.snapshot_store.clone();
+            let snapshot_lock = self.snapshot_lock.clone();
+            let account_id = request.account_id.clone();
+            let target = target.clone();
+            let source = source.clone();
+            tokio::spawn(async move {
+                match runtime.dump_database(&wid, &eng, &user, &pass, &db).await {
+                    Ok(data) => {
+                        use base64::Engine;
+                        let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+                        {
+                            let mut accounts = state_handle.write();
+                            let state = accounts.get_or_create(&account_id);
+                            if let Some(entry) = state
+                                .extras
+                                .get_mut("clusters")
+                                .and_then(|m| m.get_mut(&target))
+                                .and_then(|e| e.as_object_mut())
+                            {
+                                entry.insert("PendingRestoreDumpB64".to_string(), json!(b64));
+                            }
+                        }
+                        save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock)
+                            .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            cluster = %source,
+                            writer = %wid,
+                            "cluster PIT dump failed; falling back to metadata-only restore"
+                        );
+                    }
+                }
+            });
+        }
 
         self.emit_event(
             RdsSourceType::DbCluster,

--- a/crates/fakecloud-rds/src/service/mod.rs
+++ b/crates/fakecloud-rds/src/service/mod.rs
@@ -489,6 +489,118 @@ impl RdsService {
         }
     }
 
+    /// Reconcile DB snapshots persisted mid-dump (`creating`) after a restart.
+    ///
+    /// `CreateDBSnapshot` and the final-snapshot-on-delete path insert a
+    /// `creating` row synchronously, then a detached task runs the (unbounded)
+    /// dump and flips it to `available`. The dispatch-level auto-save can
+    /// persist the `creating` row, so a crash mid-dump leaves the snapshot
+    /// `creating` forever — never usable, id blocked, data lost. On load we
+    /// reconcile each such row:
+    ///   * source instance still present -> re-arm the dump finalizer
+    ///     (re-run the dump -> `available`);
+    ///   * source gone (the final-snapshot path removed the instance row
+    ///     synchronously before deferring teardown) -> mark the snapshot
+    ///     `failed` so the id is reusable and Describe shows a terminal state,
+    ///     and reap the orphaned source container + data volume the
+    ///     interrupted finalizer would have torn down (otherwise leaked).
+    ///
+    /// Mirrors how ACM/CloudFront re-arm their in-flight pending states on
+    /// load. The `failed`-marking is applied synchronously (persisted here);
+    /// the runtime-driven dump/reap run in detached tasks like the primary
+    /// recovery path.
+    pub async fn reconcile_inflight_snapshots(&self) {
+        let (rearm, reap) = self.plan_snapshot_recovery(self.runtime.is_some());
+        if rearm.is_empty() && reap.is_empty() {
+            return;
+        }
+        // Persist the `failed` transitions the planner applied.
+        self.save_snapshot().await;
+        let Some(runtime) = self.runtime.clone() else {
+            return;
+        };
+        for r in rearm {
+            self.spawn_finalize_snapshot(
+                runtime.clone(),
+                r.account_id,
+                r.snapshot_id,
+                r.source_id,
+                r.engine,
+                r.username,
+                r.password,
+                r.db_name,
+                // Source instance is present (a regular in-flight snapshot);
+                // no deferred teardown to run.
+                false,
+            );
+        }
+        for r in reap {
+            // Complete the deferred final-snapshot teardown the crash
+            // interrupted: reap the orphaned source container + data volume.
+            // Idempotent — a no-op if the runtime already reaped them.
+            let runtime = runtime.clone();
+            tokio::spawn(async move {
+                runtime.stop_container(&r.source_id).await;
+                runtime
+                    .remove_data_volume(&r.account_id, &r.source_id)
+                    .await;
+            });
+        }
+    }
+
+    /// Pure state reconcile for `creating` snapshots: marks the un-recoverable
+    /// ones `failed` and returns the set to re-arm plus the orphaned
+    /// final-snapshot sources to reap. Split out for Docker-free unit testing.
+    /// A snapshot is re-armed only when its source instance still exists AND a
+    /// runtime is wired (`has_runtime`); otherwise it transitions to the
+    /// terminal `failed`. `has_runtime` is passed in so the re-arm branch is
+    /// exercisable in Docker-free unit tests.
+    pub(crate) fn plan_snapshot_recovery(
+        &self,
+        has_runtime: bool,
+    ) -> (Vec<SnapshotRearm>, Vec<SnapshotReap>) {
+        let mut rearm = Vec::new();
+        let mut reap = Vec::new();
+        let mut accounts = self.state.write();
+        for (_, state) in accounts.iter_mut() {
+            let account_id = state.account_id.clone();
+            // Snapshot the present instance ids so the immutable borrow ends
+            // before we mutate `state.snapshots`.
+            let instances: std::collections::HashSet<String> =
+                state.instances.keys().cloned().collect();
+            for (id, snap) in state.snapshots.iter_mut() {
+                if snap.status != "creating" {
+                    continue;
+                }
+                let source_present = instances.contains(&snap.db_instance_identifier);
+                if source_present && has_runtime {
+                    let db_name = snap
+                        .db_name
+                        .clone()
+                        .unwrap_or_else(|| default_db_name(&snap.engine).to_string());
+                    rearm.push(SnapshotRearm {
+                        account_id: account_id.clone(),
+                        snapshot_id: id.clone(),
+                        source_id: snap.db_instance_identifier.clone(),
+                        engine: snap.engine.clone(),
+                        username: snap.master_username.clone(),
+                        password: snap.master_user_password.clone(),
+                        db_name,
+                    });
+                } else {
+                    snap.status = "failed".to_string();
+                    if !source_present {
+                        reap.push(SnapshotReap {
+                            account_id: account_id.clone(),
+                            source_id: snap.db_instance_identifier.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        (rearm, reap)
+    }
+
     /// Stop the backing container for `db_instance_identifier` and mark
     /// the row `stopped`. Synchronous wrt the runtime so callers see a
     /// real `stopped` status by the time the response goes back; mirrors
@@ -746,6 +858,26 @@ fn apply_snapshot_dump_result(
             snapshot.status = "failed".to_string();
         }
     }
+}
+
+/// A `creating` DB snapshot whose source instance still exists, so its dump
+/// can be re-run on restart. Produced by `plan_snapshot_recovery`.
+pub(crate) struct SnapshotRearm {
+    pub(crate) account_id: String,
+    pub(crate) snapshot_id: String,
+    pub(crate) source_id: String,
+    pub(crate) engine: String,
+    pub(crate) username: String,
+    pub(crate) password: String,
+    pub(crate) db_name: String,
+}
+
+/// A final-snapshot source whose instance row was removed synchronously by
+/// `DeleteDBInstance` but whose backing container + data volume were left for
+/// the (interrupted) finalizer to reap. Reaped on restart to avoid a leak.
+pub(crate) struct SnapshotReap {
+    pub(crate) account_id: String,
+    pub(crate) source_id: String,
 }
 
 /// no store is configured (memory-mode runs).

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -425,7 +425,7 @@ pub(crate) fn validate_create_request(
     // means `17` accepts `17`, `17.4`, `17.9` but never `170.x` or `16.*`.
     let version_supported = supported_versions
         .iter()
-        .any(|v| engine_version == *v || engine_version.starts_with(&format!("{v}.")));
+        .any(|v| version_matches_supported(engine_version, v));
     if !version_supported {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,
@@ -435,6 +435,29 @@ pub(crate) fn validate_create_request(
     }
     validate_db_instance_class(db_instance_class)?;
     Ok(())
+}
+
+/// True when `engine_version` is `supported` exactly, or extends it as
+/// `supported.<rest>` where every remaining `.`-separated segment is a
+/// non-empty run of ASCII digits. So a supported major of `17` accepts
+/// `17`, `17.4`, `17.9`, `17.9.1` but rejects `17.foo`, `17.` (trailing
+/// dot), `17.9.garbage`, `17..3` (empty segment), and `170` (not a
+/// boundary match). This tightens the previous bare `starts_with("{v}.")`
+/// prefix test, which over-accepted junk suffixes like `17.foo`.
+fn version_matches_supported(engine_version: &str, supported: &str) -> bool {
+    if engine_version == supported {
+        return true;
+    }
+    let Some(rest) = engine_version
+        .strip_prefix(supported)
+        .and_then(|r| r.strip_prefix('.'))
+    else {
+        return false;
+    };
+    !rest.is_empty()
+        && rest
+            .split('.')
+            .all(|seg| !seg.is_empty() && seg.chars().all(|c| c.is_ascii_digit()))
 }
 
 /// Known AWS instance-size suffixes. The `<n>xlarge` sizes are matched
@@ -456,6 +479,12 @@ const INSTANCE_SIZE_SUFFIXES: &[&str] = &["micro", "small", "medium", "large", "
 /// never influences the container runtime, so there is no need to gate on
 /// a fixed allowlist.
 pub(crate) fn is_valid_db_instance_class(class: &str) -> bool {
+    // Aurora Serverless v2 uses the single-token class `db.serverless`, which
+    // has no `<family>.<size>` shape. Accept it explicitly before the format
+    // check (issue: `db_instance_class="db.serverless"` was rejected).
+    if class == "db.serverless" {
+        return true;
+    }
     let Some(rest) = class.strip_prefix("db.") else {
         return false;
     };
@@ -2268,6 +2297,39 @@ mod engine_version_tests {
     fn rejects_unknown_engine() {
         assert!(create("cockroachdb", "1.0").is_err());
     }
+
+    #[test]
+    fn accepts_dotted_numeric_minor_and_patch() {
+        // 0.5: a supported major must accept dotted-numeric extensions.
+        for v in ["17", "17.4", "17.9", "17.9.1"] {
+            assert!(create("postgres", v).is_ok(), "postgres {v} should pass");
+        }
+    }
+
+    #[test]
+    fn rejects_non_numeric_or_malformed_version_suffix() {
+        // 0.5: the old bare `starts_with("17.")` over-accepted junk suffixes.
+        for v in ["17.foo", "17.", "17.9.garbage", "17..3"] {
+            assert!(
+                create("postgres", v).is_err(),
+                "postgres {v} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn version_matches_supported_boundary_and_numeric() {
+        // Exact + dotted-numeric suffix accepted.
+        assert!(version_matches_supported("17", "17"));
+        assert!(version_matches_supported("17.4", "17"));
+        assert!(version_matches_supported("17.9.1", "17"));
+        // Non-numeric / empty-segment / trailing-dot / non-boundary rejected.
+        assert!(!version_matches_supported("17.foo", "17"));
+        assert!(!version_matches_supported("17.", "17"));
+        assert!(!version_matches_supported("17.9.garbage", "17"));
+        assert!(!version_matches_supported("17..3", "17"));
+        assert!(!version_matches_supported("170", "17"));
+    }
 }
 
 #[cfg(test)]
@@ -2290,6 +2352,8 @@ mod instance_class_tests {
             "db.r7g.16xlarge",
             "db.m7g.48xlarge",
             "db.x2idn.metal",
+            // 0.4: Aurora Serverless v2 single-token class.
+            "db.serverless",
         ] {
             assert!(
                 is_valid_db_instance_class(class),
@@ -2305,15 +2369,16 @@ mod instance_class_tests {
     #[test]
     fn rejects_malformed_classes_with_invalid_parameter_value() {
         for class in [
-            "notaclass",         // no `db.` prefix, no segments
-            "db.foo",            // only two segments
-            "db.t3",             // missing size
-            "db.t3.",            // empty size
-            "db..large",         // empty family
-            "t3.micro",          // missing `db.` prefix
-            "db.t3.gigantic",    // unknown size suffix
-            "db.t3.micro.extra", // too many segments
-            "db.t-3.large",      // non-alphanumeric family
+            "notaclass",          // no `db.` prefix, no segments
+            "db.foo",             // only two segments
+            "db.t3",              // missing size
+            "db.t3.",             // empty size
+            "db..large",          // empty family
+            "t3.micro",           // missing `db.` prefix
+            "db.t3.gigantic",     // unknown size suffix
+            "db.t3.micro.extra",  // too many segments
+            "db.t-3.large",       // non-alphanumeric family
+            "db.serverless-typo", // 0.4: only exact `db.serverless` is special
             "",
         ] {
             assert!(

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -1853,6 +1853,144 @@ fn delete_db_snapshot_unknown_errors() {
     assert_code(svc.delete_db_snapshot(&req), "DBSnapshotNotFound");
 }
 
+/// Force a seeded snapshot's status to `creating` (persisted mid-dump).
+fn set_snapshot_creating(svc: &RdsService, snapshot_id: &str) {
+    svc.state
+        .write()
+        .default_mut()
+        .snapshots
+        .get_mut(snapshot_id)
+        .unwrap()
+        .status = "creating".to_string();
+}
+
+fn snapshot_status(svc: &RdsService, snapshot_id: &str) -> String {
+    svc.state
+        .read()
+        .default_ref()
+        .snapshots
+        .get(snapshot_id)
+        .unwrap()
+        .status
+        .clone()
+}
+
+#[test]
+fn reconcile_rearms_creating_snapshot_when_source_present() {
+    // 0.1: a `creating` snapshot present at load whose source instance still
+    // exists is re-armed (not lost, not marked terminal).
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    seed_snapshot(&svc, "snap1", "db1");
+    set_snapshot_creating(&svc, "snap1");
+    // has_runtime=true exercises the re-arm branch without Docker.
+    let (rearm, reap) = svc.plan_snapshot_recovery(true);
+    assert_eq!(rearm.len(), 1);
+    assert_eq!(rearm[0].snapshot_id, "snap1");
+    assert_eq!(rearm[0].source_id, "db1");
+    assert_eq!(rearm[0].db_name, "appdb");
+    assert!(reap.is_empty());
+    // Left `creating`; the re-armed dump flips it to `available`.
+    assert_eq!(snapshot_status(&svc, "snap1"), "creating");
+}
+
+#[test]
+fn reconcile_fails_and_reaps_creating_snapshot_when_source_gone() {
+    // 0.1: a final-snapshot orphan (source instance row removed synchronously
+    // by DeleteDBInstance) is marked `failed` so the id is reusable, and its
+    // leaked source container/volume is queued for reaping.
+    let svc = make_service();
+    seed_snapshot(&svc, "final-snap", "db-gone"); // no instance seeded
+    set_snapshot_creating(&svc, "final-snap");
+    let (rearm, reap) = svc.plan_snapshot_recovery(true);
+    assert!(rearm.is_empty());
+    assert_eq!(reap.len(), 1);
+    assert_eq!(reap[0].source_id, "db-gone");
+    assert_eq!(snapshot_status(&svc, "final-snap"), "failed");
+}
+
+#[test]
+fn reconcile_fails_creating_snapshot_without_runtime() {
+    // 0.1: no runtime on restart means the dump can never complete, so a
+    // source-present `creating` snapshot is marked terminal `failed` rather
+    // than left stuck `creating`. No reap (the source instance is present).
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    seed_snapshot(&svc, "snap1", "db1");
+    set_snapshot_creating(&svc, "snap1");
+    let (rearm, reap) = svc.plan_snapshot_recovery(false);
+    assert!(rearm.is_empty());
+    assert!(reap.is_empty());
+    assert_eq!(snapshot_status(&svc, "snap1"), "failed");
+}
+
+#[test]
+fn reconcile_ignores_available_snapshots() {
+    // 0.1: only `creating` rows are reconciled; a completed snapshot is left
+    // untouched.
+    let svc = make_service();
+    seed_instance(&svc, "db1");
+    seed_snapshot(&svc, "snap1", "db1"); // status `available` by default
+    let (rearm, reap) = svc.plan_snapshot_recovery(true);
+    assert!(rearm.is_empty());
+    assert!(reap.is_empty());
+    assert_eq!(snapshot_status(&svc, "snap1"), "available");
+}
+
+#[tokio::test]
+async fn restore_db_cluster_to_point_in_time_returns_promptly() {
+    // 1.1: the source-writer dump is backgrounded, so PITR returns without
+    // blocking on the (unbounded) mysqldump/pg_dump. Docker-free: with no
+    // runtime wired the handler records the restored-cluster placeholder
+    // synchronously and returns Ok immediately.
+    let svc = make_service();
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.default_mut();
+        state
+            .extras
+            .entry("clusters".to_string())
+            .or_default()
+            .insert(
+                "src-cluster".to_string(),
+                serde_json::json!({
+                    "DBClusterIdentifier": "src-cluster",
+                    "Engine": "postgres",
+                    "WriterDBInstanceIdentifier": "writer-1",
+                }),
+            );
+    }
+    seed_instance(&svc, "writer-1");
+
+    let req = request(
+        "RestoreDBClusterToPointInTime",
+        &[
+            ("DBClusterIdentifier", "restored-cluster"),
+            ("SourceDBClusterIdentifier", "src-cluster"),
+            ("UseLatestRestorableTime", "true"),
+        ],
+    );
+    let resp = svc
+        .restore_db_cluster_to_point_in_time(&req)
+        .await
+        .expect("PITR should return promptly");
+    let body = body_of(resp);
+    assert!(body.contains("restored-cluster"), "body: {body}");
+
+    // The target cluster placeholder was recorded synchronously, and with no
+    // runtime no dump is staged (metadata-only) — proving the handler did not
+    // block on a dump.
+    let accounts = svc.state.read();
+    let clusters = accounts.default_ref().extras.get("clusters").unwrap();
+    let target = clusters
+        .get("restored-cluster")
+        .expect("restored cluster recorded synchronously");
+    assert!(
+        target.get("PendingRestoreDumpB64").is_none(),
+        "no dump should be staged inline without a runtime"
+    );
+}
+
 #[test]
 fn describe_db_snapshots_accepts_both_filters() {
     // Both snapshot id + instance id is tolerated: the snapshot id

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -3097,6 +3097,10 @@ async fn main() {
     // spawns one task per instance and returns immediately, so a slow
     // postgres bring-up doesn't block server startup. (Issue #1338.)
     rds_service.recover_persisted_containers().await;
+    // Reconcile DB snapshots persisted mid-dump: re-arm those whose source
+    // instance still exists, mark the rest `failed`, and reap any orphaned
+    // final-snapshot source container/volume the interrupted finalizer left.
+    rds_service.reconcile_inflight_snapshots().await;
     if let Some(h) = rds_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("rds", h);
     }
@@ -3284,6 +3288,13 @@ async fn main() {
     if let Some(ref rt) = elasticache_runtime {
         elasticache_service = elasticache_service.with_runtime(rt.clone());
     }
+    // In persistent mode, root snapshot RDB artifacts under the durable data
+    // dir so they survive a restart (4.1); memory mode leaves them in temp.
+    if persistence_config.mode == fakecloud_persistence::StorageMode::Persistent {
+        if let Some(ref data_path) = persistence_config.data_path {
+            elasticache_service = elasticache_service.with_data_dir(data_path.join("elasticache"));
+        }
+    }
     if let Some(store) = elasticache_snapshot_store {
         elasticache_service = elasticache_service.with_snapshot_store(store);
     }
@@ -3292,6 +3303,9 @@ async fn main() {
     // their Docker containers don't, so respawn them on startup. See
     // RDS #1338 for the original bug class.
     elasticache_service.recover_persisted_containers().await;
+    // Reconcile snapshots persisted mid-dump: re-arm those whose source group
+    // still exists, mark the rest `failed` so they aren't stuck `creating`.
+    elasticache_service.reconcile_inflight_snapshots().await;
     if let Some(h) = elasticache_service.snapshot_hook() {
         cfn_snapshot_hooks.insert("elasticache", h);
     }


### PR DESCRIPTION
## Summary
The HIGH-priority batch from the 2026-07-24 bug-hunt — mostly regressions in the recent snapshot-backgrounding (#2388) + validation (#2386/#2392) work.

**0.1 — HIGH — Backgrounded snapshot stuck `creating` forever after a restart mid-dump.** #2388 backgrounded the dump but the dispatch auto-save persists the synchronous `creating` row while the detached finalizer is still running; `recover_persisted_containers` re-armed only instances/caches, never snapshots. A restart mid-dump left the snapshot `creating` forever (unusable, id blocked, data silently lost); the final-snapshot-on-delete path additionally leaked the source container + data volume. Add `reconcile_inflight_snapshots` (+ a pure, testable `plan_snapshot_recovery`) run right after `recover_persisted_containers`: a `creating` snapshot whose source still exists **re-arms** the dump finalizer → `available`; a source-gone / no-runtime one is marked `failed` (terminal, id reusable) and its orphaned final-snapshot container+volume are **reaped**. RDS + ElastiCache.

**1.1 — HIGH — `RestoreDBClusterToPointInTime` inline dump** (~60s client timeout). Record the restored-cluster placeholder synchronously, return immediately, and live-dump the source writer in a detached task (staging `PendingRestoreDumpB64`). `CreateDBClusterSnapshot` stays synchronous (its revert was intentional).

**4.1 — MED — ElastiCache snapshot RDB under `temp_dir`** persisted in the durable record → reboot clears temp → restore reads a missing file (silent empty cache). Root the RDB under `<data_dir>/snapshots` (temp only in memory mode).

**0.4/0.5 — RDS validation (#2386/#2392 gaps):** accept `db.serverless` (Aurora Serverless v2 apply was hard-erroring); tighten the engine-version prefix so the remainder after a supported major must be **dotted-numeric** (`17`/`17.4`/`17.9` pass; `17.foo`/`17.`/`17.9.garbage` rejected — my #2392 fix over-accepted junk).

## Test plan
- Docker-free: reconcile re-arm / source-gone-fail+reap / no-runtime-fail / ignore-available; PITR returns promptly (`creating`) without blocking; EC RDB path under data-dir vs temp; `db.serverless` + engine-version accept/reject cases.
- `cargo test -p fakecloud-rds -p fakecloud-elasticache`: 275 + 250 pass; `clippy --all-targets -D warnings` clean; `fakecloud` builds. Conformance-safe (no response-status default changed; the `failed` transition only occurs during restart-load reconciliation, never in a live probe).

## Surface impact
No API/count change. Restart-recovery correctness + AWS-faithful `creating`→`available` async snapshots. No docs/SDK update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles in-flight snapshots on restart for RDS and ElastiCache so “creating” snapshots complete or fail cleanly, backgrounds RDS cluster PIT restores to avoid timeouts, and persists ElastiCache snapshot RDBs under the data dir. Adds `db.serverless` support and stricter engine-version checks in RDS.

- **Bug Fixes**
  - `fakecloud-rds`/`fakecloud-elasticache`: new `reconcile_inflight_snapshots` runs after container recovery; re-arms dumps when the source exists, otherwise marks snapshots `failed` and (RDS) reaps orphaned final-snapshot resources.
  - `fakecloud-rds`: `RestoreDBClusterToPointInTime` now records the target cluster synchronously and stages the dump in a background task (`PendingRestoreDumpB64`) to avoid client timeouts.
  - `fakecloud-elasticache`: snapshot RDBs now write to `<data_dir>/elasticache/snapshots` in persistent mode; temp dir is used only in memory mode.
  - `fakecloud-rds` validation: accept `db.serverless`; require engine-version suffixes after a supported major to be dotted-numeric (e.g., `17`, `17.4`, `17.9.1`).

<sup>Written for commit 3cb307a948460e06b6d10ae601a42328fe227fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

