### PR TITLE
fix(cloudformation): in-place UpdateStack for ASG (no instance churn) + control-plane types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-backup"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add529e5c9172f15f0499db8170d3ce8ed0a15accc805c6c01611a74fd0b563e"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-batch"
 version = "1.113.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6918,6 +6942,7 @@ dependencies = [
  "aws-sdk-apigatewayv2",
  "aws-sdk-applicationautoscaling",
  "aws-sdk-athena",
+ "aws-sdk-backup",
  "aws-sdk-bedrock",
  "aws-sdk-bedrockagent",
  "aws-sdk-bedrockagentruntime",

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/amplify.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/amplify.rs
@@ -12,7 +12,7 @@
 
 use serde_json::{json, Value};
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 use fakecloud_amplify::shared::{app_arn, default_domain, new_app_id, now_epoch};
 use fakecloud_amplify::state::AppRecord;
 
@@ -110,6 +110,88 @@ impl ResourceProvisioner {
             },
         );
 
+        Ok(ProvisionResult::new(app_id.clone())
+            .with("AppId", app_id)
+            .with("AppName", name)
+            .with("Arn", arn)
+            .with("DefaultDomain", domain))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::Amplify::App`. Mutates the stored
+    /// `App` wire object in place instead of the reprovision fallback's
+    /// delete+recreate (which would mint a new `appId` and drop the app's
+    /// branches/domains). Applies the mutable app properties and preserves the
+    /// identity (`appId`, `appArn`, `defaultDomain`, `createTime`) and any
+    /// nested state on the `AppRecord`.
+    pub(super) fn update_amplify_app(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let app_id = existing.physical_id.clone();
+
+        let mut guard = self.amplify_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let record = data
+            .apps
+            .get_mut(&app_id)
+            .ok_or_else(|| format!("Amplify app {app_id} not yet provisioned"))?;
+        let app = record
+            .app
+            .as_object_mut()
+            .ok_or_else(|| format!("Amplify app {app_id} record is malformed"))?;
+
+        if let Some(v) = props.get("Name").and_then(Value::as_str) {
+            app.insert("name".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("Description").and_then(Value::as_str) {
+            app.insert("description".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("Repository").and_then(Value::as_str) {
+            app.insert("repository".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("Platform").and_then(Value::as_str) {
+            app.insert("platform".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("EnableBranchAutoBuild").and_then(Value::as_bool) {
+            app.insert("enableBranchAutoBuild".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("EnableBasicAuth").and_then(Value::as_bool) {
+            app.insert("enableBasicAuth".to_string(), json!(v));
+        }
+        if props.get("EnvironmentVariables").is_some() {
+            app.insert(
+                "environmentVariables".to_string(),
+                env_var_map(props.get("EnvironmentVariables")),
+            );
+        }
+        if let Some(bs) = props.get("BuildSpec").and_then(Value::as_str) {
+            app.insert("buildSpec".to_string(), json!(bs));
+        }
+        if let Some(role) = props.get("IAMServiceRole").and_then(Value::as_str) {
+            app.insert("iamServiceRoleArn".to_string(), json!(role));
+        }
+        if props.get("Tags").is_some() {
+            app.insert("tags".to_string(), key_value_map(props.get("Tags")));
+        }
+        app.insert("updateTime".to_string(), json!(now_epoch()));
+
+        let name = app
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let arn = app
+            .get("appArn")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let domain = app
+            .get("defaultDomain")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
         Ok(ProvisionResult::new(app_id.clone())
             .with("AppId", app_id)
             .with("AppName", name)

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/appsync.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/appsync.rs
@@ -11,7 +11,9 @@
 
 use serde_json::{json, Value};
 
-use super::{cfn_props_to_camel, ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{
+    cfn_props_to_camel, ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource,
+};
 
 impl ResourceProvisioner {
     // ---------------------------------------------------------- GraphQLApi
@@ -62,6 +64,75 @@ impl ResourceProvisioner {
             data.tags.insert(arn.clone(), tags);
         }
         data.graphql_apis.insert(api_id.clone(), Value::Object(api));
+
+        Ok(ProvisionResult::new(api_id.clone())
+            .with("ApiId", api_id)
+            .with("Arn", arn)
+            .with("GraphQLUrl", graphql_url)
+            .with("GraphQLDns", graphql_dns)
+            .with("RealtimeUrl", realtime_url)
+            .with("RealtimeDns", realtime_dns))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::AppSync::GraphQLApi` (matching
+    /// `UpdateGraphqlApi`). Merges the mutable camelCase members over the stored
+    /// api object instead of the reprovision fallback's delete+recreate (which
+    /// would mint a new `apiId` and orphan the api's data sources / resolvers).
+    /// Identity members (`apiId`, `arn`, `owner`, `uris`, `dns`) are preserved.
+    pub(super) fn update_appsync_graphql_api(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let api_id = existing.physical_id.clone();
+
+        let incoming = match cfn_props_to_camel(props, &[]) {
+            Value::Object(m) => m,
+            _ => serde_json::Map::new(),
+        };
+        let tags = string_tag_map(props.get("Tags"));
+
+        let mut guard = self.appsync_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let api = data
+            .graphql_apis
+            .get_mut(&api_id)
+            .ok_or_else(|| format!("GraphQL API {api_id} not yet provisioned"))?;
+        let obj = api
+            .as_object_mut()
+            .ok_or_else(|| format!("GraphQL API {api_id} record is malformed"))?;
+        const PRESERVED: &[&str] = &["apiId", "arn", "owner", "uris", "dns"];
+        for (k, v) in incoming {
+            if PRESERVED.contains(&k.as_str()) || k == "tags" {
+                continue;
+            }
+            obj.insert(k, v);
+        }
+        let arn = obj
+            .get("arn")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let sub = |group: &str, key: &str| -> String {
+            obj.get(group)
+                .and_then(|g| g.get(key))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        let graphql_url = sub("uris", "GRAPHQL");
+        let graphql_dns = sub("dns", "GRAPHQL");
+        let realtime_url = sub("uris", "REALTIME");
+        let realtime_dns = sub("dns", "REALTIME");
+
+        if tags.is_empty() {
+            data.tags.remove(&api_id);
+            data.tags.remove(&arn);
+        } else {
+            data.tags.insert(api_id.clone(), tags.clone());
+            data.tags.insert(arn.clone(), tags);
+        }
 
         Ok(ProvisionResult::new(api_id.clone())
             .with("ApiId", api_id)
@@ -145,6 +216,54 @@ impl ResourceProvisioner {
             .insert(name.clone(), Value::Object(ds));
 
         Ok(ProvisionResult::new(format!("{api_id}|{name}"))
+            .with("DataSourceArn", arn)
+            .with("Name", name))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::AppSync::DataSource` (matching
+    /// `UpdateDataSource`). Merges the mutable camelCase members over the stored
+    /// data-source object instead of the reprovision fallback's delete+recreate.
+    /// `name` and `dataSourceArn` are preserved.
+    pub(super) fn update_appsync_data_source(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (api_id, name) = physical_id
+            .split_once('|')
+            .map(|(a, n)| (a.to_string(), n.to_string()))
+            .ok_or_else(|| format!("Invalid DataSource physical id: {physical_id}"))?;
+
+        let incoming = match cfn_props_to_camel(props, &[]) {
+            Value::Object(m) => m,
+            _ => serde_json::Map::new(),
+        };
+
+        let mut guard = self.appsync_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let ds = data
+            .data_sources
+            .get_mut(&api_id)
+            .and_then(|m| m.get_mut(&name))
+            .ok_or_else(|| format!("DataSource {name} not yet provisioned"))?;
+        let obj = ds
+            .as_object_mut()
+            .ok_or_else(|| format!("DataSource {name} record is malformed"))?;
+        const PRESERVED: &[&str] = &["name", "dataSourceArn", "apiId"];
+        for (k, v) in incoming {
+            if PRESERVED.contains(&k.as_str()) {
+                continue;
+            }
+            obj.insert(k, v);
+        }
+        let arn = obj
+            .get("dataSourceArn")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        Ok(ProvisionResult::new(physical_id)
             .with("DataSourceArn", arn)
             .with("Name", name))
     }
@@ -235,6 +354,57 @@ impl ResourceProvisioner {
                 .with("TypeName", type_name)
                 .with("FieldName", field),
         )
+    }
+
+    /// In-place `UpdateStack` for an `AWS::AppSync::Resolver` (matching
+    /// `UpdateResolver`). Merges the mutable camelCase members over the stored
+    /// resolver object instead of the reprovision fallback's delete+recreate.
+    /// `typeName`, `fieldName` and `resolverArn` are preserved.
+    pub(super) fn update_appsync_resolver(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let parts: Vec<String> = physical_id.split('|').map(String::from).collect();
+        if parts.len() != 3 {
+            return Err(format!("Invalid Resolver physical id: {physical_id}"));
+        }
+        let (api_id, type_name, field) = (parts[0].clone(), parts[1].clone(), parts[2].clone());
+
+        let incoming = match cfn_props_to_camel(props, &[]) {
+            Value::Object(m) => m,
+            _ => serde_json::Map::new(),
+        };
+
+        let mut guard = self.appsync_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let key = format!("{type_name}::{field}");
+        let r = data
+            .resolvers
+            .get_mut(&api_id)
+            .and_then(|m| m.get_mut(&key))
+            .ok_or_else(|| format!("Resolver {type_name}.{field} not yet provisioned"))?;
+        let obj = r
+            .as_object_mut()
+            .ok_or_else(|| format!("Resolver {type_name}.{field} record is malformed"))?;
+        const PRESERVED: &[&str] = &["typeName", "fieldName", "resolverArn", "apiId"];
+        for (k, v) in incoming {
+            if PRESERVED.contains(&k.as_str()) {
+                continue;
+            }
+            obj.insert(k, v);
+        }
+        let arn = obj
+            .get("resolverArn")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        Ok(ProvisionResult::new(physical_id)
+            .with("ResolverArn", arn)
+            .with("TypeName", type_name)
+            .with("FieldName", field))
     }
 
     pub(super) fn delete_appsync_resolver(&self, physical_id: &str) -> Result<(), String> {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/athena.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/athena.rs
@@ -59,6 +59,53 @@ impl ResourceProvisioner {
             .with("Name", name))
     }
 
+    /// In-place `UpdateStack` for an `AWS::Athena::WorkGroup`. Mutates the stored
+    /// `WorkGroup` in place (matching `UpdateWorkGroup`) instead of the
+    /// reprovision fallback's delete+recreate, preserving `creation_time` and the
+    /// named queries / prepared statements that reference this workgroup.
+    pub(super) fn update_athena_work_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+        let arn = format!(
+            "arn:aws:athena:{}:{}:workgroup/{}",
+            self.region, self.account_id, name
+        );
+        let tags = Self::parse_athena_tags(props.get("Tags"));
+
+        let mut accounts = self.athena_state.write();
+        let account = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        let wg = account
+            .work_groups
+            .get_mut(&name)
+            .ok_or_else(|| format!("WorkGroup {name} not yet provisioned"))?;
+        if let Some(v) = props.get("Description").and_then(|v| v.as_str()) {
+            wg.description = Some(v.to_string());
+        }
+        if props.get("Configuration").is_some() {
+            wg.configuration = props.get("Configuration").cloned();
+        }
+        if let Some(v) = props.get("State").and_then(|v| v.as_str()) {
+            wg.state = v.to_string();
+        }
+        if props.get("Tags").is_some() {
+            if tags.is_empty() {
+                account.tags.remove(&arn);
+            } else {
+                account.tags.insert(arn.clone(), tags);
+            }
+        }
+        Ok(ProvisionResult::new(name.clone())
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
     pub(super) fn delete_athena_work_group(&self, physical_id: &str) -> Result<(), String> {
         let mut accounts = self.athena_state.write();
         let account = accounts
@@ -155,6 +202,55 @@ impl ResourceProvisioner {
             .with("Name", name))
     }
 
+    /// In-place `UpdateStack` for an `AWS::Athena::DataCatalog` (matching
+    /// `UpdateDataCatalog`). Mutates the stored record in place instead of the
+    /// reprovision fallback's delete+recreate.
+    pub(super) fn update_athena_data_catalog(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+        let arn = format!(
+            "arn:aws:athena:{}:{}:datacatalog/{}",
+            self.region, self.account_id, name
+        );
+        let tags = Self::parse_athena_tags(props.get("Tags"));
+
+        let mut accounts = self.athena_state.write();
+        let account = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        let cat = account
+            .data_catalogs
+            .get_mut(&name)
+            .ok_or_else(|| format!("DataCatalog {name} not yet provisioned"))?;
+        if let Some(v) = props.get("Description").and_then(|v| v.as_str()) {
+            cat.description = Some(v.to_string());
+        }
+        if let Some(obj) = props.get("Parameters").and_then(|v| v.as_object()) {
+            cat.parameters = obj
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect();
+        }
+        if let Some(v) = props.get("ConnectionType").and_then(|v| v.as_str()) {
+            cat.connection_type = Some(v.to_string());
+        }
+        if props.get("Tags").is_some() {
+            if tags.is_empty() {
+                account.tags.remove(&arn);
+            } else {
+                account.tags.insert(arn.clone(), tags);
+            }
+        }
+        Ok(ProvisionResult::new(name.clone())
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
     pub(super) fn delete_athena_data_catalog(&self, physical_id: &str) -> Result<(), String> {
         let mut accounts = self.athena_state.write();
         let account = accounts
@@ -239,6 +335,42 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone()).with("NamedQueryId", id))
     }
 
+    /// In-place `UpdateStack` for an `AWS::Athena::NamedQuery`. Mutates the
+    /// stored record in place, preserving its server-minted `named_query_id`
+    /// (`Ref`), instead of the reprovision fallback's delete+recreate (which
+    /// would mint a new id).
+    pub(super) fn update_athena_named_query(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let mut accounts = self.athena_state.write();
+        let account = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        let nq = account
+            .named_queries
+            .get_mut(&id)
+            .ok_or_else(|| format!("NamedQuery {id} not yet provisioned"))?;
+        if let Some(v) = props.get("Name").and_then(|v| v.as_str()) {
+            nq.name = v.to_string();
+        }
+        if let Some(v) = props.get("Description").and_then(|v| v.as_str()) {
+            nq.description = Some(v.to_string());
+        }
+        if let Some(v) = props.get("Database").and_then(|v| v.as_str()) {
+            nq.database = v.to_string();
+        }
+        if let Some(v) = props.get("QueryString").and_then(|v| v.as_str()) {
+            nq.query_string = v.to_string();
+        }
+        Ok(ProvisionResult::new(id.clone()).with("NamedQueryId", id))
+    }
+
     pub(super) fn delete_athena_named_query(&self, physical_id: &str) -> Result<(), String> {
         let mut accounts = self.athena_state.write();
         let account = accounts
@@ -315,6 +447,43 @@ impl ResourceProvisioner {
         };
         let physical_id = format!("{work_group_name}|{statement_name}");
         account.prepared_statements.insert(key, ps);
+        Ok(ProvisionResult::new(physical_id))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::Athena::PreparedStatement` (matching
+    /// `UpdatePreparedStatement`). Mutates the stored record in place instead of
+    /// the reprovision fallback's delete+recreate.
+    pub(super) fn update_athena_prepared_statement(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let parts: Vec<&str> = physical_id.split('|').collect();
+        if parts.len() != 2 {
+            return Err(format!(
+                "Invalid PreparedStatement physical id: {physical_id}"
+            ));
+        }
+        let key = (parts[0].to_string(), parts[1].to_string());
+
+        let mut accounts = self.athena_state.write();
+        let account = accounts
+            .accounts
+            .entry(self.account_id.clone())
+            .or_default();
+        let ps = account
+            .prepared_statements
+            .get_mut(&key)
+            .ok_or_else(|| format!("PreparedStatement {physical_id} not yet provisioned"))?;
+        if let Some(v) = props.get("QueryStatement").and_then(|v| v.as_str()) {
+            ps.query_statement = v.to_string();
+        }
+        if let Some(v) = props.get("Description").and_then(|v| v.as_str()) {
+            ps.description = Some(v.to_string());
+        }
+        ps.last_modified_time = Utc::now();
         Ok(ProvisionResult::new(physical_id))
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/autoscaling.rs
@@ -11,7 +11,7 @@ use fakecloud_autoscaling::state::{
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 
 /// Parse a CFN `LaunchTemplate` / `LaunchTemplateSpecification` block
 /// (`{LaunchTemplateId|LaunchTemplateName, Version}`) into a [`LaunchTemplateSpec`].
@@ -192,6 +192,121 @@ impl ResourceProvisioner {
             .get_or_create(&self.account_id)
             .groups
             .insert(name.clone(), group);
+        self.pending_container_spawns
+            .lock()
+            .push(super::ContainerSpawnIntent::AsgInstances {
+                group_name: name.clone(),
+            });
+        Ok(ProvisionResult::new(name).with("Arn", arn))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::AutoScaling::AutoScalingGroup`.
+    ///
+    /// The reprovision fallback would call `delete_autoscaling` (which queues an
+    /// `AsgInstances` teardown for EVERY running instance) then
+    /// `create_autoscaling_group` (which re-queues a full `AsgInstances` spawn) —
+    /// so a benign `DesiredCapacity`/`MinSize`/`Cooldown`/`HealthCheck*`/`Tags`/
+    /// `TargetGroupARNs` change would TERMINATE every instance and launch a brand
+    /// new set, churning instance ids/IPs and breaking ELB target registrations.
+    /// AWS applies all of these in place with no interruption.
+    ///
+    /// This mutates the stored group record in place (applying only the mutable
+    /// properties, preserving `arn`/`created_time`/`instances` and thus the
+    /// existing instances' ids) and then queues the SAME `AsgInstances` spawn
+    /// intent `create` uses. The drain routes it through the owning
+    /// autoscaling service's `reconcile_group`/`apply_capacity`, which
+    /// reconciles the instance set to the (possibly-new) desired capacity BY THE
+    /// DELTA: scale-up launches only the shortfall, scale-down terminates only
+    /// the excess (the newest ids), and an unchanged capacity touches no
+    /// instances. Existing instance ids are preserved.
+    pub(super) fn update_autoscaling_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+
+        let arn = {
+            let mut st = self.autoscaling_state.write();
+            let acct = st.get_or_create(&self.account_id);
+            let group = acct
+                .groups
+                .get_mut(&name)
+                .ok_or_else(|| format!("Auto Scaling group {name} not yet provisioned"))?;
+
+            // Mutable-without-replacement properties. Immutable identity (arn,
+            // name, created_time) and the live `instances` list are deliberately
+            // left untouched so the group -- and its running instances' ids --
+            // survive; the instance set is reconciled by delta below.
+            if let Some(v) = prop_i64(props, "MinSize") {
+                group.min_size = v;
+            }
+            if let Some(v) = prop_i64(props, "MaxSize") {
+                group.max_size = v;
+            }
+            if let Some(v) = prop_i64(props, "DesiredCapacity") {
+                group.desired_capacity = v;
+            }
+            if let Some(v) = prop_i64(props, "Cooldown") {
+                group.default_cooldown = v;
+            }
+            if let Some(v) = prop_str(props, "HealthCheckType") {
+                group.health_check_type = v.to_string();
+            }
+            if let Some(v) = prop_i64(props, "HealthCheckGracePeriod") {
+                group.health_check_grace_period = v;
+            }
+            if props.get("TargetGroupARNs").is_some() {
+                group.target_group_arns = str_list(props, "TargetGroupARNs");
+            }
+            if props.get("LoadBalancerNames").is_some() {
+                group.load_balancer_names = str_list(props, "LoadBalancerNames");
+            }
+            if let Some(v) = props
+                .get("NewInstancesProtectedFromScaleIn")
+                .and_then(|v| v.as_bool())
+            {
+                group.new_instances_protected_from_scale_in = v;
+            }
+            if props.get("AvailabilityZones").is_some() {
+                let azs = str_list(props, "AvailabilityZones");
+                if !azs.is_empty() {
+                    group.availability_zones = azs;
+                }
+            }
+            if let Some(vzi) = props
+                .get("VPCZoneIdentifier")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                })
+                .or_else(|| prop_str(props, "VPCZoneIdentifier").map(String::from))
+            {
+                group.vpc_zone_identifier = Some(vzi);
+            }
+            if props.get("LaunchConfigurationName").is_some() {
+                group.launch_configuration_name =
+                    prop_str(props, "LaunchConfigurationName").map(String::from);
+            }
+            if let Some(lt) = parse_cfn_launch_template(props.get("LaunchTemplate")).or_else(|| {
+                props
+                    .get("MixedInstancesPolicy")
+                    .and_then(|m| m.get("LaunchTemplate"))
+                    .and_then(|lt| lt.get("LaunchTemplateSpecification"))
+                    .and_then(|spec| parse_cfn_launch_template(Some(spec)))
+            }) {
+                group.launch_template = Some(lt);
+            }
+            group.arn.clone()
+        };
+
+        // Reconcile the instance set to the (possibly-new) desired capacity BY
+        // DELTA through the owning service, exactly as `create` does. Preserves
+        // existing instance ids; only the delta is spawned/torn down.
         self.pending_container_spawns
             .lock()
             .push(super::ContainerSpawnIntent::AsgInstances {

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/backup.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/backup.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 
 use serde_json::Value;
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 use fakecloud_backup::state::{plan_arn, vault_arn, PlanRecord, PlanVersion, VaultRecord};
 
 impl ResourceProvisioner {
@@ -63,6 +63,52 @@ impl ResourceProvisioner {
         st.vaults.insert(name.clone(), record);
         let tags = tag_map(props.get("BackupVaultTags"));
         if !tags.is_empty() {
+            st.tags.insert(arn.clone(), tags);
+        }
+
+        Ok(ProvisionResult::new(name.clone())
+            .with("BackupVaultArn", arn)
+            .with("BackupVaultName", name))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::Backup::BackupVault`. Mutates the
+    /// stored `VaultRecord` in place instead of the reprovision fallback's
+    /// delete+recreate. `delete_backup_vault` removes the vault (and with it its
+    /// `recovery_points`), so a benign `AccessPolicy` / `Notifications` / tag
+    /// change would silently WIPE every stored recovery point. This applies the
+    /// mutable properties and preserves the vault's identity (`arn`,
+    /// `creation_date`) and, critically, its `recovery_points` -- which live on
+    /// the untouched record.
+    pub(super) fn update_backup_vault(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+
+        let mut guard = self.backup_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let arn = {
+            let record = st
+                .vaults
+                .get_mut(&name)
+                .ok_or_else(|| format!("Backup vault {name} not yet provisioned"))?;
+
+            // Mutable properties. `recovery_points`, `arn`, `creation_date`,
+            // `vault_type`, `vault_state` and any lock config are preserved.
+            if props.get("AccessPolicy").is_some() {
+                record.access_policy = props.get("AccessPolicy").map(policy_to_string);
+            }
+            if let Some(v) = props.get("Notifications").filter(|v| !v.is_null()) {
+                record.notifications = Some(v.clone());
+            }
+            record.arn.clone()
+        };
+        let tags = tag_map(props.get("BackupVaultTags"));
+        if tags.is_empty() {
+            st.tags.remove(&arn);
+        } else {
             st.tags.insert(arn.clone(), tags);
         }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/eks.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/eks.rs
@@ -17,7 +17,7 @@ use fakecloud_eks::{
     IdentityProviderConfig, Nodegroup, PodIdentityAssociation, TagMap, DEFAULT_K8S_VERSION,
 };
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 
 /// Parse an EKS `Tags` property. EKS uses a JSON *map* (`{"k":"v"}`) for Tags in
 /// CloudFormation, not the `[{Key,Value}]` list other services use.
@@ -913,6 +913,311 @@ impl ResourceProvisioner {
             "AssociationId" => Some(assoc.association_id.clone()),
             _ => None,
         }
+    }
+
+    // --- In-place UpdateStack arms ---
+    //
+    // Each mutates the owning EKS record in place (applying the mutable
+    // properties, preserving the physical id / ARN / created_at) instead of the
+    // reprovision fallback's delete+recreate. A recreate would mint new ARNs and,
+    // for a Cluster, orphan every nodegroup/addon/profile keyed under its name.
+
+    pub(super) fn update_eks_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let cluster = state
+            .clusters
+            .get_mut(&name)
+            .ok_or_else(|| format!("No cluster found for name: {name}"))?;
+
+        if let Some(v) = props.get("Version").and_then(|v| v.as_str()) {
+            cluster.version = v.to_string();
+        }
+        if props.get("Logging").is_some() {
+            // Echo the CFN logging block as-is; the direct service also stores
+            // whatever `UpdateClusterConfig` sends.
+            cluster.logging = props.get("Logging").cloned().unwrap_or(json!({}));
+        }
+        if let Some(mode) = props
+            .get("AccessConfig")
+            .and_then(|v| v.get("AuthenticationMode"))
+            .and_then(|v| v.as_str())
+        {
+            cluster.access_config = json!({ "authenticationMode": mode });
+        }
+        if let Some(st) = props
+            .get("UpgradePolicy")
+            .and_then(|v| v.get("SupportType"))
+            .and_then(|v| v.as_str())
+        {
+            cluster.upgrade_policy = json!({ "supportType": st });
+        }
+        if let Some(v) = props.get("DeletionProtection").and_then(|v| v.as_bool()) {
+            cluster.deletion_protection = Some(v);
+        }
+        // Endpoint public/private access are mutable via UpdateClusterConfig.
+        if let Some(vpc) = props.get("ResourcesVpcConfig") {
+            if let Some(obj) = cluster.resources_vpc_config.as_object_mut() {
+                if let Some(v) = vpc.get("EndpointPublicAccess").and_then(|v| v.as_bool()) {
+                    obj.insert("endpointPublicAccess".to_string(), json!(v));
+                }
+                if let Some(v) = vpc.get("EndpointPrivateAccess").and_then(|v| v.as_bool()) {
+                    obj.insert("endpointPrivateAccess".to_string(), json!(v));
+                }
+                if let Some(v) = vpc.get("PublicAccessCidrs") {
+                    obj.insert("publicAccessCidrs".to_string(), v.clone());
+                }
+            }
+        }
+        if props.get("Tags").is_some() {
+            cluster.tags = parse_eks_tags(props.get("Tags"));
+        }
+
+        let arn = cluster.arn.clone();
+        let endpoint = cluster.endpoint.clone();
+        let ca_data = cluster.certificate_authority_data.clone();
+        let cluster_security_group_id = cluster.resources_vpc_config["clusterSecurityGroupId"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let key_arn = cluster
+            .encryption_config
+            .as_ref()
+            .and_then(|v| v.as_array())
+            .and_then(|a| a.first())
+            .and_then(|e| e.get("provider"))
+            .and_then(|p| p.get("keyArn"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let id = cluster_id_from_endpoint(&endpoint);
+        let oidc = format!("https://oidc.eks.amazonaws.com/id/{}", id.to_uppercase());
+        let mut result = ProvisionResult::new(name)
+            .with("Arn", arn)
+            .with("Endpoint", endpoint)
+            .with("CertificateAuthorityData", ca_data)
+            .with("ClusterSecurityGroupId", cluster_security_group_id)
+            .with("OpenIdConnectIssuerUrl", oidc)
+            .with("Id", id);
+        if let Some(k) = key_arn {
+            result = result.with("EncryptionConfigKeyArn", k);
+        }
+        Ok(result)
+    }
+
+    pub(super) fn update_eks_nodegroup(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (cluster_name, name) = physical_id
+            .split_once('/')
+            .map(|(c, n)| (c.to_string(), n.to_string()))
+            .ok_or_else(|| format!("Invalid Nodegroup physical id: {physical_id}"))?;
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let ng = state
+            .nodegroups
+            .get_mut(&cluster_name)
+            .and_then(|m| m.get_mut(&name))
+            .ok_or_else(|| format!("No nodegroup found: {physical_id}"))?;
+
+        if let Some(v) = props.get("ScalingConfig") {
+            ng.scaling_config = cfn_scaling_config(v);
+        }
+        if let Some(v) = props.get("UpdateConfig") {
+            ng.update_config = cfn_update_config(v);
+        }
+        if let Some(v) = props.get("Labels") {
+            ng.labels = v.clone();
+        }
+        if let Some(v) = props.get("Taints") {
+            ng.taints = v.clone();
+        }
+        if let Some(v) = props.get("Version").and_then(|v| v.as_str()) {
+            ng.version = v.to_string();
+        }
+        if let Some(v) = props.get("ReleaseVersion").and_then(|v| v.as_str()) {
+            ng.release_version = v.to_string();
+        }
+        if props.get("Tags").is_some() {
+            ng.tags = parse_eks_tags(props.get("Tags"));
+        }
+        ng.modified_at = Utc::now();
+
+        let arn = ng.arn.clone();
+        Ok(ProvisionResult::new(physical_id.clone())
+            .with("Arn", arn)
+            .with("Id", physical_id)
+            .with("ClusterName", cluster_name)
+            .with("NodegroupName", name))
+    }
+
+    pub(super) fn update_eks_fargate_profile(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (cluster_name, name) = physical_id
+            .split_once('|')
+            .ok_or_else(|| format!("Invalid FargateProfile physical id: {physical_id}"))?;
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let profile = state
+            .fargate_profiles
+            .get_mut(cluster_name)
+            .and_then(|m| m.get_mut(name))
+            .ok_or_else(|| format!("No fargate profile found: {physical_id}"))?;
+        // Fargate profiles are immutable except for their tags.
+        if props.get("Tags").is_some() {
+            profile.tags = parse_eks_tags(props.get("Tags"));
+        }
+        Ok(ProvisionResult::new(physical_id).with("Arn", profile.arn.clone()))
+    }
+
+    pub(super) fn update_eks_addon(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (cluster_name, name) = physical_id
+            .split_once('|')
+            .ok_or_else(|| format!("Invalid Addon physical id: {physical_id}"))?;
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let addon = state
+            .addons
+            .get_mut(cluster_name)
+            .and_then(|m| m.get_mut(name))
+            .ok_or_else(|| format!("No addon found: {physical_id}"))?;
+        if let Some(v) = props.get("AddonVersion").and_then(|v| v.as_str()) {
+            addon.addon_version = v.to_string();
+        }
+        if let Some(v) = props.get("ConfigurationValues").and_then(|v| v.as_str()) {
+            addon.configuration_values = Some(v.to_string());
+        }
+        if let Some(v) = props.get("ServiceAccountRoleArn").and_then(|v| v.as_str()) {
+            addon.service_account_role_arn = Some(v.to_string());
+        }
+        if props.get("Tags").is_some() {
+            addon.tags = parse_eks_tags(props.get("Tags"));
+        }
+        addon.modified_at = Utc::now();
+        let arn = addon.arn.clone();
+        Ok(ProvisionResult::new(physical_id)
+            .with("Arn", arn.clone())
+            .with("AddonArn", arn))
+    }
+
+    pub(super) fn update_eks_access_entry(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (cluster_name, principal_arn) = physical_id
+            .split_once('|')
+            .ok_or_else(|| format!("Invalid AccessEntry physical id: {physical_id}"))?;
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let entry = state
+            .access_entries
+            .get_mut(cluster_name)
+            .and_then(|m| m.get_mut(principal_arn))
+            .ok_or_else(|| format!("No access entry found: {physical_id}"))?;
+        if let Some(v) = props.get("KubernetesGroups").and_then(|v| v.as_array()) {
+            entry.kubernetes_groups = v
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(v) = props.get("Username").and_then(|v| v.as_str()) {
+            entry.username = v.to_string();
+        }
+        if props.get("Tags").is_some() {
+            entry.tags = parse_eks_tags(props.get("Tags"));
+        }
+        entry.modified_at = Utc::now();
+        Ok(ProvisionResult::new(physical_id).with("AccessEntryArn", entry.arn.clone()))
+    }
+
+    pub(super) fn update_eks_identity_provider_config(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (cluster_name, name) = physical_id
+            .split_once('|')
+            .ok_or_else(|| format!("Invalid IdentityProviderConfig physical id: {physical_id}"))?;
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let config = state
+            .identity_provider_configs
+            .get_mut(cluster_name)
+            .and_then(|m| m.get_mut(name))
+            .ok_or_else(|| format!("No identity provider config found: {physical_id}"))?;
+        // OIDC config is immutable except for its tags; re-reading (no delete) is
+        // still correct -- it stops the destructive reprovision.
+        if props.get("Tags").is_some() {
+            config.tags = parse_eks_tags(props.get("Tags"));
+        }
+        Ok(ProvisionResult::new(physical_id).with("IdentityProviderConfigArn", config.arn.clone()))
+    }
+
+    pub(super) fn update_eks_pod_identity_association(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let physical_id = existing.physical_id.clone();
+        let (cluster_name, association_id) = physical_id
+            .split_once('|')
+            .ok_or_else(|| format!("Invalid PodIdentityAssociation physical id: {physical_id}"))?;
+
+        let mut accounts = self.eks_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let assoc = state
+            .pod_identity_associations
+            .get_mut(cluster_name)
+            .and_then(|m| m.get_mut(association_id))
+            .ok_or_else(|| format!("No pod identity association found: {physical_id}"))?;
+        if let Some(v) = props.get("RoleArn").and_then(|v| v.as_str()) {
+            assoc.role_arn = v.to_string();
+        }
+        if let Some(v) = props.get("DisableSessionTags").and_then(|v| v.as_bool()) {
+            assoc.disable_session_tags = v;
+        }
+        if let Some(v) = props.get("TargetRoleArn").and_then(|v| v.as_str()) {
+            assoc.target_role_arn = Some(v.to_string());
+        }
+        if props.get("Tags").is_some() {
+            assoc.tags = parse_eks_tags(props.get("Tags"));
+        }
+        assoc.modified_at = Utc::now();
+        Ok(ProvisionResult::new(physical_id)
+            .with("AssociationArn", assoc.association_arn.clone())
+            .with("AssociationId", assoc.association_id.clone()))
     }
 }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/emr.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/emr.rs
@@ -10,7 +10,7 @@
 
 use serde_json::{json, Value};
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 
 impl ResourceProvisioner {
     pub(super) fn create_emr_cluster(
@@ -99,6 +99,72 @@ impl ResourceProvisioner {
         st.clusters.insert(id.clone(), Value::Object(cluster));
         st.cluster_order.push(id.clone());
 
+        Ok(ProvisionResult::new(id).with("MasterPublicDNS", master_dns))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::EMR::Cluster`. Mutates the stored
+    /// `Cluster` JSON in place instead of the destructive delete+recreate the
+    /// reprovision fallback would do (which would mint a new `j-...` cluster id
+    /// and drop the running steps / normalized-instance-hours the record
+    /// carries). Applies the properties EMR lets you change on a live cluster
+    /// (concurrency, visibility, termination protection, tags, and the scalar
+    /// echo members) and preserves the immutable identity (`Id`, `ClusterArn`,
+    /// `MasterPublicDnsName`, `Status`).
+    pub(super) fn update_emr_cluster(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let mut guard = self.emr_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let cluster = st
+            .clusters
+            .get_mut(&id)
+            .ok_or_else(|| format!("EMR cluster {id} not yet provisioned"))?;
+        let obj = cluster
+            .as_object_mut()
+            .ok_or_else(|| format!("EMR cluster {id} record is malformed"))?;
+
+        if let Some(v) = props.get("StepConcurrencyLevel").and_then(Value::as_i64) {
+            obj.insert("StepConcurrencyLevel".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("VisibleToAllUsers").and_then(Value::as_bool) {
+            obj.insert("VisibleToAllUsers".to_string(), json!(v));
+        }
+        if let Some(v) = props.get("TerminationProtected").and_then(Value::as_bool) {
+            obj.insert("TerminationProtected".to_string(), json!(v));
+        }
+        // Scalar / array echo members EMR re-reads verbatim.
+        for key in [
+            "ReleaseLabel",
+            "LogUri",
+            "LogEncryptionKmsKeyId",
+            "ServiceRole",
+            "AutoScalingRole",
+            "ScaleDownBehavior",
+            "CustomAmiId",
+            "EbsRootVolumeSize",
+            "SecurityConfiguration",
+            "Applications",
+            "Tags",
+            "Configurations",
+            "PlacementGroupConfigs",
+            "EbsRootVolumeIops",
+            "EbsRootVolumeThroughput",
+        ] {
+            if let Some(v) = props.get(key).filter(|v| !v.is_null()) {
+                obj.insert(key.to_string(), v.clone());
+            }
+        }
+
+        let master_dns = obj
+            .get("MasterPublicDnsName")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
         Ok(ProvisionResult::new(id).with("MasterPublicDNS", master_dns))
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/firehose.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/firehose.rs
@@ -84,6 +84,71 @@ impl ResourceProvisioner {
         })
     }
 
+    /// In-place `UpdateStack` for an `AWS::KinesisFirehose::DeliveryStream`.
+    /// Mutates the stored `DeliveryStream` in place instead of the reprovision
+    /// fallback's delete+recreate. Applies the mutable destination config + tags
+    /// (matching `UpdateDestination`/tag ops), bumps the `version_id`, and
+    /// preserves the identity (`arn`, `created_at`, `stream_type`) and any
+    /// `extra_destinations` on the record.
+    pub(super) fn update_firehose_delivery_stream(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+
+        let has_s3 = props.get("S3DestinationConfiguration").is_some();
+        let has_extended_s3 = props.get("ExtendedS3DestinationConfiguration").is_some();
+        if has_s3 && has_extended_s3 {
+            return Err("Only one of S3DestinationConfiguration or ExtendedS3DestinationConfiguration may be set".to_string());
+        }
+        let new_destination = if let Some(s3) = props.get("S3DestinationConfiguration") {
+            Some(parse_firehose_s3_destination(s3)?)
+        } else if let Some(s3) = props.get("ExtendedS3DestinationConfiguration") {
+            Some(parse_firehose_s3_destination(s3)?)
+        } else {
+            None
+        };
+
+        let mut state = self.firehose_state.write();
+        let account = state.get_or_create(&self.account_id, &self.region);
+        let stream = account
+            .streams_mut(&self.region)
+            .get_mut(&name)
+            .ok_or_else(|| format!("Delivery stream {name} not yet provisioned"))?;
+
+        if let Some(dest) = new_destination {
+            stream.destination = Some(dest);
+        }
+        if props.get("Tags").is_some() {
+            let mut tags = BTreeMap::new();
+            if let Some(arr) = props.get("Tags").and_then(|v| v.as_array()) {
+                for tag in arr {
+                    if let (Some(k), Some(v)) = (
+                        tag.get("Key").and_then(|v| v.as_str()),
+                        tag.get("Value").and_then(|v| v.as_str()),
+                    ) {
+                        tags.insert(k.to_string(), v.to_string());
+                    }
+                }
+            }
+            stream.tags = tags;
+        }
+        stream.last_update = Utc::now();
+        let next_version = stream.version_id.parse::<u64>().unwrap_or(1) + 1;
+        stream.version_id = next_version.to_string();
+        let arn = stream.arn.clone();
+
+        let mut attributes = BTreeMap::new();
+        attributes.insert("Arn".to_string(), arn);
+        attributes.insert("DeliveryStreamName".to_string(), name.clone());
+        Ok(ProvisionResult {
+            physical_id: name,
+            attributes,
+        })
+    }
+
     pub(super) fn delete_firehose_delivery_stream(&self, physical_id: &str) -> Result<(), String> {
         let mut state = self.firehose_state.write();
         let account = state.get_or_create(&self.account_id, &self.region);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1828,6 +1828,54 @@ impl ResourceProvisioner {
             "AWS::Glue::Database" => Some(self.update_glue_database(existing, new_def)?),
             "AWS::Glue::Table" => Some(self.update_glue_table(existing, new_def)?),
             "AWS::Timestream::Table" => Some(self.update_timestream_table(existing, new_def)?),
+            // Auto Scaling Group: mutate the stored group in place and reconcile
+            // instances BY DELTA (see `update_autoscaling_group`) so a benign
+            // capacity/tag/health-check change does not terminate + relaunch
+            // every instance (churning ids/IPs, breaking ELB registrations).
+            "AWS::AutoScaling::AutoScalingGroup" => {
+                Some(self.update_autoscaling_group(existing, new_def)?)
+            }
+            // Control-plane records. The reprovision fallback (delete + create)
+            // would mint a new physical id / ARN and, for the container-scoped
+            // deletes, drop contained state (Backup vault recovery points, an
+            // EMR cluster's steps, an Amplify app's branches). Each arm mutates
+            // the owning service's stored record in place and keeps the physical
+            // id + contained data.
+            "AWS::EMR::Cluster" => Some(self.update_emr_cluster(existing, new_def)?),
+            "AWS::EKS::Cluster" => Some(self.update_eks_cluster(existing, new_def)?),
+            "AWS::EKS::Nodegroup" => Some(self.update_eks_nodegroup(existing, new_def)?),
+            "AWS::EKS::FargateProfile" => Some(self.update_eks_fargate_profile(existing, new_def)?),
+            "AWS::EKS::Addon" => Some(self.update_eks_addon(existing, new_def)?),
+            "AWS::EKS::AccessEntry" => Some(self.update_eks_access_entry(existing, new_def)?),
+            "AWS::EKS::IdentityProviderConfig" => {
+                Some(self.update_eks_identity_provider_config(existing, new_def)?)
+            }
+            "AWS::EKS::PodIdentityAssociation" => {
+                Some(self.update_eks_pod_identity_association(existing, new_def)?)
+            }
+            "AWS::SageMaker::Model" => Some(self.update_sagemaker_model(existing, new_def)?),
+            "AWS::SageMaker::EndpointConfig" => {
+                Some(self.update_sagemaker_endpoint_config(existing, new_def)?)
+            }
+            "AWS::SageMaker::Endpoint" => Some(self.update_sagemaker_endpoint(existing, new_def)?),
+            "AWS::SageMaker::NotebookInstance" => {
+                Some(self.update_sagemaker_notebook_instance(existing, new_def)?)
+            }
+            "AWS::AppSync::GraphQLApi" => Some(self.update_appsync_graphql_api(existing, new_def)?),
+            "AWS::AppSync::DataSource" => Some(self.update_appsync_data_source(existing, new_def)?),
+            "AWS::AppSync::Resolver" => Some(self.update_appsync_resolver(existing, new_def)?),
+            "AWS::Athena::DataCatalog" => Some(self.update_athena_data_catalog(existing, new_def)?),
+            "AWS::Athena::NamedQuery" => Some(self.update_athena_named_query(existing, new_def)?),
+            "AWS::Athena::WorkGroup" => Some(self.update_athena_work_group(existing, new_def)?),
+            "AWS::Athena::PreparedStatement" => {
+                Some(self.update_athena_prepared_statement(existing, new_def)?)
+            }
+            "AWS::MWAA::Environment" => Some(self.update_mwaa_environment(existing, new_def)?),
+            "AWS::Amplify::App" => Some(self.update_amplify_app(existing, new_def)?),
+            "AWS::KinesisFirehose::DeliveryStream" => {
+                Some(self.update_firehose_delivery_stream(existing, new_def)?)
+            }
+            "AWS::Backup::BackupVault" => Some(self.update_backup_vault(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mwaa.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mwaa.rs
@@ -9,7 +9,7 @@
 
 use serde_json::{json, Value};
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 use fakecloud_mwaa::shared::{
     celery_executor_queue, environment_arn, now_epoch, service_role_arn, webserver_url,
 };
@@ -62,6 +62,65 @@ impl ResourceProvisioner {
         }
         data.environments.insert(name.clone(), Value::Object(env));
 
+        Ok(ProvisionResult::new(name)
+            .with("Arn", arn)
+            .with("WebserverUrl", webserver))
+    }
+
+    /// In-place `UpdateStack` for an `AWS::MWAA::Environment`. Mutates the stored
+    /// `Environment` JSON in place instead of the reprovision fallback's
+    /// delete+recreate. Applies the mutable, non-null CFN members over the stored
+    /// object (matching `UpdateEnvironment`) and preserves the server-minted
+    /// identity (`Name`, `Arn`, `CreatedAt`, `WebserverUrl`, `ServiceRoleArn`,
+    /// `CeleryExecutorQueue`).
+    pub(super) fn update_mwaa_environment(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+
+        let mut guard = self.mwaa_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let env = data
+            .environments
+            .get_mut(&name)
+            .ok_or_else(|| format!("Environment {name} not yet provisioned"))?;
+        let obj = env
+            .as_object_mut()
+            .ok_or_else(|| format!("Environment {name} record is malformed"))?;
+
+        // Members minted by the service that must NOT be overwritten from the
+        // template on update.
+        const PRESERVED: &[&str] = &[
+            "Name",
+            "Arn",
+            "Status",
+            "CreatedAt",
+            "WebserverUrl",
+            "ServiceRoleArn",
+            "CeleryExecutorQueue",
+        ];
+        if let Value::Object(new_props) = props {
+            for (k, v) in new_props {
+                if PRESERVED.contains(&k.as_str()) || v.is_null() {
+                    continue;
+                }
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+
+        let arn = obj
+            .get("Arn")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let webserver = obj
+            .get("WebserverUrl")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
         Ok(ProvisionResult::new(name)
             .with("Arn", arn)
             .with("WebserverUrl", webserver))

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/sagemaker.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/sagemaker.rs
@@ -13,7 +13,7 @@
 
 use serde_json::{json, Value};
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 
 impl ResourceProvisioner {
     pub(super) fn create_sagemaker_model(
@@ -90,6 +90,90 @@ impl ResourceProvisioner {
             return Err(format!("{family} {name} already exists"));
         }
         data.put_resource(family, &name, Value::Object(record));
+
+        Ok(ProvisionResult::new(name.clone())
+            .with(&arn_member, arn)
+            .with("Id", name))
+    }
+
+    pub(super) fn update_sagemaker_model(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        self.update_sagemaker_resource(existing, resource, "Model")
+    }
+
+    pub(super) fn update_sagemaker_endpoint_config(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        self.update_sagemaker_resource(existing, resource, "EndpointConfig")
+    }
+
+    pub(super) fn update_sagemaker_endpoint(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        self.update_sagemaker_resource(existing, resource, "Endpoint")
+    }
+
+    pub(super) fn update_sagemaker_notebook_instance(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        self.update_sagemaker_resource(existing, resource, "NotebookInstance")
+    }
+
+    /// In-place `UpdateStack` for a CFN-provisioned SageMaker resource. Merges
+    /// the mutable (non-null) properties over the stored record and bumps
+    /// `LastModifiedTime`, instead of the reprovision fallback's delete+recreate.
+    /// The record key (physical id), the minted `{Family}Arn` and `CreationTime`
+    /// are preserved.
+    fn update_sagemaker_resource(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+        family: &str,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+        let arn_member = format!("{family}Arn");
+
+        let mut guard = self.sagemaker_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let rec = data
+            .get_resource(family, &name)
+            .ok_or_else(|| format!("{family} {name} not yet provisioned"))?;
+        let mut obj = match rec {
+            Value::Object(m) => m.clone(),
+            _ => return Err(format!("{family} {name} record is malformed")),
+        };
+        // Members minted at create time that must survive the update.
+        let arn = obj
+            .get(&arn_member)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let creation_time = obj.get("CreationTime").cloned();
+
+        if let Value::Object(new_props) = props {
+            for (k, v) in new_props {
+                if v.is_null() || k == &arn_member || k == "CreationTime" {
+                    continue;
+                }
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+        obj.insert(arn_member.clone(), json!(arn.clone()));
+        if let Some(ct) = creation_time {
+            obj.insert("CreationTime".to_string(), ct);
+        }
+        obj.insert("LastModifiedTime".to_string(), json!(sagemaker_now()));
+        data.put_resource(family, &name, Value::Object(obj));
 
         Ok(ProvisionResult::new(name.clone())
             .with(&arn_member, arn)

--- a/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
@@ -494,3 +494,233 @@ async fn cfn_update_timestream_table_preserves_records() {
         "ingested records must survive an in-place Timestream table update; a reprovision would have wiped them"
     );
 }
+
+// --- AWS::AutoScaling::AutoScalingGroup -----------------------------------
+//
+// The reprovision fallback would delete the group (terminating EVERY running
+// instance) and recreate it (launching a brand-new set) on a benign capacity
+// change -- churning every instance id/IP and breaking ELB target
+// registrations. AWS applies the change in place, reconciling instances by the
+// DELTA. This asserts the ORIGINAL instance ids survive a `DesiredCapacity`
+// bump (only the added instance is new); a delete+recreate would replace all.
+
+const ASG_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "LC": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": { "ImageId": "ami-0a1b2c3d4e5f60001", "InstanceType": "t3.micro" }
+    },
+    "ASG": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "AutoScalingGroupName": "cfn-asg-preserve",
+        "MinSize": "1", "MaxSize": "5", "DesiredCapacity": "2",
+        "LaunchConfigurationName": { "Ref": "LC" },
+        "AvailabilityZones": ["us-east-1a"]
+      }
+    }
+  }
+}"#;
+
+// Identical except DesiredCapacity 2 -> 3 (a mutable, in-place change).
+const ASG_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "LC": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": { "ImageId": "ami-0a1b2c3d4e5f60001", "InstanceType": "t3.micro" }
+    },
+    "ASG": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "AutoScalingGroupName": "cfn-asg-preserve",
+        "MinSize": "1", "MaxSize": "5", "DesiredCapacity": "3",
+        "LaunchConfigurationName": { "Ref": "LC" },
+        "AvailabilityZones": ["us-east-1a"]
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_autoscaling_group_reconciles_by_delta() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let asg = aws_sdk_autoscaling::Client::new(&server.aws_config().await);
+
+    cfn.create_stack()
+        .stack_name("asg-preserve")
+        .template_body(ASG_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "asg-preserve", "CREATE_COMPLETE").await;
+
+    // Reconciliation to desired capacity runs in a detached task; poll until the
+    // group reports its 2 instances and capture their ids -- these are the
+    // instances a delete+recreate would terminate.
+    let ids_before = helpers::wait_until(std::time::Duration::from_secs(10), || {
+        let asg = asg.clone();
+        async move {
+            let out = asg
+                .describe_auto_scaling_groups()
+                .auto_scaling_group_names("cfn-asg-preserve")
+                .send()
+                .await
+                .ok()?;
+            let g = out.auto_scaling_groups().first()?;
+            (g.instances().len() == 2).then(|| {
+                g.instances()
+                    .iter()
+                    .filter_map(|i| i.instance_id().map(String::from))
+                    .collect::<Vec<_>>()
+            })
+        }
+    })
+    .await
+    .expect("ASG reconciled to 2 instances");
+
+    // Bump DesiredCapacity 2 -> 3. Pre-fix this delete+recreated the whole group,
+    // churning every instance id.
+    cfn.update_stack()
+        .stack_name("asg-preserve")
+        .template_body(ASG_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "asg-preserve", "UPDATE_COMPLETE").await;
+
+    // The group reconciles to 3 instances BY DELTA: the 2 original ids survive
+    // and exactly one new instance is added.
+    let ids_after = helpers::wait_until(std::time::Duration::from_secs(10), || {
+        let asg = asg.clone();
+        async move {
+            let out = asg
+                .describe_auto_scaling_groups()
+                .auto_scaling_group_names("cfn-asg-preserve")
+                .send()
+                .await
+                .ok()?;
+            let g = out.auto_scaling_groups().first()?;
+            (g.desired_capacity() == Some(3) && g.instances().len() == 3).then(|| {
+                g.instances()
+                    .iter()
+                    .filter_map(|i| i.instance_id().map(String::from))
+                    .collect::<Vec<_>>()
+            })
+        }
+    })
+    .await
+    .expect("ASG reconciled to 3 instances after in-place update");
+
+    for id in &ids_before {
+        assert!(
+            ids_after.contains(id),
+            "original instance {id} must survive an in-place DesiredCapacity update; \
+             a delete+recreate would have churned every id. before={ids_before:?} after={ids_after:?}"
+        );
+    }
+    assert_eq!(
+        ids_after.len(),
+        3,
+        "delta reconcile should add exactly one instance, not replace the set"
+    );
+}
+
+// --- AWS::Backup::BackupVault ---------------------------------------------
+//
+// `delete_backup_vault` removes the vault AND its `recovery_points`, so the
+// reprovision fallback (delete + recreate) would wipe every stored recovery
+// point AND mint a fresh `creation_date` on a benign tag change. The in-place
+// arm mutates the stored record, preserving the server-minted `creation_date`
+// (and, by construction on the untouched record, the `recovery_points`).
+
+const VAULT_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Vault": {
+      "Type": "AWS::Backup::BackupVault",
+      "Properties": {
+        "BackupVaultName": "cfn-vault-preserve",
+        "BackupVaultTags": { "env": "staging" }
+      }
+    }
+  }
+}"#;
+
+// Identical except the tag value staging -> prod (a mutable, in-place change).
+const VAULT_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Vault": {
+      "Type": "AWS::Backup::BackupVault",
+      "Properties": {
+        "BackupVaultName": "cfn-vault-preserve",
+        "BackupVaultTags": { "env": "prod" }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_backup_vault_is_in_place() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let backup = server.backup_client().await;
+
+    cfn.create_stack()
+        .stack_name("vault-preserve")
+        .template_body(VAULT_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "vault-preserve", "CREATE_COMPLETE").await;
+
+    // Record the server-minted creation date -- the vault's stable identity. A
+    // delete+recreate would mint a new one (and drop any recovery points).
+    let before = backup
+        .describe_backup_vault()
+        .backup_vault_name("cfn-vault-preserve")
+        .send()
+        .await
+        .expect("describe before");
+    let creation_before = before.creation_date().expect("creation date present");
+
+    // Change a mutable property (a tag value). Pre-fix this delete+recreated the
+    // vault, wiping its recovery points and minting a new creation date.
+    cfn.update_stack()
+        .stack_name("vault-preserve")
+        .template_body(VAULT_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "vault-preserve", "UPDATE_COMPLETE").await;
+
+    let after = backup
+        .describe_backup_vault()
+        .backup_vault_name("cfn-vault-preserve")
+        .send()
+        .await
+        .expect("describe after");
+    // The vault still exists and its stable creation date is unchanged -> the
+    // update was in place, not a destructive delete+recreate.
+    assert_eq!(
+        after.creation_date(),
+        Some(creation_before),
+        "creation date must be stable across an in-place update; a delete+recreate would mint a new one (and drop recovery points)"
+    );
+
+    // ...and the tag change was actually applied.
+    let tags = backup
+        .list_tags()
+        .resource_arn(after.backup_vault_arn().expect("vault arn"))
+        .send()
+        .await
+        .expect("list_tags");
+    assert_eq!(
+        tags.tags().and_then(|t| t.get("env")).map(String::as_str),
+        Some("prod"),
+        "the mutable tag change should have been applied in place"
+    );
+}

--- a/crates/fakecloud-testkit/Cargo.toml
+++ b/crates/fakecloud-testkit/Cargo.toml
@@ -61,6 +61,7 @@ sdk-clients = [
     "dep:aws-sdk-wafv2",
     "dep:aws-sdk-athena",
     "dep:aws-sdk-glue",
+    "dep:aws-sdk-backup",
     "dep:aws-sdk-cloudwatch",
     "dep:aws-sdk-organizations",
     "dep:aws-sdk-ec2",
@@ -130,6 +131,7 @@ aws-sdk-applicationautoscaling = { version = "1", optional = true }
 aws-sdk-wafv2 = { version = "1", optional = true }
 aws-sdk-athena = { version = "1", optional = true }
 aws-sdk-glue = { version = "1", optional = true }
+aws-sdk-backup = { version = "1", optional = true }
 aws-sdk-cloudwatch = { version = "=1.61.0", optional = true }
 aws-sdk-organizations = { version = "1", optional = true }
 aws-sdk-pipes = { version = "1", optional = true }

--- a/crates/fakecloud-testkit/src/lib.rs
+++ b/crates/fakecloud-testkit/src/lib.rs
@@ -931,6 +931,10 @@ impl TestServer {
         aws_sdk_athena::Client::new(&self.aws_config().await)
     }
 
+    pub async fn backup_client(&self) -> aws_sdk_backup::Client {
+        aws_sdk_backup::Client::new(&self.aws_config().await)
+    }
+
     pub async fn glue_client(&self) -> aws_sdk_glue::Client {
         aws_sdk_glue::Client::new(&self.aws_config().await)
     }


### PR DESCRIPTION
## Summary

bug-hunt 2026-07-25 Tier-0, #2399/#2403 CFN-update-arm remainder.

`resource_provisioner::update_resource` dispatches per type; the catch-all `_ => reprovision_resource` DELETES + RE-CREATES the backing resource. Several stateful/control-plane types still fell through to that destructive path on an otherwise-benign `UpdateStack` property/tag change. This adds in-place `update_*` arms for them, before the reprovision fallthrough.

### Primary: `AWS::AutoScaling::AutoScalingGroup` (real impact)

`delete_autoscaling` queued an `AsgInstances` teardown for EVERY launched EC2 container and `create_autoscaling_group` re-queued a full spawn — so a benign change to `DesiredCapacity`/`MinSize`/`MaxSize`/`Cooldown`/`HealthCheck*`/`TargetGroupARNs`/`NewInstancesProtectedFromScaleIn` TERMINATED every running instance and launched a brand-new set (churning instance ids/IPs, breaking ELB target registrations). AWS applies these in place with no interruption.

`update_autoscaling_group` now mutates the stored ASG record in place (applying the mutable properties, preserving `arn`/`created_time`/`instances`) and queues the SAME `AsgInstances` spawn intent `create` uses. The drain routes it through the owning autoscaling service's `reconcile_group`/`apply_capacity`, which already reconciles the instance set BY DELTA: scale-up launches only the shortfall, scale-down terminates only the excess (newest ids), and unchanged capacity touches nothing. Existing instance ids are preserved.

### Secondary: control-plane types (lower impact, in scope per no-deferral)

Added in-place `update_*` arms that mutate the stored record and keep the physical id + contained data:

- **EMR::Cluster** — mutate stored `Cluster` JSON (concurrency/visibility/termination-protection/tags/echo members), keep `Id`/`ClusterArn`/`Status`.
- **EKS** Cluster / Nodegroup / FargateProfile / Addon / AccessEntry / IdentityProviderConfig / PodIdentityAssociation — mutate the owning EKS structs in place (a Cluster recreate would orphan every nodegroup/addon keyed under its name).
- **SageMaker** Model / EndpointConfig / Endpoint / NotebookInstance — merge mutable props over the stored record, bump `LastModifiedTime`, keep `{Family}Arn`/`CreationTime`.
- **AppSync** GraphQLApi / DataSource / Resolver — merge mutable camelCase members, preserve `apiId`/arn/uris/dns (a GraphQLApi recreate would orphan its data sources/resolvers).
- **Athena** DataCatalog / NamedQuery / WorkGroup / PreparedStatement.
- **MWAA::Environment**, **Amplify::App**, **KinesisFirehose::DeliveryStream**.
- **Backup::BackupVault** — its delete removes `recovery_points`; the in-place arm mutates the record so an AccessPolicy/Notifications/tag change does NOT drop recovery points, and preserves `arn`/`creation_date`.

All route by mutating the owning service's stored record directly (keeping physical id + contained state); the ASG additionally reuses the owning service's real delta-reconcile via the existing spawn-intent drain.

Skipped: no type in the listed set lacked a create arm, so none were skipped. `Backup::BackupPlan` (has a create arm but not called out and its delete does not drop contained data) was left on the existing reprovision path.

## Test plan

- `cargo build -p fakecloud-cloudformation` — clean.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` — clean.
- `cargo clippy -p fakecloud-testkit --all-targets` — clean.
- `cargo fmt` on changed crates.
- New e2e tests in `cloudformation_update_preserves_stateful.rs`:
  - `cfn_update_autoscaling_group_reconciles_by_delta`: create ASG desired=2, capture instance ids, `UpdateStack` desired 2->3, assert the 2 ORIGINAL ids survive and exactly one instance was added (a delete+recreate would churn all ids).
  - `cfn_update_backup_vault_is_in_place`: create vault with a tag, `UpdateStack` changing the tag value, assert server-minted `creation_date` is unchanged (in-place, not recreate — which would also drop recovery points) and the tag change applied.
- Full file (`cargo test -p fakecloud-e2e --test cloudformation_update_preserves_stateful`): 4/4 pass (new 2 + existing ElastiCache/RDS).

ASG instance reconciliation runs without a container runtime (synthesized ids), so the delta behavior is verified locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CloudFormation UpdateStack apply in place for `AWS::AutoScaling::AutoScalingGroup` and several control‑plane resources to stop destructive delete+recreate behavior and preserve IDs/state. ASG updates now reconcile by delta to avoid instance churn and ELB target flaps.

- **Bug Fixes**
  - ASG updates now mutate the group and reconcile instances by delta; instance IDs are preserved and only the capacity delta is added/removed (no ELB target churn).
  - Added in‑place updates for EMR Cluster; EKS Cluster/Nodegroup/FargateProfile/Addon/AccessEntry/IdentityProviderConfig/PodIdentityAssociation; SageMaker Model/EndpointConfig/Endpoint/NotebookInstance; AppSync GraphQLApi/DataSource/Resolver; Athena DataCatalog/NamedQuery/WorkGroup/PreparedStatement; `MWAA::Environment`; `Amplify::App`; `KinesisFirehose::DeliveryStream`; `Backup::BackupVault` (keeps vault `creation_date` and recovery points).

- **Dependencies**
  - Added `aws-sdk-backup` for Backup vault e2e tests.

<sup>Written for commit acc2337f79318c84314ce0109adf89bc2e92aaf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

