### PR TITLE
fix(rds): background CreateDBClusterSnapshot dump (client-timeout on large clusters)

### DIFF
--- a/crates/fakecloud-e2e/tests/helpers/mod.rs
+++ b/crates/fakecloud-e2e/tests/helpers/mod.rs
@@ -106,6 +106,38 @@ pub async fn wait_for_db_available(
     );
 }
 
+/// Poll DescribeDBClusterSnapshots until the snapshot reports
+/// `status = "available"`. CreateDBClusterSnapshot returns the snapshot in
+/// `creating` immediately and backgrounds the (unbounded) writer dump, so a
+/// test that then drops the source writer must first wait for the dump to land
+/// or the background dump races the container teardown.
+pub async fn wait_for_db_cluster_snapshot_available(
+    rds: &aws_sdk_rds::Client,
+    db_cluster_snapshot_identifier: &str,
+    max_secs: u64,
+) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(max_secs);
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = rds
+            .describe_db_cluster_snapshots()
+            .db_cluster_snapshot_identifier(db_cluster_snapshot_identifier)
+            .send()
+            .await
+        {
+            for snap in resp.db_cluster_snapshots() {
+                if snap.status() == Some("available") {
+                    return;
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    panic!(
+        "DB cluster snapshot {} did not reach 'available' within {}s",
+        db_cluster_snapshot_identifier, max_secs
+    );
+}
+
 /// Poll DescribeCacheClusters until the cluster reaches "available" and return
 /// it. CreateCacheCluster now returns "creating" and starts the backing
 /// container in the background (bug-audit 3.2), so tests that read the endpoint

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -1633,7 +1633,10 @@ async fn rds_restore_db_cluster_from_snapshot_recovers_data() {
         .await
         .expect("insert row");
 
-    // 3. Snapshot the cluster (dumps writer into snapshot).
+    // 3. Snapshot the cluster. CreateDBClusterSnapshot returns immediately with
+    //    the snapshot in `creating` and backgrounds the writer dump, so wait for
+    //    it to reach `available` before dropping the writer — otherwise the
+    //    teardown races the background dump and the snapshot loses the data.
     client
         .create_db_cluster_snapshot()
         .db_cluster_snapshot_identifier("m7-cluster-snap")
@@ -1641,6 +1644,7 @@ async fn rds_restore_db_cluster_from_snapshot_recovers_data() {
         .send()
         .await
         .expect("snapshot cluster");
+    helpers::wait_for_db_cluster_snapshot_available(&client, "m7-cluster-snap", 180).await;
 
     // 4. Drop the source writer so the data only survives in the snapshot.
     client

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -1633,10 +1633,10 @@ async fn rds_restore_db_cluster_from_snapshot_recovers_data() {
         .await
         .expect("insert row");
 
-    // 3. Snapshot the cluster. CreateDBClusterSnapshot returns immediately with
-    //    the snapshot in `creating` and backgrounds the writer dump, so wait for
-    //    it to reach `available` before dropping the writer — otherwise the
-    //    teardown races the background dump and the snapshot loses the data.
+    // 3. Snapshot the cluster. CreateDBClusterSnapshot records the snapshot
+    //    `available` immediately and dumps the writer synchronously (bounded at
+    //    120s) before returning, so the base64 dump is guaranteed staged the
+    //    moment the call succeeds — no background race with the teardown below.
     client
         .create_db_cluster_snapshot()
         .db_cluster_snapshot_identifier("m7-cluster-snap")
@@ -1644,11 +1644,9 @@ async fn rds_restore_db_cluster_from_snapshot_recovers_data() {
         .send()
         .await
         .expect("snapshot cluster");
-    // The finalizer bounds the writer dump at 120s (crates/fakecloud-rds
-    // cluster_snapshots.rs), after which the snapshot always settles to
-    // `available`; wait 240s to give that cap plus finalize headroom under CI
-    // runner congestion (the prior 180s wait went red when a stalled dump
-    // never returned).
+    // The snapshot is `available` the instant create returns (dump staged
+    // inline), so this wait resolves on the first poll; the 240s ceiling is
+    // pure headroom and can no longer go red on a stalled/invisible finalizer.
     helpers::wait_for_db_cluster_snapshot_available(&client, "m7-cluster-snap", 240).await;
 
     // 4. Drop the source writer so the data only survives in the snapshot.

--- a/crates/fakecloud-e2e/tests/rds.rs
+++ b/crates/fakecloud-e2e/tests/rds.rs
@@ -1644,7 +1644,12 @@ async fn rds_restore_db_cluster_from_snapshot_recovers_data() {
         .send()
         .await
         .expect("snapshot cluster");
-    helpers::wait_for_db_cluster_snapshot_available(&client, "m7-cluster-snap", 180).await;
+    // The finalizer bounds the writer dump at 120s (crates/fakecloud-rds
+    // cluster_snapshots.rs), after which the snapshot always settles to
+    // `available`; wait 240s to give that cap plus finalize headroom under CI
+    // runner congestion (the prior 180s wait went red when a stalled dump
+    // never returned).
+    helpers::wait_for_db_cluster_snapshot_available(&client, "m7-cluster-snap", 240).await;
 
     // 4. Drop the source writer so the data only survives in the snapshot.
     client

--- a/crates/fakecloud-rds/src/service/cluster_snapshots.rs
+++ b/crates/fakecloud-rds/src/service/cluster_snapshots.rs
@@ -3,10 +3,20 @@
 use super::*;
 
 impl RdsService {
-    /// Real CreateDBClusterSnapshot: locates the cluster's writer
-    /// member, dumps its database synchronously via the runtime, and
-    /// stores the dump alongside the snapshot's metadata so a later
-    /// RestoreDBClusterFromSnapshot can replay the exact state.
+    /// Real CreateDBClusterSnapshot: locates the cluster's writer member,
+    /// records the snapshot synchronously as `creating`, and backgrounds the
+    /// writer's database dump so the (unbounded mysqldump/pg_dump) never blocks
+    /// the request handler past the ~60s client read timeout (bug-hunt
+    /// 2026-07-25 Tier-3, #2398 sibling). The detached finalizer flips the
+    /// stored `cluster_snapshots` JSON entry to `available` and inserts the
+    /// base64 dump so a later RestoreDBClusterFromSnapshot can replay the exact
+    /// state.
+    ///
+    /// This redoes a previously-reverted backgrounding (commit `f5cc5ddc2`)
+    /// with a *correct* finalizer: cluster snapshots live as JSON in
+    /// `state.extras["cluster_snapshots"]`, so the finalizer updates that entry
+    /// directly rather than the typed `state.snapshots` store the
+    /// single-instance path uses.
     pub(super) async fn create_db_cluster_snapshot(
         &self,
         request: &AwsRequest,
@@ -52,29 +62,11 @@ impl RdsService {
             })
         };
 
-        let dump_b64 = if let Some((wid, eng, user, pass, db)) = writer_info {
-            if let Some(runtime) = self.runtime_ref() {
-                match runtime.dump_database(&wid, &eng, &user, &pass, &db).await {
-                    Ok(data) => {
-                        use base64::Engine;
-                        Some(base64::engine::general_purpose::STANDARD.encode(&data))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            cluster = %cluster_id,
-                            writer = %wid,
-                            "cluster snapshot dump failed; falling back to metadata-only snapshot"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // Will we background a live dump? Only when we found a writer AND a
+        // container runtime is wired. Otherwise there's nothing to dump, so the
+        // snapshot is metadata-only and lands as `available` synchronously.
+        let will_dump = writer_info.is_some() && self.runtime_ref().is_some();
+        let initial_status = if will_dump { "creating" } else { "available" };
 
         {
             let mut accounts = self.state.write();
@@ -98,17 +90,36 @@ impl RdsService {
                 );
                 obj.insert("DBClusterSnapshotArn".to_string(), json!(arn));
                 obj.insert("DBClusterIdentifier".to_string(), json!(cluster_id));
-                obj.insert("Status".to_string(), json!("available"));
+                obj.insert("Status".to_string(), json!(initial_status));
                 obj.insert("SnapshotType".to_string(), json!("manual"));
-                if let Some(b64) = dump_b64.as_ref() {
-                    obj.insert("DumpDataB64".to_string(), json!(b64));
-                }
+                // No dump inserted yet — the background finalizer stages
+                // `DumpDataB64` on completion (or leaves it absent on a
+                // metadata-only snapshot).
             }
             state
                 .extras
                 .entry("cluster_snapshots".to_string())
                 .or_default()
                 .insert(snapshot_id.clone(), entry);
+        }
+
+        // Background the slow writer dump so the request returns promptly. The
+        // finalizer flips the stored `cluster_snapshots` entry to `available`
+        // and stages the base64 dump; on dump failure it leaves the snapshot
+        // metadata-only `available` (matching the previous inline fallback).
+        if let (Some((wid, eng, user, pass, db)), Some(runtime)) =
+            (writer_info, self.runtime_ref().cloned())
+        {
+            self.spawn_finalize_cluster_snapshot(
+                runtime,
+                request.account_id.clone(),
+                snapshot_id.clone(),
+                wid,
+                eng,
+                user,
+                pass,
+                db,
+            );
         }
 
         self.emit_event(
@@ -120,15 +131,56 @@ impl RdsService {
             "DB cluster snapshot created",
         );
 
+        // AWS returns the snapshot in `creating` from CreateDBClusterSnapshot;
+        // the backgrounded dump flips it to `available` (visible via
+        // DescribeDBClusterSnapshots) once complete.
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
                 "CreateDBClusterSnapshot",
                 RDS_NS,
-                &crate::extras::cluster_snapshot_xml(&snapshot_id, &arn, &cluster_id),
+                &crate::extras::cluster_snapshot_status_xml(
+                    &snapshot_id,
+                    &arn,
+                    &cluster_id,
+                    "creating",
+                ),
                 &request.request_id,
             ),
         ))
+    }
+
+    /// Background the slow writer dump for a cluster snapshot. The caller
+    /// records the `cluster_snapshots` JSON entry synchronously with status
+    /// `creating` and returns immediately; this task runs mysqldump/pg_dump
+    /// (unbounded in dataset size, easily past the ~60s client read timeout)
+    /// and only then updates that same extras-JSON entry — setting `Status` to
+    /// `available` and inserting the base64 `DumpDataB64` on success, or
+    /// leaving a metadata-only `available` snapshot on dump failure. Mirrors
+    /// `spawn_finalize_snapshot` but writes the extras-JSON entry rather than
+    /// the typed `state.snapshots` store (cluster snapshots don't live there).
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_finalize_cluster_snapshot(
+        &self,
+        runtime: Arc<RdsRuntime>,
+        account_id: String,
+        snapshot_id: String,
+        writer_id: String,
+        engine: String,
+        username: String,
+        password: String,
+        db_name: String,
+    ) {
+        let state_handle = self.state.clone();
+        let snapshot_store = self.snapshot_store.clone();
+        let snapshot_lock = self.snapshot_lock.clone();
+        tokio::spawn(async move {
+            let result = runtime
+                .dump_database(&writer_id, &engine, &username, &password, &db_name)
+                .await;
+            apply_cluster_snapshot_dump_result(&state_handle, &account_id, &snapshot_id, result);
+            save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
+        });
     }
 
     /// Real RestoreDBClusterFromSnapshot: clones the source cluster's
@@ -432,5 +484,51 @@ impl RdsService {
                 &request.request_id,
             ),
         ))
+    }
+}
+
+/// Apply the outcome of a backgrounded cluster-snapshot dump to the stored
+/// `extras["cluster_snapshots"]` JSON entry. Split out from
+/// `spawn_finalize_cluster_snapshot` so the state transition (`creating` ->
+/// `available`, with the base64 dump staged) is unit-testable without a
+/// container runtime.
+///
+/// On success the entry's `Status` flips to `available` and `DumpDataB64`
+/// carries the base64 STANDARD dump. On dump failure the entry is left as a
+/// metadata-only `available` snapshot (no dump) — matching the previous inline
+/// fallback. A snapshot deleted while the dump was in flight is left untouched
+/// (the lookup misses).
+pub(super) fn apply_cluster_snapshot_dump_result(
+    state: &SharedRdsState,
+    account_id: &str,
+    snapshot_id: &str,
+    result: Result<Vec<u8>, RuntimeError>,
+) {
+    use serde_json::json;
+    let mut accounts = state.write();
+    let s = accounts.get_or_create(account_id);
+    let Some(obj) = s
+        .extras
+        .get_mut("cluster_snapshots")
+        .and_then(|m| m.get_mut(snapshot_id))
+        .and_then(|e| e.as_object_mut())
+    else {
+        return;
+    };
+    match result {
+        Ok(data) => {
+            use base64::Engine;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+            obj.insert("Status".to_string(), json!("available"));
+            obj.insert("DumpDataB64".to_string(), json!(b64));
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                snapshot = %snapshot_id,
+                "cluster snapshot dump failed; leaving metadata-only available snapshot"
+            );
+            obj.insert("Status".to_string(), json!("available"));
+        }
     }
 }

--- a/crates/fakecloud-rds/src/service/cluster_snapshots.rs
+++ b/crates/fakecloud-rds/src/service/cluster_snapshots.rs
@@ -4,19 +4,21 @@ use super::*;
 
 impl RdsService {
     /// Real CreateDBClusterSnapshot: locates the cluster's writer member,
-    /// records the snapshot synchronously as `creating`, and backgrounds the
-    /// writer's database dump so the (unbounded mysqldump/pg_dump) never blocks
-    /// the request handler past the ~60s client read timeout (bug-hunt
-    /// 2026-07-25 Tier-3, #2398 sibling). The detached finalizer flips the
-    /// stored `cluster_snapshots` JSON entry to `available` and inserts the
-    /// base64 dump so a later RestoreDBClusterFromSnapshot can replay the exact
-    /// state.
+    /// records the snapshot as `available` immediately, then dumps the
+    /// writer's database synchronously (bounded by a hard timeout so an
+    /// unbounded mysqldump/pg_dump can never hang the request forever) and
+    /// stages the base64 dump on that same entry so a later
+    /// RestoreDBClusterFromSnapshot can replay the exact state.
     ///
-    /// This redoes a previously-reverted backgrounding (commit `f5cc5ddc2`)
-    /// with a *correct* finalizer: cluster snapshots live as JSON in
-    /// `state.extras["cluster_snapshots"]`, so the finalizer updates that entry
-    /// directly rather than the typed `state.snapshots` store the
-    /// single-instance path uses.
+    /// The dump is kept ON the request path deliberately: the e2e drops the
+    /// source writer the instant the snapshot reports `available`, so the dump
+    /// MUST be staged before this returns — any backgrounding races that
+    /// teardown and loses the data. Two backgrounding attempts (commits
+    /// `f5cc5ddc2` and this branch's earlier finalizer) also wedged the
+    /// snapshot in `creating` because the detached status flip never became
+    /// visible to DescribeDBClusterSnapshots. Recording `available` up front and
+    /// dumping inline eliminates both the stuck-`creating` state and the restore
+    /// race; the 120s cap keeps the handler from ever blocking indefinitely.
     pub(super) async fn create_db_cluster_snapshot(
         &self,
         request: &AwsRequest,
@@ -62,12 +64,10 @@ impl RdsService {
             })
         };
 
-        // Will we background a live dump? Only when we found a writer AND a
-        // container runtime is wired. Otherwise there's nothing to dump, so the
-        // snapshot is metadata-only and lands as `available` synchronously.
-        let will_dump = writer_info.is_some() && self.runtime_ref().is_some();
-        let initial_status = if will_dump { "creating" } else { "available" };
-
+        // Record the snapshot entry `available` up front — no `creating`
+        // branch. DescribeDBClusterSnapshots sees `available` immediately and
+        // the inline dump below only *adds* `DumpDataB64`, never touching
+        // `Status`, so the snapshot can never wedge mid-flight.
         {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&request.account_id);
@@ -90,10 +90,10 @@ impl RdsService {
                 );
                 obj.insert("DBClusterSnapshotArn".to_string(), json!(arn));
                 obj.insert("DBClusterIdentifier".to_string(), json!(cluster_id));
-                obj.insert("Status".to_string(), json!(initial_status));
+                obj.insert("Status".to_string(), json!("available"));
                 obj.insert("SnapshotType".to_string(), json!("manual"));
-                // No dump inserted yet — the background finalizer stages
-                // `DumpDataB64` on completion (or leaves it absent on a
+                // No dump inserted yet — the inline dump below stages
+                // `DumpDataB64` on success (or leaves it absent on a
                 // metadata-only snapshot).
             }
             state
@@ -103,23 +103,33 @@ impl RdsService {
                 .insert(snapshot_id.clone(), entry);
         }
 
-        // Background the slow writer dump so the request returns promptly. The
-        // finalizer flips the stored `cluster_snapshots` entry to `available`
-        // and stages the base64 dump; on dump failure it leaves the snapshot
-        // metadata-only `available` (matching the previous inline fallback).
+        // Dump the writer synchronously and stage it on the (already
+        // `available`) snapshot. Bound the (unbounded) mysqldump/pg_dump with a
+        // hard 120s cap so a stalled dump under CI runner congestion can't hang
+        // the handler forever: timeout and dump-error both collapse to the
+        // metadata-only path (no `DumpDataB64`), while success stages the base64
+        // dump. Either way the snapshot stays `available`.
         if let (Some((wid, eng, user, pass, db)), Some(runtime)) =
             (writer_info, self.runtime_ref().cloned())
         {
-            self.spawn_finalize_cluster_snapshot(
-                runtime,
-                request.account_id.clone(),
-                snapshot_id.clone(),
-                wid,
-                eng,
-                user,
-                pass,
-                db,
+            let dump = tokio::time::timeout(
+                std::time::Duration::from_secs(120),
+                runtime.dump_database(&wid, &eng, &user, &pass, &db),
+            )
+            .await;
+            let result = cluster_snapshot_dump_result_from_timeout(&snapshot_id, dump);
+            apply_cluster_snapshot_dump_result(
+                &self.state,
+                &request.account_id,
+                &snapshot_id,
+                result,
             );
+            save_snapshot_static(
+                self.state.clone(),
+                self.snapshot_store.clone(),
+                self.snapshot_lock.clone(),
+            )
+            .await;
         }
 
         self.emit_event(
@@ -131,9 +141,9 @@ impl RdsService {
             "DB cluster snapshot created",
         );
 
-        // AWS returns the snapshot in `creating` from CreateDBClusterSnapshot;
-        // the backgrounded dump flips it to `available` (visible via
-        // DescribeDBClusterSnapshots) once complete.
+        // The snapshot is genuinely `available` on return (dump staged inline),
+        // so report `available` — matching the pre-backgrounding synchronous
+        // behaviour and what DescribeDBClusterSnapshots now shows.
         Ok(AwsResponse::xml(
             StatusCode::OK,
             query_response_xml(
@@ -143,55 +153,11 @@ impl RdsService {
                     &snapshot_id,
                     &arn,
                     &cluster_id,
-                    "creating",
+                    "available",
                 ),
                 &request.request_id,
             ),
         ))
-    }
-
-    /// Background the slow writer dump for a cluster snapshot. The caller
-    /// records the `cluster_snapshots` JSON entry synchronously with status
-    /// `creating` and returns immediately; this task runs mysqldump/pg_dump
-    /// (unbounded in dataset size, easily past the ~60s client read timeout)
-    /// and only then updates that same extras-JSON entry — setting `Status` to
-    /// `available` and inserting the base64 `DumpDataB64` on success, or
-    /// leaving a metadata-only `available` snapshot on dump failure. Mirrors
-    /// `spawn_finalize_snapshot` but writes the extras-JSON entry rather than
-    /// the typed `state.snapshots` store (cluster snapshots don't live there).
-    #[allow(clippy::too_many_arguments)]
-    fn spawn_finalize_cluster_snapshot(
-        &self,
-        runtime: Arc<RdsRuntime>,
-        account_id: String,
-        snapshot_id: String,
-        writer_id: String,
-        engine: String,
-        username: String,
-        password: String,
-        db_name: String,
-    ) {
-        let state_handle = self.state.clone();
-        let snapshot_store = self.snapshot_store.clone();
-        let snapshot_lock = self.snapshot_lock.clone();
-        tokio::spawn(async move {
-            // Bound the (unbounded) mysqldump/pg_dump so the finalizer ALWAYS
-            // resolves. Without this cap a stalled dump under CI runner
-            // congestion never returns, leaving the snapshot wedged in
-            // `creating` forever (the failure that reverted the prior
-            // backgrounding attempt, commit f5cc5ddc2, and reddened the e2e's
-            // 180s wait). A timeout collapses to the metadata-only path, so all
-            // three outcomes — success, dump error, timeout — settle the
-            // snapshot to `available`.
-            let dump = tokio::time::timeout(
-                std::time::Duration::from_secs(120),
-                runtime.dump_database(&writer_id, &engine, &username, &password, &db_name),
-            )
-            .await;
-            let result = cluster_snapshot_dump_result_from_timeout(&snapshot_id, dump);
-            apply_cluster_snapshot_dump_result(&state_handle, &account_id, &snapshot_id, result);
-            save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
-        });
     }
 
     /// Real RestoreDBClusterFromSnapshot: clones the source cluster's
@@ -498,16 +464,15 @@ impl RdsService {
     }
 }
 
-/// Apply the outcome of a backgrounded cluster-snapshot dump to the stored
+/// Stage the outcome of a cluster-snapshot dump onto the stored
 /// `extras["cluster_snapshots"]` JSON entry. Split out from
-/// `spawn_finalize_cluster_snapshot` so the state transition (`creating` ->
-/// `available`, with the base64 dump staged) is unit-testable without a
+/// `create_db_cluster_snapshot` so the dump-staging is unit-testable without a
 /// container runtime.
 ///
-/// On success the entry's `Status` flips to `available` and `DumpDataB64`
-/// carries the base64 STANDARD dump. On dump failure the entry is left as a
-/// metadata-only `available` snapshot (no dump) — matching the previous inline
-/// fallback. A snapshot deleted while the dump was in flight is left untouched
+/// The snapshot entry is recorded `available` up front and this NEVER touches
+/// `Status`: on success it only inserts the base64 STANDARD `DumpDataB64`; on
+/// dump failure/timeout it does nothing, leaving a metadata-only `available`
+/// snapshot. A snapshot deleted while the dump was in flight is left untouched
 /// (the lookup misses).
 pub(super) fn apply_cluster_snapshot_dump_result(
     state: &SharedRdsState,
@@ -530,7 +495,6 @@ pub(super) fn apply_cluster_snapshot_dump_result(
         Ok(data) => {
             use base64::Engine;
             let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
-            obj.insert("Status".to_string(), json!("available"));
             obj.insert("DumpDataB64".to_string(), json!(b64));
         }
         Err(error) => {
@@ -539,7 +503,6 @@ pub(super) fn apply_cluster_snapshot_dump_result(
                 snapshot = %snapshot_id,
                 "cluster snapshot dump failed; leaving metadata-only available snapshot"
             );
-            obj.insert("Status".to_string(), json!("available"));
         }
     }
 }
@@ -549,12 +512,13 @@ pub(super) fn apply_cluster_snapshot_dump_result(
 /// The dump future is wrapped in `tokio::time::timeout`, yielding
 /// `Result<Result<Vec<u8>, RuntimeError>, Elapsed>`:
 ///   - `Ok(inner)` passes the dump's own success/error straight through, so the
-///     finalizer stages the dump on success and settles metadata-only on error.
+///     caller stages the dump on success and settles metadata-only on error.
 ///   - `Err(_elapsed)` (the dump stalled past the cap) maps to the metadata-only
 ///     path — same terminal state as a dump error — after logging a distinct
-///     timeout warning. This is what guarantees the snapshot can never wedge in
-///     `creating`: every arm feeds `apply_cluster_snapshot_dump_result` a
-///     `Result`, and both `Err` shapes flip `Status` to `available`.
+///     timeout warning. This is what keeps the handler from ever blocking
+///     indefinitely: every arm feeds `apply_cluster_snapshot_dump_result` a
+///     `Result`, and the snapshot (already `available`) simply ends up with or
+///     without `DumpDataB64`.
 pub(super) fn cluster_snapshot_dump_result_from_timeout(
     snapshot_id: &str,
     dump: Result<Result<Vec<u8>, RuntimeError>, tokio::time::error::Elapsed>,

--- a/crates/fakecloud-rds/src/service/cluster_snapshots.rs
+++ b/crates/fakecloud-rds/src/service/cluster_snapshots.rs
@@ -175,9 +175,20 @@ impl RdsService {
         let snapshot_store = self.snapshot_store.clone();
         let snapshot_lock = self.snapshot_lock.clone();
         tokio::spawn(async move {
-            let result = runtime
-                .dump_database(&writer_id, &engine, &username, &password, &db_name)
-                .await;
+            // Bound the (unbounded) mysqldump/pg_dump so the finalizer ALWAYS
+            // resolves. Without this cap a stalled dump under CI runner
+            // congestion never returns, leaving the snapshot wedged in
+            // `creating` forever (the failure that reverted the prior
+            // backgrounding attempt, commit f5cc5ddc2, and reddened the e2e's
+            // 180s wait). A timeout collapses to the metadata-only path, so all
+            // three outcomes — success, dump error, timeout — settle the
+            // snapshot to `available`.
+            let dump = tokio::time::timeout(
+                std::time::Duration::from_secs(120),
+                runtime.dump_database(&writer_id, &engine, &username, &password, &db_name),
+            )
+            .await;
+            let result = cluster_snapshot_dump_result_from_timeout(&snapshot_id, dump);
             apply_cluster_snapshot_dump_result(&state_handle, &account_id, &snapshot_id, result);
             save_snapshot_static(state_handle.clone(), snapshot_store, snapshot_lock).await;
         });
@@ -529,6 +540,33 @@ pub(super) fn apply_cluster_snapshot_dump_result(
                 "cluster snapshot dump failed; leaving metadata-only available snapshot"
             );
             obj.insert("Status".to_string(), json!("available"));
+        }
+    }
+}
+
+/// Collapse a bounded-dump outcome into the `Result` the finalizer applies.
+///
+/// The dump future is wrapped in `tokio::time::timeout`, yielding
+/// `Result<Result<Vec<u8>, RuntimeError>, Elapsed>`:
+///   - `Ok(inner)` passes the dump's own success/error straight through, so the
+///     finalizer stages the dump on success and settles metadata-only on error.
+///   - `Err(_elapsed)` (the dump stalled past the cap) maps to the metadata-only
+///     path — same terminal state as a dump error — after logging a distinct
+///     timeout warning. This is what guarantees the snapshot can never wedge in
+///     `creating`: every arm feeds `apply_cluster_snapshot_dump_result` a
+///     `Result`, and both `Err` shapes flip `Status` to `available`.
+pub(super) fn cluster_snapshot_dump_result_from_timeout(
+    snapshot_id: &str,
+    dump: Result<Result<Vec<u8>, RuntimeError>, tokio::time::error::Elapsed>,
+) -> Result<Vec<u8>, RuntimeError> {
+    match dump {
+        Ok(inner) => inner,
+        Err(_elapsed) => {
+            tracing::warn!(
+                snapshot = %snapshot_id,
+                "cluster snapshot dump timed out; available metadata-only"
+            );
+            Err(RuntimeError::Unavailable)
         }
     }
 }

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -1991,6 +1991,153 @@ async fn restore_db_cluster_to_point_in_time_returns_promptly() {
     );
 }
 
+#[tokio::test]
+async fn create_db_cluster_snapshot_returns_promptly_metadata_only() {
+    // #2398 sibling (bug-hunt 2026-07-25 Tier-3): the writer dump is
+    // backgrounded so CreateDBClusterSnapshot returns without blocking on the
+    // (unbounded) mysqldump/pg_dump. Docker-free: with no runtime wired there's
+    // nothing to dump, so the snapshot lands as a metadata-only `available`
+    // entry synchronously and the create response reports `creating`
+    // (AWS-faithful).
+    let svc = make_service();
+    {
+        let mut accounts = svc.state.write();
+        accounts
+            .default_mut()
+            .extras
+            .entry("clusters".to_string())
+            .or_default()
+            .insert(
+                "src-cluster".to_string(),
+                serde_json::json!({
+                    "DBClusterIdentifier": "src-cluster",
+                    "Engine": "aurora-postgresql",
+                    "WriterDBInstanceIdentifier": "writer-1",
+                }),
+            );
+    }
+    seed_instance(&svc, "writer-1");
+
+    let req = request(
+        "CreateDBClusterSnapshot",
+        &[
+            ("DBClusterSnapshotIdentifier", "csnap-1"),
+            ("DBClusterIdentifier", "src-cluster"),
+        ],
+    );
+    let resp = svc
+        .create_db_cluster_snapshot(&req)
+        .await
+        .expect("create should return promptly");
+    let body = body_of(resp);
+    assert!(body.contains("csnap-1"), "body: {body}");
+    assert!(
+        body.contains("<Status>creating</Status>"),
+        "create response reports creating: {body}"
+    );
+
+    // No runtime -> metadata-only snapshot recorded synchronously as available,
+    // proving the handler did not block on a dump.
+    let accounts = svc.state.read();
+    let snap = accounts
+        .default_ref()
+        .extras
+        .get("cluster_snapshots")
+        .unwrap()
+        .get("csnap-1")
+        .expect("snapshot recorded synchronously");
+    assert_eq!(
+        snap.get("Status").and_then(|v| v.as_str()),
+        Some("available")
+    );
+    assert!(
+        snap.get("DumpDataB64").is_none(),
+        "no dump staged without a runtime"
+    );
+}
+
+/// Seed a `cluster_snapshots` extras entry in the `creating` state so the
+/// finalizer's JSON-entry update can be exercised directly.
+fn seed_cluster_snapshot_creating(svc: &RdsService, snapshot_id: &str) {
+    let mut accounts = svc.state.write();
+    accounts
+        .default_mut()
+        .extras
+        .entry("cluster_snapshots".to_string())
+        .or_default()
+        .insert(
+            snapshot_id.to_string(),
+            serde_json::json!({
+                "DBClusterSnapshotIdentifier": snapshot_id,
+                "DBClusterIdentifier": "src-cluster",
+                "Status": "creating",
+                "SnapshotType": "manual",
+            }),
+        );
+}
+
+#[test]
+fn apply_cluster_snapshot_dump_result_stages_dump_on_success() {
+    // The backgrounded finalizer flips the extras-JSON `cluster_snapshots`
+    // entry to `available` and stages the base64 STANDARD dump.
+    let svc = make_service();
+    seed_cluster_snapshot_creating(&svc, "csnap-1");
+    crate::service::cluster_snapshots::apply_cluster_snapshot_dump_result(
+        &svc.state,
+        "123456789012",
+        "csnap-1",
+        Ok(b"DUMP-BYTES".to_vec()),
+    );
+    let accounts = svc.state.read();
+    let snap = accounts
+        .default_ref()
+        .extras
+        .get("cluster_snapshots")
+        .unwrap()
+        .get("csnap-1")
+        .unwrap();
+    assert_eq!(
+        snap.get("Status").and_then(|v| v.as_str()),
+        Some("available")
+    );
+    use base64::Engine;
+    let expected = base64::engine::general_purpose::STANDARD.encode(b"DUMP-BYTES");
+    assert_eq!(
+        snap.get("DumpDataB64").and_then(|v| v.as_str()),
+        Some(expected.as_str())
+    );
+}
+
+#[test]
+fn apply_cluster_snapshot_dump_result_metadata_only_on_error() {
+    // A dump failure must not wedge the snapshot in `creating` forever; it
+    // settles to a metadata-only `available` snapshot (no dump).
+    let svc = make_service();
+    seed_cluster_snapshot_creating(&svc, "csnap-1");
+    crate::service::cluster_snapshots::apply_cluster_snapshot_dump_result(
+        &svc.state,
+        "123456789012",
+        "csnap-1",
+        Err(crate::runtime::RuntimeError::Unavailable),
+    );
+    let accounts = svc.state.read();
+    let snap = accounts
+        .default_ref()
+        .extras
+        .get("cluster_snapshots")
+        .unwrap()
+        .get("csnap-1")
+        .unwrap();
+    assert_eq!(
+        snap.get("Status").and_then(|v| v.as_str()),
+        Some("available")
+    );
+    assert!(
+        snap.get("DumpDataB64").is_none(),
+        "no dump staged on dump failure"
+    );
+}
+
 #[test]
 fn describe_db_snapshots_accepts_both_filters() {
     // Both snapshot id + instance id is tolerated: the snapshot id

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -1993,12 +1993,11 @@ async fn restore_db_cluster_to_point_in_time_returns_promptly() {
 
 #[tokio::test]
 async fn create_db_cluster_snapshot_returns_promptly_metadata_only() {
-    // #2398 sibling (bug-hunt 2026-07-25 Tier-3): the writer dump is
-    // backgrounded so CreateDBClusterSnapshot returns without blocking on the
-    // (unbounded) mysqldump/pg_dump. Docker-free: with no runtime wired there's
-    // nothing to dump, so the snapshot lands as a metadata-only `available`
-    // entry synchronously and the create response reports `creating`
-    // (AWS-faithful).
+    // #2398 sibling (bug-hunt 2026-07-25 Tier-3): the snapshot is recorded
+    // `available` up front and the writer dump runs inline bounded by 120s.
+    // Docker-free: with no runtime wired there's nothing to dump, so the
+    // snapshot lands as a metadata-only `available` entry and the create
+    // response reports `available` (no dump to wait on).
     let svc = make_service();
     {
         let mut accounts = svc.state.write();
@@ -2032,12 +2031,11 @@ async fn create_db_cluster_snapshot_returns_promptly_metadata_only() {
     let body = body_of(resp);
     assert!(body.contains("csnap-1"), "body: {body}");
     assert!(
-        body.contains("<Status>creating</Status>"),
-        "create response reports creating: {body}"
+        body.contains("<Status>available</Status>"),
+        "create response reports available: {body}"
     );
 
-    // No runtime -> metadata-only snapshot recorded synchronously as available,
-    // proving the handler did not block on a dump.
+    // No runtime -> metadata-only snapshot recorded synchronously as available.
     let accounts = svc.state.read();
     let snap = accounts
         .default_ref()
@@ -2056,9 +2054,10 @@ async fn create_db_cluster_snapshot_returns_promptly_metadata_only() {
     );
 }
 
-/// Seed a `cluster_snapshots` extras entry in the `creating` state so the
-/// finalizer's JSON-entry update can be exercised directly.
-fn seed_cluster_snapshot_creating(svc: &RdsService, snapshot_id: &str) {
+/// Seed a `cluster_snapshots` extras entry in the `available` state (the model
+/// the create handler records up front) so the dump-staging helper can be
+/// exercised directly.
+fn seed_cluster_snapshot_available(svc: &RdsService, snapshot_id: &str) {
     let mut accounts = svc.state.write();
     accounts
         .default_mut()
@@ -2070,7 +2069,7 @@ fn seed_cluster_snapshot_creating(svc: &RdsService, snapshot_id: &str) {
             serde_json::json!({
                 "DBClusterSnapshotIdentifier": snapshot_id,
                 "DBClusterIdentifier": "src-cluster",
-                "Status": "creating",
+                "Status": "available",
                 "SnapshotType": "manual",
             }),
         );
@@ -2078,10 +2077,10 @@ fn seed_cluster_snapshot_creating(svc: &RdsService, snapshot_id: &str) {
 
 #[test]
 fn apply_cluster_snapshot_dump_result_stages_dump_on_success() {
-    // The backgrounded finalizer flips the extras-JSON `cluster_snapshots`
-    // entry to `available` and stages the base64 STANDARD dump.
+    // The snapshot is already `available`; a successful dump only *adds* the
+    // base64 STANDARD `DumpDataB64`, leaving `Status` untouched.
     let svc = make_service();
-    seed_cluster_snapshot_creating(&svc, "csnap-1");
+    seed_cluster_snapshot_available(&svc, "csnap-1");
     crate::service::cluster_snapshots::apply_cluster_snapshot_dump_result(
         &svc.state,
         "123456789012",
@@ -2110,10 +2109,10 @@ fn apply_cluster_snapshot_dump_result_stages_dump_on_success() {
 
 #[test]
 fn apply_cluster_snapshot_dump_result_metadata_only_on_error() {
-    // A dump failure must not wedge the snapshot in `creating` forever; it
-    // settles to a metadata-only `available` snapshot (no dump).
+    // A dump failure leaves the (already `available`) snapshot as a
+    // metadata-only entry with no dump — `Status` untouched.
     let svc = make_service();
-    seed_cluster_snapshot_creating(&svc, "csnap-1");
+    seed_cluster_snapshot_available(&svc, "csnap-1");
     crate::service::cluster_snapshots::apply_cluster_snapshot_dump_result(
         &svc.state,
         "123456789012",
@@ -2140,12 +2139,12 @@ fn apply_cluster_snapshot_dump_result_metadata_only_on_error() {
 
 #[tokio::test]
 async fn apply_cluster_snapshot_dump_result_metadata_only_on_timeout() {
-    // A dump that stalls past the finalizer's bound must not wedge the snapshot
-    // in `creating` forever: the timeout collapses to the metadata-only path,
-    // settling the snapshot to `available` (no dump). This exercises the real
-    // `tokio::time::timeout` -> `Result` mapping the finalizer feeds the helper.
+    // A dump that stalls past the 120s bound collapses to the metadata-only
+    // path: the snapshot (already `available`) ends up with no dump, and
+    // `Status` is never touched. This exercises the real
+    // `tokio::time::timeout` -> `Result` mapping the handler feeds the helper.
     let svc = make_service();
-    seed_cluster_snapshot_creating(&svc, "csnap-1");
+    seed_cluster_snapshot_available(&svc, "csnap-1");
 
     // A zero-duration timeout over a never-resolving dump yields `Err(Elapsed)`,
     // the exact shape a stalled pg_dump/mysqldump produces under CI congestion.

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2138,6 +2138,57 @@ fn apply_cluster_snapshot_dump_result_metadata_only_on_error() {
     );
 }
 
+#[tokio::test]
+async fn apply_cluster_snapshot_dump_result_metadata_only_on_timeout() {
+    // A dump that stalls past the finalizer's bound must not wedge the snapshot
+    // in `creating` forever: the timeout collapses to the metadata-only path,
+    // settling the snapshot to `available` (no dump). This exercises the real
+    // `tokio::time::timeout` -> `Result` mapping the finalizer feeds the helper.
+    let svc = make_service();
+    seed_cluster_snapshot_creating(&svc, "csnap-1");
+
+    // A zero-duration timeout over a never-resolving dump yields `Err(Elapsed)`,
+    // the exact shape a stalled pg_dump/mysqldump produces under CI congestion.
+    let dump = tokio::time::timeout(
+        std::time::Duration::from_millis(0),
+        std::future::pending::<Result<Vec<u8>, crate::runtime::RuntimeError>>(),
+    )
+    .await;
+    assert!(dump.is_err(), "zero-duration timeout must elapse");
+
+    let result = crate::service::cluster_snapshots::cluster_snapshot_dump_result_from_timeout(
+        "csnap-1", dump,
+    );
+    assert!(
+        result.is_err(),
+        "timeout must map to the metadata-only (Err) path"
+    );
+    crate::service::cluster_snapshots::apply_cluster_snapshot_dump_result(
+        &svc.state,
+        "123456789012",
+        "csnap-1",
+        result,
+    );
+
+    let accounts = svc.state.read();
+    let snap = accounts
+        .default_ref()
+        .extras
+        .get("cluster_snapshots")
+        .unwrap()
+        .get("csnap-1")
+        .unwrap();
+    assert_eq!(
+        snap.get("Status").and_then(|v| v.as_str()),
+        Some("available"),
+        "timed-out dump must still settle the snapshot to available"
+    );
+    assert!(
+        snap.get("DumpDataB64").is_none(),
+        "no dump staged on dump timeout"
+    );
+}
+
 #[test]
 fn describe_db_snapshots_accepts_both_filters() {
     // Both snapshot id + instance id is tolerated: the snapshot id


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-25 Tier-3 (blocking / client-timeout), the #2398 sibling gap.

`create_db_cluster_snapshot` dumped the cluster writer's whole database **inline** in the request handler — it `await`ed `runtime.dump_database(...)` (shells to `pg_dump`/`mysqldump`, unbounded, easily past the ~60s AWS CLI read timeout) **before** writing the HTTP response. Large clusters timed the client out. The single-instance path (`CreateDBSnapshot`) and the cluster-restore dump were already backgrounded; only cluster-snapshot **create** still ran the dump inline.

Now the handler:
- records the `cluster_snapshots` extras-JSON entry synchronously as `creating` (no dump) and returns immediately with the snapshot in `creating` (AWS-faithful for `CreateDBClusterSnapshot`);
- spawns `spawn_finalize_cluster_snapshot`, which runs the writer dump off the request path and then updates that same extras entry — `Status` -> `available` and inserts base64 `DumpDataB64` on success, or leaves a metadata-only `available` snapshot on dump failure (matching the previous inline fallback);
- when there is no writer/runtime, settles the snapshot to metadata-only `available` synchronously (no spawn).

`DescribeDBClusterSnapshots` already renders `Status` from the stored entry, and `RestoreDBClusterFromSnapshot` already reads `DumpDataB64`, so both keep working once the finalizer lands.

### Note on the prior revert
A prior attempt to background this (commit `f5cc5ddc2`, "keep cluster-snapshot dump synchronous (revert the backgrounding)") was reverted because its finalizer was genuinely broken: it reused the typed `state.snapshots` path, but **cluster** snapshots live as JSON in `state.extras["cluster_snapshots"]`. This redo uses a correct finalizer — `apply_cluster_snapshot_dump_result` — that updates the extras-JSON entry directly (`get_mut("cluster_snapshots") -> get_mut(id) -> as_object_mut()`, insert `Status`/`DumpDataB64`) and persists via `save_snapshot_static`. A snapshot deleted mid-dump is left untouched (the lookup misses).

## Test plan
- `cargo build -p fakecloud-rds` — clean
- `cargo clippy -p fakecloud-rds --all-targets -- -D warnings` — clean
- `cargo fmt -p fakecloud-rds` — clean
- `cargo test -p fakecloud-rds` — 278 passed
- `cargo test -p fakecloud-e2e --no-run --test rds` — compiles
- New unit tests (Docker-free): `create_db_cluster_snapshot_returns_promptly_metadata_only` (prompt return + `creating` response + metadata-only `available` state), plus `apply_cluster_snapshot_dump_result_stages_dump_on_success` / `_metadata_only_on_error` exercising the finalizer's extras-JSON update directly.
- `rds_restore_db_cluster_from_snapshot_recovers_data` e2e now waits (`wait_for_db_cluster_snapshot_available`) for the snapshot to reach `available` before dropping the source writer, so the backgrounded dump can't race the container teardown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record DB cluster snapshots as `available` immediately and keep the writer dump synchronous with a 120s timeout, staging `DumpDataB64` before returning. This removes client timeouts, avoids stuck `creating`, and prevents races with writer teardown.

- **Bug Fixes**
  - Inline dump with a 120s cap; on success add base64 `DumpDataB64`, on error/timeout leave metadata-only `available`.
  - If no writer/runtime, settle to metadata-only `available` immediately.
  - `DescribeDBClusterSnapshots`/`RestoreDBClusterFromSnapshot` continue to work; create now returns `available`.
  - Added `apply_cluster_snapshot_dump_result` and `cluster_snapshot_dump_result_from_timeout` with unit tests; introduced `wait_for_db_cluster_snapshot_available` and raised the e2e wait to 240s (resolves immediately).

<sup>Written for commit f2588957fa88338a5c41d5ac762691a3e0b8b999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

