### PR TITLE
fix(release): survive crates.io rate limits instead of dying on the first 429

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
             exit 1
           fi
 
+  release-tooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # A crate missing from (or misplaced in) the publish list only shows up as
+      # a half-published release, so gate it here instead.
+      - name: release publish list covers the workspace
+        run: bash scripts/publish-crates.sh --check
+      - name: crates.io rate-limit handling
+        run: bash scripts/tests/publish-crates-test.sh
+
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 75

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,29 @@ on:
     tags: ["v*"]
   # Manual escape hatch — re-run an existing tag's publish flow. Used
   # to backfill v0.15.1 to npm after the original push-triggered run
-  # failed at publish-npm (expired NPM_TOKEN; OIDC ships post-merge).
-  # On workflow_dispatch only the publish-npm job runs; binary build,
-  # GitHub Release, crates.io, PyPI, Maven, Packagist, Go are all
-  # push-only because they either can't be re-published (Maven Central)
-  # or the existing artifact is already there (everything else).
+  # failed at publish-npm (expired NPM_TOKEN; OIDC ships post-merge),
+  # and to resume a crates.io publish that ran out of wall clock (the
+  # crate loop skips everything already in the index, so a resume costs
+  # nothing for the crates already up). Binary build, GitHub Release,
+  # PyPI, Maven, Packagist and Go stay push-only because they either
+  # can't be re-published (Maven Central) or the existing artifact is
+  # already there.
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to backfill to npm (e.g. v0.15.1).'
+        description: 'Existing tag to re-publish from (e.g. v0.15.1).'
         required: true
         type: string
+      npm:
+        description: 'Publish the npm package.'
+        required: false
+        default: true
+        type: boolean
+      crates:
+        description: 'Resume the crates.io publish (skips crates already indexed).'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -113,200 +125,62 @@ jobs:
 
   publish-crates:
     name: Publish Crates
-    if: github.event_name == 'push'
     needs: check
+    # Runs on push (release flow) and on workflow_dispatch with
+    # crates=true (resume a publish that a rate-limit wait pushed past
+    # the job's wall clock). On dispatch `check` is skipped because that
+    # job is itself gated on push, so allow the skipped result.
+    if: |
+      always()
+      && (needs.check.result == 'success' || needs.check.result == 'skipped')
+      && (github.event_name == 'push' || inputs.crates)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # crates.io hands out publish tokens on a refill schedule, so the
+    # tail of a ~110-crate release is spent waiting, not uploading (see
+    # scripts/publish-crates.sh). Budget for that; the script's own
+    # DEADLINE_MINUTES bails out with a resume hint before GitHub's
+    # hard 6h job ceiling kills the step mid-crate.
+    timeout-minutes: 350
+    # Two releases publishing at once would drain the same rate-limit
+    # buckets and 429 each other. Queue them instead of racing.
+    concurrency:
+      group: publish-crates
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # On push the default ref is the tag; on a dispatched resume,
+          # whatever tag the operator supplied.
+          ref: ${{ inputs.tag || github.ref }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Verify tag matches Cargo.toml version
+      - name: Resolve release version
         run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
+          if [ -n "${{ inputs.tag }}" ]; then
+            TAG="${{ inputs.tag }}"
+            TAG="${TAG#v}"
+          else
+            TAG="${GITHUB_REF#refs/tags/v}"
+          fi
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
           if [ "$TAG" != "$VERSION" ]; then
             echo "::error::Tag v${TAG} does not match Cargo.toml version ${VERSION}"
             exit 1
           fi
           echo "Tag v${TAG} matches Cargo.toml version ${VERSION}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Verify publish list covers the workspace
+        run: |
+          if [ ! -f scripts/publish-crates.sh ]; then
+            echo "::error::this tag predates scripts/publish-crates.sh — publish it by hand from a detached checkout of the tag (cargo publish -p <crate>)"
+            exit 1
+          fi
+          bash scripts/publish-crates.sh --check
 
       - name: Publish all crates
-        run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-
-          wait_for_crate() {
-            # Check the sparse index (what cargo actually uses to resolve deps)
-            local name="$1"
-            local prefix
-            case ${#name} in
-              1) prefix="1" ;;
-              2) prefix="2" ;;
-              3) prefix="3/${name:0:1}" ;;
-              *) prefix="${name:0:2}/${name:2:2}" ;;
-            esac
-            local url="https://index.crates.io/${prefix}/${name}"
-            echo "Waiting for $name@$TAG in sparse index..."
-            for i in $(seq 1 60); do
-              if curl -sf "$url" 2>/dev/null | grep -q "\"vers\":\"$TAG\""; then
-                echo "$name@$TAG indexed after $((i * 5))s"
-                return 0
-              fi
-              sleep 5
-            done
-            echo "WARNING: timed out waiting for $name@$TAG, continuing anyway"
-          }
-
-          publish() {
-            echo "Publishing $1..."
-            OUTPUT=$(cargo publish -p "$1" 2>&1) && {
-              echo "Successfully published $1"
-            } || {
-              if echo "$OUTPUT" | grep -qE "already uploaded|already exists"; then
-                echo "Skipping $1: already published"
-                return 0
-              else
-                echo "ERROR publishing $1:"
-                echo "$OUTPUT"
-                exit 1
-              fi
-            }
-            wait_for_crate "$1"
-          }
-
-          # Layer 1: no internal deps
-          publish fakecloud-aws
-          publish fakecloud-sdk
-          publish fakecloud-persistence
-          publish fakecloud-k8s   # only external deps (kube/k8s-openapi); dependents: lambda/elasticache/rds/ecs/server
-
-          # Layer 2: depends on fakecloud-aws
-          publish fakecloud-core
-
-          # Layer 3a: depend on aws + core + persistence only
-          publish fakecloud-sqs
-          publish fakecloud-iam
-          publish fakecloud-organizations
-          publish fakecloud-ec2            # depends on aws + core only
-          publish fakecloud-lambda
-          publish fakecloud-logs
-          publish fakecloud-kms
-          publish fakecloud-ses
-          publish fakecloud-rds
-          publish fakecloud-rds-data        # depends on rds
-          publish fakecloud-dsql
-          publish fakecloud-resource-groups  # only core/persistence/aws deps
-          publish fakecloud-resource-groups-tagging  # only core/persistence/aws deps
-          publish fakecloud-elasticbeanstalk # only core/persistence/aws deps
-          publish fakecloud-memorydb         # only core/persistence/aws deps
-          publish fakecloud-kinesisanalyticsv2 # only core/persistence/aws deps
-          publish fakecloud-eks              # only core/persistence/aws deps
-          publish fakecloud-efs              # depends on ec2 (subnet AZ/VPC resolution)
-          publish fakecloud-mq               # only core/persistence/aws deps
-          publish fakecloud-kafka            # only core/persistence deps
-          publish fakecloud-mwaa             # only core/persistence deps
-          publish fakecloud-fis              # only core/persistence deps
-          publish fakecloud-xray             # only core/persistence deps
-          publish fakecloud-appsync          # only core/persistence deps
-          publish fakecloud-amplify          # only core/persistence deps
-          publish fakecloud-mediaconvert     # only core/persistence deps
-          publish fakecloud-serverlessrepo   # only core/persistence deps
-          publish fakecloud-iotdata          # only core/persistence deps
-          publish fakecloud-pinpoint         # only core/persistence deps
-          publish fakecloud-iot              # only core/persistence deps
-          publish fakecloud-iotwireless      # only core/persistence deps
-          publish fakecloud-sagemaker        # only core/persistence deps
-          publish fakecloud-managedblockchain # only core/persistence/aws deps
-          publish fakecloud-servicediscovery # only core/persistence/aws deps
-          publish fakecloud-account          # only core/persistence/aws deps
-          publish fakecloud-identitystore    # only core/persistence/aws deps
-          publish fakecloud-ssoadmin         # only core/persistence/aws deps
-          publish fakecloud-verifiedpermissions # core/persistence/aws + cedar-policy
-          publish fakecloud-redshift         # only core/persistence/aws deps
-          publish fakecloud-dms              # only core/persistence/aws deps
-          publish fakecloud-docdb            # only core/persistence/aws deps
-          publish fakecloud-neptune          # only core/persistence/aws deps
-          publish fakecloud-opensearch       # only core/persistence/aws deps (ES + OpenSearch)
-          publish fakecloud-backup           # only core/persistence/aws deps
-          publish fakecloud-glacier          # only core/persistence/aws deps
-          publish fakecloud-transfer         # only core/persistence/aws deps
-          publish fakecloud-appconfig        # only core/persistence/aws deps
-          publish fakecloud-cloudtrail       # only core/persistence/aws deps
-          publish fakecloud-ram               # only core/persistence/aws deps
-          publish fakecloud-ce                # only core/persistence/aws deps
-          publish fakecloud-s3tables          # only core/persistence/aws deps
-          publish fakecloud-lakeformation     # only core/persistence/aws deps
-          publish fakecloud-codeconnections   # only core/persistence/aws deps
-          publish fakecloud-codecommit        # only core/persistence/aws deps
-          publish fakecloud-codedeploy        # only core/persistence/aws deps
-          publish fakecloud-codepipeline      # only core/persistence/aws deps
-          publish fakecloud-codeartifact      # only core/persistence/aws deps
-          publish fakecloud-emr               # only core/persistence/aws deps
-          publish fakecloud-textract          # only core/persistence/aws deps
-          publish fakecloud-transcribe          # only core/persistence/aws deps
-          publish fakecloud-translate           # only core/persistence/aws deps
-          publish fakecloud-shield              # only core/persistence/aws deps
-          publish fakecloud-comprehend             # only core/persistence/aws deps
-          publish fakecloud-swf                    # only core/persistence/aws deps
-          publish fakecloud-timestream             # only core/persistence/aws deps
-          publish fakecloud-support             # only core/persistence/aws deps
-          publish fakecloud-kinesis
-          publish fakecloud-scheduler
-          publish fakecloud-bedrock
-          publish fakecloud-cloudfront
-          publish fakecloud-acm
-          publish fakecloud-application-autoscaling
-          publish fakecloud-autoscaling
-          publish fakecloud-wafv2
-          publish fakecloud-cloudwatch
-          publish fakecloud-glue
-          publish fakecloud-bedrock-agent
-
-          # Layer 3b: depend on layer 3a
-          publish fakecloud-sns            # depends on ses
-          publish fakecloud-secretsmanager # depends on iam
-          publish fakecloud-cognito        # depends on iam
-          publish fakecloud-elbv2          # depends on wafv2
-          publish fakecloud-apigatewayv2   # depends on wafv2
-          publish fakecloud-bedrock-agent-runtime  # depends on bedrock-agent
-          publish fakecloud-eventbridge    # depends on iam, lambda, logs
-
-          # Layer 4: depend on layer 3a/3b crates
-          publish fakecloud-s3             # depends on kms
-          publish fakecloud-elasticache    # depends on s3
-          publish fakecloud-route53resolver  # depends on ec2, s3 (ImportFirewallDomains)
-          publish fakecloud-acmpca         # depends on s3 (audit-report delivery), acm, kms
-          publish fakecloud-ecr            # depends on iam, kms
-          publish fakecloud-ssm            # depends on secretsmanager
-          publish fakecloud-codebuild      # depends on secretsmanager, ssm, logs (real buildspec exec)
-          publish fakecloud-apigateway     # depends on elbv2, wafv2
-
-          # Layer 5: depend on layer 4
-          publish fakecloud-dynamodb       # depends on s3
-          publish fakecloud-firehose       # depends on s3
-          publish fakecloud-athena         # depends on glue, s3
-          publish fakecloud-route53        # depends on cloudfront, elbv2, logs, s3
-          publish fakecloud-ecs            # depends on logs, secretsmanager, ssm
-          publish fakecloud-batch          # depends on ecs (drives ECS for real job execution)
-          publish fakecloud-config         # depends on s3, iam, ec2, lambda (records cross-service state)
-
-          # Layer 6: depends on layer 5
-          publish fakecloud-stepfunctions  # depends on dynamodb
-
-          # EventBridge Pipes: control plane depends only on core/aws/persistence,
-          # but cloudformation provisions AWS::Pipes::Pipe, so publish it before
-          # cloudformation.
-          publish fakecloud-pipes
-
-          # Layer 7: depends on all services
-          publish fakecloud-cloudformation
-
-          # Layer 8: depends on cloudformation (drives its resource provisioners)
-          publish fakecloud-cloudcontrol
-
-          # Layer 9: the binary
-          publish fakecloud
+        run: bash scripts/publish-crates.sh "$VERSION"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -317,7 +191,11 @@ jobs:
     # backfill of an existing tag whose original publish-npm failed).
     # When dispatched manually `needs: check` is skipped because the
     # check job itself is gated on push; allow that via the if guard.
-    if: always() && (needs.check.result == 'success' || needs.check.result == 'skipped')
+    # npm=false lets a dispatch resume only the crates.io publish.
+    if: |
+      always()
+      && (needs.check.result == 'success' || needs.check.result == 'skipped')
+      && (github.event_name == 'push' || inputs.npm)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     # OIDC auth via npm Trusted Publishing (configured at

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ cargo fmt --check                        # format check
 - Do not ship stub responses; implement the behavior or return an appropriate error.
 - Do not leave small follow-up correctness issues unresolved when they are part of the task at hand.
 
+### Releasing
+
+- A new publishable crate must be added to the `CRATES` list in `scripts/publish-crates.sh`, positioned after every workspace crate it depends on. CI (`release-tooling`) fails otherwise.
+- That script owns the crates.io publish: it backs off on rate-limit 429s and skips versions already in the index, so a failed release is resumed by re-running it, never by publishing the tail by hand.
+
 ### Source And Naming
 
 - Avoid referencing Moto in Rust source or user-facing implementation details. Existing protocol paths like `/moto-api/reset` are fine where already established.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -418,8 +418,14 @@ publish_crate() {
     # Retry a flaky registry, but only a few times: the pattern below is broad
     # enough to catch a genuine failure whose text happens to mention a
     # connection, and burning 40 backoffs on that would hide it for an hour.
+    #
+    # "failed to select a version" is in here because the sparse index is
+    # CDN-cached: a dependency we published seconds ago can still be invisible to
+    # the next crate's resolver. Retrying rides that out. When the cause is a
+    # genuine ordering bug instead, this costs MAX_TRANSIENT backoffs before the
+    # error surfaces — acceptable, since --check catches that class pre-merge.
     if [ "$transient" -lt "$MAX_TRANSIENT" ] &&
-      printf '%s' "$out" | grep -qEi 'status 5[0-9][0-9]|timed out|timeout|spurious network|connection|reset by peer|gateway|temporarily unavailable|handshake|SSL'; then
+      printf '%s' "$out" | grep -qEi 'status 5[0-9][0-9]|timed out|timeout|spurious network|connection|reset by peer|gateway|temporarily unavailable|handshake|SSL|failed to select a version|no matching package named'; then
       transient=$((transient + 1))
       if [ "$transient" -gt 5 ]; then wait=300; else wait=$((15 * 2 ** (transient - 1))); fi
       log "transient registry error publishing $name (transient $transient/$MAX_TRANSIENT):"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,591 @@
+#!/usr/bin/env bash
+#
+# Publish every publishable workspace crate to crates.io, in dependency order,
+# respecting crates.io's rate limits.
+#
+# crates.io meters publishes with two independent token buckets: one for brand
+# new crates (slow — minutes per token) and one for new versions of crates that
+# already exist (faster, but a 100+ crate workspace still drains it partway
+# through a release). When a bucket is empty the API answers 429 and names the
+# exact instant the next token frees up:
+#
+#   the remote server responded with an error (status 429 Too Many Requests):
+#   You have published too many updates to existing crates in a short period of
+#   time. Please try again after Sat, 25 Jul 2026 12:35:41 GMT and see
+#   https://crates.io/docs/rate-limits for more details.
+#
+# So nothing here hardcodes crates.io's limits. On a 429 the script parses that
+# instant, sleeps until it passes, and retries the same crate; it also learns
+# the bucket's refill interval from the 429 (next-token instant minus the last
+# accepted upload of that kind) and paces subsequent publishes by it, so the
+# steady state is one upload attempt per crate instead of an attempt plus a
+# rejection. Each new 429 refines the estimate upward.
+#
+# Idempotent and resumable: a crate whose version is already in the sparse index
+# is skipped without touching the API. That matters for more than speed — a
+# republish attempt is metered *before* crates.io notices the version already
+# exists, so blindly re-running a partially-finished release burns the whole
+# bucket on no-ops and then 429s forever. Re-run after any failure and the
+# script picks up where it stopped.
+#
+# Usage:
+#   scripts/publish-crates.sh <version>   Publish/resume version <version>.
+#   scripts/publish-crates.sh --check     Validate the crate list against the
+#                                         workspace (membership + topo order).
+#                                         No network, no publishing.
+#
+# Environment:
+#   CARGO_REGISTRY_TOKEN  crates.io token (required to publish).
+#   DRY_RUN=1             Log what would happen; never call cargo publish.
+#   DEADLINE_MINUTES=330  Give up (with a resume hint) before a GitHub Actions
+#                         job would be killed at its 6h ceiling.
+#   MAX_ATTEMPTS=40       Per-crate attempt cap.
+#   MAX_TRANSIENT=6       Per-crate cap on retries of non-429 registry errors.
+#   MAX_SLEEP=1800        Cap on any single wait, in seconds.
+#   MAX_REFILL=3600       Sanity bound on a learned rate-limit interval.
+#   START_AT=<crate>      Skip ahead to this crate (manual recovery).
+#
+# Publish order is hand-maintained: a crate must come after every workspace
+# crate it depends on, because crates.io resolves the dependency from the index
+# at publish time. `--check` enforces that, so CI fails on a misplaced or
+# missing crate instead of a release failing halfway through.
+set -uo pipefail
+
+CRATES=(
+  # Layer 1: no internal deps
+  fakecloud-aws
+  fakecloud-sdk
+  fakecloud-persistence
+  fakecloud-k8s   # only external deps (kube/k8s-openapi); dependents: lambda/elasticache/rds/ecs/server
+
+  # Layer 2: depends on fakecloud-aws
+  fakecloud-core
+
+  # Layer 3a: depend on aws + core + persistence only
+  fakecloud-sqs
+  fakecloud-iam
+  fakecloud-organizations
+  fakecloud-ec2            # depends on aws + core only
+  fakecloud-lambda
+  fakecloud-logs
+  fakecloud-kms
+  fakecloud-ses
+  fakecloud-rds
+  fakecloud-rds-data        # depends on rds
+  fakecloud-dsql
+  fakecloud-resource-groups  # only core/persistence/aws deps
+  fakecloud-resource-groups-tagging  # only core/persistence/aws deps
+  fakecloud-elasticbeanstalk # only core/persistence/aws deps
+  fakecloud-memorydb         # only core/persistence/aws deps
+  fakecloud-kinesisanalyticsv2 # only core/persistence/aws deps
+  fakecloud-eks              # only core/persistence/aws deps
+  fakecloud-efs              # depends on ec2 (subnet AZ/VPC resolution)
+  fakecloud-mq               # only core/persistence/aws deps
+  fakecloud-kafka            # only core/persistence deps
+  fakecloud-mwaa             # only core/persistence deps
+  fakecloud-fis              # only core/persistence deps
+  fakecloud-xray             # only core/persistence deps
+  fakecloud-appsync          # only core/persistence deps
+  fakecloud-amplify          # only core/persistence deps
+  fakecloud-mediaconvert     # only core/persistence deps
+  fakecloud-serverlessrepo   # only core/persistence deps
+  fakecloud-iotdata          # only core/persistence deps
+  fakecloud-pinpoint         # only core/persistence deps
+  fakecloud-iot              # only core/persistence deps
+  fakecloud-iotwireless      # only core/persistence deps
+  fakecloud-sagemaker        # only core/persistence deps
+  fakecloud-managedblockchain # only core/persistence/aws deps
+  fakecloud-servicediscovery # only core/persistence/aws deps
+  fakecloud-account          # only core/persistence/aws deps
+  fakecloud-identitystore    # only core/persistence/aws deps
+  fakecloud-ssoadmin         # only core/persistence/aws deps
+  fakecloud-verifiedpermissions # core/persistence/aws + cedar-policy
+  fakecloud-redshift         # only core/persistence/aws deps
+  fakecloud-dms              # only core/persistence/aws deps
+  fakecloud-docdb            # only core/persistence/aws deps
+  fakecloud-neptune          # only core/persistence/aws deps
+  fakecloud-opensearch       # only core/persistence/aws deps (ES + OpenSearch)
+  fakecloud-backup           # only core/persistence/aws deps
+  fakecloud-glacier          # only core/persistence/aws deps
+  fakecloud-transfer         # only core/persistence/aws deps
+  fakecloud-appconfig        # only core/persistence/aws deps
+  fakecloud-cloudtrail       # only core/persistence/aws deps
+  fakecloud-ram               # only core/persistence/aws deps
+  fakecloud-ce                # only core/persistence/aws deps
+  fakecloud-s3tables          # only core/persistence/aws deps
+  fakecloud-lakeformation     # only core/persistence/aws deps
+  fakecloud-codeconnections   # only core/persistence/aws deps
+  fakecloud-codecommit        # only core/persistence/aws deps
+  fakecloud-codedeploy        # only core/persistence/aws deps
+  fakecloud-codepipeline      # only core/persistence/aws deps
+  fakecloud-codeartifact      # only core/persistence/aws deps
+  fakecloud-emr               # only core/persistence/aws deps
+  fakecloud-textract          # only core/persistence/aws deps
+  fakecloud-transcribe          # only core/persistence/aws deps
+  fakecloud-translate           # only core/persistence/aws deps
+  fakecloud-shield              # only core/persistence/aws deps
+  fakecloud-comprehend             # only core/persistence/aws deps
+  fakecloud-swf                    # only core/persistence/aws deps
+  fakecloud-timestream             # only core/persistence/aws deps
+  fakecloud-support             # only core/persistence/aws deps
+  fakecloud-kinesis
+  fakecloud-scheduler
+  fakecloud-bedrock
+  fakecloud-cloudfront
+  fakecloud-acm
+  fakecloud-application-autoscaling
+  fakecloud-autoscaling
+  fakecloud-wafv2
+  fakecloud-cloudwatch
+  fakecloud-glue
+  fakecloud-bedrock-agent
+
+  # Layer 3b: depend on layer 3a
+  fakecloud-sns            # depends on ses
+  fakecloud-secretsmanager # depends on iam
+  fakecloud-cognito        # depends on iam
+  fakecloud-elbv2          # depends on wafv2
+  fakecloud-apigatewayv2   # depends on wafv2
+  fakecloud-bedrock-agent-runtime  # depends on bedrock-agent
+  fakecloud-eventbridge    # depends on iam, lambda, logs
+
+  # Layer 4: depend on layer 3a/3b crates
+  fakecloud-s3             # depends on kms
+  fakecloud-elasticache    # depends on s3
+  fakecloud-route53resolver  # depends on ec2, s3 (ImportFirewallDomains)
+  fakecloud-acmpca         # depends on s3 (audit-report delivery), acm, kms
+  fakecloud-ecr            # depends on iam, kms
+  fakecloud-ssm            # depends on secretsmanager
+  fakecloud-codebuild      # depends on secretsmanager, ssm, logs (real buildspec exec)
+  fakecloud-apigateway     # depends on elbv2, wafv2
+
+  # Layer 5: depend on layer 4
+  fakecloud-dynamodb       # depends on s3
+  fakecloud-firehose       # depends on s3
+  fakecloud-athena         # depends on glue, s3
+  fakecloud-route53        # depends on cloudfront, elbv2, logs, s3
+  fakecloud-ecs            # depends on logs, secretsmanager, ssm
+  fakecloud-batch          # depends on ecs (drives ECS for real job execution)
+  fakecloud-config         # depends on s3, iam, ec2, lambda (records cross-service state)
+
+  # Layer 6: depends on layer 5
+  fakecloud-stepfunctions  # depends on dynamodb
+
+  # EventBridge Pipes: control plane depends only on core/aws/persistence,
+  # but cloudformation provisions AWS::Pipes::Pipe, so publish it before
+  # cloudformation.
+  fakecloud-pipes
+
+  # Layer 7: depends on all services
+  fakecloud-cloudformation
+
+  # Layer 8: depends on cloudformation (drives its resource provisioners)
+  fakecloud-cloudcontrol
+
+  # Layer 9: the binary
+  fakecloud
+)
+
+readonly INDEX_HOST="https://index.crates.io"
+
+# cargo publish -p and cargo metadata both need the workspace root.
+SELF=$(cd "$(dirname "$0")" && pwd)/$(basename "$0")
+readonly SELF
+cd "$(dirname "$SELF")/.." || exit 1
+
+DEADLINE_MINUTES=${DEADLINE_MINUTES:-330}
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-40}
+MAX_TRANSIENT=${MAX_TRANSIENT:-6}
+MAX_SLEEP=${MAX_SLEEP:-1800}
+# Sanity bound on a learned refill interval, so a nonsense timestamp cannot
+# stall the release. Deliberately separate from MAX_SLEEP, which caps one sleep.
+MAX_REFILL=${MAX_REFILL:-3600}
+DRY_RUN=${DRY_RUN:-0}
+START_AT=${START_AT:-}
+# Only used when a 429 arrives without a parseable "try again after" instant.
+FALLBACK_WAIT_EXISTING=${FALLBACK_WAIT_EXISTING:-60}
+FALLBACK_WAIT_NEW=${FALLBACK_WAIT_NEW:-600}
+
+DEADLINE=$(( $(date -u +%s) + DEADLINE_MINUTES * 60 ))
+VERSION=""
+
+# Seconds between rate-limit tokens, learned from 429s. 0 = never observed, so
+# no pacing yet — the first publishes run at full speed off the burst budget.
+refill_existing=0
+refill_new=0
+# Epoch of the last upload crates.io accepted from each bucket.
+last_existing=0
+last_new=0
+
+# Crates still to go, for the resume hint if we run out of wall clock. Seeded
+# with the full list because bash 3.2 (macOS, for a local publish) treats
+# ${remaining[*]} on an empty array as an unbound variable under `set -u`.
+remaining=("${CRATES[@]}")
+
+now() { date -u +%s; }
+log() { printf '%s  %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die() { printf '::error::%s\n' "$*" >&2; exit 1; }
+
+refill_of() { case "$1" in new) printf '%s' "$refill_new" ;; *) printf '%s' "$refill_existing" ;; esac; }
+last_of() { case "$1" in new) printf '%s' "$last_new" ;; *) printf '%s' "$last_existing" ;; esac; }
+set_refill() { case "$1" in new) refill_new=$2 ;; *) refill_existing=$2 ;; esac; }
+set_last() { case "$1" in new) last_new=$2 ;; *) last_existing=$2 ;; esac; }
+
+# Sparse-index path layout: 1/x, 2/xy, 3/x/xyz, then xx/yy/name.
+index_url() {
+  local n=$1
+  case ${#n} in
+    1) printf '%s/1/%s' "$INDEX_HOST" "$n" ;;
+    2) printf '%s/2/%s' "$INDEX_HOST" "$n" ;;
+    3) printf '%s/3/%s/%s' "$INDEX_HOST" "${n:0:1}" "$n" ;;
+    *) printf '%s/%s/%s/%s' "$INDEX_HOST" "${n:0:2}" "${n:2:2}" "$n" ;;
+  esac
+}
+
+INDEX_BODY=""
+
+# Fetch a crate's index entry into INDEX_BODY. 0 = fetched, 1 = the registry
+# says the crate does not exist, 2 = the index was unreachable. The three cases
+# are kept distinct because "unknown" must not be mistaken for "new": pacing a
+# 100-crate release against the new-crate bucket would idle it for hours.
+fetch_index() {
+  local n=$1 attempt code
+  for attempt in 1 2 3; do
+    INDEX_BODY=$(curl -sf --max-time 30 -H 'cache-control: no-cache' "$(index_url "$n")" 2>/dev/null)
+    code=$?
+    case $code in
+      0) return 0 ;;
+      22) return 1 ;; # HTTP >= 400 under curl -f: not in the index
+      *) sleep $((attempt * 3)) ;;
+    esac
+  done
+  INDEX_BODY=""
+  return 2
+}
+
+# published | existing | new | unknown
+index_state() {
+  local rc
+  fetch_index "$1"
+  rc=$?
+  case $rc in
+    2) printf 'unknown' ;;
+    1) printf 'new' ;;
+    *)
+      if printf '%s' "$INDEX_BODY" | grep -Fq "\"vers\":\"$2\""; then
+        printf 'published'
+      else
+        printf 'existing'
+      fi
+      ;;
+  esac
+}
+
+deadline_exit() {
+  printf '::error::out of wall clock after %s minutes (%s)\n' "$DEADLINE_MINUTES" "$1" >&2
+  printf '::error::%s crate(s) not yet published: %s\n' "${#remaining[@]}" "${remaining[*]}" >&2
+  printf '::error::this is resumable — re-run the crates publish for the same tag and it will skip everything already indexed:\n' >&2
+  printf '::error::  gh workflow run release.yml -f tag=v%s -f crates=true -f npm=false\n' "$VERSION" >&2
+  exit 1
+}
+
+snooze() {
+  local secs=$1 reason=$2
+  [ "$secs" -lt 1 ] && return 0
+  [ "$secs" -gt "$MAX_SLEEP" ] && secs=$MAX_SLEEP
+  if [ $(( $(now) + secs )) -gt "$DEADLINE" ]; then
+    deadline_exit "$reason"
+  fi
+  log "waiting ${secs}s — $reason"
+  sleep "$secs"
+}
+
+# Sleep so the next upload of this kind lands no sooner than one refill interval
+# after the previous one. No-op until a 429 has taught us the interval.
+pace() {
+  local kind=$1 r last target nowt
+  r=$(refill_of "$kind")
+  last=$(last_of "$kind")
+  if [ "$r" -gt 0 ] && [ "$last" -gt 0 ]; then
+    target=$((last + r))
+    nowt=$(now)
+    if [ "$target" -gt "$nowt" ]; then
+      snooze $((target - nowt)) "pacing inside the ${kind}-crate rate limit"
+    fi
+  fi
+  return 0
+}
+
+# Pull the "Please try again after <RFC 2822 date>" instant out of a 429 body and
+# print it as epoch seconds. Returns 1 if the message carried no parseable date.
+retry_after_epoch() {
+  local when epoch
+  when=$(printf '%s' "$1" |
+    sed -nE 's/.*try again after ([A-Za-z]{3}, [0-9]{1,2} [A-Za-z]{3} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Za-z]{3,4}).*/\1/p' |
+    head -1)
+  [ -n "$when" ] || return 1
+  # GNU date (CI) first, then BSD date (a local publish from macOS).
+  epoch=$(date -u -d "$when" +%s 2>/dev/null) ||
+    epoch=$(TZ=UTC date -j -f '%a, %d %b %Y %H:%M:%S %Z' "$when" +%s 2>/dev/null) ||
+    return 1
+  printf '%s' "$epoch"
+}
+
+# Which bucket the last 429 came from, so publish_crate can re-key the crate it
+# is working on when crates.io metered it differently than the index suggested.
+RATE_BUCKET=""
+
+# Wait out a 429 for one crate, refining the learned refill interval.
+handle_rate_limit() {
+  local out=$1 kind=$2 name=$3 bucket target last interval known wait
+  # crates.io names the bucket it metered against; that beats our guess from the
+  # index, and publish_crate adopts it so the eventual success and the pacing
+  # that follows are attributed to the same bucket.
+  bucket=$kind
+  printf '%s' "$out" | grep -q 'too many new crates' && bucket=new
+  printf '%s' "$out" | grep -q 'existing crates' && bucket=existing
+  RATE_BUCKET=$bucket
+
+  target=$(retry_after_epoch "$out") || target=""
+  last=$(last_of "$bucket")
+
+  if [ -n "$target" ]; then
+    # The bucket is empty and the next token lands at $target. Once we are past
+    # the burst budget every upload consumes the token that just appeared, so
+    # $target minus that upload is the refill interval. Keep the largest
+    # observation: underestimating costs one more 429, overestimating would idle
+    # the rest of the release.
+    if [ "$last" -gt 0 ]; then
+      interval=$((target - last))
+      known=$(refill_of "$bucket")
+      if [ "$interval" -gt "$known" ] && [ "$interval" -le "$MAX_REFILL" ]; then
+        set_refill "$bucket" "$interval"
+        log "learned crates.io ${bucket}-crate limit: ~${interval}s per publish"
+        log "${#remaining[@]} crate(s) left at that rate: ~$((${#remaining[@]} * interval))s (~$(((${#remaining[@]} * interval + 59) / 60)) min)"
+      fi
+    fi
+    wait=$(( target - $(now) + 3 )) # +3s slack for clock skew
+  else
+    wait=$(refill_of "$bucket")
+    if [ "$wait" -le 0 ]; then
+      case $bucket in
+        new) wait=$FALLBACK_WAIT_NEW ;;
+        *) wait=$FALLBACK_WAIT_EXISTING ;;
+      esac
+    fi
+    log "429 without a parseable retry instant; falling back to ${wait}s"
+  fi
+  [ "$wait" -lt 5 ] && wait=5
+  snooze "$wait" "crates.io ${bucket}-crate rate limit — next token before retrying $name"
+}
+
+publish_crate() {
+  local name=$1 kind=$2 attempt out wait transient=0
+  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    pace "$kind"
+
+    if [ "$DRY_RUN" = 1 ]; then
+      log "DRY_RUN: would publish $name ($kind crate)"
+      set_last "$kind" "$(now)"
+      return 0
+    fi
+
+    if out=$(cargo publish -p "$name" 2>&1); then
+      set_last "$kind" "$(now)"
+      log "published $name"
+      return 0
+    fi
+
+    if printf '%s' "$out" | grep -qE 'already uploaded|already exists'; then
+      log "$name@$VERSION is already on crates.io — continuing"
+      return 0
+    fi
+
+    if printf '%s' "$out" | grep -qE '429 Too Many Requests|status 429'; then
+      handle_rate_limit "$out" "$kind" "$name"
+      kind=$RATE_BUCKET
+      continue
+    fi
+
+    # Before retrying anything, ask the index: cargo can fail after crates.io
+    # accepted the upload (e.g. it gives up waiting for the version to appear),
+    # and re-uploading would spend a rate-limit token to be told so.
+    if [ "$(index_state "$name" "$VERSION")" = published ]; then
+      log "$name@$VERSION landed on crates.io despite the error above — continuing"
+      return 0
+    fi
+
+    # Retry a flaky registry, but only a few times: the pattern below is broad
+    # enough to catch a genuine failure whose text happens to mention a
+    # connection, and burning 40 backoffs on that would hide it for an hour.
+    if [ "$transient" -lt "$MAX_TRANSIENT" ] &&
+      printf '%s' "$out" | grep -qEi 'status 5[0-9][0-9]|timed out|timeout|spurious network|connection|reset by peer|gateway|temporarily unavailable|handshake|SSL'; then
+      transient=$((transient + 1))
+      if [ "$transient" -gt 5 ]; then wait=300; else wait=$((15 * 2 ** (transient - 1))); fi
+      log "transient registry error publishing $name (transient $transient/$MAX_TRANSIENT):"
+      printf '%s\n' "$out" | tail -15
+      snooze "$wait" "retrying $name"
+      continue
+    fi
+
+    printf '::error::failed to publish %s\n' "$name" >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  done
+  printf '::error::gave up on %s after %s attempts\n' "$name" "$MAX_ATTEMPTS" >&2
+  return 1
+}
+
+# Wait for a freshly published version to show up in the sparse index, so the
+# next crate in the order can resolve it as a dependency. cargo already does
+# this for its own publishes; this covers the case where it gave up early.
+wait_for_index() {
+  local name=$1 i
+  for i in $(seq 1 60); do
+    if [ "$(index_state "$name" "$VERSION")" = published ]; then
+      [ "$i" -gt 1 ] && log "$name@$VERSION indexed after $((i * 5))s"
+      return 0
+    fi
+    sleep 5
+  done
+  log "WARNING: $name@$VERSION still not in the sparse index after 5 min — continuing"
+  return 0
+}
+
+# Validate the hand-maintained list against the workspace: every publishable
+# member listed exactly once, nothing stale, and every crate after the workspace
+# crates it depends on (crates.io resolves those from the index at publish time).
+check_list() {
+  command -v cargo >/dev/null 2>&1 || die "cargo not found"
+  command -v python3 >/dev/null 2>&1 || die "python3 not found"
+  CRATE_LIST=$(printf '%s\n' "${CRATES[@]}") python3 - <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+listed = os.environ["CRATE_LIST"].split()
+# --no-deps resolves nothing, so this needs no network.
+proc = subprocess.run(
+    ["cargo", "metadata", "--no-deps", "--format-version", "1", "--offline"],
+    capture_output=True,
+    text=True,
+)
+if proc.returncode != 0:
+    print("::error::cargo metadata failed:", file=sys.stderr)
+    print(proc.stderr, file=sys.stderr)
+    sys.exit(1)
+meta = json.loads(proc.stdout)
+
+# `publish = false` in Cargo.toml surfaces as an empty list here.
+packages = {p["name"]: p for p in meta["packages"] if p.get("publish") != []}
+position = {}
+errors = []
+
+for i, name in enumerate(listed):
+    if name in position:
+        errors.append(f"{name} is listed twice")
+    position[name] = i
+
+for name in sorted(set(listed) - set(packages)):
+    errors.append(f"{name} is in the publish list but is not a publishable workspace member")
+for name in sorted(set(packages) - set(listed)):
+    errors.append(
+        f"{name} is a publishable workspace member but is missing from the publish list "
+        "in scripts/publish-crates.sh — insert it after every crate it depends on"
+    )
+
+for name, pkg in packages.items():
+    if name not in position:
+        continue
+    for dep in pkg["dependencies"]:
+        # dev-dependencies do not affect publish order; normal and build deps do.
+        if dep.get("kind") not in (None, "build"):
+            continue
+        if not dep.get("path") or dep["name"] not in position:
+            continue
+        if position[dep["name"]] > position[name]:
+            errors.append(
+                f"{name} is published before its dependency {dep['name']} — "
+                f"move {name} after {dep['name']}"
+            )
+
+if errors:
+    for e in errors:
+        print(f"::error::{e}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"publish list OK: {len(listed)} crates, dependency order valid")
+PY
+}
+
+main() {
+  [ $# -ge 1 ] || die "usage: $(basename "$0") <version> | --check"
+
+  case $1 in
+    --check)
+      check_list
+      exit $?
+      ;;
+    -h | --help)
+      sed -n '2,60p' "$SELF"
+      exit 0
+      ;;
+  esac
+
+  VERSION=$1
+  case $VERSION in
+    v*) die "pass the version without the leading v (got $VERSION)" ;;
+  esac
+  # Publishing anything other than the checked-out version cannot work, and the
+  # usual way to get here is running from main instead of a detached tag.
+  local workspace_version
+  workspace_version=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+  if [ "$VERSION" != "$workspace_version" ]; then
+    die "asked to publish $VERSION but this checkout is $workspace_version — check out the tag first"
+  fi
+
+  check_list || exit 1
+
+  local total=${#CRATES[@]} i=0 published=0 present=0 jumped=0 name state kind reached=0
+  if [ -n "$START_AT" ]; then
+    log "START_AT=$START_AT — skipping everything before it"
+  fi
+  log "publishing $total crates at version $VERSION (deadline: ${DEADLINE_MINUTES} min)"
+
+  for name in "${CRATES[@]}"; do
+    i=$((i + 1))
+
+    if [ -n "$START_AT" ] && [ "$reached" -eq 0 ]; then
+      if [ "$name" = "$START_AT" ]; then
+        reached=1
+      else
+        jumped=$((jumped + 1))
+        continue
+      fi
+    fi
+
+    # Rebuild the not-yet-done tail so a deadline exit can name it.
+    remaining=("${CRATES[@]:$((i - 1))}")
+
+    state=$(index_state "$name" "$VERSION")
+    case $state in
+      published)
+        present=$((present + 1))
+        log "[$i/$total] $name@$VERSION already published — skipping"
+        continue
+        ;;
+      new) kind=new ;;
+      *) kind=existing ;;
+    esac
+
+    log "[$i/$total] publishing $name ($kind crate)"
+    publish_crate "$name" "$kind" || exit 1
+    published=$((published + 1))
+    [ "$DRY_RUN" = 1 ] || wait_for_index "$name"
+  done
+
+  log "done: $published published, $present already on crates.io, $jumped skipped by START_AT, $total total"
+}
+
+main "$@"

--- a/scripts/tests/publish-crates-test.sh
+++ b/scripts/tests/publish-crates-test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/publish-crates.sh — the crates.io rate-limit handling in
+# particular, which is otherwise only exercised by a real release.
+#
+# Hermetic: `cargo publish` and the sparse-index `curl` are both stubbed on PATH,
+# so nothing here touches crates.io. `cargo metadata` is forwarded to the real
+# cargo (the script validates the publish list against the workspace on every
+# run). MAX_SLEEP=1 clamps every wait to a second so a test that would idle for a
+# rate-limit refill finishes immediately.
+#
+#   bash scripts/tests/publish-crates-test.sh
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SCRIPT="$ROOT/scripts/publish-crates.sh"
+CARGO_REAL=$(command -v cargo) || {
+  echo "cargo not found" >&2
+  exit 1
+}
+export CARGO_REAL
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+STUB="$TMP/bin"
+mkdir -p "$STUB"
+
+export STUB_STATE="$TMP/index"   # one "<crate>@<vers>" or "<crate>@EXISTS" per line
+export STUB_COUNT="$TMP/calls"   # number of `cargo publish` invocations
+# The script refuses to publish a version other than the checked-out one, so the
+# stub registry speaks the workspace version.
+STUB_VERSION=$(grep -m1 '^version' "$ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+export STUB_VERSION
+
+# Stub sparse index. Reports the published version, an older version (the crate
+# exists but not at this version), or 404 (curl exit 22, crate unknown).
+cat > "$STUB/curl" <<'STUBEOF'
+#!/usr/bin/env bash
+url=""
+for arg in "$@"; do case "$arg" in https://*) url="$arg" ;; esac; done
+name="${url##*/}"
+if grep -qx "${name}@${STUB_VERSION}" "$STUB_STATE" 2>/dev/null; then
+  printf '{"name":"%s","vers":"%s","deps":[]}\n' "$name" "$STUB_VERSION"
+  exit 0
+fi
+if grep -qx "${name}@EXISTS" "$STUB_STATE" 2>/dev/null; then
+  printf '{"name":"%s","vers":"0.0.1","deps":[]}\n' "$name"
+  exit 0
+fi
+exit 22
+STUBEOF
+
+# Stub cargo. Fails invocations (SKIP, SKIP+TIMES] with the chosen error, then
+# succeeds and records the publish in the stub index.
+cat > "$STUB/cargo" <<'STUBEOF'
+#!/usr/bin/env bash
+[ "${1:-}" = metadata ] && exec "$CARGO_REAL" "$@"
+name="$3"
+n=$(cat "$STUB_COUNT" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "$STUB_COUNT"
+if [ "$n" -gt "${STUB_FAIL_SKIP:-0}" ] &&
+  [ "$n" -le $((${STUB_FAIL_SKIP:-0} + ${STUB_FAIL_TIMES:-0})) ]; then
+  case "${STUB_FAIL_MODE:-429}" in
+    429)
+      when=$(date -u -d "+${STUB_RETRY_IN:-30} seconds" +'%a, %d %b %Y %H:%M:%S GMT' 2>/dev/null ||
+        date -u -v"+${STUB_RETRY_IN:-30}S" +'%a, %d %b %Y %H:%M:%S GMT')
+      echo "error: failed to publish $name to registry at https://crates.io"
+      echo "Caused by:"
+      echo "  the remote server responded with an error (status 429 Too Many Requests):" \
+        "You have published too many updates to existing crates in a short period of time." \
+        "Please try again after $when and see https://crates.io/docs/rate-limits for more details."
+      exit 1
+      ;;
+    429new)
+      when=$(date -u -d "+${STUB_RETRY_IN:-30} seconds" +'%a, %d %b %Y %H:%M:%S GMT' 2>/dev/null ||
+        date -u -v"+${STUB_RETRY_IN:-30}S" +'%a, %d %b %Y %H:%M:%S GMT')
+      echo "error: failed to publish $name to registry at https://crates.io"
+      echo "  the remote server responded with an error (status 429 Too Many Requests):" \
+        "You have published too many new crates in a short period of time." \
+        "Please try again after $when and see https://crates.io/docs/rate-limits for more details."
+      exit 1
+      ;;
+    429bare)
+      echo "error: the remote server responded with an error (status 429 Too Many Requests): slow down"
+      exit 1
+      ;;
+    503)
+      echo "error: failed to publish $name"
+      echo "Caused by: the remote server responded with an error (status 503 Service Unavailable)"
+      exit 1
+      ;;
+    fatal)
+      echo "error: failed to verify package tarball"
+      echo "Caused by: mismatched types: expected struct Foo"
+      exit 1
+      ;;
+    silent-success)
+      # crates.io accepted the upload but cargo still failed (it gave up waiting
+      # for the version to appear in the index).
+      echo "$name@$STUB_VERSION" >> "$STUB_STATE"
+      echo "error: timed out waiting for $name to be available in the registry"
+      exit 1
+      ;;
+  esac
+fi
+echo "$name@$STUB_VERSION" >> "$STUB_STATE"
+echo "    Uploading $name v$STUB_VERSION"
+exit 0
+STUBEOF
+
+chmod +x "$STUB/curl" "$STUB/cargo"
+
+FAILURES=0
+OUT="$TMP/out"
+
+# run <index-state-lines> [env=value ...] -- <script args>
+run() {
+  printf '%s\n' "$1" > "$STUB_STATE"
+  : > "$STUB_COUNT"
+  shift
+  env PATH="$STUB:$PATH" MAX_SLEEP=1 "$@" bash "$SCRIPT" "$STUB_VERSION" > "$OUT" 2>&1
+  echo $?
+}
+
+check() { # check <label> <condition-description> <0|1 result>
+  if [ "$3" = 0 ]; then
+    printf 'ok   %s: %s\n' "$1" "$2"
+  else
+    printf 'FAIL %s: %s\n' "$1" "$2"
+    FAILURES=$((FAILURES + 1))
+    sed 's/^/       | /' "$OUT"
+  fi
+}
+
+saw() { grep -q "$1" "$OUT"; }
+
+echo "== publish-crates.sh =="
+
+# A single 429 is waited out and the crate is retried, not failed.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=429)
+check A "429 retried to success" "$([ "$code" = 0 ] && saw 'rate limit' && saw 'published fakecloud' && echo 0 || echo 1)"
+
+# Repeated 429s teach the script the refill interval, which then paces the next
+# crate instead of waiting for another rejection.
+code=$(run 'fakecloud-cloudformation@EXISTS
+fakecloud-cloudcontrol@EXISTS
+fakecloud@EXISTS' START_AT=fakecloud-cloudformation STUB_FAIL_SKIP=1 STUB_FAIL_TIMES=2 STUB_FAIL_MODE=429)
+check B "refill interval learned from 429s and used to pace" \
+  "$([ "$code" = 0 ] && saw 'learned crates.io existing-crate limit' && saw 'pacing inside the existing-crate rate limit' && echo 0 || echo 1)"
+
+# A new-crate 429 is attributed to the new-crate bucket, not the existing one.
+code=$(run '' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=429new)
+check C "new-crate 429 attributed to the new-crate bucket" \
+  "$([ "$code" = 0 ] && saw 'new-crate rate limit' && echo 0 || echo 1)"
+
+# A 429 without a parseable instant still backs off instead of failing.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=429bare)
+check D "429 with no retry instant falls back to a fixed wait" \
+  "$([ "$code" = 0 ] && saw 'without a parseable retry instant' && saw 'published fakecloud' && echo 0 || echo 1)"
+
+# Already-indexed versions are skipped without calling the API at all — a
+# republish attempt would consume a rate-limit token for nothing.
+code=$(run "fakecloud@$STUB_VERSION" START_AT=fakecloud)
+check E "already-published version skipped without publishing" \
+  "$([ "$code" = 0 ] && saw 'already published — skipping' && [ ! -s "$STUB_COUNT" ] && echo 0 || echo 1)"
+
+# cargo failing after crates.io accepted the upload is not a release failure.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=silent-success)
+check F "upload that landed despite a cargo error is treated as published" \
+  "$([ "$code" = 0 ] && saw 'landed on crates.io despite the error' && echo 0 || echo 1)"
+
+# A transient registry error is retried with backoff.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=503)
+check G "503 retried to success" \
+  "$([ "$code" = 0 ] && saw 'transient registry error' && saw 'published fakecloud' && echo 0 || echo 1)"
+
+# ...but not forever: a persistent error surfaces instead of looping for an hour.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=99 STUB_FAIL_MODE=503 MAX_TRANSIENT=2)
+check H "persistent transient error gives up at MAX_TRANSIENT" \
+  "$([ "$code" = 1 ] && saw '::error::failed to publish fakecloud' && [ "$(cat "$STUB_COUNT")" = 3 ] && echo 0 || echo 1)"
+
+# A real failure is never retried or swallowed.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=fatal)
+check I "genuine publish failure aborts the release" \
+  "$([ "$code" = 1 ] && saw 'mismatched types' && [ "$(cat "$STUB_COUNT")" = 1 ] && echo 0 || echo 1)"
+
+# Running out of wall clock reports what is left and how to resume.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud DEADLINE_MINUTES=0 STUB_FAIL_TIMES=1 STUB_FAIL_MODE=429)
+check J "deadline exit names the remaining crates and the resume command" \
+  "$([ "$code" = 1 ] && saw 'not yet published: fakecloud' && saw 'gh workflow run release.yml' && echo 0 || echo 1)"
+
+echo
+if [ "$FAILURES" -ne 0 ]; then
+  echo "$FAILURES test(s) failed"
+  exit 1
+fi
+echo "all tests passed"

--- a/scripts/tests/publish-crates-test.sh
+++ b/scripts/tests/publish-crates-test.sh
@@ -90,6 +90,11 @@ if [ "$n" -gt "${STUB_FAIL_SKIP:-0}" ] &&
       echo "Caused by: the remote server responded with an error (status 503 Service Unavailable)"
       exit 1
       ;;
+    stale-index)
+      echo "error: failed to prepare local package for uploading"
+      echo "Caused by: failed to select a version for the requirement \`fakecloud-core = \"^$STUB_VERSION\"\`"
+      exit 1
+      ;;
     fatal)
       echo "error: failed to verify package tarball"
       echo "Caused by: mismatched types: expected struct Foo"
@@ -179,6 +184,12 @@ check G "503 retried to success" \
 code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=99 STUB_FAIL_MODE=503 MAX_TRANSIENT=2)
 check H "persistent transient error gives up at MAX_TRANSIENT" \
   "$([ "$code" = 1 ] && saw '::error::failed to publish fakecloud' && [ "$(cat "$STUB_COUNT")" = 3 ] && echo 0 || echo 1)"
+
+# A dependency the CDN-cached index has not caught up on yet is retried, not
+# treated as a release-ending ordering bug.
+code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=stale-index)
+check I2 "stale index read on a just-published dep is retried" \
+  "$([ "$code" = 0 ] && saw 'failed to select a version' && saw 'published fakecloud' && echo 0 || echo 1)"
 
 # A real failure is never retried or swallowed.
 code=$(run 'fakecloud@EXISTS' START_AT=fakecloud STUB_FAIL_TIMES=1 STUB_FAIL_MODE=fatal)


### PR DESCRIPTION
## Summary

The v0.44.3 release published 57 of 109 crates and then failed ([run](https://github.com/faiscadev/fakecloud/actions/runs/30155767545/job/89679003010)):

```
error: failed to publish fakecloud-codeconnections v0.44.3 to registry at https://crates.io
  the remote server responded with an error (status 429 Too Many Requests): You have
  published too many updates to existing crates in a short period of time. Please try
  again after Sat, 25 Jul 2026 12:35:41 GMT
```

crates.io meters publishes with a token bucket. The workspace is far larger than the burst budget, and the publish step had no backoff, so the first 429 killed the release and the tail had to be published by hand. `fakecloud` itself never made it: crates.io still serves 0.44.2 for the binary crate while npm/PyPI/Maven are on 0.44.3.

The publish loop moves to `scripts/publish-crates.sh`, which:

- parses the exact `Please try again after <instant>` that crates.io returns with the 429, sleeps until then, and retries the same crate. No limit constant is hardcoded on our side, so a change to crates.io's numbers needs no change here.
- learns the bucket's refill interval from that instant (next token minus the last accepted upload) and paces subsequent publishes by it, so the steady state is one upload per crate instead of an upload plus a rejection. Each 429 refines the estimate upward.
- tracks the new-crate and existing-crate buckets separately, keyed off the bucket crates.io names in the 429 body. The new-crate limit is the one that bit the Timestream-era releases.
- skips versions already in the sparse index. This is what makes a resume cheap: a republish attempt is metered *before* crates.io notices the version already exists, so re-running a half-finished release used to burn the whole bucket on no-ops and then 429 forever.
- retries transient registry errors (5xx, timeouts, resets) with exponential backoff, capped at `MAX_TRANSIENT` so a genuine failure whose text happens to mention a connection surfaces instead of looping for an hour.
- asks the index before retrying or failing, since cargo can fail after crates.io accepted the upload.
- exits with the remaining crates and a ready-to-paste resume command if it runs out of wall clock, instead of being killed mid-crate at GitHub's 6h job ceiling.

Workflow changes:

- `Publish Crates` timeout 90 -> 350 min. The tail of a release is spent waiting for tokens, not uploading; 90 min was not enough even without a failure.
- a `publish-crates` concurrency group, so two releases can't drain the same buckets and 429 each other.
- the `workflow_dispatch` escape hatch gains `crates` and `npm` toggles, so a publish can be resumed against an existing tag without cutting a new release. Default behavior (npm-only backfill) is unchanged.

The publish order is still hand-maintained, so `--check` now validates it against `cargo metadata`: every publishable workspace member listed exactly once, no stale entries, and every crate positioned after the workspace crates it depends on. That closes the recurring "new crate missing from the release list" failure, which previously only showed up as a half-published release.

## Test plan

- `scripts/tests/publish-crates-test.sh` — hermetic suite (both `cargo publish` and the sparse index are stubbed on PATH; nothing touches crates.io). Eleven cases: 429 retried to success; refill interval learned from repeated 429s and used to pace the next crate; new-crate 429 attributed to the new-crate bucket; 429 with no parseable instant falling back to a fixed wait; already-indexed version skipped with zero publish calls; upload that landed despite a cargo error treated as published; 503 retried; persistent transient error giving up at `MAX_TRANSIENT`; genuine failure aborting immediately without retries; deadline exit naming the remaining crates and the resume command; and a stale CDN-cached index read on a just-published dependency being retried rather than aborting the release. Two real bugs in this change were caught by these tests (the learned interval being clamped by `MAX_SLEEP`, and a retry firing before the index was consulted).
- `scripts/publish-crates.sh --check` passes on the workspace: 109 crates, order valid. Verified it fails on a crate removed from the list and on a crate moved before its dependency.
- `DRY_RUN=1 scripts/publish-crates.sh 0.44.3` against the real sparse index: correctly identifies 108 of 109 already published and only `fakecloud` outstanding, which matches crates.io.
- Both scripts run green under bash 3.2 (macOS), since a local publish from a tag is the manual fallback.
- Wired into CI as a `release-tooling` job (`--check` + the test suite).

## Surfaces

Release infrastructure only: no API surface, no new endpoint or field, no service/operation/conformance count change — so SDKs, website docs, README counts and the repo description are all untouched by design. `AGENTS.md` gains the two release rules (new crate goes in the list; resume rather than hand-publish) since that's the agent-facing surface this changes.

## Follow-up outside this PR

`fakecloud@0.44.3` is still missing from crates.io. This PR can't fix already-published state; that needs `cargo publish -p fakecloud` from a detached `v0.44.3` checkout (the dispatch resume path only works for tags that contain the new script).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the crates.io publish resilient to rate limits and resumable for large workspace releases. Prevents half-published releases and removes the need for manual tail publishes.

- **Bug Fixes**
  - Survive 429s by parsing “retry-after”, waiting, learning the refill interval, and pacing uploads; tracks new vs existing crate buckets.
  - Skip versions already in the sparse index; check the index before retry/fail; treat sparse-index lag (“failed to select a version…”) as transient with capped backoff; retry transient 5xx/timeouts.
  - Exit before the job ceiling with a list of remaining crates and a ready-to-run resume command.

- **New Features**
  - Move the publish loop to `scripts/publish-crates.sh`; increase `Publish Crates` timeout to 350 min; add a `publish-crates` concurrency group.
  - `workflow_dispatch` adds `crates` and `npm` toggles to resume from an existing tag without cutting a new release.
  - Add a `release-tooling` CI job and a `--check` that validates the hand-maintained publish order; `AGENTS.md` documents the release rules.

<sup>Written for commit dd8eba090ad77a4b71a5282fae4948cf76917bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

