### PR TITLE
fix(cloudformation): in-place UpdateStack for stateful resource types (stop wiping data on a benign change)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -444,6 +444,78 @@ impl ResourceProvisioner {
         Ok(result)
     }
 
+    /// In-place stack update for `AWS::EC2::Instance`. An instance is stateful
+    /// (a real backing container / attached EBS with data), so a benign
+    /// property or tag change must NOT terminate + relaunch it the way the
+    /// reprovision fallback would -- that destroys the container and its data.
+    /// This applies the mutable-without-replacement attributes through the REAL
+    /// `ModifyInstanceAttribute` handler (instance type, EBS-optimized flag,
+    /// user data, security groups) and re-applies tags through `CreateTags`,
+    /// keeping the instance id and its backing container intact. Properties that
+    /// genuinely force replacement in real AWS (AMI, subnet, AZ) are left to the
+    /// instance's existing value here; an in-place update never replaces it.
+    pub(super) fn update_ec2_instance(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let instance_id = existing.physical_id.clone();
+
+        // Mutable attributes via ModifyInstanceAttribute (convenience form).
+        let mut attr_params: HashMap<String, String> = HashMap::new();
+        attr_params.insert("InstanceId".to_string(), instance_id.clone());
+        let mut has_attr_change = false;
+        if let Some(v) = prop_str(props, "InstanceType") {
+            attr_params.insert("InstanceType.Value".to_string(), v.to_string());
+            has_attr_change = true;
+        }
+        if let Some(v) = prop_bool(props, "EbsOptimized") {
+            attr_params.insert("EbsOptimized.Value".to_string(), v.to_string());
+            has_attr_change = true;
+        }
+        if let Some(v) = prop_str(props, "UserData") {
+            attr_params.insert("UserData.Value".to_string(), v.to_string());
+            has_attr_change = true;
+        }
+        if let Some(sgs) = props.get("SecurityGroupIds").and_then(|v| v.as_array()) {
+            for (i, sg) in sgs.iter().enumerate() {
+                if let Some(s) = sg.as_str() {
+                    let n = i + 1;
+                    attr_params.insert(format!("GroupId.{n}"), s.to_string());
+                    has_attr_change = true;
+                }
+            }
+        }
+        if has_attr_change {
+            self.ec2_dispatch("ModifyInstanceAttribute", attr_params)?;
+        }
+
+        // Re-apply the template's Tags in place (mirrors a direct CreateTags),
+        // so an added / changed tag never triggers replacement.
+        if let Some(tags) = props.get("Tags").and_then(|v| v.as_array()) {
+            if !tags.is_empty() {
+                let mut params = HashMap::new();
+                params.insert("ResourceId.1".to_string(), instance_id.clone());
+                for (i, t) in tags.iter().enumerate() {
+                    if let (Some(k), Some(v)) = (
+                        t.get("Key").and_then(|v| v.as_str()),
+                        t.get("Value").and_then(|v| v.as_str()),
+                    ) {
+                        let n = i + 1;
+                        params.insert(format!("Tag.{n}.Key"), k.to_string());
+                        params.insert(format!("Tag.{n}.Value"), v.to_string());
+                    }
+                }
+                self.ec2_dispatch("CreateTags", params)?;
+            }
+        }
+
+        // The identity attributes (private ip, AZ, public ip) do not change on
+        // an in-place modify; carry the ones captured at create time forward.
+        Ok(ProvisionResult::new(instance_id).merge_attributes(existing.attributes.clone()))
+    }
+
     /// Delete an EC2 resource by its physical id, routing through the real
     /// handler so dependent default resources are cleaned up correctly.
     pub(super) fn delete_ec2_resource(

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/elasticache.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/elasticache.rs
@@ -478,6 +478,95 @@ impl ResourceProvisioner {
             .with("ConfigurationEndpoint.Port", port.to_string()))
     }
 
+    /// In-place stack update for `AWS::ElastiCache::CacheCluster`. A cache
+    /// cluster is stateful (container-backed Redis/Memcached holding real
+    /// keys), so a benign property or tag change must NOT delete+recreate it the
+    /// way the reprovision fallback would -- that would stop the container and
+    /// wipe the cache. This mirrors `ModifyCacheCluster`: it mutates the stored
+    /// record's modifiable fields in place while preserving the id, arn,
+    /// endpoint, backing container id/port, and create time (the data survives).
+    pub(crate) fn update_ec_cache_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let cluster = state
+            .cache_clusters
+            .get_mut(&id)
+            .ok_or_else(|| format!("Cache cluster {id} not yet provisioned"))?;
+
+        if let Some(v) = props.get("CacheNodeType").and_then(|v| v.as_str()) {
+            cluster.cache_node_type = v.to_string();
+        }
+        if let Some(v) = props.get("EngineVersion").and_then(|v| v.as_str()) {
+            cluster.engine_version = v.to_string();
+        }
+        if let Some(v) = props.get("NumCacheNodes").and_then(|v| v.as_i64()) {
+            cluster.num_cache_nodes = v as i32;
+        }
+        if let Some(v) = props
+            .get("AutoMinorVersionUpgrade")
+            .and_then(|v| v.as_bool())
+        {
+            cluster.auto_minor_version_upgrade = v;
+        }
+        if let Some(v) = props
+            .get("PreferredMaintenanceWindow")
+            .and_then(|v| v.as_str())
+        {
+            cluster.preferred_maintenance_window = Some(v.to_string());
+        }
+        if let Some(v) = props
+            .get("CacheParameterGroupName")
+            .and_then(|v| v.as_str())
+        {
+            cluster.cache_parameter_group_name = Some(v.to_string());
+        }
+        if let Some(v) = props.get("NotificationTopicArn").and_then(|v| v.as_str()) {
+            cluster.notification_topic_arn = Some(v.to_string());
+        }
+        if let Some(v) = props.get("SnapshotRetentionLimit").and_then(|v| v.as_i64()) {
+            cluster.snapshot_retention_limit = v as i32;
+        }
+        if let Some(v) = props.get("SnapshotWindow").and_then(|v| v.as_str()) {
+            cluster.snapshot_window = Some(v.to_string());
+        }
+        if let Some(v) = props.get("AZMode").and_then(|v| v.as_str()) {
+            cluster.az_mode = Some(v.to_string());
+        }
+        if let Some(arr) = props.get("VpcSecurityGroupIds").and_then(|v| v.as_array()) {
+            cluster.security_group_ids = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(arr) = props
+            .get("CacheSecurityGroupNames")
+            .and_then(|v| v.as_array())
+        {
+            cluster.cache_security_group_names = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+
+        let arn = cluster.arn.clone();
+        let endpoint = cluster.endpoint_address.clone();
+        let port = cluster.port;
+
+        Ok(ProvisionResult::new(id)
+            .with("Arn", arn)
+            .with("RedisEndpoint.Address", endpoint.clone())
+            .with("RedisEndpoint.Port", port.to_string())
+            .with("ConfigurationEndpoint.Address", endpoint)
+            .with("ConfigurationEndpoint.Port", port.to_string()))
+    }
+
     pub(crate) fn delete_ec_cache_cluster(&self, physical_id: &str) -> Result<(), String> {
         {
             let mut accounts = self.elasticache_state.write();
@@ -739,6 +828,107 @@ impl ResourceProvisioner {
             .with("PrimaryEndPoint.Address", endpoint_address.clone())
             .with("PrimaryEndPoint.Port", port.to_string())
             .with("ReadEndPoint.Addresses", endpoint_address.clone())
+            .with("ReadEndPoint.Ports", port.to_string());
+        if let Some(cfg) = configuration_endpoint {
+            result = result
+                .with("ConfigurationEndPoint.Address", cfg)
+                .with("ConfigurationEndPoint.Port", port.to_string());
+        }
+        Ok(result)
+    }
+
+    /// In-place stack update for `AWS::ElastiCache::ReplicationGroup`. Like a
+    /// cache cluster, a replication group is stateful and container-backed, so a
+    /// benign property or tag change must NOT delete+recreate it. This mirrors
+    /// `ModifyReplicationGroup`: it mutates the stored record's modifiable
+    /// fields in place while preserving the id, arn, endpoints, member clusters,
+    /// backing container id/port, and create time (the data survives).
+    pub(crate) fn update_ec_replication_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let group = state
+            .replication_groups
+            .get_mut(&id)
+            .ok_or_else(|| format!("Replication group {id} not yet provisioned"))?;
+
+        if let Some(v) = props
+            .get("ReplicationGroupDescription")
+            .and_then(|v| v.as_str())
+        {
+            group.description = v.to_string();
+        }
+        if let Some(v) = props.get("CacheNodeType").and_then(|v| v.as_str()) {
+            group.cache_node_type = v.to_string();
+        }
+        if let Some(v) = props.get("EngineVersion").and_then(|v| v.as_str()) {
+            group.engine_version = v.to_string();
+        }
+        if let Some(v) = props
+            .get("AutomaticFailoverEnabled")
+            .and_then(|v| v.as_bool())
+        {
+            group.automatic_failover_enabled = v;
+        }
+        if let Some(v) = props.get("MultiAZEnabled").and_then(|v| v.as_bool()) {
+            group.multi_az_enabled = v;
+        }
+        if let Some(v) = props.get("SnapshotRetentionLimit").and_then(|v| v.as_i64()) {
+            group.snapshot_retention_limit = v as i32;
+        }
+        if let Some(v) = props.get("SnapshotWindow").and_then(|v| v.as_str()) {
+            group.snapshot_window = v.to_string();
+        }
+        if let Some(v) = props
+            .get("PreferredMaintenanceWindow")
+            .and_then(|v| v.as_str())
+        {
+            group.preferred_maintenance_window = Some(v.to_string());
+        }
+        if let Some(v) = props.get("NotificationTopicArn").and_then(|v| v.as_str()) {
+            group.notification_topic_arn = Some(v.to_string());
+        }
+        if let Some(v) = props
+            .get("CacheParameterGroupName")
+            .and_then(|v| v.as_str())
+        {
+            group.cache_parameter_group_name = Some(v.to_string());
+        }
+        if let Some(v) = props
+            .get("AutoMinorVersionUpgrade")
+            .and_then(|v| v.as_bool())
+        {
+            group.auto_minor_version_upgrade = v;
+        }
+        if let Some(arr) = props.get("UserGroupIds").and_then(|v| v.as_array()) {
+            group.user_group_ids = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(arr) = props.get("SecurityGroupIds").and_then(|v| v.as_array()) {
+            group.security_group_ids = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+
+        let arn = group.arn.clone();
+        let endpoint = group.endpoint_address.clone();
+        let port = group.port;
+        let configuration_endpoint = group.configuration_endpoint_address.clone();
+
+        let mut result = ProvisionResult::new(id)
+            .with("Arn", arn)
+            .with("PrimaryEndPoint.Address", endpoint.clone())
+            .with("PrimaryEndPoint.Port", port.to_string())
+            .with("ReadEndPoint.Addresses", endpoint.clone())
             .with("ReadEndPoint.Ports", port.to_string());
         if let Some(cfg) = configuration_endpoint {
             result = result

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1799,6 +1799,29 @@ impl ResourceProvisioner {
             "AWS::ElasticBeanstalk::ConfigurationTemplate" => {
                 Some(self.update_eb_configuration_template(existing, new_def)?)
             }
+            // Stateful / container-backed types. These MUST update in place:
+            // the reprovision fallback (delete + create) would tear down the
+            // backing Redis/Aurora/Redshift/OpenSearch/DocDB/Neptune/EC2
+            // resource and wipe its data on an otherwise-benign property or tag
+            // change. Each arm applies the mutable properties through the
+            // owning service's real modify path and preserves the physical id.
+            "AWS::ElastiCache::CacheCluster" => {
+                Some(self.update_ec_cache_cluster(existing, new_def)?)
+            }
+            "AWS::ElastiCache::ReplicationGroup" => {
+                Some(self.update_ec_replication_group(existing, new_def)?)
+            }
+            "AWS::RDS::DBCluster" => Some(self.update_rds_db_cluster(existing, new_def)?),
+            "AWS::Redshift::Cluster" => Some(self.update_redshift_cluster(existing, new_def)?),
+            "AWS::OpenSearchService::Domain" => {
+                Some(self.update_opensearch_domain(existing, new_def)?)
+            }
+            "AWS::Elasticsearch::Domain" => {
+                Some(self.update_elasticsearch_domain(existing, new_def)?)
+            }
+            "AWS::DocDB::DBCluster" => Some(self.update_docdb_cluster(existing, new_def)?),
+            "AWS::Neptune::DBCluster" => Some(self.update_neptune_cluster(existing, new_def)?),
+            "AWS::EC2::Instance" => Some(self.update_ec2_instance(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/opensearch.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/opensearch.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 
 use serde_json::Value;
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 use fakecloud_opensearch::state::{domain_arn, Domain};
 
 impl ResourceProvisioner {
@@ -100,6 +100,87 @@ impl ResourceProvisioner {
             return Err(format!("Domain {name} already exists"));
         }
         st.domains.insert(name.clone(), domain);
+
+        Ok(ProvisionResult::new(name)
+            .with("Arn", arn.clone())
+            .with("DomainArn", arn)
+            .with("Id", domain_id)
+            .with("DomainEndpoint", endpoint.clone())
+            .with("DomainEndpointV2", format!("{endpoint}.v2")))
+    }
+
+    pub(super) fn update_opensearch_domain(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        self.update_opensearch_domain_inner(existing, resource, false)
+    }
+
+    pub(super) fn update_elasticsearch_domain(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        self.update_opensearch_domain_inner(existing, resource, true)
+    }
+
+    /// In-place stack update for an OpenSearch / Elasticsearch domain. A domain
+    /// is stateful (it holds indices/documents and can be container-backed), so
+    /// a benign config or tag change must NOT delete+recreate it -- that would
+    /// wipe every index. This mirrors `UpdateDomainConfig`: it re-projects the
+    /// mutable configuration and tags from the new template onto the EXISTING
+    /// stored domain, preserving its name, arn, endpoint, id, indices, data
+    /// sources, and create time (the data survives).
+    fn update_opensearch_domain_inner(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+        es: bool,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+        let engine_version = canonical_engine_version(props, es);
+
+        let mut config: BTreeMap<String, Value> = BTreeMap::new();
+        if let Some(obj) = props.as_object() {
+            for (k, v) in obj {
+                if matches!(k.as_str(), "DomainName" | "Tags" | "TagList") {
+                    continue;
+                }
+                config.insert(k.clone(), v.clone());
+            }
+        }
+
+        let mut tags: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(arr) = props.get("Tags").and_then(Value::as_array) {
+            for t in arr {
+                if let (Some(k), Some(val)) = (
+                    t.get("Key").and_then(Value::as_str),
+                    t.get("Value").and_then(Value::as_str),
+                ) {
+                    tags.insert(k.to_string(), val.to_string());
+                }
+            }
+        }
+
+        let mut guard = self.opensearch_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let domain = st
+            .domains
+            .get_mut(&name)
+            .ok_or_else(|| format!("Domain {name} not yet provisioned"))?;
+
+        // Apply the new config/version/tags in place. Everything else on the
+        // record -- indices, data_sources, endpoint, arn, created_at -- is left
+        // untouched so the data behind the domain survives the update.
+        domain.engine_version = engine_version;
+        domain.config = config;
+        domain.tags = tags;
+
+        let arn = domain.arn.clone();
+        let domain_id = domain.domain_id.clone();
+        let endpoint = domain.endpoint.clone();
 
         Ok(ProvisionResult::new(name)
             .with("Arn", arn.clone())

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -856,6 +856,110 @@ impl ResourceProvisioner {
             .with("DBClusterResourceId", cluster_resource_id))
     }
 
+    /// In-place stack update for `AWS::RDS::DBCluster`. Aurora clusters are
+    /// stateful (they can be container-backed and hold real data), so a benign
+    /// property or tag change must NOT delete+recreate the cluster the way the
+    /// reprovision fallback would -- that would wipe the data. This mutates the
+    /// stored cluster record in place for the properties `ModifyDBCluster`
+    /// applies without replacement (engine version, backup retention, port,
+    /// deletion protection, security groups, storage, log exports, ...) while
+    /// preserving the identifier, ARN, endpoints, resource id, and create time.
+    pub(super) fn update_rds_db_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let identifier = existing.physical_id.clone();
+
+        let mut accounts = self.rds_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let body = state
+            .extras
+            .get_mut("clusters")
+            .and_then(|m| m.get_mut(&identifier))
+            .ok_or_else(|| format!("DB cluster {identifier} not yet provisioned"))?;
+        let obj = body
+            .as_object_mut()
+            .ok_or_else(|| format!("DB cluster {identifier} record is malformed"))?;
+
+        // Mutable-without-replacement properties. Immutable ones (identifier,
+        // ARN, endpoints, resource id, create time) are deliberately left
+        // untouched so the cluster -- and its backing data -- survives.
+        if let Some(v) = props.get("EngineVersion").filter(|v| !v.is_null()) {
+            obj.insert("EngineVersion".to_string(), v.clone());
+        }
+        if let Some(v) = props.get("BackupRetentionPeriod").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+        }) {
+            obj.insert("BackupRetentionPeriod".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = props.get("Port").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+        }) {
+            obj.insert("Port".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = props.get("DeletionProtection").and_then(|v| v.as_bool()) {
+            obj.insert("DeletionProtection".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = props.get("StorageEncrypted").and_then(|v| v.as_bool()) {
+            obj.insert("StorageEncrypted".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = props.get("AllocatedStorage").and_then(|v| v.as_i64()) {
+            obj.insert("AllocatedStorage".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = props.get("VpcSecurityGroupIds").filter(|v| v.is_array()) {
+            obj.insert("VpcSecurityGroupIds".to_string(), v.clone());
+        }
+        if let Some(v) = props
+            .get("EnableCloudwatchLogsExports")
+            .filter(|v| v.is_array())
+        {
+            obj.insert("EnabledCloudwatchLogsExports".to_string(), v.clone());
+        }
+        if let Some(v) = props.get("PreferredBackupWindow").filter(|v| !v.is_null()) {
+            obj.insert("PreferredBackupWindow".to_string(), v.clone());
+        }
+        if let Some(v) = props
+            .get("PreferredMaintenanceWindow")
+            .filter(|v| !v.is_null())
+        {
+            obj.insert("PreferredMaintenanceWindow".to_string(), v.clone());
+        }
+
+        // Read back the (unchanged) identity attributes for Ref/GetAtt.
+        let arn = obj
+            .get("DBClusterArn")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let endpoint = obj
+            .get("Endpoint")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let reader_endpoint = obj
+            .get("ReaderEndpoint")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let port = obj.get("Port").and_then(|v| v.as_i64()).unwrap_or(5432);
+        let resource_id = obj
+            .get("DbClusterResourceId")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        Ok(ProvisionResult::new(identifier)
+            .with("DBClusterArn", arn)
+            .with("Endpoint.Address", endpoint)
+            .with("ReadEndpoint.Address", reader_endpoint)
+            .with("Endpoint.Port", port.to_string())
+            .with("DBClusterResourceId", resource_id))
+    }
+
     pub(super) fn delete_rds_db_cluster(&self, physical_id: &str) -> Result<(), String> {
         let mut accounts = self.rds_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/redshiftlike.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/redshiftlike.rs
@@ -14,7 +14,7 @@ use fakecloud_core::service::AwsRequest;
 use http::{HeaderMap, Method};
 use serde_json::Value;
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 
 /// Build a Query-protocol `AwsRequest` for a control-plane action.
 fn cluster_request(
@@ -124,6 +124,46 @@ impl ResourceProvisioner {
             .with("Endpoint.Port", port.to_string()))
     }
 
+    /// In-place stack update for `AWS::Redshift::Cluster`. Routes the changed
+    /// properties through the REAL `ModifyCluster` handler so the backing
+    /// cluster (and any data behind it) is preserved instead of being
+    /// delete+recreated by the reprovision fallback. `ModifyCluster` reads only
+    /// the properties it can mutate without replacement and ignores the rest,
+    /// so a benign tag/property tweak never destroys the cluster. The physical
+    /// id (ClusterIdentifier) is held stable -- the CFN template never carries a
+    /// `NewClusterIdentifier`, so no rename occurs.
+    pub(super) fn update_redshift_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let id = existing.physical_id.clone();
+        let mut params = props_to_query(&resource.properties);
+        params.insert("ClusterIdentifier".to_string(), id.clone());
+        // Never let a changed `ClusterIdentifier` property drive a rename here;
+        // CloudFormation treats that as replacement, which the reprovision path
+        // owns. An in-place update keeps the existing physical id.
+        params.remove("NewClusterIdentifier");
+
+        let svc = fakecloud_redshift::RedshiftService::new(self.redshift_state.clone());
+        let req = cluster_request(self, "redshift", "ModifyCluster", params);
+        svc.provision_sync(&req)
+            .map_err(|e| format!("Redshift ModifyCluster failed: {}", e.message()))?;
+
+        let (endpoint, port) = {
+            let mut guard = self.redshift_state.write();
+            let acct = guard.account(&self.account_id);
+            match acct.clusters.get(&id) {
+                Some(c) => (c.endpoint_address.clone(), c.endpoint_port),
+                None => (String::new(), 5439),
+            }
+        };
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("Endpoint.Address", endpoint)
+            .with("Endpoint.Port", port.to_string()))
+    }
+
     pub(super) fn delete_redshift_cluster(&self, physical_id: &str) -> Result<(), String> {
         let svc = fakecloud_redshift::RedshiftService::new(self.redshift_state.clone());
         let mut params = HashMap::new();
@@ -188,6 +228,43 @@ impl ResourceProvisioner {
         Ok(result)
     }
 
+    /// In-place stack update for `AWS::DocDB::DBCluster`. Routes through the
+    /// REAL `ModifyDBCluster` handler, preserving the backing cluster and its
+    /// data rather than delete+recreating it. Mutable properties (engine
+    /// version, backup retention, maintenance window, deletion protection,
+    /// security groups, log exports, ...) are applied in place; the physical id
+    /// (DBClusterIdentifier) is held stable.
+    pub(super) fn update_docdb_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let id = existing.physical_id.clone();
+        let mut params = props_to_query(&resource.properties);
+        params.insert("DBClusterIdentifier".to_string(), id.clone());
+        params.remove("NewDBClusterIdentifier");
+
+        let svc = fakecloud_docdb::DocDbService::new(self.docdb_state.clone());
+        let req = cluster_request(self, "docdb", "ModifyDBCluster", params);
+        svc.provision_sync(&req)
+            .map_err(|e| format!("DocDB ModifyDBCluster failed: {}", e.message()))?;
+
+        let result = {
+            let mut guard = self.docdb_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            let mut r = ProvisionResult::new(id.clone());
+            if let Some(c) = st.clusters.get(&id) {
+                r = r
+                    .with("Endpoint", c.endpoint.clone())
+                    .with("ReadEndpoint", c.reader_endpoint.clone())
+                    .with("Port", c.port.to_string())
+                    .with("ClusterResourceId", c.db_cluster_resource_id.clone());
+            }
+            r
+        };
+        Ok(result)
+    }
+
     pub(super) fn delete_docdb_cluster(&self, physical_id: &str) -> Result<(), String> {
         let svc = fakecloud_docdb::DocDbService::new(self.docdb_state.clone());
         let mut params = HashMap::new();
@@ -235,6 +312,41 @@ impl ResourceProvisioner {
         let req = cluster_request(self, "neptune", "CreateDBCluster", params);
         svc.provision_sync(&req)
             .map_err(|e| format!("Neptune CreateDBCluster failed: {}", e.message()))?;
+
+        let result = {
+            let mut guard = self.neptune_state.write();
+            let st = guard.get_or_create(&self.account_id);
+            let mut r = ProvisionResult::new(id.clone());
+            if let Some(c) = st.clusters.get(&id) {
+                r = r
+                    .with("Endpoint", c.endpoint.clone())
+                    .with("ReadEndpoint", c.reader_endpoint.clone())
+                    .with("Port", c.port.to_string())
+                    .with("ClusterResourceId", c.db_cluster_resource_id.clone());
+            }
+            r
+        };
+        Ok(result)
+    }
+
+    /// In-place stack update for `AWS::Neptune::DBCluster`. Routes through the
+    /// REAL `ModifyDBCluster` handler, preserving the backing cluster and its
+    /// data rather than delete+recreating it. Mutable properties are applied in
+    /// place; the physical id (DBClusterIdentifier) is held stable.
+    pub(super) fn update_neptune_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let id = existing.physical_id.clone();
+        let mut params = props_to_query(&resource.properties);
+        params.insert("DBClusterIdentifier".to_string(), id.clone());
+        params.remove("NewDBClusterIdentifier");
+
+        let svc = fakecloud_neptune::NeptuneService::new(self.neptune_state.clone());
+        let req = cluster_request(self, "neptune", "ModifyDBCluster", params);
+        svc.provision_sync(&req)
+            .map_err(|e| format!("Neptune ModifyDBCluster failed: {}", e.message()))?;
 
         let result = {
             let mut guard = self.neptune_state.write();

--- a/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
@@ -1,0 +1,243 @@
+//! Regression coverage for the CloudFormation `UpdateStack` data-loss bug on
+//! stateful, container-backed resource types (#2380 follow-up).
+//!
+//! `update_resource` had dedicated in-place arms only for some resource types;
+//! stateful ones without an arm (ElastiCache clusters, Aurora `DBCluster`,
+//! Redshift/OpenSearch/DocDB/Neptune, EC2 instances) fell to
+//! `reprovision_resource`, which DELETES and RE-CREATES the backing resource.
+//! So a benign property or tag change on such a resource (e.g. `cdk deploy`
+//! bumping an engine version or adding a tag) tore down the Redis/Aurora/...
+//! backend and wiped its data while the stack still reported `UPDATE_COMPLETE`.
+//! (#2380 fixed the UNCHANGED case; this covers the CHANGED case.)
+//!
+//! After the fix each of those types has an in-place `update_*` arm that
+//! applies the change through the owning service's real modify path and keeps
+//! the backing resource. These tests assert, without needing a container
+//! runtime, that a CHANGED-property stack update updates the resource in place
+//! rather than replacing it:
+//!   * a distinctive out-of-band field set on the resource survives the update
+//!     (it would be reset by a delete+recreate), and
+//!   * the resource's stable server-minted identity (its resource id) is
+//!     unchanged (a recreate would mint a new one).
+
+mod helpers;
+
+use helpers::TestServer;
+
+async fn wait_for_status(server: &TestServer, stack: &str, want: &str) {
+    let cfn = server.cloudformation_client().await;
+    let got = helpers::wait_until(std::time::Duration::from_secs(10), || {
+        let cfn = cfn.clone();
+        async move {
+            let out = cfn.describe_stacks().stack_name(stack).send().await.ok()?;
+            let status = out.stacks().first()?.stack_status()?;
+            (status.as_str() == want).then_some(())
+        }
+    })
+    .await;
+    assert!(got.is_some(), "stack {stack} never reached {want}");
+}
+
+// --- AWS::ElastiCache::CacheCluster ---------------------------------------
+
+const EC_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Cache": {
+      "Type": "AWS::ElastiCache::CacheCluster",
+      "Properties": {
+        "ClusterName": "cfn-ec-preserve",
+        "Engine": "redis",
+        "EngineVersion": "6.2",
+        "CacheNodeType": "cache.t3.micro",
+        "NumCacheNodes": 1
+      }
+    }
+  }
+}"#;
+
+// Identical except EngineVersion bumped 6.2 -> 7.0 (a mutable, in-place change).
+const EC_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Cache": {
+      "Type": "AWS::ElastiCache::CacheCluster",
+      "Properties": {
+        "ClusterName": "cfn-ec-preserve",
+        "Engine": "redis",
+        "EngineVersion": "7.0",
+        "CacheNodeType": "cache.t3.micro",
+        "NumCacheNodes": 1
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_elasticache_cache_cluster_is_in_place() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let ec = server.elasticache_client().await;
+
+    cfn.create_stack()
+        .stack_name("ec-preserve")
+        .template_body(EC_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "ec-preserve", "CREATE_COMPLETE").await;
+
+    // Out-of-band config the template never carries: a distinctive maintenance
+    // window. A delete+recreate would reset it to the (absent) template value.
+    ec.modify_cache_cluster()
+        .cache_cluster_id("cfn-ec-preserve")
+        .preferred_maintenance_window("sun:23:00-mon:01:30")
+        .send()
+        .await
+        .expect("modify_cache_cluster");
+
+    // Sanity: v1 engine version and the out-of-band window are present.
+    let before = ec
+        .describe_cache_clusters()
+        .cache_cluster_id("cfn-ec-preserve")
+        .send()
+        .await
+        .expect("describe before");
+    let c0 = before.cache_clusters().first().expect("cluster exists");
+    assert_eq!(c0.engine_version(), Some("6.2"));
+    assert_eq!(
+        c0.preferred_maintenance_window(),
+        Some("sun:23:00-mon:01:30")
+    );
+
+    // Change a mutable property (EngineVersion). Pre-fix this delete+recreated
+    // the cluster, wiping its data and the out-of-band window.
+    cfn.update_stack()
+        .stack_name("ec-preserve")
+        .template_body(EC_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "ec-preserve", "UPDATE_COMPLETE").await;
+
+    let after = ec
+        .describe_cache_clusters()
+        .cache_cluster_id("cfn-ec-preserve")
+        .send()
+        .await
+        .expect("describe after");
+    let c1 = after
+        .cache_clusters()
+        .first()
+        .expect("cluster still exists after update");
+    // The template change was applied...
+    assert_eq!(
+        c1.engine_version(),
+        Some("7.0"),
+        "the mutable EngineVersion change should have been applied in place"
+    );
+    // ...and the out-of-band window survived -> in-place update, not replace.
+    assert_eq!(
+        c1.preferred_maintenance_window(),
+        Some("sun:23:00-mon:01:30"),
+        "out-of-band config must survive an in-place update; a delete+recreate would have reset it"
+    );
+}
+
+// --- AWS::RDS::DBCluster --------------------------------------------------
+
+const RDS_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Cluster": {
+      "Type": "AWS::RDS::DBCluster",
+      "Properties": {
+        "DBClusterIdentifier": "cfn-dbcluster-preserve",
+        "Engine": "aurora-postgresql",
+        "MasterUsername": "admin",
+        "MasterUserPassword": "correcthorsebattery",
+        "BackupRetentionPeriod": 1
+      }
+    }
+  }
+}"#;
+
+// Identical except BackupRetentionPeriod 1 -> 7 (a mutable, in-place change).
+const RDS_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Cluster": {
+      "Type": "AWS::RDS::DBCluster",
+      "Properties": {
+        "DBClusterIdentifier": "cfn-dbcluster-preserve",
+        "Engine": "aurora-postgresql",
+        "MasterUsername": "admin",
+        "MasterUserPassword": "correcthorsebattery",
+        "BackupRetentionPeriod": 7
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_rds_db_cluster_is_in_place() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let rds = server.rds_client().await;
+
+    cfn.create_stack()
+        .stack_name("rds-preserve")
+        .template_body(RDS_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "rds-preserve", "CREATE_COMPLETE").await;
+
+    // Record the server-minted resource id -- the cluster's stable identity. A
+    // delete+recreate would mint a brand-new one.
+    let before = rds
+        .describe_db_clusters()
+        .db_cluster_identifier("cfn-dbcluster-preserve")
+        .send()
+        .await
+        .expect("describe before");
+    let c0 = before.db_clusters().first().expect("cluster exists");
+    let resource_id_before = c0
+        .db_cluster_resource_id()
+        .expect("resource id present")
+        .to_string();
+    assert_eq!(c0.backup_retention_period(), Some(1));
+
+    // Change a mutable property. Pre-fix this delete+recreated the Aurora
+    // cluster, wiping its data and minting a new resource id.
+    cfn.update_stack()
+        .stack_name("rds-preserve")
+        .template_body(RDS_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "rds-preserve", "UPDATE_COMPLETE").await;
+
+    let after = rds
+        .describe_db_clusters()
+        .db_cluster_identifier("cfn-dbcluster-preserve")
+        .send()
+        .await
+        .expect("describe after");
+    let c1 = after
+        .db_clusters()
+        .first()
+        .expect("cluster still exists after update");
+    // The template change was applied...
+    assert_eq!(
+        c1.backup_retention_period(),
+        Some(7),
+        "the mutable BackupRetentionPeriod change should have been applied in place"
+    );
+    // ...and the stable resource id is unchanged -> in-place, not replaced.
+    assert_eq!(
+        c1.db_cluster_resource_id(),
+        Some(resource_id_before.as_str()),
+        "resource id must be stable across an in-place update; a delete+recreate would mint a new one"
+    );
+}


### PR DESCRIPTION
## Summary
MED/HIGH data-loss fix from the 2026-07-24 bug-hunt. `update_resource` had dedicated in-place arms for some types (RDS::DBInstance, DynamoDB, SQS, …) but fell to `_ => reprovision_resource` (delete + create) for types without one. For **container-backed stateful** types that delete+create **wipes the data** — a benign `cdk deploy` / `aws cloudformation deploy` that adds a Tag or tweaks a mutable property destroys the Redis/Aurora/Redshift/OpenSearch/instance data while the stack reports `UPDATE_COMPLETE`. #2380 closed the *unchanged*-resource case; this closes the *changed*-resource case.

## Fix
Added dedicated in-place `update_resource` arms for all 9 affected types — each holds the physical id stable (strips `New*Identifier` rename params) and returns the existing attributes so `Ref`/`GetAtt` keep resolving:

| Type | Modify path |
|---|---|
| `ElastiCache::CacheCluster` / `ReplicationGroup` | mutate stored record (mirror ModifyCacheCluster/ModifyReplicationGroup) — node type, engine version, windows, param group, SGs, … |
| `RDS::DBCluster` | mutate stored cluster body — engine version, backup retention, port, deletion protection, SGs, … |
| `Redshift::Cluster`, `DocDB::DBCluster`, `Neptune::DBCluster` | real ModifyCluster/ModifyDBCluster via provision_sync |
| `OpenSearchService::Domain`, `Elasticsearch::Domain` | re-project config + tags onto the existing domain (preserves indices/endpoint/arn) |
| `EC2::Instance` | real ModifyInstanceAttribute + CreateTags (container preserved) |

MVP semantics: an in-place update never replaces — mutable props + template tags are applied, replacement-forcing props (AMI/subnet/MasterUsername/…) keep their existing value. The core guarantee holds: **no benign change reprovisions**, so stateful data survives.

Found by the 2026-07-24 bug-hunt (class: orchestration).

## Test plan
- `cloudformation_update_preserves_stateful.rs` (Docker-free): (1) `CacheCluster` — set an out-of-band `PreferredMaintenanceWindow`, UpdateStack changing `EngineVersion` 6.2→7.0, assert the new version applied **and** the out-of-band window survived (a recreate would reset it); (2) `DBCluster` — record `DbClusterResourceId`, UpdateStack changing `BackupRetentionPeriod`, assert new value + **unchanged** resource id.
- `cargo build/clippy -p fakecloud-cloudformation --all-targets -D warnings` clean.

## Surface impact
No API/count change — a CFN update to a stateful resource is now non-destructive. No docs/SDK update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss during CloudFormation `UpdateStack` by updating stateful resources in place instead of delete+recreate. Benign changes like tags or engine version no longer wipe data for Redis/Aurora/Redshift/OpenSearch/DocDB/Neptune/EC2.

- **Bug Fixes**
  - Add in-place update arms for: `AWS::ElastiCache::CacheCluster` / `ReplicationGroup`, `AWS::RDS::DBCluster`, `AWS::Redshift::Cluster`, `AWS::DocDB::DBCluster`, `AWS::Neptune::DBCluster`, `AWS::OpenSearchService::Domain` / `AWS::Elasticsearch::Domain`, `AWS::EC2::Instance`.
  - Keep physical IDs stable and strip rename params; apply mutable properties via each service’s real modify path; return existing attributes so `Ref`/`GetAtt` stay valid.
  - Add e2e tests for ElastiCache `CacheCluster` and RDS `DBCluster` to confirm updates are in place (out-of-band config survives; resource ID unchanged).

<sup>Written for commit b790b6b66b1c67ad5767f7c55e80f356e4c5263c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

