### PR TITLE
fix(kms,iam,lambda,ses): pagination resumes past a deleted marker (no page-1 restart)

### DIFF
--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -813,9 +813,17 @@ pub(crate) fn paginate_policy_names(
         .unwrap_or(100);
     let marker = req.query_params.get("Marker").cloned();
     names.sort();
+    // Resume at the first name strictly greater than the marker (the last name of
+    // the previous page). A deleted marker then still advances instead of falling
+    // back to 0 and restarting the listing.
     let start = marker
         .as_ref()
-        .and_then(|m| names.iter().position(|n| n == m).map(|p| p + 1))
+        .map(|m| {
+            names
+                .iter()
+                .position(|n| n.as_str() > m.as_str())
+                .unwrap_or(names.len())
+        })
         .unwrap_or(0);
     let rest: Vec<String> = names.into_iter().skip(start).collect();
     let is_truncated = rest.len() > max_items;
@@ -876,9 +884,17 @@ pub(crate) fn paginate_attached_policies(
         .collect();
     items.sort_by(|a, b| a.1.cmp(&b.1));
 
+    // Resume at the first ARN strictly greater than the marker (the last ARN of
+    // the previous page). A deleted marker then still advances instead of falling
+    // back to 0 and restarting the listing.
     let start = marker
         .as_ref()
-        .and_then(|m| items.iter().position(|(_, a)| a == m).map(|p| p + 1))
+        .map(|m| {
+            items
+                .iter()
+                .position(|(_, a)| a.as_str() > m.as_str())
+                .unwrap_or(items.len())
+        })
         .unwrap_or(0);
     let rest: Vec<(String, String)> = items.into_iter().skip(start).collect();
     let is_truncated = rest.len() > max_items;

--- a/crates/fakecloud-iam/src/iam_service/instance_profiles.rs
+++ b/crates/fakecloud-iam/src/iam_service/instance_profiles.rs
@@ -470,9 +470,17 @@ where
     F: Fn(&T) -> &str,
 {
     let marker = req.query_params.get("Marker").cloned();
+    // Resume at the first item whose name is strictly greater than the marker (the
+    // last name of the previous page). items is already sorted by name, so a
+    // deleted marker still advances instead of falling back to 0 and restarting.
     let start = marker
         .as_ref()
-        .and_then(|m| items.iter().position(|it| name_of(it) == m).map(|p| p + 1))
+        .map(|m| {
+            items
+                .iter()
+                .position(|it| name_of(it) > m.as_str())
+                .unwrap_or(items.len())
+        })
         .unwrap_or(0)
         .min(items.len());
     let rest = &items[start..];

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -240,13 +240,22 @@ impl IamService {
             });
         }
 
-        policies.sort_by(|a, b| a.policy_name.cmp(&b.policy_name));
+        // Sort by ARN, the stable cursor AWS uses for ListPolicies, so the marker
+        // and the iteration order agree.
+        policies.sort_by(|a, b| a.arn.cmp(&b.arn));
 
-        // Marker-based pagination: resume after the marked item (by ARN, the
-        // stable cursor AWS uses for ListPolicies).
+        // Marker-based pagination: the marker is the ARN of the last item on the
+        // previous page. Resume at the first policy whose ARN is strictly greater
+        // than the marker, so a marker whose policy was deleted between pages still
+        // advances instead of restarting at the first policy.
         let start_idx = marker
             .as_ref()
-            .and_then(|m| policies.iter().position(|p| p.arn == *m).map(|p| p + 1))
+            .map(|m| {
+                policies
+                    .iter()
+                    .position(|p| p.arn.as_str() > m.as_str())
+                    .unwrap_or(policies.len())
+            })
             .unwrap_or(0);
         let page = policies.get(start_idx..).unwrap_or(&[]);
         let is_truncated = page.len() > max_items;
@@ -774,6 +783,13 @@ impl IamService {
             }
         }
 
+        let rank = |k: Kind| -> u8 {
+            match k {
+                Kind::Role => 0,
+                Kind::User => 1,
+                Kind::Group => 2,
+            }
+        };
         let cursor = |k: Kind, name: &str| {
             let prefix = match k {
                 Kind::Role => "role",
@@ -783,19 +799,7 @@ impl IamService {
             format!("{prefix}:{name}")
         };
         // Stable order: by kind (role, user, group) then name.
-        entities.sort_by(|a, b| {
-            let ka = match a.0 {
-                Kind::Role => 0,
-                Kind::User => 1,
-                Kind::Group => 2,
-            };
-            let kb = match b.0 {
-                Kind::Role => 0,
-                Kind::User => 1,
-                Kind::Group => 2,
-            };
-            ka.cmp(&kb).then_with(|| a.1.cmp(&b.1))
-        });
+        entities.sort_by(|a, b| rank(a.0).cmp(&rank(b.0)).then_with(|| a.1.cmp(&b.1)));
 
         let max_items: usize = req
             .query_params
@@ -803,13 +807,29 @@ impl IamService {
             .and_then(|v| v.parse().ok())
             .unwrap_or(100);
         let marker = req.query_params.get("Marker").cloned();
+        // Decode a marker cursor ("<kind>:<name>") back into the same
+        // (kind-rank, name) order the list is sorted by. The cursor string's own
+        // lexical order does NOT match the kind order (e.g. "group" < "role"), so
+        // resume must compare on the decoded tuple, not the raw string.
+        fn marker_order(m: &str) -> (u8, &str) {
+            match m.split_once(':') {
+                Some(("role", name)) => (0, name),
+                Some(("user", name)) => (1, name),
+                Some(("group", name)) => (2, name),
+                _ => (u8::MAX, m),
+            }
+        }
+        // Resume at the first entity strictly after the marker, so a marker whose
+        // entity was detached/deleted between pages still advances instead of
+        // restarting at the first entity.
         let start_idx = marker
             .as_ref()
-            .and_then(|m| {
+            .map(|m| {
+                let mk = marker_order(m);
                 entities
                     .iter()
-                    .position(|(k, name, _)| cursor(*k, name) == *m)
-                    .map(|p| p + 1)
+                    .position(|(k, name, _)| (rank(*k), name.as_str()) > mk)
+                    .unwrap_or(entities.len())
             })
             .unwrap_or(0);
         let rest = entities.get(start_idx..).unwrap_or(&[]);

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -379,10 +379,19 @@ impl IamService {
         }
         users.sort_by(|a, b| a.user_name.cmp(&b.user_name));
 
-        // Marker-based pagination: resume after the marked item.
+        // Marker-based pagination: the marker is the user name of the last item
+        // on the previous page. users is sorted by user_name, so resume at the
+        // first user strictly greater than the marker; that way a marker whose
+        // user was deleted between pages still advances instead of restarting at
+        // the first user (which an exact-match lookup did).
         let start_idx = marker
             .as_ref()
-            .and_then(|m| users.iter().position(|u| u.user_name == *m).map(|p| p + 1))
+            .map(|m| {
+                users
+                    .iter()
+                    .position(|u| u.user_name.as_str() > m.as_str())
+                    .unwrap_or(users.len())
+            })
             .unwrap_or(0);
         let page = users.get(start_idx..).unwrap_or(&[]);
         let is_truncated = page.len() > max_items;

--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -789,14 +789,17 @@ impl KmsService {
             })
             .collect();
 
-        let start = if let Some(m) = marker {
-            all_keys
+        // Resume at the first key whose KeyId is strictly greater than the
+        // marker. all_keys is in KeyId order (BTreeMap-backed) and the marker is
+        // the last KeyId of the previous page, so if that key was deleted between
+        // pages we still advance to the next one instead of falling back to 0 and
+        // restarting the listing (which an exact-match lookup did).
+        let start = match marker {
+            Some(m) => all_keys
                 .iter()
-                .position(|k| k["KeyId"].as_str() == Some(m))
-                .map(|pos| pos + 1)
-                .unwrap_or(0)
-        } else {
-            0
+                .position(|k| k["KeyId"].as_str() > Some(m))
+                .unwrap_or(all_keys.len()),
+            None => 0,
         };
 
         let page = &all_keys[start..all_keys.len().min(start + limit)];

--- a/crates/fakecloud-kms/src/service_aliases.rs
+++ b/crates/fakecloud-kms/src/service_aliases.rs
@@ -211,17 +211,17 @@ impl KmsService {
             })
             .collect();
 
-        // Real Limit/Marker pagination (mirrors ListGrants): the marker
-        // is the AliasName of the last item on the previous page; resume
-        // after it.
-        let start = if let Some(m) = marker {
-            all_aliases
+        // Real Limit/Marker pagination (mirrors ListGrants): the marker is the
+        // AliasName of the last item on the previous page. all_aliases is in
+        // AliasName order (BTreeMap-backed), so resume at the first alias strictly
+        // greater than the marker; that way a marker whose alias was deleted
+        // between pages still advances instead of restarting from 0.
+        let start = match marker {
+            Some(m) => all_aliases
                 .iter()
-                .position(|a| a["AliasName"].as_str() == Some(m))
-                .map(|pos| pos + 1)
-                .unwrap_or(0)
-        } else {
-            0
+                .position(|a| a["AliasName"].as_str() > Some(m))
+                .unwrap_or(all_aliases.len()),
+            None => 0,
         };
 
         let page = &all_aliases[start..all_aliases.len().min(start + limit)];

--- a/crates/fakecloud-kms/src/service_grants.rs
+++ b/crates/fakecloud-kms/src/service_grants.rs
@@ -147,7 +147,7 @@ impl KmsService {
         let accounts = self.state.read();
         let empty = KmsState::new(&req.account_id, &req.region);
         let state = accounts.get(&req.account_id).unwrap_or(&empty);
-        let all_grants: Vec<Value> = state
+        let mut all_grants: Vec<Value> = state
             .grants
             .iter()
             .filter(|g| {
@@ -157,15 +157,21 @@ impl KmsService {
             })
             .map(|g| grant_to_json(g, &req.account_id))
             .collect();
+        // Sort by GrantId so the marker (the GrantId of the last item on the
+        // previous page) is a stable total-ordering key. Grants are stored in an
+        // insertion-order Vec, so without this the marker could not be resolved
+        // by comparison.
+        all_grants.sort_by(|a, b| a["GrantId"].as_str().cmp(&b["GrantId"].as_str()));
 
-        let start = if let Some(m) = marker {
-            all_grants
+        // Resume at the first grant whose GrantId is strictly greater than the
+        // marker, so a marker whose grant was retired/revoked between pages still
+        // advances instead of falling back to 0 and restarting the listing.
+        let start = match marker {
+            Some(m) => all_grants
                 .iter()
-                .position(|g| g["GrantId"].as_str() == Some(m))
-                .map(|pos| pos + 1)
-                .unwrap_or(0)
-        } else {
-            0
+                .position(|g| g["GrantId"].as_str() > Some(m))
+                .unwrap_or(all_grants.len()),
+            None => 0,
         };
 
         let page = &all_grants[start..all_grants.len().min(start + limit)];

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -3784,6 +3784,78 @@ fn re_encrypt_to_rsa_destination_round_trips() {
 /// L5: a non-string EncryptionContext value is rejected, not silently
 /// dropped (which would change the AAD bound at encrypt time).
 #[test]
+fn list_keys_resumes_past_a_deleted_marker_without_restarting() {
+    // Regression: resolving the ListKeys marker by exact match with a
+    // `.unwrap_or(0)` fallback restarted the listing from the first key whenever
+    // the key named by the marker was deleted between pages, so a delete-as-you-go
+    // loop re-emitted page 1 forever. The marker must advance past a missing key.
+    let svc = make_service();
+
+    // Create enough keys to force a second page at Limit=2.
+    for _ in 0..5 {
+        create_key(&svc);
+    }
+
+    let page1_resp = svc
+        .list_keys(&make_request("ListKeys", json!({ "Limit": 2 })))
+        .unwrap();
+    let page1: Value = serde_json::from_slice(page1_resp.body.expect_bytes()).unwrap();
+    assert_eq!(
+        page1["Truncated"],
+        json!(true),
+        "first page must be truncated"
+    );
+    let page1_ids: Vec<String> = page1["Keys"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|k| k["KeyId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(page1_ids.len(), 2);
+    let marker = page1["NextMarker"].as_str().unwrap().to_string();
+    assert_eq!(marker, page1_ids[1], "marker is the last KeyId of the page");
+
+    // Delete the key the marker names, simulating a delete between pages.
+    {
+        let mut accounts = svc.state.write();
+        let state = accounts.get_or_create("123456789012");
+        assert!(state.keys.remove(&marker).is_some(), "marker key existed");
+    }
+
+    let page2_resp = svc
+        .list_keys(&make_request(
+            "ListKeys",
+            json!({ "Limit": 2, "Marker": marker }),
+        ))
+        .unwrap();
+    let page2: Value = serde_json::from_slice(page2_resp.body.expect_bytes()).unwrap();
+    let page2_ids: Vec<String> = page2["Keys"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|k| k["KeyId"].as_str().unwrap().to_string())
+        .collect();
+
+    assert!(
+        !page2_ids.is_empty(),
+        "second page must make forward progress"
+    );
+    // No restart: the first key of page 1 must not reappear on page 2.
+    assert!(
+        !page2_ids.contains(&page1_ids[0]),
+        "page 2 restarted at page 1 (got {page2_ids:?}, page1 started with {})",
+        page1_ids[0]
+    );
+    // Every returned key sorts strictly after the (now deleted) marker.
+    for id in &page2_ids {
+        assert!(
+            id.as_str() > marker.as_str(),
+            "page 2 key {id} is not past the marker {marker}"
+        );
+    }
+}
+
+#[test]
 fn encrypt_rejects_non_string_encryption_context_value() {
     use base64::Engine;
     let svc = make_service();

--- a/crates/fakecloud-lambda/src/extras/mod.rs
+++ b/crates/fakecloud-lambda/src/extras/mod.rs
@@ -754,12 +754,27 @@ impl LambdaService {
             // Pagination: skip past Marker if supplied (Marker is the
             // Version string of the entry to start *after*), then take
             // up to MaxItems. Emit a NextMarker when truncated.
+            //
+            // Resume at the first entry strictly after the marker in the list's
+            // ($LATEST-first, then ascending-numeric) order. A version can be
+            // deleted between pages, so an exact-match lookup would fall back to 0
+            // and re-emit $LATEST; comparing on the decoded (is-numbered, number)
+            // rank advances correctly instead. Lexical string order is wrong here
+            // ("10" < "2"), so we must decode the numeric version.
+            let version_rank = |v: &str| -> (u8, u64) {
+                if v == "$LATEST" {
+                    (0, 0)
+                } else {
+                    (1, v.parse::<u64>().unwrap_or(u64::MAX))
+                }
+            };
             let start = match marker.as_deref() {
-                Some(m) => all
-                    .iter()
-                    .position(|v| v["Version"].as_str() == Some(m))
-                    .map(|i| i + 1)
-                    .unwrap_or(0),
+                Some(m) => {
+                    let mr = version_rank(m);
+                    all.iter()
+                        .position(|v| version_rank(v["Version"].as_str().unwrap_or("")) > mr)
+                        .unwrap_or(all.len())
+                }
                 None => 0,
             };
             let end = (start + max_items).min(all.len());

--- a/crates/fakecloud-ses/src/service/misc.rs
+++ b/crates/fakecloud-ses/src/service/misc.rs
@@ -318,11 +318,16 @@ impl SesV2Service {
         templates.sort_by(|a, b| a.template_name.cmp(&b.template_name));
 
         let next_token = req.query_params.get("NextToken");
+        // The token is the TemplateName of the FIRST item on the next page (an
+        // inclusive cursor), and templates is sorted by name, so resume at the
+        // first template whose name is >= the token. If the template named by the
+        // token was deleted between pages the listing still advances instead of
+        // falling back to 0 and restarting from the first template.
         let start_idx = if let Some(token) = next_token {
             templates
                 .iter()
-                .position(|t| t.template_name == *token)
-                .unwrap_or(0)
+                .position(|t| t.template_name.as_str() >= token.as_str())
+                .unwrap_or(templates.len())
         } else {
             0
         };


### PR DESCRIPTION
## Summary (bug-hunt 2026-07-25 Tier-1, correctness / pagination stale-marker)

Several List ops resolved their pagination marker by **exact-match** position with a `.unwrap_or(0)` fallback. If the item named by the marker was **deleted between pages**, `position()` returned `None`, the code fell back to offset `0`, and the next page **restarted from page 1** (re-emitting items). A delete-as-you-go loop then never terminated. AWS markers keep advancing past a deleted item.

Fix mirrors the precedent already in `crates/fakecloud-kinesis/src/service.rs` `ListStreams`: resume at the first element **strictly greater** than the marker in the list's own ordering (`position(|x| key(x) > marker).unwrap_or(len)`).

Each site was checked so the resume key matches both the iteration order and the emitted marker (choosing `>` vs `>=` accordingly):

| Site | Ordering | Marker | Resume |
|---|---|---|---|
| KMS `ListKeys` | KeyId (BTreeMap) | last KeyId | `>` |
| KMS `ListAliases` | AliasName (BTreeMap) | last AliasName | `>` |
| KMS `ListRetirableGrants` | Vec insertion -> **now sorted by GrantId** | last GrantId | `>` |
| IAM `ListUsers` | user_name | last name | `>` |
| IAM inline-policy-name helper (`ListRole/User/GroupPolicies`) | name | last name | `>` |
| IAM attached-policy helper (`ListAttached*Policies`) | ARN | last ARN | `>` |
| IAM instance-profile helper (`ListInstanceProfiles*`) | name | last name | `>` |
| IAM `ListPolicies` | name -> **now sorted by ARN** to match cursor | last ARN | `>` |
| IAM `ListEntitiesForPolicy` | (kind-rank, name) | `<kind>:<name>` | decoded tuple compare |
| Lambda `ListVersionsByFunction` | $LATEST-first, then numeric | Version | decoded (is-numbered, number) rank |
| SES `ListCustomVerificationEmailTemplates` | template_name | **first item of next page** | `>=` |

Two sites needed more than a plain string `>` because the cursor's lexical order does not match the iteration order:
- **ListEntitiesForPolicy**: `"group" < "role"` lexically but roles sort before groups, so the raw cursor string can't be compared directly -> it is decoded back to `(kind-rank, name)`.
- **ListVersionsByFunction**: `"10" < "2"` lexically -> the version is decoded to a numeric rank with `$LATEST` pinned first.

Two sites had a sort-key / marker mismatch and were aligned:
- **ListRetirableGrants** iterated an insertion-ordered `Vec` while emitting a `GrantId` marker; now sorted by `GrantId` so the marker is a valid total-ordering key.
- **ListPolicies** sorted by name while emitting the ARN as marker; now sorted by ARN.

### Skipped
- KMS `ListGrants` (`service_grants.rs:71`) -- does **not** paginate at all (hardcodes `Truncated: false`, ignores Limit/Marker), so it has no stale-marker restart. Left unchanged.

## Test plan
- New unit test `list_keys_resumes_past_a_deleted_marker_without_restarting` (KMS): create 5 keys, page at `Limit=2`, delete the key named by the returned marker, page again with that marker, and assert the second page makes forward progress and never re-emits the first key of page 1.
- `cargo build -p fakecloud-kms -p fakecloud-iam -p fakecloud-lambda -p fakecloud-ses` -- clean.
- `cargo clippy ... --all-targets -- -D warnings` -- clean.
- `cargo fmt` on the four crates.
- `cargo test -p fakecloud-kms -p fakecloud-iam -p fakecloud-lambda -p fakecloud-ses` -- all green (KMS 540, IAM 223, Lambda 213, SES 263).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pagination to resume after markers across `fakecloud-kms`, `fakecloud-iam`, `fakecloud-lambda`, and `fakecloud-ses`, even when the marked item was deleted. This prevents page-1 restarts and infinite loops in delete-as-you-go flows.

- **Bug Fixes**
  - Resume at the first item > marker (or >= token for `ses`) so listings advance when the marked item is missing.
  - Applied across: `kms` Keys/Aliases/RetirableGrants; `iam` Users/InstanceProfiles/policy-name helpers/attached-policy helpers/Policies/EntitiesForPolicy; `lambda` ListVersionsByFunction; `ses` CustomVerificationEmailTemplates.

- **Refactors**
  - Align sort keys with markers: `kms` RetirableGrants by GrantId; `iam` Policies by ARN.
  - Compare using decoded order where strings don’t match list order: `iam` EntitiesForPolicy (`kind:name` → kind rank, name), `lambda` Versions (`$LATEST` first, then numeric).
  - Added a KMS regression test; all four crates build, lint, and test clean.

<sup>Written for commit b0cccf2019445a1ea421a03e2b7e3067af100f09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

