### PR TITLE
fix(apigatewayv2,config,ses): region-scope RoutingRule/config-event/mail-from/WS identity ARNs

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -810,8 +810,8 @@ impl ApiGatewayV2Service {
                 let entry = json!({
                     "RoutingRuleId": id,
                     "RoutingRuleArn": format!(
-                        "arn:aws:apigateway:us-east-1::/domainnames/{}/routingrules/{}",
-                        domain, id
+                        "arn:aws:apigateway:{}::/domainnames/{}/routingrules/{}",
+                        req.region, domain, id
                     ),
                     "Priority": priority,
                     "Conditions": conditions,
@@ -843,8 +843,8 @@ impl ApiGatewayV2Service {
                 let entry = json!({
                     "RoutingRuleId": id,
                     "RoutingRuleArn": format!(
-                        "arn:aws:apigateway:us-east-1::/domainnames/{}/routingrules/{}",
-                        domain, id
+                        "arn:aws:apigateway:{}::/domainnames/{}/routingrules/{}",
+                        req.region, domain, id
                     ),
                     "Priority": priority,
                     "Conditions": conditions,
@@ -2003,8 +2003,8 @@ impl ApiGatewayV2Service {
                 json!({
                     "ProductPageId": id,
                     "ProductPageArn": format!(
-                        "arn:aws:apigateway:us-east-1::/portalproducts/{}/productpages/{}",
-                        parent, id
+                        "arn:aws:apigateway:{}::/portalproducts/{}/productpages/{}",
+                        req.region, parent, id
                     ),
                     // Internal-only: the summary shape requires pageTitle
                     // but Create/Update responses don't carry it. We
@@ -2045,8 +2045,8 @@ impl ApiGatewayV2Service {
                 json!({
                     "ProductRestEndpointPageId": id,
                     "ProductRestEndpointPageArn": format!(
-                        "arn:aws:apigateway:us-east-1::/portalproducts/{}/productrestendpointpages/{}",
-                        parent, id
+                        "arn:aws:apigateway:{}::/portalproducts/{}/productrestendpointpages/{}",
+                        req.region, parent, id
                     ),
                     // Internal-only: summary shape requires endpoint at
                     // root but Create/Update responses don't carry it.
@@ -2288,6 +2288,41 @@ mod tests {
         resource_id: Option<&str>,
     ) {
         run(&svc(), action, body, segs, api_id, resource_id);
+    }
+
+    #[test]
+    fn routing_rule_arn_uses_request_region() {
+        let s = svc();
+        let mut r = req(
+            "CreateRoutingRule",
+            r#"{"Priority":10,"Actions":[],"Conditions":[]}"#,
+            &["v2", "domainnames", "example.com", "routingrules"],
+        );
+        // The client's request targets eu-west-1; the stored + returned ARN
+        // must carry that region, not a hardcoded us-east-1, or the next
+        // GetRoutingRule call round-trips the wrong region.
+        r.region = "eu-west-1".to_string();
+        let resp = s
+            .handle_extra_action("CreateRoutingRule", &r, None, Some("example.com"))
+            .expect("CreateRoutingRule");
+        let created: serde_json::Value =
+            serde_json::from_slice(resp.body.expect_bytes()).expect("json response");
+        // Responses are camelCased on the way out (to_camel).
+        let arn = created["routingRuleArn"].as_str().unwrap();
+        assert!(
+            arn.starts_with("arn:aws:apigateway:eu-west-1::/domainnames/example.com/routingrules/"),
+            "unexpected ARN: {arn}"
+        );
+        assert!(!arn.contains("us-east-1"), "ARN leaked us-east-1: {arn}");
+
+        // GetRoutingRule reads back the stored ARN, which must match.
+        let rule_id = created["routingRuleId"].as_str().unwrap();
+        let get = s
+            .handle_extra_action("GetRoutingRule", &r, Some(rule_id), Some("example.com"))
+            .expect("GetRoutingRule");
+        let fetched: serde_json::Value =
+            serde_json::from_slice(get.body.expect_bytes()).expect("json response");
+        assert_eq!(fetched["routingRuleArn"], created["routingRuleArn"]);
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
+++ b/crates/fakecloud-apigatewayv2/src/websocket_dispatch.rs
@@ -42,6 +42,7 @@ pub fn resolve_route_key(expression: &str, body: &str) -> String {
 #[allow(clippy::too_many_arguments)]
 fn construct_event(
     api_id: &str,
+    region: &str,
     stage: &str,
     connection_id: &str,
     route_key: &str,
@@ -77,7 +78,7 @@ fn construct_event(
     request_context.insert("connectionId".to_string(), json!(connection_id));
     request_context.insert(
         "domainName".to_string(),
-        json!(format!("{api_id}.execute-api.us-east-1.amazonaws.com")),
+        json!(format!("{api_id}.execute-api.{region}.amazonaws.com")),
     );
     request_context.insert("eventType".to_string(), json!(event_type));
     request_context.insert("extendedRequestId".to_string(), json!(extended_request_id));
@@ -208,6 +209,7 @@ pub async fn dispatch_websocket_event(
 
     let event = construct_event(
         api_id,
+        region,
         stage,
         connection_id,
         &matched_route_key,
@@ -286,6 +288,7 @@ mod tests {
     fn construct_connect_event_has_null_body() {
         let event = construct_event(
             "api-1",
+            "eu-west-1",
             "dev",
             "conn-id=",
             "$connect",
@@ -309,12 +312,19 @@ mod tests {
         assert_eq!(event["isBase64Encoded"], false);
         assert_eq!(event["headers"]["X-Custom"], "val");
         assert_eq!(event["queryStringParameters"]["token"], "abc");
+        // The proxy event's domainName carries the request region, not a
+        // hardcoded us-east-1, so the Lambda sees a region-consistent host.
+        assert_eq!(
+            event["requestContext"]["domainName"],
+            "api-1.execute-api.eu-west-1.amazonaws.com"
+        );
     }
 
     #[test]
     fn construct_message_event_has_message_id() {
         let event = construct_event(
             "api-1",
+            "us-east-1",
             "dev",
             "conn-id=",
             "$default",

--- a/crates/fakecloud-config/src/service.rs
+++ b/crates/fakecloud-config/src/service.rs
@@ -507,7 +507,7 @@ impl AwsService for ConfigService {
             "DescribeConformancePacks" => self.describe_conformance_packs(&account, &body),
             "DeleteConformancePack" => self.delete_conformance_pack(&account, &body),
             "DescribeConformancePackStatus" => {
-                self.describe_conformance_pack_status(&account, &body)
+                self.describe_conformance_pack_status(&account, &region, &body)
             }
             "DescribeConformancePackCompliance" => {
                 self.ensure_evaluated(&account);
@@ -1670,7 +1670,7 @@ impl ConfigService {
     async fn start_config_rules_evaluation(
         &self,
         account: &str,
-        _region: &str,
+        region: &str,
         body: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
         self.ensure_evaluated(account);
@@ -1702,6 +1702,7 @@ impl ConfigService {
         for (rule_name, lambda_arn, input_parameters) in custom_rules {
             self.invoke_custom_rule(
                 account,
+                region,
                 &rule_name,
                 &lambda_arn,
                 input_parameters.as_deref(),
@@ -1718,6 +1719,7 @@ impl ConfigService {
     async fn invoke_custom_rule(
         &self,
         account: &str,
+        region: &str,
         rule_name: &str,
         lambda_arn: &str,
         input_parameters: Option<&str>,
@@ -1733,7 +1735,7 @@ impl ConfigService {
             .unwrap_or(lambda_arn)
             .to_string();
         let result_token = format!("{rule_name}#{}", Uuid::new_v4());
-        let event = custom_rule_event(account, rule_name, input_parameters, &result_token);
+        let event = custom_rule_event(account, region, rule_name, input_parameters, &result_token);
         // Resolve the Lambda in the rule's own account (not just the default
         // account) so a custom rule in a non-default account finds its function.
         let resolved = {
@@ -2776,6 +2778,7 @@ impl ConfigService {
     fn describe_conformance_pack_status(
         &self,
         account: &str,
+        region: &str,
         body: &Value,
     ) -> Result<AwsResponse, AwsServiceError> {
         let names = string_list(body, "ConformancePackNames");
@@ -2793,7 +2796,7 @@ impl ConfigService {
                             "ConformancePackId": p.id,
                             "ConformancePackArn": p.arn,
                             "ConformancePackState": "CREATE_COMPLETE",
-                            "StackArn": format!("arn:aws:cloudformation:us-east-1:{account}:stack/awsconfigconforms-{}/{}", p.name, short_id()),
+                            "StackArn": format!("arn:aws:cloudformation:{region}:{account}:stack/awsconfigconforms-{}/{}", p.name, short_id()),
                             "LastUpdateRequestedTime": now,
                             "LastUpdateCompletedTime": now,
                         })
@@ -4375,6 +4378,7 @@ fn paged_response(field: &str, items: Vec<Value>, body: &Value, token_field: &st
 /// declared none — a custom rule that reads its parameters must see them.
 fn custom_rule_event(
     account: &str,
+    region: &str,
     rule_name: &str,
     input_parameters: Option<&str>,
     result_token: &str,
@@ -4394,7 +4398,7 @@ fn custom_rule_event(
         "invokingEvent": invoking_event,
         "ruleParameters": rule_parameters,
         "resultToken": result_token,
-        "configRuleArn": format!("arn:aws:config:us-east-1:{account}:config-rule/{rule_name}"),
+        "configRuleArn": format!("arn:aws:config:{region}:{account}:config-rule/{rule_name}"),
         "configRuleName": rule_name,
         "accountId": account,
     })
@@ -4424,20 +4428,32 @@ mod unit_tests {
     #[test]
     fn custom_rule_event_passes_stored_input_parameters() {
         let params = r#"{"maxAccessKeyAge":"90"}"#;
-        let event = custom_rule_event("111122223333", "my-rule", Some(params), "my-rule#tok");
+        let event = custom_rule_event(
+            "111122223333",
+            "eu-west-1",
+            "my-rule",
+            Some(params),
+            "my-rule#tok",
+        );
         // ruleParameters must carry the rule's stored InputParameters verbatim,
         // not a hardcoded "{}".
         assert_eq!(event["ruleParameters"], json!(params));
         assert_eq!(event["configRuleName"], json!("my-rule"));
         assert_eq!(event["accountId"], json!("111122223333"));
         assert_eq!(event["resultToken"], json!("my-rule#tok"));
+        // The event's configRuleArn must carry the rule's region so it matches
+        // the ARN DescribeConfigRules returns, not a hardcoded us-east-1.
+        assert_eq!(
+            event["configRuleArn"],
+            json!("arn:aws:config:eu-west-1:111122223333:config-rule/my-rule")
+        );
     }
 
     #[test]
     fn custom_rule_event_defaults_empty_parameters_to_empty_object() {
-        let none = custom_rule_event("111122223333", "r", None, "r#t");
+        let none = custom_rule_event("111122223333", "us-west-2", "r", None, "r#t");
         assert_eq!(none["ruleParameters"], json!("{}"));
-        let empty = custom_rule_event("111122223333", "r", Some(""), "r#t");
+        let empty = custom_rule_event("111122223333", "us-west-2", "r", Some(""), "r#t");
         assert_eq!(empty["ruleParameters"], json!("{}"));
     }
 

--- a/crates/fakecloud-ses/src/service/identities.rs
+++ b/crates/fakecloud-ses/src/service/identities.rs
@@ -222,7 +222,10 @@ impl SesV2Service {
     ) -> Result<AwsResponse, AwsServiceError> {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-        let region = state.region.clone();
+        // Use the request region (not the frozen state.region) so the
+        // MAIL FROM MX host matches this response's identity ARN below,
+        // which is also derived from req.region.
+        let region = req.region.clone();
         let identity = match state.identities.get_mut(identity_name) {
             Some(id) => id,
             None => {

--- a/crates/fakecloud-ses/src/service/tests.rs
+++ b/crates/fakecloud-ses/src/service/tests.rs
@@ -2453,6 +2453,51 @@ async fn test_mail_from_status_lifecycle() {
 }
 
 #[tokio::test]
+async fn test_mail_from_mx_uses_request_region() {
+    let state = make_state();
+    let svc = SesV2Service::new(state.clone());
+
+    // Client operates in eu-west-1; the MAIL FROM MX host must carry that
+    // region (feedback-smtp.eu-west-1.amazonses.com), matching the identity
+    // ARN in the same response — not the frozen state region (us-east-1).
+    let with_region = |method: Method, path: &str, body: &str| {
+        let mut r = make_request(method, path, body);
+        r.region = "eu-west-1".to_string();
+        r
+    };
+
+    svc.handle(with_region(
+        Method::POST,
+        "/v2/email/identities",
+        r#"{"EmailIdentity": "example.com"}"#,
+    ))
+    .await
+    .unwrap();
+    svc.handle(with_region(
+        Method::PUT,
+        "/v2/email/identities/example.com/mail-from",
+        r#"{"MailFromDomain": "mail.example.com", "BehaviorOnMxFailure": "USE_DEFAULT_VALUE"}"#,
+    ))
+    .await
+    .unwrap();
+
+    let resp = svc
+        .handle(with_region(
+            Method::GET,
+            "/v2/email/identities/example.com",
+            "",
+        ))
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let dns = &body["MailFromAttributes"]["MailFromDomainDnsRecords"];
+    assert_eq!(
+        dns[0]["Value"], "10 feedback-smtp.eu-west-1.amazonses.com",
+        "MX host must use the request region, not us-east-1"
+    );
+}
+
+#[tokio::test]
 async fn test_put_email_identity_configuration_set_attributes() {
     let state = make_state();
     let svc = SesV2Service::new(state.clone());


### PR DESCRIPTION
## Summary

bug-hunt 2026-07-25 Tier-0, region-in-ARN family (non-EC2 remainder; a sibling PR already fixed the EC2 renderers). Several handlers stamped a hardcoded `us-east-1` (or the frozen `state.region`) into a client-visible ARN/URL/host instead of the request's region. The client stores and reuses these values, so the wrong region breaks the next call. Every site here derives the region from the request instead.

- **apigatewayv2 `extras.rs`**: `CreateRoutingRule` / `PutRoutingRule` now build `RoutingRuleArn` from `req.region` (mirrors the sibling `DomainNameArn`); because the ARN is stored, `GetRoutingRule` / `ListRoutingRules` now read back the region-correct value. `ProductPageArn` and `ProductRestEndpointPageArn` likewise use `req.region`.
- **apigatewayv2 `websocket_dispatch.rs`**: threaded the request region (already a param on `dispatch_websocket_event`) into `construct_event` so the WebSocket proxy event's `$context.domainName` is `{api_id}.execute-api.{region}.amazonaws.com`.
- **config `service.rs`**: `custom_rule_event` gained a `region: &str` param (threaded from `start_config_rules_evaluation` -> `invoke_custom_rule`) so the evaluation event's `configRuleArn` matches the create-time region in DescribeConfigRules. The conformance-pack `StackArn` in `DescribeConformancePackStatus` now uses the request region (threaded from dispatch).
- **ses `identities.rs`**: `get_email_identity` builds the MAIL FROM MX host (`feedback-smtp.{region}.amazonses.com`) from `req.region` instead of the frozen `state.region`, so it is self-consistent with the identity ARN in the same response.

Left unchanged (verified out of the ARN/URL/host round-trip class): config `region_for`/aggregator fallbacks (`unwrap_or("us-east-1")` defaults when the request/source carries no region), the `AwsRegion` descriptive fields in aggregate-compliance report rows (not endpoints the client reuses), and SES not-verified error-message text that names a region. These are noted rather than changed.

## Test plan

- `cargo build -p fakecloud-apigatewayv2 -p fakecloud-config -p fakecloud-ses` -- clean.
- `cargo clippy -p fakecloud-apigatewayv2 -p fakecloud-config -p fakecloud-ses --all-targets -- -D warnings` -- clean.
- `cargo fmt` on the touched crates.
- `cargo test -p fakecloud-apigatewayv2 -p fakecloud-config -p fakecloud-ses` -- green.
- New unit tests: `routing_rule_arn_uses_request_region` (create with `eu-west-1`, assert stored+read-back ARN carries `eu-west-1`, not `us-east-1`), `test_mail_from_mx_uses_request_region` (MX host uses request region), a `construct_event` domainName assertion, and a region assertion added to `custom_rule_event_passes_stored_input_parameters`. Existing `custom_rule_event_*` tests updated for the new param.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix region-scoped ARNs and hostnames to use the request region across API Gateway v2, Config, and SES, avoiding cross-region round-trips. This ensures stored ARNs/hosts match the caller’s region so subsequent requests succeed.

- **Bug Fixes**
  - `fakecloud-apigatewayv2`
    - Build `RoutingRuleArn`, `ProductPageArn`, and `ProductRestEndpointPageArn` with `req.region`; Get/List return the stored region-correct value.
    - WebSocket proxy event `$context.domainName` is now `{api_id}.execute-api.{region}.amazonaws.com`.
  - `fakecloud-config`
    - Thread region into `custom_rule_event`; `configRuleArn` now uses the request region.
    - `DescribeConformancePackStatus` `StackArn` uses the request region.
  - `fakecloud-ses`
    - `get_email_identity` builds MAIL FROM MX host as `feedback-smtp.{region}.amazonses.com` using `req.region`.

<sup>Written for commit 68fe7112da2bdf1cb0f45ed9177075c2fa8d65ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

