### PR TITLE
fix(rds): accept mysql 8.4 + postgres 18 GA majors (stale engine-version allowlist)

### DIFF
--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -16,10 +16,11 @@ async fn rds_describe_db_engine_versions() {
         .unwrap();
 
     let versions = response.db_engine_versions();
-    assert_eq!(versions.len(), 5); // All postgres versions
+    assert_eq!(versions.len(), 6); // All postgres versions
     assert!(versions.iter().all(|v| v.engine() == Some("postgres")));
     assert!(versions.iter().any(|v| v.engine_version() == Some("16.3")));
     assert!(versions.iter().any(|v| v.engine_version() == Some("17.4")));
+    assert!(versions.iter().any(|v| v.engine_version() == Some("18.0")));
 }
 
 #[tokio::test]

--- a/crates/fakecloud-rds/src/runtime/mod.rs
+++ b/crates/fakecloud-rds/src/runtime/mod.rs
@@ -243,9 +243,13 @@ impl RdsRuntime {
                 // 5.7 was dropped after Oracle community support ended
                 // (Oct 2023) — the image base no longer ships the build
                 // deps we need for the UDF. Any 5.7.* engine version
-                // resolves to 8.0.
-                let _ = engine_version;
-                let major_version = "8.0";
+                // resolves to 8.0. 8.4 (LTS) has its own upstream
+                // `mysql:8.4` image and resolves to a distinct major.
+                let major_version = if engine_version.starts_with("8.4") {
+                    "8.4"
+                } else {
+                    "8.0"
+                };
                 let image = self.ensure_mysql_image(major_version).await?;
                 let env_vars = vec![
                     format!("MYSQL_ROOT_PASSWORD={password}"),

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -401,9 +401,9 @@ pub(crate) fn validate_create_request(
     // forms and the runtime resolves the matching prebuilt image regardless.
     let supported_versions = match engine {
         "postgres" => vec![
-            "17", "16", "15", "14", "13", "17.4", "16.3", "15.5", "14.10", "13.13",
+            "18", "17", "16", "15", "14", "13", "17.4", "16.3", "15.5", "14.10", "13.13",
         ],
-        "mysql" => vec!["8.0", "8.0.35", "8.0.28", "5.7.44"],
+        "mysql" => vec!["8.4", "8.0", "8.0.35", "8.0.28", "5.7.44"],
         "mariadb" => vec!["10.6", "10.11", "11.4", "11.4.5", "10.11.6", "10.6.16"],
         "oracle-ee" | "oracle-se2" | "oracle-ee-cdb" | "oracle-se2-cdb" => {
             vec!["23.0.0", "21.0.0", "19.0.0"]
@@ -2290,7 +2290,27 @@ mod engine_version_tests {
         // `17` never accepts `170.x` or a different major.
         assert!(create("postgres", "9.6").is_err());
         assert!(create("postgres", "170.1").is_err());
-        assert!(create("postgres", "18.0").is_err());
+        // 19 is not yet a GA major (no image mapping), so it stays rejected
+        // even though the adjacent 18 was added.
+        assert!(create("postgres", "19.0").is_err());
+    }
+
+    #[test]
+    fn accepts_current_ga_majors() {
+        // Regression for the stale major-version allowlist (bug-hunt
+        // 2026-07-25 Tier-1): RDS MySQL 8.4 LTS and PostgreSQL 18 are GA on
+        // AWS. #2392 fixed minor matching but left the backing major list
+        // hardcoded and lagging, so these were wrongly rejected — wedging
+        // Terraform state through destroy (issue #2107 shape).
+        for v in ["18", "18.0", "18.1"] {
+            assert!(
+                create("postgres", v).is_ok(),
+                "postgres {v} should be accepted"
+            );
+        }
+        for v in ["8.4", "8.4.0", "8.4.2"] {
+            assert!(create("mysql", v).is_ok(), "mysql {v} should be accepted");
+        }
     }
 
     #[test]

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -114,7 +114,7 @@ fn filter_engine_versions_matches_requested_engine() {
 
     let filtered = filter_engine_versions(&versions, &Some("postgres".to_string()), &None, &None);
 
-    assert_eq!(filtered.len(), 5); // All postgres versions
+    assert_eq!(filtered.len(), 6); // All postgres versions
     assert!(filtered.iter().all(|v| v.engine == "postgres"));
 }
 

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -778,6 +778,14 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
         // PostgreSQL versions
         EngineVersionInfo {
             engine: "postgres".to_string(),
+            engine_version: "18.0".to_string(),
+            db_parameter_group_family: "postgres18".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 18.0".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "postgres".to_string(),
             engine_version: "17.4".to_string(),
             db_parameter_group_family: "postgres17".to_string(),
             db_engine_description: "PostgreSQL".to_string(),
@@ -817,6 +825,14 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
             status: "available".to_string(),
         },
         // MySQL versions
+        EngineVersionInfo {
+            engine: "mysql".to_string(),
+            engine_version: "8.4.0".to_string(),
+            db_parameter_group_family: "mysql8.4".to_string(),
+            db_engine_description: "MySQL Community Edition".to_string(),
+            db_engine_version_description: "MySQL 8.4.0".to_string(),
+            status: "available".to_string(),
+        },
         EngineVersionInfo {
             engine: "mysql".to_string(),
             engine_version: "8.0.35".to_string(),
@@ -872,11 +888,13 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
 pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
     let mut options = Vec::new();
     let engines_and_versions = vec![
+        ("postgres", "18.0", "postgresql-license"),
         ("postgres", "17.4", "postgresql-license"),
         ("postgres", "16.3", "postgresql-license"),
         ("postgres", "15.5", "postgresql-license"),
         ("postgres", "14.10", "postgresql-license"),
         ("postgres", "13.13", "postgresql-license"),
+        ("mysql", "8.4.0", "general-public-license"),
         ("mysql", "8.0.35", "general-public-license"),
         ("mysql", "8.0.28", "general-public-license"),
         ("mysql", "5.7.44", "general-public-license"),
@@ -909,11 +927,13 @@ pub fn default_parameter_groups(
     let mut groups = BTreeMap::new();
 
     let families = vec![
+        ("postgres18", "Default parameter group for postgres18"),
         ("postgres17", "Default parameter group for postgres17"),
         ("postgres16", "Default parameter group for postgres16"),
         ("postgres15", "Default parameter group for postgres15"),
         ("postgres14", "Default parameter group for postgres14"),
         ("postgres13", "Default parameter group for postgres13"),
+        ("mysql8.4", "Default parameter group for mysql8.4"),
         ("mysql8.0", "Default parameter group for mysql8.0"),
         ("mysql5.7", "Default parameter group for mysql5.7"),
         ("mariadb11.4", "Default parameter group for mariadb11.4"),
@@ -1110,11 +1130,11 @@ mod tests {
     fn default_engine_versions_are_postgres_metadata() {
         let versions = default_engine_versions();
 
-        assert_eq!(versions.len(), 11); // 5 postgres + 3 mysql + 3 mariadb
+        assert_eq!(versions.len(), 13); // 6 postgres + 4 mysql + 3 mariadb
                                         // Check first (newest) postgres version
         assert_eq!(versions[0].engine, "postgres");
-        assert_eq!(versions[0].engine_version, "17.4");
-        assert_eq!(versions[0].db_parameter_group_family, "postgres17");
+        assert_eq!(versions[0].engine_version, "18.0");
+        assert_eq!(versions[0].db_parameter_group_family, "postgres18");
     }
 
     #[test]
@@ -1122,8 +1142,8 @@ mod tests {
         let versions = default_engine_versions();
         let options = default_orderable_options();
 
-        // 11 engine versions * every representative instance class.
-        assert_eq!(options.len(), 11 * SUPPORTED_INSTANCE_CLASSES.len());
+        // 13 engine versions * every representative instance class.
+        assert_eq!(options.len(), 13 * SUPPORTED_INSTANCE_CLASSES.len());
         // Verify all engines and versions have orderable options
         for version in &versions {
             assert!(options.iter().any(|opt| {

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -775,15 +775,11 @@ impl RdsState {
 
 pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
     vec![
-        // PostgreSQL versions
-        EngineVersionInfo {
-            engine: "postgres".to_string(),
-            engine_version: "18.0".to_string(),
-            db_parameter_group_family: "postgres18".to_string(),
-            db_engine_description: "PostgreSQL".to_string(),
-            db_engine_version_description: "PostgreSQL 18.0".to_string(),
-            status: "available".to_string(),
-        },
+        // PostgreSQL versions. The first entry per engine is what
+        // `DescribeDBEngineVersions` with `DefaultOnly=true` returns (and what
+        // Terraform's `aws_rds_engine_version` data source resolves to), so the
+        // established GA default (17.x / 8.0.x) stays first; newer majors that
+        // AWS also accepts (18, 8.4) are appended as non-default options.
         EngineVersionInfo {
             engine: "postgres".to_string(),
             engine_version: "17.4".to_string(),
@@ -824,15 +820,15 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
             db_engine_version_description: "PostgreSQL 13.13".to_string(),
             status: "available".to_string(),
         },
-        // MySQL versions
         EngineVersionInfo {
-            engine: "mysql".to_string(),
-            engine_version: "8.4.0".to_string(),
-            db_parameter_group_family: "mysql8.4".to_string(),
-            db_engine_description: "MySQL Community Edition".to_string(),
-            db_engine_version_description: "MySQL 8.4.0".to_string(),
+            engine: "postgres".to_string(),
+            engine_version: "18.0".to_string(),
+            db_parameter_group_family: "postgres18".to_string(),
+            db_engine_description: "PostgreSQL".to_string(),
+            db_engine_version_description: "PostgreSQL 18.0".to_string(),
             status: "available".to_string(),
         },
+        // MySQL versions
         EngineVersionInfo {
             engine: "mysql".to_string(),
             engine_version: "8.0.35".to_string(),
@@ -855,6 +851,14 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
             db_parameter_group_family: "mysql5.7".to_string(),
             db_engine_description: "MySQL Community Edition".to_string(),
             db_engine_version_description: "MySQL 5.7.44".to_string(),
+            status: "available".to_string(),
+        },
+        EngineVersionInfo {
+            engine: "mysql".to_string(),
+            engine_version: "8.4.0".to_string(),
+            db_parameter_group_family: "mysql8.4".to_string(),
+            db_engine_description: "MySQL Community Edition".to_string(),
+            db_engine_version_description: "MySQL 8.4.0".to_string(),
             status: "available".to_string(),
         },
         // MariaDB versions
@@ -887,17 +891,20 @@ pub fn default_engine_versions() -> Vec<EngineVersionInfo> {
 
 pub fn default_orderable_options() -> Vec<OrderableDbInstanceOption> {
     let mut options = Vec::new();
+    // Default (first-per-engine) versions stay the established GA release so
+    // `DefaultOnly`/`aws_rds_engine_version` resolves to them; the newer majors
+    // AWS also accepts (18, 8.4) are appended as non-default options.
     let engines_and_versions = vec![
-        ("postgres", "18.0", "postgresql-license"),
         ("postgres", "17.4", "postgresql-license"),
         ("postgres", "16.3", "postgresql-license"),
         ("postgres", "15.5", "postgresql-license"),
         ("postgres", "14.10", "postgresql-license"),
         ("postgres", "13.13", "postgresql-license"),
-        ("mysql", "8.4.0", "general-public-license"),
+        ("postgres", "18.0", "postgresql-license"),
         ("mysql", "8.0.35", "general-public-license"),
         ("mysql", "8.0.28", "general-public-license"),
         ("mysql", "5.7.44", "general-public-license"),
+        ("mysql", "8.4.0", "general-public-license"),
         ("mariadb", "11.4.5", "general-public-license"),
         ("mariadb", "10.11.6", "general-public-license"),
         ("mariadb", "10.6.16", "general-public-license"),
@@ -1131,10 +1138,20 @@ mod tests {
         let versions = default_engine_versions();
 
         assert_eq!(versions.len(), 13); // 6 postgres + 4 mysql + 3 mariadb
-                                        // Check first (newest) postgres version
+                                        // The first postgres entry is the DefaultOnly/default version (17.4);
+                                        // 18.0 is present but appended as a non-default option.
         assert_eq!(versions[0].engine, "postgres");
-        assert_eq!(versions[0].engine_version, "18.0");
-        assert_eq!(versions[0].db_parameter_group_family, "postgres18");
+        assert_eq!(versions[0].engine_version, "17.4");
+        assert_eq!(versions[0].db_parameter_group_family, "postgres17");
+        assert!(versions
+            .iter()
+            .any(|v| v.engine == "postgres" && v.engine_version == "18.0"));
+        // The first mysql entry is the default (8.0.35); 8.4.0 is appended.
+        let first_mysql = versions.iter().find(|v| v.engine == "mysql").unwrap();
+        assert_eq!(first_mysql.engine_version, "8.0.35");
+        assert!(versions
+            .iter()
+            .any(|v| v.engine == "mysql" && v.engine_version == "8.4.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-25 Tier-1 (stale-enum / reject-valid).

RDS `CreateDBInstance` validated `EngineVersion` against a hand-maintained MAJOR-version allowlist that had gone stale, so it **rejected current AWS-GA majors**. #2392 fixed minor-version matching (any minor of a listed major is accepted) but the backing major list stayed hardcoded and lagged AWS:

- `mysql` `8.4` — RDS MySQL 8.4 LTS is GA; the list had only `8.0`/`5.7`.
- `postgres` `18` — RDS PostgreSQL 18 is GA; the list topped out at `17`.

A rejected create wedges Terraform state through `destroy` (issue #2107 shape).

## Fix

- **`service_helpers.rs`**: append `postgres` `"18"` and `mysql` `"8.4"` to the `supported_versions` allowlist. #2392's minor-acceptance (`version_matches_supported`) is preserved unchanged, so `18` accepts `18.0`/`18.1` and `8.4` accepts `8.4.0`/`8.4.2`. Oracle/SQL Server/Db2 (pinned to dev-edition container images) untouched; mariadb left alone (no `11.8` runtime image mapping).
- **`runtime/mod.rs`**: `mysql` `8.4` now resolves to its own upstream `mysql:8.4` image instead of the hardcoded `8.0`. `postgres` already derives the image tag generically from the major (`FROM postgres:${PG_VERSION}`), so `postgres:18` needs no runtime change.

## Seeded downstream surfaces (Describe* consistency)

1. `default_engine_versions()` — `postgres` `18.0` (family `postgres18`) + `mysql` `8.4.0` (family `mysql8.4`) -> `DescribeDBEngineVersions`.
2. `default_orderable_options()` — orderable rows for `18.0` / `8.4.0` -> `DescribeOrderableDBInstanceOptions`.
3. `default_parameter_groups()` — `default.postgres18` / `default.mysql8.4` families.
4. (allowlist gate above) -> `CreateDBInstance` accepts the new majors.

## Test plan

- Added unit test `accepts_current_ga_majors` asserting `CreateDBInstance` validation accepts `mysql` `8.4`/`8.4.0`/`8.4.2` and `postgres` `18`/`18.0`/`18.1`.
- Updated the prior `rejects_unsupported_major` assertion (postgres 18 no longer rejected; swapped to not-yet-GA `19.0`).
- Updated count/index assertions: `default_engine_versions_are_postgres_metadata` (11->13, index-0 now `18.0`/`postgres18`), `default_orderable_options_match_engine_versions` (11->13), `filter_engine_versions_matches_requested_engine` (5->6 postgres), and e2e `rds_describe_db_engine_versions` (5->6, asserts `18.0` present).
- `cargo build -p fakecloud-rds`, `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` clean, `cargo fmt`, `cargo test -p fakecloud-rds` green (276 passed), e2e `rds` test binary compiles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `mysql` 8.4 and `postgres` 18 in `CreateDBInstance`, and list them in Describe APIs while keeping existing defaults (`postgres` 17.x, `mysql` 8.0.x). MySQL 8.4 now resolves to the `mysql:8.4` runtime image.

- **Bug Fixes**
  - Validation: add supported majors `mysql` 8.4 and `postgres` 18; minor versions auto-accepted.
  - Runtime: map `mysql` 8.4 to `mysql:8.4`; `postgres` continues to derive the major tag.
  - Describe*: seed `postgres` `18.0` and `mysql` `8.4.0` in engine versions, orderable options, and default parameter groups; keep `DefaultOnly` as `postgres` `17.4` and `mysql` `8.0.35`.
  - Tests: update counts and assertions; add acceptance coverage; build, clippy, and tests pass.

<sup>Written for commit 575a0c07742f76f66680a2ed8760cf82368622be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

