### PR TITLE
fix(cloudwatch,ses,mq,elbv2,redshift): C0-control-safe XML escaping (use canonical helper)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6188,6 +6188,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "fakecloud-aws",
  "fakecloud-core",
  "fakecloud-persistence",
  "http 1.4.0",

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -655,13 +655,10 @@ pub(crate) fn parse_tags(req: &AwsRequest, prefix: &str) -> BTreeMap<String, Str
     out
 }
 
-pub(crate) fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
+/// Re-export the canonical XML escaper, which also encodes C0 control chars
+/// as numeric character references so a poisoned field cannot make a whole
+/// list-response document unparseable by a strict XML SDK.
+pub(crate) use fakecloud_aws::xml::xml_escape;
 
 /// Encode a pagination offset into an opaque base64 NextToken.
 pub(crate) fn encode_offset_token(offset: usize) -> String {
@@ -2273,4 +2270,32 @@ fn push_action_list(s: &mut String, name: &str, actions: &[String]) {
         s.push_str(&format!("<member>{}</member>", xml_escape(action)));
     }
     s.push_str(&format!("</{name}>"));
+}
+
+#[cfg(test)]
+mod xml_escape_tests {
+    use super::xml_escape;
+
+    #[test]
+    fn escapes_c0_control_chars_as_numeric_references() {
+        // A raw C0 control byte (here a vertical tab, U+000B) is not a legal
+        // XML 1.0 character. If it were passed through verbatim, a single
+        // poisoned field would make the whole list-response document
+        // unparseable by a strict SDK XML parser. The canonical escaper the
+        // crate now uses must emit a numeric character reference instead.
+        let out = xml_escape("a\u{0b}b");
+        assert!(
+            !out.contains('\u{0b}'),
+            "raw control byte leaked into XML output: {out:?}"
+        );
+        assert_eq!(out, "a&#xB;b");
+    }
+
+    #[test]
+    fn still_escapes_the_five_standard_entities() {
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+    }
 }

--- a/crates/fakecloud-elbv2/src/service_helpers.rs
+++ b/crates/fakecloud-elbv2/src/service_helpers.rs
@@ -14,20 +14,10 @@ pub(crate) fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
     AwsResponse::xml(StatusCode::OK, xml)
 }
 
-pub(crate) fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '&' => out.push_str("&amp;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&apos;"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
+/// Re-export the canonical XML escaper, which also encodes C0 control chars
+/// as numeric character references so a poisoned field cannot make a whole
+/// list-response document unparseable by a strict XML SDK.
+pub(crate) use fakecloud_aws::xml::xml_escape;
 
 pub(crate) fn parse_member_list(req: &AwsRequest, prefix: &str) -> Vec<String> {
     let mut out = Vec::new();

--- a/crates/fakecloud-mq/Cargo.toml
+++ b/crates/fakecloud-mq/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 version.workspace = true
 
 [dependencies]
+fakecloud-aws = { workspace = true }
 fakecloud-core = { workspace = true }
 fakecloud-persistence = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fakecloud-mq/src/runtime/mod.rs
+++ b/crates/fakecloud-mq/src/runtime/mod.rs
@@ -1056,14 +1056,10 @@ fn rabbit_hostname(broker_id: &str) -> String {
     label
 }
 
-/// XML-escape a value for an attribute.
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
+/// XML-escape a value for an attribute. The canonical helper also encodes C0
+/// control chars as numeric character references, keeping the generated broker
+/// config a valid XML 1.0 document.
+use fakecloud_aws::xml::xml_escape;
 
 /// Build the `activemq.xml` that configures an ActiveMQ container.
 ///

--- a/crates/fakecloud-redshift/src/service/helpers.rs
+++ b/crates/fakecloud-redshift/src/service/helpers.rs
@@ -28,20 +28,10 @@ pub(crate) fn xml_metadata_only(action: &str, request_id: &str) -> AwsResponse {
     )
 }
 
-pub(crate) fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '&' => out.push_str("&amp;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&apos;"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
+/// Re-export the canonical XML escaper, which also encodes C0 control chars
+/// as numeric character references so a poisoned field cannot make a whole
+/// list-response document unparseable by a strict XML SDK.
+pub(crate) use fakecloud_aws::xml::xml_escape;
 
 /// `<Name>escaped(value)</Name>`.
 pub(crate) fn tag_elem(name: &str, value: &str) -> String {

--- a/crates/fakecloud-ses/src/v1_helpers.rs
+++ b/crates/fakecloud-ses/src/v1_helpers.rs
@@ -684,13 +684,10 @@ pub(crate) fn receipt_action_xml(action: &ReceiptAction) -> String {
     xml
 }
 
-pub(crate) fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
+/// Re-export the canonical XML escaper, which also encodes C0 control chars
+/// as numeric character references so a poisoned field cannot make a whole
+/// list-response document unparseable by a strict XML SDK.
+pub(crate) use fakecloud_aws::xml::xml_escape;
 
 pub(crate) fn verify_email_identity(
     state: &SharedSesState,


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-25 Tier-1 (encoding / XML injection). Five crates each defined a **local** `xml_escape` that escaped only the five standard XML entities (`& < > " '`) and passed raw C0 control bytes through unchanged (`_ => out.push(c)`). A C0 control char (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F) is not a legal XML 1.0 character, so a strict SDK XML parser (aws-sdk-java / expat / libxml) rejects the **whole** response document. Because a list response serializes every resource into one body, a single poisoned field made the entire list page unparseable.

Fix: drop all five duplicated copies and route every call site to the canonical `fakecloud_aws::xml::xml_escape`, which already escapes C0 controls as `&#xN;` numeric character references (and carries an `xml_escape_control_chars` test).

Per-crate change (all signatures were identical `fn(&str) -> String`, so a `use`/re-export is a drop-in — no call sites touched):

- **cloudwatch** (`src/service.rs`): local `pub(crate) fn` replaced with `pub(crate) use fakecloud_aws::xml::xml_escape;` re-export; keeps `crate::service::xml_escape` resolving for the other files that import it. Dep already present.
- **ses** (`src/v1_helpers.rs`): same `pub(crate) use` re-export. Dep already present.
- **elbv2** (`src/service_helpers.rs`): same `pub(crate) use` re-export. Dep already present.
- **redshift** (`src/service/helpers.rs`): same `pub(crate) use` re-export. Dep already present.
- **mq** (`src/runtime/mod.rs`): private `fn` replaced with `use fakecloud_aws::xml::xml_escape;`. **Added `fakecloud-aws = { workspace = true }`** to `crates/fakecloud-mq/Cargo.toml` (it was the only one of the five not already depending on it).

## Test plan

- `cargo build` the five crates — clean.
- `cargo clippy --all-targets -- -D warnings` the five crates — clean.
- `cargo fmt` the touched crates.
- `cargo test` the five crates — green (cloudwatch 63, ses 263, mq 33, elbv2 30, redshift 53).
- Added a cloudwatch unit test asserting `xml_escape("a\u{0b}b")` does not emit the raw byte and yields `a&#xB;b`, plus a regression check that the five standard entities still escape.
- Existing ses `test_send_bounce_v1_xml_escapes_user_fields` and mq entity-escape assertion still pass (canonical helper escapes the same five entities identically).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes XML escaping across CloudWatch, SES, MQ, ELBv2, and Redshift by routing all code to `fakecloud_aws::xml::xml_escape`, which escapes C0 control characters as numeric references. This keeps XML 1.0 responses valid so strict SDK parsers don’t reject whole documents.

- **Bug Fixes**
  - C0 controls now escape as `&#xN;` in all XML output.
  - Added a CloudWatch test for control chars; existing SES/MQ escape tests still pass.

- **Refactors**
  - Removed per-crate `xml_escape` and re-exported the canonical helper (cloudwatch, ses, elbv2, redshift); switched to `use` in mq.
  - Added `fakecloud-aws` dependency to `fakecloud-mq`.

<sup>Written for commit f961c6eb15ffa16c3f449fc08f6ce47de78a4842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

