### PR TITLE
fix(cloudformation): in-place UpdateStack for Glue Database/Table + Timestream Table (stop wiping catalog/records)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
@@ -73,6 +73,59 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// In-place `UpdateDatabase`: mutate the database's editable properties
+    /// while preserving every contained table and partition. Real AWS
+    /// `UpdateDatabase` is a "No interruption" update; the previous
+    /// reprovision (delete+create) fallback dropped the whole catalog subtree
+    /// on a benign `Description`/`Parameters`/`LocationUri` change.
+    pub(super) fn update_glue_database(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let input = props
+            .get("DatabaseInput")
+            .ok_or("DatabaseInput is required")?;
+        // A changed `Name` is a replacement in CloudFormation; an in-place
+        // update keeps the existing physical id.
+        let name = existing.physical_id.clone();
+
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let dbs = state.dbs_in_mut(&self.region);
+        let db = dbs
+            .get_mut(&name)
+            .ok_or_else(|| format!("Database {name} not found"))?;
+        db.description = input
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        db.location_uri = input
+            .get("LocationUri")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        db.parameters = input
+            .get("Parameters")
+            .and_then(|v| v.as_object())
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+        db.target_database = input
+            .get("TargetDatabase")
+            .filter(|v| !v.is_null())
+            .cloned();
+        db.federated_database = input
+            .get("FederatedDatabase")
+            .filter(|v| !v.is_null())
+            .cloned();
+        // db.tables intentionally left untouched.
+        Ok(ProvisionResult::new(name))
+    }
+
     pub(super) fn create_glue_table(
         &self,
         resource: &ResourceDefinition,
@@ -153,6 +206,62 @@ impl ResourceProvisioner {
             .ok_or_else(|| format!("Database {} not found", parts[0]))?;
         db.tables.remove(parts[1]);
         Ok(())
+    }
+
+    /// In-place `UpdateTable`: mutate the table's editable properties while
+    /// preserving every partition and the stored data location. Real AWS
+    /// `UpdateTable` is a "No interruption" update; the previous reprovision
+    /// fallback dropped all partitions on a benign property change.
+    pub(super) fn update_glue_table(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let input = props.get("TableInput").ok_or("TableInput is required")?;
+        // Physical id is `{db}|{table}`; a changed DatabaseName/Name is a
+        // replacement (owned by the reprovision path), not an in-place update.
+        let physical_id = existing.physical_id.clone();
+        let parts: Vec<&str> = physical_id.split('|').collect();
+        if parts.len() != 2 {
+            return Err(format!("Invalid Glue table physical id: {physical_id}"));
+        }
+        let (db_name, table_name) = (parts[0].to_string(), parts[1].to_string());
+
+        let mut accounts = self.glue_state.write();
+        let state = accounts.get_or_create(&self.account_id, &self.region);
+        let dbs = state.dbs_in_mut(&self.region);
+        let db = dbs
+            .get_mut(&db_name)
+            .ok_or_else(|| format!("Database {db_name} not found"))?;
+        let table = db
+            .tables
+            .get_mut(&table_name)
+            .ok_or_else(|| format!("Table {table_name} not found"))?;
+        table.description = input
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        table.owner = input
+            .get("Owner")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        table.retention = input.get("Retention").and_then(|v| v.as_i64()).unwrap_or(0);
+        table.view_original_text = input
+            .get("ViewOriginalText")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        table.view_expanded_text = input
+            .get("ViewExpandedText")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        table.table_type = input
+            .get("TableType")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        table.update_time = Utc::now();
+        // table.partitions and storage_descriptor location intentionally kept.
+        Ok(ProvisionResult::new(physical_id))
     }
 
     pub(super) fn create_glue_partition(

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1822,6 +1822,12 @@ impl ResourceProvisioner {
             "AWS::DocDB::DBCluster" => Some(self.update_docdb_cluster(existing, new_def)?),
             "AWS::Neptune::DBCluster" => Some(self.update_neptune_cluster(existing, new_def)?),
             "AWS::EC2::Instance" => Some(self.update_ec2_instance(existing, new_def)?),
+            // Stateful catalog/timeseries types: an in-place update preserves
+            // the contained data (Glue tables/partitions, Timestream records)
+            // that a reprovision (delete+create) would silently wipe.
+            "AWS::Glue::Database" => Some(self.update_glue_database(existing, new_def)?),
+            "AWS::Glue::Table" => Some(self.update_glue_table(existing, new_def)?),
+            "AWS::Timestream::Table" => Some(self.update_timestream_table(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/timestream.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/timestream.rs
@@ -11,7 +11,7 @@
 
 use serde_json::{json, Value};
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 use fakecloud_timestream::shared::{database_arn, now_epoch, table_arn, table_key};
 use fakecloud_timestream::state::{Database, Table};
 
@@ -171,6 +171,60 @@ impl ResourceProvisioner {
             }
         }
         Ok(())
+    }
+
+    /// In-place `UpdateTable`: mutate the table's editable properties while
+    /// preserving every ingested record. Real AWS `UpdateTable`
+    /// (RetentionProperties / MagneticStoreWriteProperties / Schema / Tags) is
+    /// applied in place; the previous reprovision fallback deleted the table's
+    /// entire `records` set on a benign retention/tag change.
+    pub(super) fn update_timestream_table(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        // A changed DatabaseName/TableName is a replacement (reprovision path);
+        // an in-place update keeps the existing physical id and its records.
+        let physical_id = existing.physical_id.clone();
+        let Some((database, table)) = physical_id.split_once('|') else {
+            return Err(format!(
+                "Invalid Timestream table physical id: {physical_id}"
+            ));
+        };
+        let key = table_key(database, table);
+
+        let mut guard = self.timestream_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let arn = {
+            let record = data
+                .tables
+                .get_mut(&key)
+                .ok_or_else(|| format!("Table {table} not found"))?;
+            if let Some(rp) = props.get("RetentionProperties").filter(|v| !v.is_null()) {
+                record.retention_properties = rp.clone();
+            }
+            record.magnetic_store_write_properties = props
+                .get("MagneticStoreWriteProperties")
+                .filter(|v| !v.is_null())
+                .cloned();
+            if let Some(schema) = props.get("Schema").filter(|v| !v.is_null()) {
+                record.schema = schema.clone();
+            }
+            record.last_updated_time = now_epoch();
+            record.arn.clone()
+        };
+        // Tags are replaced wholesale on update, matching CFN tag semantics.
+        let tags = string_tag_map(props.get("Tags"));
+        if tags.is_empty() {
+            data.tags.remove(&arn);
+        } else {
+            data.tags.insert(arn.clone(), tags);
+        }
+        // data.records[key] intentionally left untouched.
+        Ok(ProvisionResult::new(physical_id.clone())
+            .with("Arn", arn)
+            .with("Name", table.to_string()))
     }
 
     pub(super) fn get_att_timestream_table(

--- a/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
@@ -241,3 +241,256 @@ async fn cfn_update_rds_db_cluster_is_in_place() {
         "resource id must be stable across an in-place update; a delete+recreate would mint a new one"
     );
 }
+
+// --- AWS::Glue::Database / AWS::Glue::Table -------------------------------
+// A benign Description change on a Glue Database/Table used to reprovision
+// (delete+create), dropping every contained table/partition. These assert the
+// out-of-band catalog data survives an in-place update.
+
+const GLUE_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Db": {
+      "Type": "AWS::Glue::Database",
+      "Properties": {
+        "CatalogId": "000000000000",
+        "DatabaseInput": { "Name": "cfn_glue_preserve", "Description": "v1" }
+      }
+    },
+    "Tbl": {
+      "Type": "AWS::Glue::Table",
+      "Properties": {
+        "CatalogId": "000000000000",
+        "DatabaseName": "cfn_glue_preserve",
+        "TableInput": { "Name": "events", "Description": "t-v1" }
+      }
+    }
+  }
+}"#;
+
+// Identical except both Descriptions bumped (mutable, in-place changes).
+const GLUE_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Db": {
+      "Type": "AWS::Glue::Database",
+      "Properties": {
+        "CatalogId": "000000000000",
+        "DatabaseInput": { "Name": "cfn_glue_preserve", "Description": "v2" }
+      }
+    },
+    "Tbl": {
+      "Type": "AWS::Glue::Table",
+      "Properties": {
+        "CatalogId": "000000000000",
+        "DatabaseName": "cfn_glue_preserve",
+        "TableInput": { "Name": "events", "Description": "t-v2" }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_glue_database_and_table_preserve_contents() {
+    use aws_sdk_glue::types::{Column, PartitionInput, StorageDescriptor};
+
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let glue = server.glue_client().await;
+
+    cfn.create_stack()
+        .stack_name("glue-preserve")
+        .template_body(GLUE_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "glue-preserve", "CREATE_COMPLETE").await;
+
+    // Out-of-band: add a partition to the CFN-created table. A delete+recreate
+    // of the table (or its database) would drop this partition.
+    glue.create_partition()
+        .database_name("cfn_glue_preserve")
+        .table_name("events")
+        .partition_input(
+            PartitionInput::builder()
+                .values("2026-01-01")
+                .storage_descriptor(
+                    StorageDescriptor::builder()
+                        .location("s3://bucket/events/2026-01-01/")
+                        .columns(
+                            Column::builder()
+                                .name("id")
+                                .r#type("string")
+                                .build()
+                                .expect("column"),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create_partition");
+
+    // Change a mutable property on BOTH the database and the table.
+    cfn.update_stack()
+        .stack_name("glue-preserve")
+        .template_body(GLUE_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "glue-preserve", "UPDATE_COMPLETE").await;
+
+    // The description changes were applied in place...
+    let db = glue
+        .get_database()
+        .name("cfn_glue_preserve")
+        .send()
+        .await
+        .expect("get_database")
+        .database
+        .expect("database present");
+    assert_eq!(db.description(), Some("v2"));
+
+    let tbl = glue
+        .get_table()
+        .database_name("cfn_glue_preserve")
+        .name("events")
+        .send()
+        .await
+        .expect("get_table")
+        .table
+        .expect("table present");
+    assert_eq!(tbl.description(), Some("t-v2"));
+
+    // ...and the out-of-band partition survived -> in-place, not reprovision.
+    let parts = glue
+        .get_partitions()
+        .database_name("cfn_glue_preserve")
+        .table_name("events")
+        .send()
+        .await
+        .expect("get_partitions")
+        .partitions
+        .unwrap_or_default();
+    assert_eq!(
+        parts.len(),
+        1,
+        "the out-of-band partition must survive an in-place Glue update; a reprovision would have dropped it"
+    );
+}
+
+// --- AWS::Timestream::Table ----------------------------------------------
+// A RetentionProperties change on a Timestream table used to reprovision,
+// deleting every ingested record. This asserts the records survive.
+
+const TS_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Db": {
+      "Type": "AWS::Timestream::Database",
+      "Properties": { "DatabaseName": "cfn_ts_preserve" }
+    },
+    "Tbl": {
+      "Type": "AWS::Timestream::Table",
+      "Properties": {
+        "DatabaseName": "cfn_ts_preserve",
+        "TableName": "cpu",
+        "RetentionProperties": {
+          "MemoryStoreRetentionPeriodInHours": "24",
+          "MagneticStoreRetentionPeriodInDays": "7"
+        }
+      }
+    }
+  }
+}"#;
+
+// Identical except MagneticStoreRetentionPeriodInDays 7 -> 30 (mutable).
+const TS_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Db": {
+      "Type": "AWS::Timestream::Database",
+      "Properties": { "DatabaseName": "cfn_ts_preserve" }
+    },
+    "Tbl": {
+      "Type": "AWS::Timestream::Table",
+      "Properties": {
+        "DatabaseName": "cfn_ts_preserve",
+        "TableName": "cpu",
+        "RetentionProperties": {
+          "MemoryStoreRetentionPeriodInHours": "24",
+          "MagneticStoreRetentionPeriodInDays": "30"
+        }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_timestream_table_preserves_records() {
+    use aws_sdk_timestreamwrite::types::{Dimension, MeasureValueType, Record, TimeUnit};
+
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let write = server.timestream_write_client().await;
+    let query = server.timestream_query_client().await;
+
+    cfn.create_stack()
+        .stack_name("ts-preserve")
+        .template_body(TS_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "ts-preserve", "CREATE_COMPLETE").await;
+
+    // Out-of-band: ingest records into the CFN-created table.
+    let rec = |host: &str, value: &str, t: &str| {
+        Record::builder()
+            .dimensions(
+                Dimension::builder()
+                    .name("host")
+                    .value(host)
+                    .build()
+                    .expect("dimension"),
+            )
+            .measure_name("cpu")
+            .measure_value(value)
+            .measure_value_type(MeasureValueType::Double)
+            .time(t)
+            .time_unit(TimeUnit::Milliseconds)
+            .build()
+    };
+    write
+        .write_records()
+        .database_name("cfn_ts_preserve")
+        .table_name("cpu")
+        .records(rec("host-a", "42.5", "1700000000000"))
+        .records(rec("host-b", "13.25", "1700000001000"))
+        .send()
+        .await
+        .expect("write_records");
+
+    // Change a mutable retention property. Pre-fix this delete+recreated the
+    // table, wiping every ingested record.
+    cfn.update_stack()
+        .stack_name("ts-preserve")
+        .template_body(TS_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "ts-preserve", "UPDATE_COMPLETE").await;
+
+    // The ingested records survived -> in-place, not reprovision.
+    let count = query
+        .query()
+        .query_string(r#"SELECT COUNT(*) FROM "cfn_ts_preserve"."cpu""#)
+        .send()
+        .await
+        .expect("query count");
+    assert_eq!(
+        count.rows()[0].data()[0].scalar_value(),
+        Some("2"),
+        "ingested records must survive an in-place Timestream table update; a reprovision would have wiped them"
+    );
+}


### PR DESCRIPTION
## Summary
Bug-hunt 2026-07-25 Tier-0 (Family B, #2399 propagation gap). #2399 added in-place `update_*` arms for 9 stateful CFN types but several data-bearing types still fell through to `reprovision_resource` (delete+create), silently wiping their contained data on a benign property change while the stack reported `UPDATE_COMPLETE`.

Adds the missing in-place arms:
- **AWS::Glue::Database** — `update_glue_database`: mutates Description/LocationUri/Parameters/TargetDatabase/FederatedDatabase; **preserves every contained table**.
- **AWS::Glue::Table** — `update_glue_table`: mutates Description/Owner/Retention/View*/TableType; **preserves every partition**.
- **AWS::Timestream::Table** — `update_timestream_table`: mutates RetentionProperties/MagneticStoreWriteProperties/Schema/Tags; **preserves every ingested record**.

A changed Name/DatabaseName still routes through replacement (reprovision), matching CloudFormation semantics.

## Test plan
- New e2e regression tests in `cloudformation_update_preserves_stateful.rs`:
  - `cfn_update_glue_database_and_table_preserve_contents` — out-of-band Glue partition survives a CHANGED-Description UpdateStack on both the DB and the table.
  - `cfn_update_timestream_table_preserves_records` — ingested Timestream records survive a CHANGED RetentionProperties UpdateStack.
- Both pass locally (35s, no container runtime needed). `cargo clippy -p fakecloud-cloudformation --all-targets -D warnings` clean; fmt clean.

## Surface
No API/SDK/doc surface change — internal CFN provisioner behavior only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss on CloudFormation updates by performing in-place updates for Glue Database/Table and Timestream Table. Editable fields are now mutated without deleting resources, so catalog contents and ingested records persist.

- **Bug Fixes**
  - AWS::Glue::Database: in-place updates for Description, LocationUri, Parameters, TargetDatabase, FederatedDatabase; preserves tables.
  - AWS::Glue::Table: in-place updates for Description, Owner, Retention, ViewOriginalText/ViewExpandedText, TableType; preserves partitions and storage location.
  - AWS::Timestream::Table: in-place updates for RetentionProperties, MagneticStoreWriteProperties, Schema, Tags; preserves records.
  - Name/DatabaseName changes still trigger replacement to match CloudFormation.
  - Added e2e tests to ensure Glue partitions and Timestream records survive updates.

<sup>Written for commit fae347ab8db48f0fa46c302cf0256e9f6b91948b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

