### PR TITLE
fix(ec2): region-scope TransitGateway/NetworkInsights/ICE/VerifiedAccess/LocalGateway ARNs

### DIFF
--- a/crates/fakecloud-ec2/src/service/ice.rs
+++ b/crates/fakecloud-ec2/src/service/ice.rs
@@ -13,11 +13,11 @@ const IP_TYPES: &[&str] = &["ipv4", "dualstack", "ipv6"];
 
 // ---- instance connect endpoints ----
 
-fn ice_xml(e: &InstanceConnectEndpoint, tags: &[Tag], owner: &str) -> String {
+fn ice_xml(e: &InstanceConnectEndpoint, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
         "{}{}{}<state>create-complete</state>{}<createdAt>{}</createdAt><preserveClientIp>true</preserveClientIp>{}",
         ec2_elem("instanceConnectEndpointId", &e.id),
-        ec2_elem("instanceConnectEndpointArn", &format!("arn:aws:ec2:us-east-1:{owner}:instance-connect-endpoint/{}", e.id)),
+        ec2_elem("instanceConnectEndpointArn", &format!("arn:aws:ec2:{region}:{owner}:instance-connect-endpoint/{}", e.id)),
         ec2_elem("ownerId", owner),
         ec2_elem("subnetId", &e.subnet_id),
         FIXED_TIME,
@@ -62,7 +62,7 @@ pub(crate) fn create_instance_connect_endpoint(
         &req.request_id,
         &format!(
             "<instanceConnectEndpoint>{}</instanceConnectEndpoint>{}",
-            ice_xml(&e, &tags, &owner),
+            ice_xml(&e, &tags, &owner, &req.region),
             ec2_elem("clientToken", &token)
         ),
     ))
@@ -90,7 +90,7 @@ pub(crate) fn delete_instance_connect_endpoint(
         &req.request_id,
         &format!(
             "<instanceConnectEndpoint>{}</instanceConnectEndpoint>",
-            ice_xml(&e, &tags, &owner)
+            ice_xml(&e, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -107,7 +107,7 @@ pub(crate) fn describe_instance_connect_endpoints(
     let mut items: Vec<String> = state
         .instance_connect_endpoints
         .values()
-        .map(|e| ice_xml(e, state.tags_for(&e.id), &owner))
+        .map(|e| ice_xml(e, state.tags_for(&e.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/service/lgw.rs
+++ b/crates/fakecloud-ec2/src/service/lgw.rs
@@ -15,8 +15,8 @@ fn mr(req: &AwsRequest) -> Result<(), AwsServiceError> {
     validate_max_results(&req.query_params, 5, 1000)
 }
 
-fn owner_arn(owner: &str, kind: &str, id: &str) -> String {
-    format!("arn:aws:ec2:us-east-1:{owner}:{kind}/{id}")
+fn owner_arn(region: &str, owner: &str, kind: &str, id: &str) -> String {
+    format!("arn:aws:ec2:{region}:{owner}:{kind}/{id}")
 }
 
 // ---- carrier gateways ----
@@ -121,7 +121,13 @@ fn ins(
 
 // ---- CoIP pools + CIDRs ----
 
-fn coip_pool_xml(p: &CoipPool, cidrs: &[String], tags: &[Tag], owner: &str) -> String {
+fn coip_pool_xml(
+    p: &CoipPool,
+    cidrs: &[String],
+    tags: &[Tag],
+    owner: &str,
+    region: &str,
+) -> String {
     format!(
         "{}{}{}{}",
         ec2_elem("poolId", &p.id),
@@ -133,7 +139,7 @@ fn coip_pool_xml(p: &CoipPool, cidrs: &[String], tags: &[Tag], owner: &str) -> S
                 .collect::<Vec<_>>()
         ),
         ec2_elem("localGatewayRouteTableId", &p.route_table_id)
-            + &ec2_elem("poolArn", &owner_arn(owner, "coip-pool", &p.id)),
+            + &ec2_elem("poolArn", &owner_arn(region, owner, "coip-pool", &p.id)),
         super::tags::tag_set_xml(tags),
     )
 }
@@ -157,7 +163,7 @@ pub(crate) fn create_coip_pool(
         &req.request_id,
         &format!(
             "<coipPool>{}</coipPool>",
-            coip_pool_xml(&p, &[], &tags, &owner)
+            coip_pool_xml(&p, &[], &tags, &owner, &req.region)
         ),
     ))
 }
@@ -182,7 +188,7 @@ pub(crate) fn delete_coip_pool(
         &req.request_id,
         &format!(
             "<coipPool>{}</coipPool>",
-            coip_pool_xml(&p, &cidrs, &tags, &owner)
+            coip_pool_xml(&p, &cidrs, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -205,7 +211,7 @@ pub(crate) fn describe_coip_pools(
                 .get(&p.id)
                 .cloned()
                 .unwrap_or_default();
-            coip_pool_xml(p, &cidrs, state.tags_for(&p.id), &owner)
+            coip_pool_xml(p, &cidrs, state.tags_for(&p.id), &owner, &req.region)
         })
         .collect();
     items.sort();
@@ -297,11 +303,11 @@ pub(crate) fn get_coip_pool_usage(
 
 // ---- local gateway route tables ----
 
-fn lgrt_xml(rt: &LocalGatewayRouteTable, tags: &[Tag], owner: &str) -> String {
+fn lgrt_xml(rt: &LocalGatewayRouteTable, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
-        "{}{}{}<outpostArn>arn:aws:outposts:us-east-1:{owner}:outpost/op-0</outpostArn>{}<state>available</state><mode>{}</mode>{}",
+        "{}{}{}<outpostArn>arn:aws:outposts:{region}:{owner}:outpost/op-0</outpostArn>{}<state>available</state><mode>{}</mode>{}",
         ec2_elem("localGatewayRouteTableId", &rt.id),
-        ec2_elem("localGatewayRouteTableArn", &owner_arn(owner, "local-gateway-route-table", &rt.id)),
+        ec2_elem("localGatewayRouteTableArn", &owner_arn(region, owner, "local-gateway-route-table", &rt.id)),
         ec2_elem("localGatewayId", &rt.local_gateway_id),
         ec2_elem("ownerId", owner),
         rt.mode,
@@ -334,7 +340,7 @@ pub(crate) fn create_local_gateway_route_table(
         &req.request_id,
         &format!(
             "<localGatewayRouteTable>{}</localGatewayRouteTable>",
-            lgrt_xml(&rt, &tags, &owner)
+            lgrt_xml(&rt, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -363,7 +369,7 @@ pub(crate) fn delete_local_gateway_route_table(
         &req.request_id,
         &format!(
             "<localGatewayRouteTable>{}</localGatewayRouteTable>",
-            lgrt_xml(&rt, &tags, &owner)
+            lgrt_xml(&rt, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -380,7 +386,7 @@ pub(crate) fn describe_local_gateway_route_tables(
     let mut items: Vec<String> = state
         .lg_route_tables
         .values()
-        .map(|rt| lgrt_xml(rt, state.tags_for(&rt.id), &owner))
+        .map(|rt| lgrt_xml(rt, state.tags_for(&rt.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -392,14 +398,14 @@ pub(crate) fn describe_local_gateway_route_tables(
 
 // ---- local gateway routes ----
 
-fn route_xml(cidr: &str, rt: &str, owner: &str) -> String {
+fn route_xml(cidr: &str, rt: &str, owner: &str, region: &str) -> String {
     format!(
         "{}<type>static</type><state>active</state>{}{}{}",
         ec2_elem("destinationCidrBlock", cidr),
         ec2_elem("localGatewayRouteTableId", rt),
         ec2_elem(
             "localGatewayRouteTableArn",
-            &owner_arn(owner, "local-gateway-route-table", rt)
+            &owner_arn(region, owner, "local-gateway-route-table", rt)
         ),
         ec2_elem("ownerId", owner),
     )
@@ -427,7 +433,10 @@ pub(crate) fn create_local_gateway_route(
     Ok(Ec2Service::respond(
         "CreateLocalGatewayRoute",
         &req.request_id,
-        &format!("<route>{}</route>", route_xml(&cidr, &rt, &req.account_id)),
+        &format!(
+            "<route>{}</route>",
+            route_xml(&cidr, &rt, &req.account_id, &req.region)
+        ),
     ))
 }
 
@@ -454,7 +463,10 @@ pub(crate) fn delete_local_gateway_route(
     Ok(Ec2Service::respond(
         "DeleteLocalGatewayRoute",
         &req.request_id,
-        &format!("<route>{}</route>", route_xml(&cidr, &rt, &req.account_id)),
+        &format!(
+            "<route>{}</route>",
+            route_xml(&cidr, &rt, &req.account_id, &req.region)
+        ),
     ))
 }
 
@@ -471,7 +483,10 @@ pub(crate) fn modify_local_gateway_route(
     Ok(Ec2Service::respond(
         "ModifyLocalGatewayRoute",
         &req.request_id,
-        &format!("<route>{}</route>", route_xml(&cidr, &rt, &req.account_id)),
+        &format!(
+            "<route>{}</route>",
+            route_xml(&cidr, &rt, &req.account_id, &req.region)
+        ),
     ))
 }
 
@@ -485,7 +500,11 @@ pub(crate) fn search_local_gateway_routes(
     let items: Vec<String> = accounts
         .get(&req.account_id)
         .and_then(|s| s.lg_routes.get(&rt))
-        .map(|rs| rs.iter().map(|c| route_xml(c, &rt, &owner)).collect())
+        .map(|rs| {
+            rs.iter()
+                .map(|c| route_xml(c, &rt, &owner, &req.region))
+                .collect()
+        })
         .unwrap_or_default();
     Ok(Ec2Service::respond(
         "SearchLocalGatewayRoutes",

--- a/crates/fakecloud-ec2/src/service/ni.rs
+++ b/crates/fakecloud-ec2/src/service/ni.rs
@@ -21,14 +21,14 @@ fn mr(req: &AwsRequest) -> Result<(), AwsServiceError> {
 
 // ---- paths ----
 
-fn path_xml(p: &NetworkInsightsPath, tags: &[Tag], owner: &str) -> String {
+fn path_xml(p: &NetworkInsightsPath, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
         "{}{}<createdDate>{}</createdDate>{}{}<protocol>{}</protocol>{}",
         ec2_elem("networkInsightsPathId", &p.id),
         ec2_elem(
             "networkInsightsPathArn",
             &format!(
-                "arn:aws:ec2:us-east-1:{owner}:network-insights-path/{}",
+                "arn:aws:ec2:{region}:{owner}:network-insights-path/{}",
                 p.id
             )
         ),
@@ -85,7 +85,7 @@ pub(crate) fn create_network_insights_path(
         &req.request_id,
         &format!(
             "<networkInsightsPath>{}</networkInsightsPath>",
-            path_xml(&p, &tags, &owner)
+            path_xml(&p, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -120,7 +120,7 @@ pub(crate) fn describe_network_insights_paths(
     let mut items: Vec<String> = state
         .ni_paths
         .values()
-        .map(|p| path_xml(p, state.tags_for(&p.id), &owner))
+        .map(|p| path_xml(p, state.tags_for(&p.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -132,11 +132,11 @@ pub(crate) fn describe_network_insights_paths(
 
 // ---- analyses ----
 
-fn analysis_xml(a: &NetworkInsightsAnalysis, tags: &[Tag], owner: &str) -> String {
+fn analysis_xml(a: &NetworkInsightsAnalysis, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
         "{}{}{}<startDate>{}</startDate><status>succeeded</status><networkPathFound>true</networkPathFound>{}",
         ec2_elem("networkInsightsAnalysisId", &a.id),
-        ec2_elem("networkInsightsAnalysisArn", &format!("arn:aws:ec2:us-east-1:{owner}:network-insights-analysis/{}", a.id)),
+        ec2_elem("networkInsightsAnalysisArn", &format!("arn:aws:ec2:{region}:{owner}:network-insights-analysis/{}", a.id)),
         ec2_elem("networkInsightsPathId", &a.path_id),
         FIXED_TIME,
         super::tags::tag_set_xml(tags),
@@ -173,7 +173,7 @@ pub(crate) fn start_network_insights_analysis(
         &req.request_id,
         &format!(
             "<networkInsightsAnalysis>{}</networkInsightsAnalysis>",
-            analysis_xml(&a, &tags, &owner)
+            analysis_xml(&a, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -208,7 +208,7 @@ pub(crate) fn describe_network_insights_analyses(
     let mut items: Vec<String> = state
         .ni_analyses
         .values()
-        .map(|a| analysis_xml(a, state.tags_for(&a.id), &owner))
+        .map(|a| analysis_xml(a, state.tags_for(&a.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -220,14 +220,14 @@ pub(crate) fn describe_network_insights_analyses(
 
 // ---- access scopes ----
 
-fn scope_xml(sc: &NetworkInsightsAccessScope, tags: &[Tag], owner: &str) -> String {
+fn scope_xml(sc: &NetworkInsightsAccessScope, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
         "{}{}<createdDate>{}</createdDate>{}",
         ec2_elem("networkInsightsAccessScopeId", &sc.id),
         ec2_elem(
             "networkInsightsAccessScopeArn",
             &format!(
-                "arn:aws:ec2:us-east-1:{owner}:network-insights-access-scope/{}",
+                "arn:aws:ec2:{region}:{owner}:network-insights-access-scope/{}",
                 sc.id
             )
         ),
@@ -269,7 +269,7 @@ pub(crate) fn create_network_insights_access_scope(
         &req.request_id,
         &format!(
             "<networkInsightsAccessScope>{}</networkInsightsAccessScope>{}",
-            scope_xml(&sc, &tags, &owner),
+            scope_xml(&sc, &tags, &owner, &req.region),
             scope_content_xml(&id)
         ),
     ))
@@ -305,7 +305,7 @@ pub(crate) fn describe_network_insights_access_scopes(
     let mut items: Vec<String> = state
         .ni_access_scopes
         .values()
-        .map(|sc| scope_xml(sc, state.tags_for(&sc.id), &owner))
+        .map(|sc| scope_xml(sc, state.tags_for(&sc.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -329,11 +329,16 @@ pub(crate) fn get_network_insights_access_scope_content(
 
 // ---- scope analyses ----
 
-fn scope_analysis_xml(a: &NetworkInsightsAccessScopeAnalysis, tags: &[Tag], owner: &str) -> String {
+fn scope_analysis_xml(
+    a: &NetworkInsightsAccessScopeAnalysis,
+    tags: &[Tag],
+    owner: &str,
+    region: &str,
+) -> String {
     format!(
         "{}{}{}<status>succeeded</status><startDate>{}</startDate><findingsFound>true</findingsFound><analyzedEniCount>0</analyzedEniCount>{}",
         ec2_elem("networkInsightsAccessScopeAnalysisId", &a.id),
-        ec2_elem("networkInsightsAccessScopeAnalysisArn", &format!("arn:aws:ec2:us-east-1:{owner}:network-insights-access-scope-analysis/{}", a.id)),
+        ec2_elem("networkInsightsAccessScopeAnalysisArn", &format!("arn:aws:ec2:{region}:{owner}:network-insights-access-scope-analysis/{}", a.id)),
         ec2_elem("networkInsightsAccessScopeId", &a.scope_id),
         FIXED_TIME,
         super::tags::tag_set_xml(tags),
@@ -370,7 +375,7 @@ pub(crate) fn start_network_insights_access_scope_analysis(
         &req.request_id,
         &format!(
             "<networkInsightsAccessScopeAnalysis>{}</networkInsightsAccessScopeAnalysis>",
-            scope_analysis_xml(&a, &tags, &owner)
+            scope_analysis_xml(&a, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -405,7 +410,7 @@ pub(crate) fn describe_network_insights_access_scope_analyses(
     let mut items: Vec<String> = state
         .ni_scope_analyses
         .values()
-        .map(|a| scope_analysis_xml(a, state.tags_for(&a.id), &owner))
+        .map(|a| scope_analysis_xml(a, state.tags_for(&a.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/service/tgw.rs
+++ b/crates/fakecloud-ec2/src/service/tgw.rs
@@ -16,7 +16,7 @@ fn mr(req: &AwsRequest) -> Result<(), AwsServiceError> {
 
 // ---- transit gateways ----
 
-fn tgw_xml(t: &TransitGateway, tags: &[Tag], owner: &str) -> String {
+fn tgw_xml(t: &TransitGateway, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
         "{}{}{}{}{}{}<options><amazonSideAsn>64512</amazonSideAsn>\
          <autoAcceptSharedAttachments>disable</autoAcceptSharedAttachments>\
@@ -27,7 +27,7 @@ fn tgw_xml(t: &TransitGateway, tags: &[Tag], owner: &str) -> String {
         ec2_elem("state", &t.state),
         ec2_elem(
             "transitGatewayArn",
-            &format!("arn:aws:ec2:us-east-1:{owner}:transit-gateway/{}", t.id)
+            &format!("arn:aws:ec2:{region}:{owner}:transit-gateway/{}", t.id)
         ),
         ec2_elem("ownerId", owner),
         ec2_elem("description", &t.description),
@@ -69,7 +69,7 @@ pub(crate) fn create_transit_gateway(
         &req.request_id,
         &format!(
             "<transitGateway>{}</transitGateway>",
-            tgw_xml(&t, &tags, &owner)
+            tgw_xml(&t, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -97,7 +97,7 @@ pub(crate) fn delete_transit_gateway(
         &req.request_id,
         &format!(
             "<transitGateway>{}</transitGateway>",
-            tgw_xml(&t, &tags, &owner)
+            tgw_xml(&t, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -116,7 +116,7 @@ pub(crate) fn describe_transit_gateways(
         .transit_gateways
         .values()
         .filter(|t| wanted.is_empty() || wanted.contains(&t.id))
-        .map(|t| tgw_xml(t, state.tags_for(&t.id), &owner))
+        .map(|t| tgw_xml(t, state.tags_for(&t.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -154,7 +154,7 @@ pub(crate) fn modify_transit_gateway(
         &req.request_id,
         &format!(
             "<transitGateway>{}</transitGateway>",
-            tgw_xml(&t, &tags, &owner)
+            tgw_xml(&t, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -982,5 +982,22 @@ mod modify_tests {
         let accounts = svc.state.read();
         let a = &accounts.get("000000000000").unwrap().tgw_attachments["tgw-attach-1"];
         assert_eq!(a.subnet_ids, vec!["subnet-b".to_string()]);
+    }
+
+    #[test]
+    fn transit_gateway_arn_uses_request_region() {
+        let t = TransitGateway {
+            id: "tgw-abc123".into(),
+            description: String::new(),
+            state: "available".into(),
+        };
+        let xml = tgw_xml(&t, &[], "000000000000", "eu-central-1");
+        assert!(
+            xml.contains(
+                "<transitGatewayArn>arn:aws:ec2:eu-central-1:000000000000:transit-gateway/tgw-abc123</transitGatewayArn>"
+            ),
+            "{xml}"
+        );
+        assert!(!xml.contains("us-east-1"), "{xml}");
     }
 }

--- a/crates/fakecloud-ec2/src/service/tgw_mcast.rs
+++ b/crates/fakecloud-ec2/src/service/tgw_mcast.rs
@@ -18,13 +18,13 @@ fn mr(req: &AwsRequest) -> Result<(), AwsServiceError> {
 
 // ---- multicast domains ----
 
-fn mcast_xml(d: &TgwMulticastDomain, owner: &str) -> String {
+fn mcast_xml(d: &TgwMulticastDomain, owner: &str, region: &str) -> String {
     format!(
         "{}{}{}{}<state>available</state><options><igmpv2Support>disable</igmpv2Support>\
          <staticSourcesSupport>disable</staticSourcesSupport><autoAcceptSharedAssociations>disable</autoAcceptSharedAssociations></options>{}",
         ec2_elem("transitGatewayMulticastDomainId", &d.id),
         ec2_elem("transitGatewayId", &d.tgw_id),
-        ec2_elem("transitGatewayMulticastDomainArn", &format!("arn:aws:ec2:us-east-1:{owner}:transit-gateway-multicast-domain/{}", d.id)),
+        ec2_elem("transitGatewayMulticastDomainArn", &format!("arn:aws:ec2:{region}:{owner}:transit-gateway-multicast-domain/{}", d.id)),
         ec2_elem("ownerId", owner),
         ec2_elem("creationTime", FIXED_TIME),
     )
@@ -52,7 +52,7 @@ pub(crate) fn create_transit_gateway_multicast_domain(
         &req.request_id,
         &format!(
             "<transitGatewayMulticastDomain>{}</transitGatewayMulticastDomain>",
-            mcast_xml(&d, &req.account_id)
+            mcast_xml(&d, &req.account_id, &req.region)
         ),
     ))
 }
@@ -78,7 +78,7 @@ pub(crate) fn delete_transit_gateway_multicast_domain(
         &req.request_id,
         &format!(
             "<transitGatewayMulticastDomain>{}</transitGatewayMulticastDomain>",
-            mcast_xml(&d, &req.account_id)
+            mcast_xml(&d, &req.account_id, &req.region)
         ),
     ))
 }
@@ -95,7 +95,7 @@ pub(crate) fn describe_transit_gateway_multicast_domains(
     let mut items: Vec<String> = state
         .tgw_multicast_domains
         .values()
-        .map(|d| mcast_xml(d, &owner))
+        .map(|d| mcast_xml(d, &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(

--- a/crates/fakecloud-ec2/src/service/va.rs
+++ b/crates/fakecloud-ec2/src/service/va.rs
@@ -382,7 +382,7 @@ fn attach_detach(
 
 // ---- groups ----
 
-fn group_xml(g: &VerifiedAccessGroup, tags: &[Tag], owner: &str) -> String {
+fn group_xml(g: &VerifiedAccessGroup, tags: &[Tag], owner: &str, region: &str) -> String {
     format!(
         "{}{}{}{}<owner>{}</owner><creationTime>{}</creationTime>{}",
         ec2_elem("verifiedAccessGroupId", &g.id),
@@ -391,7 +391,7 @@ fn group_xml(g: &VerifiedAccessGroup, tags: &[Tag], owner: &str) -> String {
         ec2_elem(
             "verifiedAccessGroupArn",
             &format!(
-                "arn:aws:ec2:us-east-1:{owner}:verified-access-group/{}",
+                "arn:aws:ec2:{region}:{owner}:verified-access-group/{}",
                 g.id
             )
         ),
@@ -438,7 +438,7 @@ pub(crate) fn create_verified_access_group(
         &req.request_id,
         &format!(
             "<verifiedAccessGroup>{}</verifiedAccessGroup>",
-            group_xml(&g, &tags, &owner)
+            group_xml(&g, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -464,7 +464,7 @@ pub(crate) fn delete_verified_access_group(
         &req.request_id,
         &format!(
             "<verifiedAccessGroup>{}</verifiedAccessGroup>",
-            group_xml(&g, &tags, &owner)
+            group_xml(&g, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -481,7 +481,7 @@ pub(crate) fn describe_verified_access_groups(
     let mut items: Vec<String> = state
         .va_groups
         .values()
-        .map(|g| group_xml(g, state.tags_for(&g.id), &owner))
+        .map(|g| group_xml(g, state.tags_for(&g.id), &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -525,7 +525,7 @@ pub(crate) fn modify_verified_access_group(
         &req.request_id,
         &format!(
             "<verifiedAccessGroup>{}</verifiedAccessGroup>",
-            group_xml(&g, &tags, &owner)
+            group_xml(&g, &tags, &owner, &req.region)
         ),
     ))
 }
@@ -898,8 +898,9 @@ pub(crate) fn export_verified_access_instance_client_configuration(
 ) -> Result<AwsResponse, AwsServiceError> {
     let inst = require(&req.query_params, "VerifiedAccessInstanceId")?;
     let body = format!(
-        "<version>1</version>{}<region>us-east-1</region>{}",
+        "<version>1</version>{}<region>{}</region>{}",
         ec2_elem("verifiedAccessInstanceId", &inst),
+        req.region,
         ec2_list("openVpnConfigurationSet", &[]),
     );
     Ok(Ec2Service::respond(


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-25 Tier-0, region-in-ARN family (#2356 sibling).

Nine EC2 resource renderers built the ARNs they return with a hardcoded `us-east-1` region instead of the request's region. A resource created in e.g. `eu-central-1` therefore reported a `us-east-1` ARN, which breaks RAM shares, tag-by-ARN, IAM resource matching, and Terraform refresh. Sibling EC2 renderers (e.g. `sg.rs` security-group-rule ARNs) already thread a `region` param; this applies the same fix to the transit-gateway / network-insights / instance-connect / verified-access / local-gateway families.

Threaded a `region: &str` param into each affected render/helper fn and passed `req.region` at every call site:

- `tgw.rs` -- `transitGatewayArn` (`tgw_xml`)
- `tgw_mcast.rs` -- `transitGatewayMulticastDomainArn` (`mcast_xml`)
- `ice.rs` -- `instanceConnectEndpointArn` (`ice_xml`)
- `ni.rs` -- `networkInsightsPathArn`, `networkInsightsAnalysisArn`, `networkInsightsAccessScopeArn`, `networkInsightsAccessScopeAnalysisArn`
- `va.rs` -- `verifiedAccessGroupArn` (`group_xml`), plus the hardcoded `<region>` element returned by `ExportVerifiedAccessInstanceClientConfiguration` (same request-region-propagation bug, folded in)
- `lgw.rs` -- `owner_arn(region, owner, kind, id)` feeding the whole local-gateway family (`poolArn`, `localGatewayRouteTableArn`, local-gateway route ARN) plus the embedded `outpostArn`

`vpc_att_xml` / `plr_xml` in `tgw.rs` build no ARN and were left untouched. The `us-east-1` literal at `tgw.rs:929` is a test-helper `AwsRequest.region` field, not an ARN, and was left as-is.

## Test plan

- `cargo build -p fakecloud-ec2` -- pass
- `cargo clippy -p fakecloud-ec2 --all-targets -- -D warnings` -- clean
- `cargo fmt -p fakecloud-ec2` -- applied
- `cargo test -p fakecloud-ec2` -- 197 passed, 0 failed
- New unit test `transit_gateway_arn_uses_request_region` asserts `tgw_xml` for `eu-central-1` emits `arn:aws:ec2:eu-central-1:...` and contains no `us-east-1`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EC2 ARNs to use the request’s region instead of a hardcoded us-east-1 for several resource families. This restores correct cross-region behavior for RAM shares, tag-by-ARN, IAM matching, and Terraform refresh.

- Bug Fixes
  - Threaded `region` into renderers and used `req.region` when building ARNs for: TransitGateway, TGW Multicast Domains, Network Insights (paths, analyses, access scopes, scope analyses), Instance Connect Endpoints, Verified Access Groups, and Local Gateway (CoIP pools, route tables, routes), plus the embedded Outposts ARN in LGW route tables.
  - `ExportVerifiedAccessInstanceClientConfiguration` now emits `<region>` from the request.
  - Added a unit test to ensure TransitGateway ARN reflects the request region.

<sup>Written for commit b30e5a5dd129f9e9551026e068c82ba7cb769fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

