### PR TITLE
fix(apigateway,apigatewayv2): AWS_PROXY Lambda function-error -> 502 + v2 payload-2.0 simple response

### DIFF
--- a/crates/fakecloud-apigateway/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigateway/src/lambda_proxy.rs
@@ -198,7 +198,51 @@ pub async fn invoke_lambda(
     parse_lambda_response(resp_json)
 }
 
+/// True when a proxied Lambda response is actually a **function-error**
+/// envelope rather than a proxy response. A handler that throws makes the
+/// Lambda runtime reply HTTP 200 with a body shaped like
+/// `{"errorMessage": "...", "errorType": "...", "stackTrace": [...]}` and
+/// no `statusCode`.
+///
+/// The guard requires BOTH `errorType` AND `errorMessage` as strings AND
+/// the absence of `statusCode` — exactly the check the Lambda `Invoke`
+/// handler and StepFunctions interpreter use. That avoids over-rejecting a
+/// SUCCESSFUL Lambda whose 200 body legitimately carries an `errorMessage`
+/// field: such a response either sets `statusCode` (a proxy response) or is
+/// a plain object, so it will not trip all three conditions.
+fn is_function_error_envelope(response: &serde_json::Value) -> bool {
+    let Some(obj) = response.as_object() else {
+        return false;
+    };
+    obj.get("errorType").and_then(|v| v.as_str()).is_some()
+        && obj.get("errorMessage").and_then(|v| v.as_str()).is_some()
+        && !obj.contains_key("statusCode")
+}
+
+/// AWS's response for a malformed proxy response or a Lambda function
+/// error: HTTP 502 with `{"message":"Internal server error"}` and
+/// `Content-Type: application/json`. Real API Gateway also logs
+/// "Execution failed ... malformed Lambda proxy response".
+fn malformed_proxy_response() -> AwsResponse {
+    AwsResponse {
+        status: StatusCode::BAD_GATEWAY,
+        content_type: "application/json".to_string(),
+        headers: HeaderMap::new(),
+        body: Bytes::from_static(br#"{"message":"Internal server error"}"#).into(),
+    }
+}
+
 fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, AwsServiceError> {
+    // A thrown handler surfaces as a 200 error envelope with no statusCode.
+    // AWS maps a Lambda function error to HTTP 502. A REST (v1) proxy
+    // integration also REQUIRES statusCode on every response, so any
+    // response lacking it — function error or otherwise malformed — is a
+    // 502. (v2 payload format 2.0's statusCode-less "simple response" is
+    // handled separately in the apigatewayv2 parser.)
+    if is_function_error_envelope(&response) || response.get("statusCode").is_none() {
+        return Ok(malformed_proxy_response());
+    }
+
     let status_code = response
         .get("statusCode")
         .and_then(|v| v.as_i64())
@@ -352,6 +396,44 @@ mod tests {
         .unwrap();
         assert_eq!(r.status, StatusCode::CREATED);
         assert_eq!(r.body.expect_bytes(), b"ok".as_slice());
+    }
+
+    #[test]
+    fn parse_lambda_response_function_error_is_502() {
+        // A thrown handler: 200 body with errorType+errorMessage, no
+        // statusCode. REST maps it to 502 {"message":"Internal server error"}.
+        let r = parse_lambda_response(json!({
+            "errorMessage": "boom",
+            "errorType": "RuntimeError",
+            "stackTrace": ["line 1"],
+        }))
+        .unwrap();
+        assert_eq!(r.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(r.content_type, "application/json");
+        assert_eq!(
+            r.body.expect_bytes(),
+            br#"{"message":"Internal server error"}"#.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_lambda_response_no_status_code_is_502() {
+        // A proxy response missing statusCode is malformed -> 502.
+        let r = parse_lambda_response(json!({"body": "ok"})).unwrap();
+        assert_eq!(r.status, StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn parse_lambda_response_success_with_error_message_in_body_not_502() {
+        // A legit success whose body string mentions errorMessage but which
+        // sets statusCode must NOT be turned into a 502.
+        let r = parse_lambda_response(json!({
+            "statusCode": 200,
+            "body": r#"{"errorMessage":"x"}"#,
+        }))
+        .unwrap();
+        assert_eq!(r.status, StatusCode::OK);
+        assert_eq!(r.body.expect_bytes(), br#"{"errorMessage":"x"}"#.as_slice());
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
+++ b/crates/fakecloud-apigatewayv2/src/lambda_proxy.rs
@@ -249,10 +249,16 @@ fn encode_body(req: &AwsRequest) -> (bool, Option<String>) {
 }
 
 /// Invokes a Lambda function via the delivery bus and parses the response.
+///
+/// `payload_v2` reflects the integration's `payloadFormatVersion`: `true`
+/// for the HTTP-API default `"2.0"`, `false` for `"1.0"` (the REST-shaped
+/// envelope). It controls how a response that omits `statusCode` is
+/// interpreted — see [`parse_lambda_response`].
 pub async fn invoke_lambda(
     delivery: &DeliveryBus,
     function_arn: &str,
     event: serde_json::Value,
+    payload_v2: bool,
 ) -> Result<AwsResponse, AwsServiceError> {
     let event_json = serde_json::to_string(&event).map_err(|e| {
         AwsServiceError::aws_error(
@@ -292,11 +298,91 @@ pub async fn invoke_lambda(
             )
         })?;
 
-    parse_lambda_response(response_json)
+    parse_lambda_response(response_json, payload_v2)
 }
 
-/// Parses a Lambda proxy integration response in v2.0 format.
-fn parse_lambda_response(response: serde_json::Value) -> Result<AwsResponse, AwsServiceError> {
+/// True when a proxied Lambda response is actually a **function-error**
+/// envelope rather than a proxy response. A handler that throws makes the
+/// Lambda runtime reply HTTP 200 with a body shaped like
+/// `{"errorMessage": "...", "errorType": "...", "stackTrace": [...]}` and
+/// no `statusCode`.
+///
+/// The guard requires BOTH `errorType` AND `errorMessage` as strings AND
+/// the absence of `statusCode` — exactly the check the Lambda `Invoke`
+/// handler and StepFunctions interpreter use. That avoids over-rejecting a
+/// SUCCESSFUL Lambda whose 200 body legitimately carries an `errorMessage`
+/// field: such a response either sets `statusCode` (proxy response) or is a
+/// plain simple-response object, so it will not trip all three conditions.
+fn is_function_error_envelope(response: &serde_json::Value) -> bool {
+    let Some(obj) = response.as_object() else {
+        return false;
+    };
+    obj.get("errorType").and_then(|v| v.as_str()).is_some()
+        && obj.get("errorMessage").and_then(|v| v.as_str()).is_some()
+        && !obj.contains_key("statusCode")
+}
+
+/// AWS's response for a malformed proxy response or a Lambda function
+/// error: HTTP 502 with `{"message":"Internal server error"}` and
+/// `Content-Type: application/json`.
+fn malformed_proxy_response() -> AwsResponse {
+    AwsResponse {
+        status: StatusCode::BAD_GATEWAY,
+        content_type: "application/json".to_string(),
+        headers: HeaderMap::new(),
+        body: Bytes::from_static(br#"{"message":"Internal server error"}"#).into(),
+    }
+}
+
+/// Parses a Lambda proxy integration response.
+///
+/// `payload_v2` selects how a response lacking `statusCode` is handled:
+/// - `true` (payload format 2.0): a "simple response" — AWS assumes status
+///   200, `Content-Type: application/json`, and serializes the ENTIRE
+///   return value as the body.
+/// - `false` (payload format 1.0, REST-shaped): `statusCode` is required;
+///   its absence is a malformed proxy response and maps to HTTP 502.
+///
+/// A function-error envelope (see [`is_function_error_envelope`]) always
+/// maps to HTTP 502 regardless of `payload_v2`.
+fn parse_lambda_response(
+    response: serde_json::Value,
+    payload_v2: bool,
+) -> Result<AwsResponse, AwsServiceError> {
+    // A thrown handler surfaces as a 200 error envelope with no statusCode.
+    // Detect it BEFORE the simple-response branch so a function error never
+    // gets echoed back to the client as a successful 200.
+    if is_function_error_envelope(&response) {
+        return Ok(malformed_proxy_response());
+    }
+
+    if response.get("statusCode").is_none() {
+        if payload_v2 {
+            // Payload format 2.0 simple response: no statusCode -> 200 with
+            // the whole return value serialized as the JSON body. A plain
+            // string is used verbatim; anything else is JSON-serialized.
+            let body = match &response {
+                serde_json::Value::String(s) => s.clone().into_bytes(),
+                other => serde_json::to_vec(other).map_err(|e| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_GATEWAY,
+                        "BadGatewayException",
+                        format!("Failed to serialize Lambda simple response: {}", e),
+                    )
+                })?,
+            };
+            return Ok(AwsResponse {
+                status: StatusCode::OK,
+                content_type: "application/json".to_string(),
+                headers: HeaderMap::new(),
+                body: Bytes::from(body).into(),
+            });
+        }
+        // Payload format 1.0 (REST-shaped) requires statusCode; its absence
+        // is a malformed proxy response -> 502.
+        return Ok(malformed_proxy_response());
+    }
+
     let status_code = match response.get("statusCode") {
         Some(v) => v.as_i64().ok_or_else(|| {
             AwsServiceError::aws_error(
@@ -528,7 +614,7 @@ mod tests {
             "isBase64Encoded": false
         });
 
-        let result = parse_lambda_response(response).unwrap();
+        let result = parse_lambda_response(response, true).unwrap();
 
         assert_eq!(result.status, StatusCode::OK);
         assert_eq!(result.content_type, "application/json");
@@ -547,7 +633,7 @@ mod tests {
             "isBase64Encoded": true
         });
 
-        let result = parse_lambda_response(response).unwrap();
+        let result = parse_lambda_response(response, true).unwrap();
 
         assert_eq!(result.status, StatusCode::OK);
         assert_eq!(result.body.expect_bytes(), b"binary data".as_slice());
@@ -556,7 +642,7 @@ mod tests {
     #[test]
     fn test_parse_lambda_response_no_body_defaults_empty() {
         let response = json!({"statusCode": 204});
-        let result = parse_lambda_response(response).unwrap();
+        let result = parse_lambda_response(response, true).unwrap();
         assert_eq!(result.status, StatusCode::NO_CONTENT);
         assert!(result.body.expect_bytes().is_empty());
     }
@@ -564,7 +650,7 @@ mod tests {
     #[test]
     fn test_parse_lambda_response_invalid_status_errors() {
         let response = json!({"statusCode": 9999, "body": ""});
-        assert!(parse_lambda_response(response).is_err());
+        assert!(parse_lambda_response(response, true).is_err());
     }
 
     #[test]
@@ -574,7 +660,66 @@ mod tests {
             "body": "not-base64!!!",
             "isBase64Encoded": true
         });
-        assert!(parse_lambda_response(response).is_err());
+        assert!(parse_lambda_response(response, true).is_err());
+    }
+
+    #[test]
+    fn test_parse_lambda_response_function_error_is_502() {
+        // A thrown handler: 200 body with errorType+errorMessage and no
+        // statusCode. Maps to 502 regardless of payload format, and MUST
+        // take priority over the 2.0 simple-response branch.
+        let envelope = json!({
+            "errorMessage": "boom",
+            "errorType": "RuntimeError",
+            "stackTrace": ["line 1"],
+        });
+        for payload_v2 in [true, false] {
+            let r = parse_lambda_response(envelope.clone(), payload_v2).unwrap();
+            assert_eq!(r.status, StatusCode::BAD_GATEWAY, "payload_v2={payload_v2}");
+            assert_eq!(r.content_type, "application/json");
+            assert_eq!(
+                r.body.expect_bytes(),
+                br#"{"message":"Internal server error"}"#.as_slice()
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_lambda_response_v2_simple_response() {
+        // Payload format 2.0, no statusCode: AWS assumes 200 and serializes
+        // the whole return value as the JSON body.
+        let r = parse_lambda_response(json!({"message": "hi"}), true).unwrap();
+        assert_eq!(r.status, StatusCode::OK);
+        assert_eq!(r.content_type, "application/json");
+        assert_eq!(r.body.expect_bytes(), br#"{"message":"hi"}"#.as_slice());
+    }
+
+    #[test]
+    fn test_parse_lambda_response_v2_simple_response_string() {
+        // A bare string return is used verbatim as the body.
+        let r = parse_lambda_response(json!("hello"), true).unwrap();
+        assert_eq!(r.status, StatusCode::OK);
+        assert_eq!(r.body.expect_bytes(), b"hello".as_slice());
+    }
+
+    #[test]
+    fn test_parse_lambda_response_v1_no_status_code_is_502() {
+        // Payload format 1.0 requires statusCode; its absence is malformed.
+        let r = parse_lambda_response(json!({"body": "ok"}), false).unwrap();
+        assert_eq!(r.status, StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_parse_lambda_response_success_with_error_message_in_body_not_502() {
+        // A legit success whose body mentions errorMessage but which sets
+        // statusCode must NOT be turned into a 502 (counter-strategy).
+        let r = parse_lambda_response(
+            json!({"statusCode": 200, "body": r#"{"errorMessage":"x"}"#}),
+            true,
+        )
+        .unwrap();
+        assert_eq!(r.status, StatusCode::OK);
+        assert_eq!(r.body.expect_bytes(), br#"{"errorMessage":"x"}"#.as_slice());
     }
 
     #[test]

--- a/crates/fakecloud-apigatewayv2/src/service/execute.rs
+++ b/crates/fakecloud-apigatewayv2/src/service/execute.rs
@@ -516,12 +516,12 @@ impl ApiGatewayV2Service {
                         // Honour the integration's payloadFormatVersion:
                         // "1.0" sends the REST-shaped envelope, "2.0" (the
                         // default) sends the HTTP-API envelope.
-                        let event = if integration
+                        let is_v1 = integration
                             .payload_format_version
                             .as_deref()
                             .map(|v| v == "1.0")
-                            .unwrap_or(false)
-                        {
+                            .unwrap_or(false);
+                        let event = if is_v1 {
                             lambda_proxy::construct_event_v1(
                                 &req,
                                 &route_match.route.route_key,
@@ -538,7 +538,11 @@ impl ApiGatewayV2Service {
                                 authorizer_info,
                             )
                         };
-                        lambda_proxy::invoke_lambda(delivery, integration_uri, event).await?
+                        // payload_v2 controls simple-response handling: 2.0
+                        // (the default, !is_v1) serializes a statusCode-less
+                        // return value as the body; 1.0 requires statusCode.
+                        lambda_proxy::invoke_lambda(delivery, integration_uri, event, !is_v1)
+                            .await?
                     } else {
                         dispatch_aws_service_integration(delivery, integration_uri, &req)?
                     }

--- a/crates/fakecloud-e2e/tests/apigateway.rs
+++ b/crates/fakecloud-e2e/tests/apigateway.rs
@@ -1087,3 +1087,120 @@ async fn apigw_generate_client_certificate_returns_real_pem() {
         .expect("PEM body is valid base64 DER");
     assert!(der.len() > 100, "decoded certificate is non-trivial");
 }
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn require_docker_or_skip(test: &str) -> bool {
+    if docker_available() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        panic!("docker is required for {test} in CI");
+    }
+    eprintln!("skipping {test}: docker is not available");
+    false
+}
+
+/// A REST (v1) AWS_PROXY Lambda that throws surfaces as HTTP 502
+/// `{"message":"Internal server error"}`, matching real API Gateway, rather
+/// than a 200 echoing the raw `{errorMessage,errorType}` envelope.
+#[tokio::test]
+async fn data_plane_lambda_function_error_returns_502() {
+    if !require_docker_or_skip("data_plane_lambda_function_error_returns_502") {
+        return;
+    }
+    use aws_sdk_lambda::primitives::Blob;
+    use std::io::Write;
+
+    let server = TestServer::start().await;
+    let apigw = server.apigateway_client().await;
+    let lambda = server.lambda_client().await;
+
+    // Package a throwing handler.
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    let opts = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.js", opts).unwrap();
+    writer
+        .write_all(b"exports.handler = async () => { throw new Error('boom'); };")
+        .unwrap();
+    let zip_bytes = writer.finish().unwrap().into_inner();
+
+    lambda
+        .create_function()
+        .function_name("v1-throwing-fn")
+        .runtime(aws_sdk_lambda::types::Runtime::Nodejs20x)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(zip_bytes))
+                .build(),
+        )
+        .send()
+        .await
+        .expect("create_function");
+
+    let api = apigw
+        .create_rest_api()
+        .name("v1-error-api")
+        .send()
+        .await
+        .expect("create_rest_api");
+    let api_id = api.id().unwrap().to_string();
+    let root = api.root_resource_id().unwrap().to_string();
+    let resource = apigw
+        .create_resource()
+        .rest_api_id(&api_id)
+        .parent_id(&root)
+        .path_part("boom")
+        .send()
+        .await
+        .expect("create_resource");
+    let res_id = resource.id().unwrap().to_string();
+    apigw
+        .put_method()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .authorization_type("NONE")
+        .send()
+        .await
+        .expect("put_method");
+    apigw
+        .put_integration()
+        .rest_api_id(&api_id)
+        .resource_id(&res_id)
+        .http_method("GET")
+        .r#type(aws_sdk_apigateway::types::IntegrationType::AwsProxy)
+        .integration_http_method("POST")
+        .uri("arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:v1-throwing-fn/invocations")
+        .send()
+        .await
+        .expect("put_integration");
+    apigw
+        .create_deployment()
+        .rest_api_id(&api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .expect("create_deployment");
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/prod/boom", server.endpoint()))
+        .header("host", execute_api_host(&api_id))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 502);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "Internal server error");
+}

--- a/crates/fakecloud-e2e/tests/apigatewayv2.rs
+++ b/crates/fakecloud-e2e/tests/apigatewayv2.rs
@@ -1218,6 +1218,160 @@ exports.handler = async (event) => {
     assert_eq!(body["queryParams"]["greeting"], "hi");
 }
 
+/// Zip a single-file `index.js` Node handler for Lambda create_function.
+fn zip_node_handler(source: &str) -> Vec<u8> {
+    use std::io::Write;
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("index.js", options).unwrap();
+    writer.write_all(source.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// Stand up an HTTP API (v2) whose `GET /hello` route proxies to a Lambda
+/// created from `handler_source`, returning `(server, invoke_url)`.
+async fn provision_v2_lambda_api(
+    server: &TestServer,
+    fn_name: &str,
+    handler_source: &str,
+    payload_format_version: &str,
+) -> String {
+    use aws_sdk_lambda::primitives::Blob;
+    let lambda_client = server.lambda_client().await;
+    let apigw_client = server.apigatewayv2_client().await;
+
+    lambda_client
+        .create_function()
+        .function_name(fn_name)
+        .runtime(aws_sdk_lambda::types::Runtime::Nodejs20x)
+        .role("arn:aws:iam::123456789012:role/lambda-role")
+        .handler("index.handler")
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .zip_file(Blob::new(zip_node_handler(handler_source)))
+                .build(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let api = apigw_client
+        .create_api()
+        .name(format!("{fn_name}-api"))
+        .protocol_type(aws_sdk_apigatewayv2::types::ProtocolType::Http)
+        .send()
+        .await
+        .unwrap();
+    let api_id = api.api_id().unwrap();
+
+    let integration = apigw_client
+        .create_integration()
+        .api_id(api_id)
+        .integration_type(aws_sdk_apigatewayv2::types::IntegrationType::AwsProxy)
+        .integration_uri(format!(
+            "arn:aws:lambda:us-east-1:123456789012:function:{fn_name}"
+        ))
+        .payload_format_version(payload_format_version)
+        .send()
+        .await
+        .unwrap();
+    let integration_id = integration.integration_id().unwrap();
+
+    apigw_client
+        .create_route()
+        .api_id(api_id)
+        .route_key("GET /hello")
+        .target(format!("integrations/{}", integration_id))
+        .send()
+        .await
+        .unwrap();
+
+    apigw_client
+        .create_stage()
+        .api_id(api_id)
+        .stage_name("prod")
+        .send()
+        .await
+        .unwrap();
+
+    format!("{}/prod/hello", server.endpoint())
+}
+
+/// A Lambda handler that throws must surface as HTTP 502
+/// `{"message":"Internal server error"}`, not a 200 echoing the raw
+/// error envelope.
+#[tokio::test]
+async fn v2_lambda_function_error_returns_502() {
+    if !require_docker_or_skip("v2_lambda_function_error_returns_502") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let url = provision_v2_lambda_api(
+        &server,
+        "v2-throwing-fn",
+        "exports.handler = async () => { throw new Error('boom'); };",
+        "2.0",
+    )
+    .await;
+
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 502);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "Internal server error");
+}
+
+/// Payload format 2.0 "simple response": a plain object with no statusCode
+/// -> HTTP 200 with the whole return value serialized as the JSON body.
+#[tokio::test]
+async fn v2_simple_response_serializes_whole_value() {
+    if !require_docker_or_skip("v2_simple_response_serializes_whole_value") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let url = provision_v2_lambda_api(
+        &server,
+        "v2-simple-fn",
+        "exports.handler = async () => ({ message: 'hi' });",
+        "2.0",
+    )
+    .await;
+
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .map(|v| v.to_str().unwrap().to_string()),
+        Some("application/json".to_string())
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "hi");
+}
+
+/// Regression: a normal proxy response (statusCode + body) still passes
+/// through, AND a success whose body string merely mentions `errorMessage`
+/// (but sets statusCode) is NOT mistaken for a function error.
+#[tokio::test]
+async fn v2_success_with_error_message_in_body_not_502() {
+    if !require_docker_or_skip("v2_success_with_error_message_in_body_not_502") {
+        return;
+    }
+    let server = TestServer::start().await;
+    let url = provision_v2_lambda_api(
+        &server,
+        "v2-legit-fn",
+        r#"exports.handler = async () => ({ statusCode: 200, body: JSON.stringify({ errorMessage: 'x' }) });"#,
+        "2.0",
+    )
+    .await;
+
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["errorMessage"], "x");
+}
+
 #[tokio::test]
 async fn test_cors_actual_request() {
     let server = TestServer::start().await;


### PR DESCRIPTION
## Summary

bug-hunt 2026-07-25 Tier-1 (client/tool compatibility). Two related defects in how the API Gateway AWS_PROXY parsers interpret a proxied Lambda response. Both parsers skipped the function-error detection that the direct Lambda `Invoke` handler and the StepFunctions interpreter already perform, so:

- **Defect 1 (function error -> 200 instead of 502):** when a Lambda handler throws, the runtime replies HTTP 200 with `{"errorMessage","errorType","stackTrace"}` and no `statusCode`. Both parsers (`apigateway/src/lambda_proxy.rs`, `apigatewayv2/src/lambda_proxy.rs`) defaulted the absent `statusCode` to 200 and echoed the raw error envelope to the client. Real AWS returns **HTTP 502 `{"message":"Internal server error"}`** and logs "malformed Lambda proxy response".
- **Defect 2 (v2 payload-format-2.0 simple response -> empty body):** for an HTTP API v2 integration with `payloadFormatVersion = "2.0"`, a plain object/string return with no `statusCode` should be assumed 200, `Content-Type: application/json`, with the **entire return value serialized as the body**. The v2 parser read an absent `response["body"]` and produced an empty body instead.

## Fix

Payload-based detection (not trait-widening) — the parsers already hold the raw Lambda response payload, so this mirrors exactly the check `invoke.rs`/`interpreter.rs` already use and needs no change to `LambdaDelivery::invoke_lambda`. Lower-risk and localized.

- Added `is_function_error_envelope()` to both parsers: a response is a function error only when it has BOTH `errorType` AND `errorMessage` as strings AND no `statusCode`. Maps to 502.
- v1 REST: a response lacking `statusCode` (function error or otherwise malformed) -> 502.
- v2: threaded the integration's `payloadFormatVersion` into `invoke_lambda`/`parse_lambda_response` via a `payload_v2` bool. Format 2.0 + no `statusCode` (and not a function error) -> 200 with the whole value serialized as the JSON body; format 1.0 + no `statusCode` -> 502. Function-error detection runs first so a thrown handler under 2.0 still 502s rather than being serialized as a "simple response".

## Counter-strategy (avoids over-rejecting a legit success)

The guard deliberately requires `errorType` + `errorMessage` (both, as strings) AND the absence of `statusCode` — the same guard as `invoke.rs`. A successful Lambda whose 200 body legitimately contains an `errorMessage` field (e.g. `{statusCode:200, body:"{\"errorMessage\":\"x\"}"}`) sets `statusCode` and is NOT turned into a 502. This is stated explicitly in the code comment on `is_function_error_envelope`.

## Test plan

- Unit tests on `parse_lambda_response` in both crates covering all four cases: function-error envelope -> 502; malformed no-`statusCode` -> 502 (v1 / v2 1.0); v2 2.0 simple response object + bare string -> 200 with serialized body; success-with-errorMessage-in-body (has `statusCode`) -> 200 unchanged. All green.
- E2E tests (Docker-gated, real Lambda): `data_plane_lambda_function_error_returns_502` (v1 REST), `v2_lambda_function_error_returns_502`, `v2_simple_response_serializes_whole_value`, `v2_success_with_error_message_in_body_not_502`. Compiled; skip when Docker is unavailable (they panic in CI where Docker is required).
- `cargo build` / `cargo clippy --all-targets -- -D warnings` clean on all three crates; `cargo fmt` applied; full lib suites green (111 + 173).
- No tfacc suite exists for apigateway/apigatewayv2.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS_PROXY handling in `fakecloud-apigateway` and `fakecloud-apigatewayv2` to match AWS: Lambda function errors now return 502, and v2 payload 2.0 simple responses are serialized correctly. Prevents accidental 200s with error envelopes and empty bodies.

- **Bug Fixes**
  - Detect Lambda function-error envelopes (`errorType` + `errorMessage`, no `statusCode`) and return 502 with `{"message":"Internal server error"}`.
  - For v2 `payloadFormatVersion: "2.0"`, a response without `statusCode` returns 200 with the entire value as the JSON body (strings echo verbatim).
  - For v1 REST and v2 `"1.0"`, responses without `statusCode` are treated as malformed and return 502.

<sup>Written for commit 863fd35c8ccd88985722acd61c144fce8f0a2054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

