### PR TITLE
fix(core,sigv4): non-S3 body-hash binding + anonymous public-read under --verify-sigv4

### DIFF
--- a/crates/fakecloud-core/src/dispatch.rs
+++ b/crates/fakecloud-core/src/dispatch.rs
@@ -324,7 +324,25 @@ pub async fn dispatch(
     // handler so a failing signature never reaches business logic. The
     // reserved `test*` root identity short-circuits verification to keep
     // local-dev workflows frictionless.
-    if config.verify_sigv4 && !is_root_bypass(caller_akid) && config.credential_resolver.is_some() {
+    //
+    // A fully anonymous request — no `Authorization` header AND no presigned
+    // credential (SigV4 `X-Amz-Credential` or SigV2 `AWSAccessKeyId`) — carries
+    // no signature to verify, so it must NOT be hard-403'd here even under
+    // `--verify-sigv4`. AWS treats an unsigned request as the anonymous
+    // principal and lets a resource policy / public-read ACL authorize it
+    // (e.g. a public S3 object GET). Let it fall through to the
+    // anonymous-authorization path below, which allows a public resource and
+    // otherwise denies. A request that DID present a credential but failed to
+    // parse is NOT anonymous (`Authorization` non-empty or a presign query
+    // present) and still returns the malformed-signature error below.
+    let is_fully_anonymous = auth_header.is_empty()
+        && !query_params.contains_key("X-Amz-Credential")
+        && sigv2_presigned_access_key(&query_params).is_none();
+    if config.verify_sigv4
+        && !is_fully_anonymous
+        && !is_root_bypass(caller_akid)
+        && config.credential_resolver.is_some()
+    {
         let amz_date = parts
             .headers
             .get("x-amz-date")
@@ -370,7 +388,41 @@ pub async fn dispatch(
             &resolved_for_verify.secret_access_key,
             chrono::Utc::now(),
         ) {
-            Ok(()) => {}
+            Ok(()) => {
+                // Bind the buffered request body to the signed
+                // `x-amz-content-sha256`. The sigv4 canonical builder uses that
+                // header value verbatim (it is a signed header) and deliberately
+                // does NOT re-hash the body: for streaming / aws-chunked routes
+                // `body_bytes` is empty at that layer, so re-hashing there would
+                // reject legitimate signed requests (see the
+                // `feedback_sigv4_body_hash_wrong_layer` caveat). S3 rebinds the
+                // body hash in its own write path (`XAmzContentSHA256Mismatch`);
+                // every other service is bound HERE, where the full buffered body
+                // is available. Only a genuine 64-char lowercase-hex digest is
+                // checked — `UNSIGNED-PAYLOAD`, `STREAMING-*`, and presigned
+                // (UNSIGNED-PAYLOAD) requests are skipped, so correct clients are
+                // unaffected. A mismatch means the body was altered after signing;
+                // AWS would then compute a different canonical request, so return
+                // `SignatureDoesNotMatch`.
+                if !parsed.is_presigned && detected.service != "s3" {
+                    if let Some(signed_hash) = parts
+                        .headers
+                        .get("x-amz-content-sha256")
+                        .and_then(|v| v.to_str().ok())
+                        .filter(|h| is_hex_sha256(h))
+                    {
+                        if sha256_hex_lower(&body_bytes) != signed_hash {
+                            return build_error_response(
+                                StatusCode::FORBIDDEN,
+                                "SignatureDoesNotMatch",
+                                "The request signature we calculated does not match the signature you provided",
+                                &request_id,
+                                detected.protocol,
+                            );
+                        }
+                    }
+                }
+            }
             Err(fakecloud_aws::sigv4::SigV4Error::RequestTimeTooSkewed { .. }) => {
                 return build_error_response(
                     StatusCode::FORBIDDEN,
@@ -1311,6 +1363,29 @@ fn sigv2_presigned_access_key(query_params: &HashMap<String, String>) -> Option<
     }
 }
 
+/// True when `s` is a 64-character lowercase-hex SHA-256 digest — the form a
+/// signed `x-amz-content-sha256` payload hash takes. Distinguishes a real body
+/// hash from the `UNSIGNED-PAYLOAD` / `STREAMING-*` markers (shorter and
+/// containing non-hex characters), so only genuine hashes are re-bound to the
+/// buffered body.
+fn is_hex_sha256(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// Lowercase-hex SHA-256 of `bytes`, used to re-bind a signed
+/// `x-amz-content-sha256` to the buffered request body for non-S3 services.
+fn sha256_hex_lower(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    const HEX: &[u8] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for b in digest {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
 fn anonymous_s3_bucket(uri: &http::Uri, config: &DispatchConfig) -> Option<String> {
     let provider = config.resource_policy_provider.as_ref()?;
     let segment = uri.path().split('/').find(|s| !s.is_empty())?.to_string();
@@ -1446,6 +1521,38 @@ mod tests {
     #[test]
     fn sigv2_presigned_access_key_none_for_unsigned_request() {
         assert_eq!(sigv2_presigned_access_key(&HashMap::new()), None);
+    }
+
+    #[test]
+    fn is_hex_sha256_accepts_real_digest_rejects_markers() {
+        // A genuine 64-char lowercase-hex digest is a bindable body hash.
+        assert!(is_hex_sha256(&sha256_hex_lower(b"hello")));
+        assert!(is_hex_sha256(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ));
+        // The SigV4 payload markers are NOT hashes and must be skipped.
+        assert!(!is_hex_sha256("UNSIGNED-PAYLOAD"));
+        assert!(!is_hex_sha256("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"));
+        assert!(!is_hex_sha256("STREAMING-UNSIGNED-PAYLOAD-TRAILER"));
+        // Wrong length or non-lowercase-hex characters are rejected.
+        assert!(!is_hex_sha256("abc123"));
+        assert!(!is_hex_sha256(
+            "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+        ));
+    }
+
+    #[test]
+    fn sha256_hex_lower_matches_known_vectors() {
+        // Empty input -> the well-known SHA-256 of "".
+        assert_eq!(
+            sha256_hex_lower(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex_lower(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(sha256_hex_lower(b"abc").len(), 64);
     }
 
     #[test]

--- a/crates/fakecloud-e2e/tests/s3_anonymous_access.rs
+++ b/crates/fakecloud-e2e/tests/s3_anonymous_access.rs
@@ -9,10 +9,27 @@
 
 mod helpers;
 
+use aws_credential_types::Credentials;
 use aws_sdk_s3::types::ObjectCannedAcl;
 use helpers::TestServer;
 
 const PUBLIC_READ_POLICY: &str = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::probe/*"}]}"#;
+
+/// An S3 client signing with root-bypass `test` creds — always passes SigV4
+/// verification, so it can seed bucket/object/policy state even when the server
+/// runs with `--verify-sigv4`.
+async fn root_bypass_s3_client(server: &TestServer) -> aws_sdk_s3::Client {
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new("test", "test", None, None, "root-bypass"))
+        .load()
+        .await;
+    let s3_config = aws_sdk_s3::config::Builder::from(&config)
+        .force_path_style(true)
+        .build();
+    aws_sdk_s3::Client::from_conf(s3_config)
+}
 
 /// Default mode: an anonymous GET serves the object (fakecloud is permissive
 /// by default), both before and after a public-read bucket policy. The bug was
@@ -189,6 +206,75 @@ async fn anonymous_get_object_iam_strict_public_acl() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 403, "private object must stay denied");
+}
+
+/// SigV4 verification ON + IAM strict: a fully anonymous (unsigned) request
+/// must NOT be hard-rejected with `IncompleteSignature` before authorization
+/// runs. AWS treats an unsigned request as the anonymous principal and lets a
+/// public-read policy/ACL authorize it. A public-read object is served (200);
+/// a private object is denied by the anonymous-authorization path with
+/// `AccessDenied` (403) — NOT a pre-auth `IncompleteSignature`.
+#[tokio::test]
+async fn anonymous_get_reaches_public_read_under_verify_sigv4() {
+    let server = TestServer::start_with_env(&[
+        ("FAKECLOUD_IAM", "strict"),
+        ("FAKECLOUD_VERIFY_SIGV4", "true"),
+    ])
+    .await;
+    // Seed S3 state with root-bypass creds (always pass verification).
+    let s3 = root_bypass_s3_client(&server).await;
+
+    s3.create_bucket().bucket("probe").send().await.unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("public.txt")
+        .body(b"world".to_vec().into())
+        .acl(ObjectCannedAcl::PublicRead)
+        .send()
+        .await
+        .unwrap();
+    s3.put_object()
+        .bucket("probe")
+        .key("private.txt")
+        .body(b"secret".to_vec().into())
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+
+    // Public-read object: the anonymous GET is authorized (200), proving the
+    // request reached the anonymous-authorization path rather than being
+    // hard-403'd for lacking a signature.
+    let resp = http
+        .get(format!("{}/probe/public.txt", server.endpoint()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "public-read object must be served to an anonymous caller under --verify-sigv4"
+    );
+    assert_eq!(resp.bytes().await.unwrap().as_ref(), b"world");
+
+    // Private object: denied by authorization, not by a pre-auth signature
+    // check. The error must be AccessDenied, never IncompleteSignature.
+    let resp = http
+        .get(format!("{}/probe/private.txt", server.endpoint()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 403);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("AccessDenied"),
+        "expected AccessDenied for a private object, got {body}"
+    );
+    assert!(
+        !body.contains("IncompleteSignature"),
+        "anonymous request must not be pre-auth rejected under --verify-sigv4: {body}"
+    );
 }
 
 /// IAM strict mode: an explicit `Deny` in the bucket policy overrides a

--- a/crates/fakecloud-e2e/tests/sigv4_body_binding.rs
+++ b/crates/fakecloud-e2e/tests/sigv4_body_binding.rs
@@ -1,0 +1,235 @@
+//! End-to-end tests for binding a signed request body to its SigV4 signature
+//! for NON-S3 services under `--verify-sigv4`.
+//!
+//! The sigv4 canonical-request builder uses the client-supplied
+//! `x-amz-content-sha256` header value verbatim (it is a signed header) and
+//! deliberately does NOT re-hash the body there — streaming / aws-chunked
+//! routes leave the buffered body empty at that layer, so re-hashing would
+//! reject legitimate signed requests. S3 re-binds the hash in its own write
+//! path; every other service is bound at the dispatch layer, where the full
+//! buffered body is known. These tests drive hand-crafted signed requests to
+//! prove:
+//!   * a correctly signed request whose header hash matches the body passes,
+//!   * an on-path body tamper (signed headers kept, body altered) is rejected
+//!     with `SignatureDoesNotMatch`,
+//!   * an `UNSIGNED-PAYLOAD` request is unaffected by the body-hash check.
+
+mod helpers;
+
+use aws_credential_types::Credentials;
+use helpers::TestServer;
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+async fn start_verified() -> TestServer {
+    TestServer::start_with_env(&[("FAKECLOUD_VERIFY_SIGV4", "true")]).await
+}
+
+/// Bootstrap a real IAM user + access key using root-bypass `test` creds
+/// (which always pass verification). Returns a resolvable (akid, secret) pair
+/// so hand-signed requests exercise the real verify path.
+async fn bootstrap_access_key(server: &TestServer, user: &str) -> (String, String) {
+    let boot = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .endpoint_url(server.endpoint())
+        .region(aws_config::Region::new("us-east-1"))
+        .credentials_provider(Credentials::new("test", "test", None, None, "root-bypass"))
+        .load()
+        .await;
+    let iam = aws_sdk_iam::Client::new(&boot);
+    iam.create_user().user_name(user).send().await.unwrap();
+    let ak = iam
+        .create_access_key()
+        .user_name(user)
+        .send()
+        .await
+        .unwrap();
+    let key = ak.access_key().unwrap();
+    (
+        key.access_key_id().to_string(),
+        key.secret_access_key().to_string(),
+    )
+}
+
+fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).unwrap();
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    hex::encode(Sha256::digest(data))
+}
+
+/// Produce a SigV4 `Authorization` header value for a header-signed POST.
+/// `payload_hash_header` is the literal value placed in (and signed as) the
+/// `x-amz-content-sha256` header — a real 64-char hex digest, or a marker like
+/// `UNSIGNED-PAYLOAD`. The signature covers exactly that value, mirroring what
+/// a real client (or an on-path attacker who keeps the signed headers) sends.
+#[allow(clippy::too_many_arguments)]
+fn authorization_header(
+    host: &str,
+    payload_hash_header: &str,
+    akid: &str,
+    secret: &str,
+    region: &str,
+    service: &str,
+    amz_date: &str,
+) -> String {
+    let date_stamp = &amz_date[..8];
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+    let canonical_headers =
+        format!("host:{host}\nx-amz-content-sha256:{payload_hash_header}\nx-amz-date:{amz_date}\n");
+    // POST "/" with an empty canonical query string.
+    let canonical_request =
+        format!("POST\n/\n\n{canonical_headers}\n{signed_headers}\n{payload_hash_header}");
+    let scope = format!("{date_stamp}/{region}/{service}/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let k_date = hmac(format!("AWS4{secret}").as_bytes(), date_stamp.as_bytes());
+    let k_region = hmac(&k_date, region.as_bytes());
+    let k_service = hmac(&k_region, service.as_bytes());
+    let k_signing = hmac(&k_service, b"aws4_request");
+    let signature = hex::encode(hmac(&k_signing, string_to_sign.as_bytes()));
+    format!(
+        "AWS4-HMAC-SHA256 Credential={akid}/{scope}, SignedHeaders={signed_headers}, Signature={signature}"
+    )
+}
+
+fn host_of(endpoint: &str) -> String {
+    endpoint
+        .strip_prefix("http://")
+        .or_else(|| endpoint.strip_prefix("https://"))
+        .unwrap_or(endpoint)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+const STS_BODY: &[u8] = b"Action=GetCallerIdentity&Version=2011-06-15";
+
+/// A correctly signed STS request whose `x-amz-content-sha256` matches the body
+/// verifies and reaches the handler.
+#[tokio::test]
+async fn correctly_signed_body_is_accepted() {
+    let server = start_verified().await;
+    let (akid, secret) = bootstrap_access_key(&server, "signer-ok").await;
+    let host = host_of(server.endpoint());
+    let amz_date = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let body_hash = sha256_hex(STS_BODY);
+    let auth = authorization_header(
+        &host,
+        &body_hash,
+        &akid,
+        &secret,
+        "us-east-1",
+        "sts",
+        &amz_date,
+    );
+
+    let resp = reqwest::Client::new()
+        .post(server.endpoint())
+        .header("host", &host)
+        .header("x-amz-date", &amz_date)
+        .header("x-amz-content-sha256", &body_hash)
+        .header("authorization", &auth)
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(STS_BODY.to_vec())
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(status, 200, "correctly signed request must pass: {text}");
+    assert!(
+        text.contains("GetCallerIdentityResponse"),
+        "expected a GetCallerIdentity response, got {text}"
+    );
+}
+
+/// An on-path body tamper — the signed headers (including the original
+/// `x-amz-content-sha256`) are kept, but the body is replaced — must be
+/// rejected. The signature still matches (it covers the header value verbatim),
+/// so this is caught by the body-hash re-binding, returning
+/// `SignatureDoesNotMatch`.
+#[tokio::test]
+async fn tampered_body_is_rejected() {
+    let server = start_verified().await;
+    let (akid, secret) = bootstrap_access_key(&server, "signer-tamper").await;
+    let host = host_of(server.endpoint());
+    let amz_date = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+
+    // Sign the ORIGINAL body's hash...
+    let original_hash = sha256_hex(STS_BODY);
+    let auth = authorization_header(
+        &host,
+        &original_hash,
+        &akid,
+        &secret,
+        "us-east-1",
+        "sts",
+        &amz_date,
+    );
+
+    // ...but send a DIFFERENT body while keeping every signed header.
+    let tampered = b"Action=GetCallerIdentity&Version=2011-06-15&injected=1".to_vec();
+    let resp = reqwest::Client::new()
+        .post(server.endpoint())
+        .header("host", &host)
+        .header("x-amz-date", &amz_date)
+        .header("x-amz-content-sha256", &original_hash)
+        .header("authorization", &auth)
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(tampered)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(status, 403, "tampered body must be rejected: {text}");
+    assert!(
+        text.contains("SignatureDoesNotMatch"),
+        "expected SignatureDoesNotMatch, got {text}"
+    );
+}
+
+/// An `UNSIGNED-PAYLOAD` request carries no body hash to bind against, so the
+/// body-hash check is skipped entirely and the request is unaffected: a valid
+/// signature over `UNSIGNED-PAYLOAD` still reaches the handler.
+#[tokio::test]
+async fn unsigned_payload_marker_is_unaffected() {
+    let server = start_verified().await;
+    let (akid, secret) = bootstrap_access_key(&server, "signer-unsigned").await;
+    let host = host_of(server.endpoint());
+    let amz_date = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let auth = authorization_header(
+        &host,
+        "UNSIGNED-PAYLOAD",
+        &akid,
+        &secret,
+        "us-east-1",
+        "sts",
+        &amz_date,
+    );
+
+    let resp = reqwest::Client::new()
+        .post(server.endpoint())
+        .header("host", &host)
+        .header("x-amz-date", &amz_date)
+        .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+        .header("authorization", &auth)
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(STS_BODY.to_vec())
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "UNSIGNED-PAYLOAD request must be unaffected by the body-hash check: {text}"
+    );
+    assert!(text.contains("GetCallerIdentityResponse"), "got {text}");
+}


### PR DESCRIPTION
## Summary

Two related `--verify-sigv4` correctness fixes from the 2026-07-25 Tier-5 bug hunt (enforcement-when-enabled; fakecloud auth is off by default, both bugs are only reachable when the operator opts into `--verify-sigv4`).

**Finding 1 (LOW-MED) — signed request body not bound to the signature for non-S3 services.** For a non-presigned request that sends `x-amz-content-sha256` as a signed header, sigv4 `verify()` uses that header value verbatim as the canonical payload hash and never recomputes `SHA256(body)`. Only S3 rebinds the body hash (in its own write path). For every other service (SQS/SNS/IAM/STS/DynamoDB/…) the full body is buffered but never compared to the signed hash, so an on-path attacker could alter the body while keeping the signed headers + signature and it still verified. Query-protocol services carry the `Action`+params in the body, so this is a real integrity gap. Fixed by re-binding the buffered body to the signed hash after a successful verify, returning `SignatureDoesNotMatch` on mismatch (what AWS returns for a query/JSON service whose recomputed canonical request diverges).

**Finding 2 (LOW) — anonymous request hard-rejected before reaching S3 public-read authorization.** A fully anonymous request (no `Authorization`, no presign) entered the verify block, both parsers returned `None`, and dispatch returned `403 IncompleteSignature` *before* the anonymous-authorization path that consults a public bucket policy / public-read ACL. A legitimately public S3 object GET was rejected purely for lacking a signature. AWS treats an unsigned request as the anonymous principal and lets resource-policy/ACL authorize it. Fixed by letting a fully anonymous request fall through to the existing anonymous-authorization path.

## Where the body-hash check lives (streaming-body caveat)

The body-hash comparison is deliberately at the **buffered-body dispatch layer** (`crates/fakecloud-core/src/dispatch.rs`, in the `Ok(())` arm right after `sigv4::verify` succeeds), **NOT** inside the sigv4 canonical-request builder. For streaming / aws-chunked routes the body bytes are empty at the sigv4 layer, so re-hashing there rejects legitimate signed requests (this exact mistake was shipped and reverted once before — see `feedback_sigv4_body_hash_wrong_layer`). Scoping:

- **S3 skipped** (`detected.service != "s3"`) — S3 already rebinds in its write path (`XAmzContentSHA256Mismatch`); don't double-check.
- **Presigned skipped** (`!parsed.is_presigned`) — presigned uses `UNSIGNED-PAYLOAD`.
- **Streaming / markers skipped** — only a genuine 64-char lowercase-hex digest is checked (`is_hex_sha256`), so `UNSIGNED-PAYLOAD`, `STREAMING-*`, and `STREAMING-UNSIGNED-PAYLOAD-TRAILER` flow through untouched.

For Finding 2, "no creds at all" is distinguished from "malformed creds": the fall-through triggers only when `Authorization` is empty **and** there is no SigV4 `X-Amz-Credential` **and** no SigV2 `AWSAccessKeyId` presign. A request that *did* present a credential but failed to parse is not anonymous and still returns the malformed-signature error.

## Test plan

New/updated tests (all green locally):

- `sigv4_body_binding.rs` (new): a non-S3 signed request whose body is altered after signing (signed `x-amz-content-sha256` = hash of the ORIGINAL body) is now rejected with `SignatureDoesNotMatch`; a correctly-signed request still passes; an `UNSIGNED-PAYLOAD` request is unaffected. (3/3)
- `s3_anonymous_access.rs`: added `anonymous_get_reaches_public_read_under_verify_sigv4` — under `FAKECLOUD_IAM=strict` + `FAKECLOUD_VERIFY_SIGV4=true`, an anonymous GET of a public-read object succeeds (200) and an anonymous GET of a private object is denied with `AccessDenied` (403), NOT `IncompleteSignature`. (7/7)
- `dispatch.rs` unit tests for `is_hex_sha256` (accepts real digests, rejects the markers/uppercase/wrong-length) and `sha256_hex_lower` (known vectors).

Enforcement suites run locally, all green:

- `cargo test -p fakecloud-e2e --test iam_enforcement` — 50/50
- `cargo test -p fakecloud-e2e --test sigv4_verification` — 6/6
- `cargo test -p fakecloud-e2e --test s3_anonymous_access` — 7/7
- `cargo test -p fakecloud-e2e --test sigv4_body_binding` — 3/3
- `cargo test -p fakecloud-core -p fakecloud-aws` — 248 + 37
- `cargo clippy -p fakecloud-core -p fakecloud-aws --all-targets -- -D warnings` clean; `cargo fmt` applied.

No existing enforcement assertion was weakened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two `--verify-sigv4` gaps: binds non‑S3 request bodies to their signatures to prevent tampering, and lets truly anonymous S3 requests reach public‑read authorization instead of failing pre‑auth.

- **Bug Fixes**
  - Non‑S3 SigV4 body binding: after a successful verify, recompute SHA‑256 of the buffered body and compare to `x-amz-content-sha256`; on mismatch return `SignatureDoesNotMatch`. Skips S3, presigned requests, and `UNSIGNED-PAYLOAD`/`STREAMING-*` markers.
  - Anonymous S3 under verify: if there’s no `Authorization`, no `X-Amz-Credential`, and no SigV2 `AWSAccessKeyId`, bypass verification and run the anonymous-authorization path. Public objects return 200; private return `AccessDenied`. Requests that present creds but fail parsing still return signature errors.

<sup>Written for commit c7d9d5f24ebd9d0cc4b6c89957cf802c5626b933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

