### PR TITLE
fix(elasticache): accept Valkey 7.2 for serverless caches (stale MajorEngineVersion gate)

### DIFF
--- a/crates/fakecloud-e2e/tests/elasticache.rs
+++ b/crates/fakecloud-e2e/tests/elasticache.rs
@@ -1431,10 +1431,19 @@ async fn elasticache_describe_cache_engine_versions_filter_by_engine() {
         .unwrap();
 
     let versions = response.cache_engine_versions();
-    assert_eq!(versions.len(), 1);
-    assert_eq!(versions[0].engine(), Some("valkey"));
-    assert_eq!(versions[0].engine_version(), Some("8.0"));
-    assert_eq!(versions[0].cache_parameter_group_family(), Some("valkey8"));
+    // Valkey ships both 8.0 (family valkey8) and 7.2 (family valkey7).
+    assert_eq!(versions.len(), 2);
+    assert!(versions.iter().all(|v| v.engine() == Some("valkey")));
+    let v8 = versions
+        .iter()
+        .find(|v| v.engine_version() == Some("8.0"))
+        .expect("valkey 8.0 present");
+    assert_eq!(v8.cache_parameter_group_family(), Some("valkey8"));
+    let v7 = versions
+        .iter()
+        .find(|v| v.engine_version() == Some("7.2"))
+        .expect("valkey 7.2 present");
+    assert_eq!(v7.cache_parameter_group_family(), Some("valkey7"));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-elasticache/src/helpers.rs
+++ b/crates/fakecloud-elasticache/src/helpers.rs
@@ -98,8 +98,12 @@ pub(crate) fn default_full_engine_version(
         ));
     }
 
+    // Valkey serverless/self-designed supports both 7.2 and 8.x on AWS; the
+    // gate previously accepted only 8.x and rejected a valid MajorEngineVersion
+    // of 7 / 7.2.
     if (engine == ENGINE_REDIS && !major_engine_version.starts_with('7'))
-        || (engine == ENGINE_VALKEY && !major_engine_version.starts_with('8'))
+        || (engine == ENGINE_VALKEY
+            && !(major_engine_version.starts_with('7') || major_engine_version.starts_with('8')))
     {
         return Err(AwsServiceError::aws_error(
             StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -862,6 +862,29 @@ async fn create_serverless_cache_rejects_memcached() {
 }
 
 #[tokio::test]
+async fn create_serverless_cache_accepts_valkey_7() {
+    // AWS supports Valkey 7.2 (and 8.x) for serverless; the MajorEngineVersion
+    // gate previously rejected 7 as "not supported for engine valkey".
+    let shared = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new("123456789012", "us-east-1", ""),
+    ));
+    let service = ElastiCacheService::new(shared);
+
+    let req = request(
+        "CreateServerlessCache",
+        &[
+            ("ServerlessCacheName", "sc-vk7"),
+            ("Engine", "valkey"),
+            ("MajorEngineVersion", "7"),
+        ],
+    );
+    assert!(
+        service.create_serverless_cache(&req).await.is_ok(),
+        "Valkey MajorEngineVersion 7 must be accepted for a serverless cache"
+    );
+}
+
+#[tokio::test]
 async fn create_cache_cluster_without_runtime_falls_back_to_metadata_only() {
     // No container runtime is configured. The Smithy model has no
     // "Docker missing" error shape, so refusing the call would emit an

--- a/crates/fakecloud-elasticache/src/state.rs
+++ b/crates/fakecloud-elasticache/src/state.rs
@@ -998,6 +998,13 @@ pub fn default_engine_versions() -> Vec<CacheEngineVersion> {
             cache_engine_version_description: "Valkey 8.0".to_string(),
         },
         CacheEngineVersion {
+            engine: "valkey".to_string(),
+            engine_version: "7.2".to_string(),
+            cache_parameter_group_family: "valkey7".to_string(),
+            cache_engine_description: "Valkey".to_string(),
+            cache_engine_version_description: "Valkey 7.2".to_string(),
+        },
+        CacheEngineVersion {
             engine: "memcached".to_string(),
             engine_version: "1.6.22".to_string(),
             cache_parameter_group_family: "memcached1.6".to_string(),
@@ -1032,6 +1039,19 @@ fn default_parameter_groups(account_id: &str, region: &str) -> Vec<CacheParamete
                 region,
                 account_id,
                 "parametergroup:default.valkey8",
+            )
+            .to_string(),
+        },
+        CacheParameterGroup {
+            cache_parameter_group_name: "default.valkey7".to_string(),
+            cache_parameter_group_family: "valkey7".to_string(),
+            description: "Default parameter group for valkey7".to_string(),
+            is_global: false,
+            arn: Arn::new(
+                "elasticache",
+                region,
+                account_id,
+                "parametergroup:default.valkey7",
             )
             .to_string(),
         },
@@ -1098,7 +1118,7 @@ pub fn default_parameters_for_family(family: &str) -> Vec<EngineDefaultParameter
                 minimum_engine_version: "7.0.0".to_string(),
             },
         ],
-        "valkey8" => vec![
+        "valkey8" | "valkey7" => vec![
             EngineDefaultParameter {
                 parameter_name: "maxmemory-policy".to_string(),
                 parameter_value: "volatile-lru".to_string(),
@@ -1194,19 +1214,21 @@ mod tests {
     #[test]
     fn default_engine_versions_contains_redis_valkey_memcached() {
         let versions = default_engine_versions();
-        assert_eq!(versions.len(), 3);
+        assert_eq!(versions.len(), 4);
         assert_eq!(versions[0].engine, "redis");
         assert_eq!(versions[0].engine_version, "7.1");
         assert_eq!(versions[1].engine, "valkey");
         assert_eq!(versions[1].engine_version, "8.0");
-        assert_eq!(versions[2].engine, "memcached");
-        assert_eq!(versions[2].engine_version, "1.6.22");
+        assert_eq!(versions[2].engine, "valkey");
+        assert_eq!(versions[2].engine_version, "7.2");
+        assert_eq!(versions[3].engine, "memcached");
+        assert_eq!(versions[3].engine_version, "1.6.22");
     }
 
     #[test]
     fn state_new_creates_default_parameter_groups() {
         let state = ElastiCacheState::new("123456789012", "us-east-1");
-        assert_eq!(state.parameter_groups.len(), 3);
+        assert_eq!(state.parameter_groups.len(), 4);
         assert_eq!(
             state.parameter_groups[0].cache_parameter_group_name,
             "default.redis7"
@@ -1217,6 +1239,10 @@ mod tests {
         );
         assert_eq!(
             state.parameter_groups[2].cache_parameter_group_name,
+            "default.valkey7"
+        );
+        assert_eq!(
+            state.parameter_groups[3].cache_parameter_group_name,
             "default.memcached1.6"
         );
     }
@@ -1242,7 +1268,7 @@ mod tests {
         state.parameter_groups.clear();
         assert!(state.parameter_groups.is_empty());
         state.reset();
-        assert_eq!(state.parameter_groups.len(), 3);
+        assert_eq!(state.parameter_groups.len(), 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Bug-hunt 2026-07-25 Tier-1 (stale-enum / reject-valid). The serverless-cache MajorEngineVersion gate required Valkey majors to start with `8`, rejecting a valid `MajorEngineVersion=7` / `7.2` with `InvalidParameterValue`. AWS supports both Valkey 7.2 and 8.x for serverless caches.

- Gate accepts Valkey major `7` or `8` (Redis unchanged at `7`).
- Seeds a Valkey 7.2 `CacheEngineVersion` (family `valkey7`) for `DescribeCacheEngineVersions` + a `default.valkey7` parameter group; `valkey7` shares the `valkey8` default parameter set.
- Backing container image is engine-keyed (not version-keyed), so a Valkey 7.2 cache boots the same valkey image — no runtime change.

## Test plan
- New unit test `create_serverless_cache_accepts_valkey_7`.
- Updated the three seed-count assertions (engine-versions 3->4, parameter-groups 3->4, reset).
- `cargo test -p fakecloud-elasticache --lib` 251 passed; clippy `--all-targets -D warnings` clean; fmt clean.

## Surface
Internal validation + seed data; no API/SDK/doc surface change (DescribeCacheEngineVersions now additionally lists Valkey 7.2, matching AWS).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept Valkey 7.x for serverless caches and seed Valkey 7.2 so it appears in DescribeCacheEngineVersions. Fixes invalid rejections from the stale MajorEngineVersion gate; no runtime or API changes.

- **Bug Fixes**
  - Accept `valkey` MajorEngineVersion 7 or 8 (Redis stays 7).
  - Seed engine version `valkey 7.2` (family `valkey7`) and `default.valkey7` parameter group; shares defaults with `valkey8`.
  - Tests: add unit test `create_serverless_cache_accepts_valkey_7`; update seed-count assertions and e2e to expect both `valkey 8.0` and `valkey 7.2` in DescribeCacheEngineVersions (filter by engine).

<sup>Written for commit 53a7b9d26d432b1b65ea272c4a93eb9e834364a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

