### PR TITLE
fix(route53,acm,s3): clamp/resume delegation-set pagination + stable ACM sort + offload S3 large reads

### DIFF
--- a/crates/fakecloud-acm/src/service.rs
+++ b/crates/fakecloud-acm/src/service.rs
@@ -683,9 +683,25 @@ impl AcmService {
         // requested direction (AWS defaults to ASCENDING). Otherwise fall back to
         // the stable ARN ordering.
         if sort_by == Some("CREATED_AT") {
-            all.sort_by_key(|c| c.created_at);
+            // Break `created_at` ties on the ARN so the order is total and
+            // deterministic. `certificates` is a HashMap, so equal-timestamp
+            // certs would otherwise land in a non-deterministic order and the
+            // numeric-offset NextToken could skip or duplicate them across
+            // pages. For DESCENDING, invert only the timestamp (reverse the
+            // whole vec would also flip the tie-break, reintroducing the
+            // instability).
             if sort_order == Some("DESCENDING") {
-                all.reverse();
+                all.sort_by(|a, b| {
+                    b.created_at
+                        .cmp(&a.created_at)
+                        .then_with(|| a.arn.cmp(&b.arn))
+                });
+            } else {
+                all.sort_by(|a, b| {
+                    a.created_at
+                        .cmp(&b.created_at)
+                        .then_with(|| a.arn.cmp(&b.arn))
+                });
             }
         } else {
             all.sort_by(|a, b| a.arn.cmp(&b.arn));
@@ -2969,6 +2985,179 @@ mod tests {
                 arn["b.example.com"].clone(),
                 arn["c.example.com"].clone(),
             ]
+        );
+    }
+
+    // With equal `created_at`, the sort must still be total (tie-broken on the
+    // ARN) so offset-based pagination never skips or duplicates a certificate
+    // across pages, and the order is deterministic despite the HashMap source.
+    #[tokio::test]
+    async fn list_certificates_equal_created_at_stable_pagination() {
+        let svc = AcmService::default();
+        let mut created_arns = Vec::new();
+        for d in [
+            "a.example.com",
+            "b.example.com",
+            "c.example.com",
+            "d.example.com",
+        ] {
+            let resp = svc
+                .handle(make_req("RequestCertificate", json!({ "DomainName": d })))
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            created_arns.push(body["CertificateArn"].as_str().unwrap().to_string());
+        }
+        // Force every certificate to the SAME creation timestamp so every
+        // comparison is a tie.
+        {
+            let mut state = svc.state.write();
+            let certs = &mut state.accounts.get_mut("123456789012").unwrap().certificates;
+            let now = chrono::Utc::now();
+            for c in certs.values_mut() {
+                c.created_at = now;
+            }
+        }
+
+        let arns = |body: &Value| -> Vec<String> {
+            body["CertificateSummaryList"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|r| r["CertificateArn"].as_str().unwrap().to_string())
+                .collect()
+        };
+
+        // Walk the whole list one item per page (MaxItems=1) and collect.
+        let mut walked = Vec::new();
+        let mut token: Option<String> = None;
+        loop {
+            let mut req =
+                json!({ "SortBy": "CREATED_AT", "SortOrder": "ASCENDING", "MaxItems": 1 });
+            if let Some(t) = &token {
+                req.as_object_mut()
+                    .unwrap()
+                    .insert("NextToken".to_string(), Value::String(t.clone()));
+            }
+            let resp = svc.handle(make_req("ListCertificates", req)).await.unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            walked.extend(arns(&body));
+            match body.get("NextToken").and_then(Value::as_str) {
+                Some(t) => token = Some(t.to_string()),
+                None => break,
+            }
+        }
+
+        // No skips, no duplicates: the paged walk visits exactly the full set.
+        let mut expected = created_arns.clone();
+        expected.sort();
+        let mut walked_sorted = walked.clone();
+        walked_sorted.sort();
+        assert_eq!(
+            walked_sorted, expected,
+            "paged walk must cover every cert once"
+        );
+        assert_eq!(
+            walked.len(),
+            created_arns.len(),
+            "no duplicates across pages"
+        );
+
+        // The tie-break is deterministic: full ASCENDING order == ARN-ascending.
+        let full = |order: &'static str| {
+            let svc = &svc;
+            async move {
+                let resp = svc
+                    .handle(make_req(
+                        "ListCertificates",
+                        json!({ "SortBy": "CREATED_AT", "SortOrder": order, "MaxItems": 100 }),
+                    ))
+                    .await
+                    .unwrap();
+                let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+                body["CertificateSummaryList"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|r| r["CertificateArn"].as_str().unwrap().to_string())
+                    .collect::<Vec<_>>()
+            }
+        };
+        let asc = full("ASCENDING").await;
+        assert_eq!(
+            asc, expected,
+            "equal-timestamp order is deterministic ARN order"
+        );
+        // Stable across repeated calls (HashMap iteration doesn't leak through).
+        assert_eq!(full("ASCENDING").await, asc);
+        // With all timestamps equal, DESCENDING must NOT reverse the ARN ties —
+        // the tie order is stable, so DESCENDING equals ASCENDING here.
+        assert_eq!(
+            full("DESCENDING").await,
+            asc,
+            "ties must not flip on DESCENDING"
+        );
+    }
+
+    // DESCENDING is the exact inverse of ASCENDING on the primary key when
+    // timestamps are distinct (guards the (Reverse(created_at), arn) ordering).
+    #[tokio::test]
+    async fn list_certificates_descending_is_inverse_for_distinct_timestamps() {
+        let svc = AcmService::default();
+        let mut arn: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
+        for d in ["a.example.com", "b.example.com", "c.example.com"] {
+            let resp = svc
+                .handle(make_req("RequestCertificate", json!({ "DomainName": d })))
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+            arn.insert(d, body["CertificateArn"].as_str().unwrap().to_string());
+        }
+        {
+            let mut state = svc.state.write();
+            let certs = &mut state.accounts.get_mut("123456789012").unwrap().certificates;
+            let now = chrono::Utc::now();
+            for c in certs.values_mut() {
+                match c.domain_name.as_str() {
+                    "a.example.com" => c.created_at = now - chrono::Duration::hours(2),
+                    "b.example.com" => c.created_at = now - chrono::Duration::hours(1),
+                    _ => c.created_at = now,
+                }
+            }
+        }
+        let arns = |body: &Value| -> Vec<String> {
+            body["CertificateSummaryList"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|r| r["CertificateArn"].as_str().unwrap().to_string())
+                .collect()
+        };
+        let asc = {
+            let resp = svc
+                .handle(make_req(
+                    "ListCertificates",
+                    json!({ "SortBy": "CREATED_AT", "SortOrder": "ASCENDING" }),
+                ))
+                .await
+                .unwrap();
+            arns(&serde_json::from_slice(resp.body.expect_bytes()).unwrap())
+        };
+        let desc = {
+            let resp = svc
+                .handle(make_req(
+                    "ListCertificates",
+                    json!({ "SortBy": "CREATED_AT", "SortOrder": "DESCENDING" }),
+                ))
+                .await
+                .unwrap();
+            arns(&serde_json::from_slice(resp.body.expect_bytes()).unwrap())
+        };
+        let mut asc_rev = asc.clone();
+        asc_rev.reverse();
+        assert_eq!(
+            desc, asc_rev,
+            "distinct timestamps: DESCENDING == reverse(ASCENDING)"
         );
     }
 

--- a/crates/fakecloud-route53/src/helpers.rs
+++ b/crates/fakecloud-route53/src/helpers.rs
@@ -1342,7 +1342,15 @@ impl Route53Service {
                     min: 0,
                     max: 64,
                 },
-                MAX_ITEMS_CONSTRAINT,
+                // AWS still rejects a non-integer / non-positive MaxItems, but
+                // it does NOT error when MaxItems exceeds 100 — it silently
+                // clamps to 100 (handled below). So validate the shape without
+                // the upper bound that `MAX_ITEMS_CONSTRAINT` would enforce.
+                QueryConstraint::IntRange {
+                    key: "maxitems",
+                    min: 1,
+                    max: i64::MAX,
+                },
             ],
         )?;
         let state = self.state.read();
@@ -1356,19 +1364,25 @@ impl Route53Service {
 
         // Paginate on `marker` (the next delegation set id) + `maxitems`,
         // mirroring the other route53 List operations.
+        // AWS caps MaxItems at 100 and echoes the capped value back, so clamp
+        // any larger request rather than honoring it verbatim.
         let max_items = req
             .query_params
             .get("maxitems")
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|n| *n > 0)
-            .unwrap_or(100);
+            .unwrap_or(100)
+            .min(100);
         let marker = req.query_params.get("marker").cloned().unwrap_or_default();
+        // Resume from the first set whose id is >= the marker (the insertion
+        // point in the id-sorted list), not an exact id match. If the marker's
+        // set was deleted between pages, an exact `position` lookup would miss
+        // and fall back to `sets.len()`, silently dropping every remaining set;
+        // the insertion point lands on the next surviving set instead.
         let start_idx = if marker.is_empty() {
             0
         } else {
-            sets.iter()
-                .position(|d| d.id == marker)
-                .unwrap_or(sets.len())
+            sets.partition_point(|d| d.id < marker)
         };
         let page: Vec<&StoredReusableDelegationSet> =
             sets.iter().skip(start_idx).take(max_items).collect();
@@ -2442,5 +2456,133 @@ mod hardening_tests {
             .map(|r| r.value)
             .collect();
         assert_eq!(vals, vec!["1.1.1.1".to_string(), "2.2.2.2".to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod list_reusable_delegation_sets_tests {
+    use super::*;
+    use crate::state::{AccountState, Route53Accounts, StoredReusableDelegationSet};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn svc_with_sets(ids: &[&str]) -> Route53Service {
+        let mut account = AccountState::default();
+        for id in ids {
+            account.reusable_delegation_sets.insert(
+                id.to_string(),
+                StoredReusableDelegationSet {
+                    id: id.to_string(),
+                    caller_reference: format!("ref-{id}"),
+                    name_servers: vec!["ns-1.example.com".to_string()],
+                },
+            );
+        }
+        let mut accounts = Route53Accounts::default();
+        accounts
+            .accounts
+            .insert(DEFAULT_ACCOUNT.to_string(), account);
+        Route53Service::new(Arc::new(parking_lot::RwLock::new(accounts)))
+    }
+
+    fn list_req(params: &[(&str, &str)]) -> AwsRequest {
+        let mut query_params: HashMap<String, String> = HashMap::new();
+        for (k, v) in params {
+            query_params.insert((*k).to_string(), (*v).to_string());
+        }
+        AwsRequest {
+            service: "route53".to_string(),
+            action: "ListReusableDelegationSets".to_string(),
+            region: "us-east-1".to_string(),
+            account_id: DEFAULT_ACCOUNT.to_string(),
+            request_id: "test".to_string(),
+            headers: HeaderMap::new(),
+            query_params,
+            body: Bytes::new(),
+            body_stream: parking_lot::Mutex::new(None),
+            path_segments: vec!["2013-04-01".into(), "delegationset".into()],
+            raw_path: "/2013-04-01/delegationset".to_string(),
+            raw_query: String::new(),
+            method: http::Method::GET,
+            is_query_protocol: false,
+            access_key_id: None,
+            principal: None,
+        }
+    }
+
+    fn body_of(resp: AwsResponse) -> String {
+        String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
+    }
+
+    fn set_ids(body: &str) -> Vec<String> {
+        body.match_indices("<Id>")
+            .map(|(i, _)| {
+                let rest = &body[i + 4..];
+                let end = rest.find("</Id>").unwrap();
+                rest[..end].to_string()
+            })
+            .collect()
+    }
+
+    // MaxItems is capped at 100: a request for 500 returns at most 100 sets and
+    // the echoed <MaxItems> is the capped 100, not the verbatim 500.
+    #[test]
+    fn maxitems_over_100_is_clamped_and_echoed() {
+        let ids: Vec<String> = (0..150).map(|i| format!("N{i:04}")).collect();
+        let refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+        let svc = svc_with_sets(&refs);
+        let resp = svc
+            .list_reusable_delegation_sets(&list_req(&[("maxitems", "500")]))
+            .unwrap();
+        let body = body_of(resp);
+        assert!(body.contains("<MaxItems>100</MaxItems>"), "body: {body}");
+        assert_eq!(set_ids(&body).len(), 100, "page must be capped at 100");
+        assert!(body.contains("<IsTruncated>true</IsTruncated>"));
+    }
+
+    // When the set named by the marker was deleted between pages, paging must
+    // resume from the next surviving set (the insertion point in the sorted
+    // list), never drop the remaining sets by falling off the end.
+    #[test]
+    fn resumes_after_deleted_marker() {
+        // Sorted ids: S1 S2 S3 S4 S5. Simulate S3 deleted after page 1 handed
+        // out NextMarker=S3 by simply not inserting S3.
+        let svc = svc_with_sets(&["S1", "S2", "S4", "S5"]);
+        let resp = svc
+            .list_reusable_delegation_sets(&list_req(&[("marker", "S3"), ("maxitems", "10")]))
+            .unwrap();
+        let body = body_of(resp);
+        assert_eq!(
+            set_ids(&body),
+            vec!["S4".to_string(), "S5".to_string()],
+            "deleted marker must resume at next surviving set, not drop the tail"
+        );
+        assert!(body.contains("<IsTruncated>false</IsTruncated>"));
+    }
+
+    // A live marker still resumes exactly at that set (regression guard for the
+    // insertion-point change).
+    #[test]
+    fn resumes_at_live_marker() {
+        let svc = svc_with_sets(&["S1", "S2", "S3", "S4"]);
+        let resp = svc
+            .list_reusable_delegation_sets(&list_req(&[("marker", "S3"), ("maxitems", "10")]))
+            .unwrap();
+        let body = body_of(resp);
+        assert_eq!(set_ids(&body), vec!["S3".to_string(), "S4".to_string()]);
+    }
+
+    // Truncation + NextMarker are preserved for an in-range MaxItems.
+    #[test]
+    fn truncates_and_sets_next_marker() {
+        let svc = svc_with_sets(&["S1", "S2", "S3", "S4"]);
+        let resp = svc
+            .list_reusable_delegation_sets(&list_req(&[("maxitems", "2")]))
+            .unwrap();
+        let body = body_of(resp);
+        assert_eq!(set_ids(&body), vec!["S1".to_string(), "S2".to_string()]);
+        assert!(body.contains("<IsTruncated>true</IsTruncated>"));
+        assert!(body.contains("<NextMarker>S3</NextMarker>"));
+        assert!(body.contains("<MaxItems>2</MaxItems>"));
     }
 }

--- a/crates/fakecloud-s3/src/service/objects/read.rs
+++ b/crates/fakecloud-s3/src/service/objects/read.rs
@@ -97,8 +97,11 @@ impl S3Service {
         // instead of returning the raw envelope to the caller.
         let decrypted_body: Option<Bytes> =
             if obj.sse_algorithm.as_deref() == Some("aws:kms") && self.kms_hook.is_some() {
-                let raw = state
-                    .read_body(&obj.body)
+                // Offload the (potentially multi-GB) full-object disk read
+                // onto a blocking thread so it doesn't stall the tokio worker
+                // while we decrypt the envelope, mirroring the multipart
+                // assembly path.
+                let raw = run_blocking_io(|| state.read_body(&obj.body))
                     .map_err(crate::service::io_to_aws)?;
                 Some(self.decrypt_object_body(account_id, bucket, &raw)?)
             } else {
@@ -228,8 +231,9 @@ impl S3Service {
                             let e = (start + len as usize).min(plain.len());
                             plain.slice(s..e).into()
                         } else {
-                            state
-                                .read_body_range(&obj.body, start as u64, len)
+                            // Seek+read on a blocking thread so a large ranged
+                            // read doesn't starve the tokio worker.
+                            run_blocking_io(|| state.read_body_range(&obj.body, start as u64, len))
                                 .map_err(crate::service::io_to_aws)?
                                 .into()
                         };
@@ -308,10 +312,13 @@ impl S3Service {
                     let e = (part_start + part_size).min(plain.len());
                     plain.slice(s..e).into()
                 } else {
-                    state
-                        .read_body_range(&obj.body, part_start as u64, part_size as u64)
-                        .map_err(crate::service::io_to_aws)?
-                        .into()
+                    // Seek+read on a blocking thread so a large part read
+                    // doesn't starve the tokio worker.
+                    run_blocking_io(|| {
+                        state.read_body_range(&obj.body, part_start as u64, part_size as u64)
+                    })
+                    .map_err(crate::service::io_to_aws)?
+                    .into()
                 };
                 response_status = StatusCode::PARTIAL_CONTENT;
             } else {

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -3526,6 +3526,39 @@ async fn get_object_range_open_ended() {
     assert_eq!(resp.body.expect_bytes(), b"789");
 }
 
+// A large object read (the case the spawn_blocking / block_in_place offload
+// targets) must still return the exact bytes for both a full GET and a ranged
+// GET. Behavior is unchanged; this guards the run_blocking_io wrapping.
+#[tokio::test]
+async fn get_object_large_full_and_range_returns_exact_bytes() {
+    let svc = make_service();
+    seed_bucket(&svc, "big");
+    // ~1 MiB of a repeating, position-dependent pattern so a wrong offset or a
+    // truncated read is detectable.
+    let data: Vec<u8> = (0..1_048_576u32).map(|i| (i % 251) as u8).collect();
+    let req = make_request(Method::PUT, "/big/obj", &[], &data);
+    svc.put_object("123456789012", &req, "big", "obj")
+        .await
+        .unwrap();
+
+    // Full GET returns every byte.
+    let req = make_request(Method::GET, "/big/obj", &[], b"");
+    let resp = svc.get_object("123456789012", &req, "big", "obj").unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.body.expect_bytes(), Bytes::from(data.clone()));
+
+    // Ranged GET slices the correct window.
+    let mut req = make_request(Method::GET, "/big/obj", &[], b"");
+    req.headers
+        .insert("range", "bytes=1000-1999".parse().unwrap());
+    let resp = svc.get_object("123456789012", &req, "big", "obj").unwrap();
+    assert_eq!(resp.status, StatusCode::PARTIAL_CONTENT);
+    assert_eq!(
+        resp.body.expect_bytes(),
+        Bytes::copy_from_slice(&data[1000..=1999])
+    );
+}
+
 #[tokio::test]
 async fn get_object_range_invalid_format() {
     let svc = make_service();


### PR DESCRIPTION
## Summary
Correctness/perf tail from the 2026-07-24 bug-hunt (route53/ACM edges are #2384 follow-ons).

**route53 `ListReusableDelegationSets` (LOW).** Took `MaxItems` verbatim (the shared `IntRange` constraint even *rejected* >100 — the opposite of AWS, which clamps), and the marker resume fell off the end if the marker's set was deleted mid-page, dropping the tail. Now clamps MaxItems to 100 (echoes 100) and resumes via `partition_point` (insertion point) so a deleted marker resumes at the next surviving set.

**ACM `ListCertificates` CREATED_AT tie-break (LOW).** Sorted by `created_at` then `reverse()` over HashMap iteration → non-deterministic tie order, so the numeric-offset `NextToken` could skip/dup certs with equal timestamps across pages. Now a total, stable sort: ASCENDING `(created_at, arn)`; DESCENDING `(Reverse(created_at), arn ASC)` so ties don't flip.

**S3 large reads on the tokio worker (LOW-MED).** `get_object` did full/range/part blocking `std::fs` reads on the worker (SSE-KMS full read + range + part) — a multi-GB read starves the worker. Wrapped the three in the existing `run_blocking_io` helper (`block_in_place`); the non-KMS full read already streams via `ResponseBody::File`.

## Test plan
- route53: MaxItems=500 → ≤100 + echoes 100; resume after a deleted marker returns the surviving tail.
- ACM: 4 certs with identical `created_at` paginate covering each exactly once, deterministic + stable across calls; DESCENDING is the inverse of ASCENDING for distinct timestamps.
- S3: ~1 MiB object exact bytes on full GET and a `bytes=1000-1999` range GET.
- route53 32 / acm 83 / s3 401 tests green; `clippy --all-targets -D warnings` clean. Touched-op conformance verified (ListReusableDelegationSets 28/28, ListCertificates 44/44).

## Surface impact
No API/count change — pagination correctness + worker-starvation fix. No docs/SDK update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination correctness in Route 53 and ACM, and moves large S3 reads off the Tokio worker to prevent stalls. No API changes; prevents skipped/duplicated items and worker starvation.

- **Bug Fixes**
  - `fakecloud-route53`: `ListReusableDelegationSets` now clamps `MaxItems` to 100 (and echoes 100) and resumes from the insertion point so a deleted marker continues at the next surviving set.
  - `fakecloud-acm`: `ListCertificates` with `SortBy=CREATED_AT` now uses a stable total order—ASC `(created_at, arn)` and DESC `(Reverse(created_at), arn)`—so `NextToken` pagination is deterministic with no skips or dups.
  - `fakecloud-s3`: `get_object` KMS full reads, byte-range reads, and multipart part reads now run via `run_blocking_io` to avoid blocking the Tokio worker; I/O behavior is unchanged.

<sup>Written for commit 103c9060818d42db010d60ec820bdf3a6c2f459e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

