### PR TITLE
fix(apigatewayv2,ec2,bedrock): region-scope ImportApi/TGW-peering/ClientVPN/inference-profile ARNs

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -1266,7 +1266,7 @@ impl ApiGatewayV2Service {
                 let spec = parse_openapi_spec(&spec_raw)?;
                 let new_api_id = generate_id("api");
                 let (api, routes, integrations) =
-                    build_api_from_spec(&spec, new_api_id.clone(), &region);
+                    build_api_from_spec(&spec, new_api_id.clone(), &req.region);
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 state.apis.insert(new_api_id.clone(), api.clone());
@@ -2975,6 +2975,31 @@ mod tests {
             &["v2", "apis", "a1", "stages", "prod", "cache", "authorizers"],
             Some("a1"),
             Some("prod"),
+        );
+    }
+
+    #[test]
+    fn import_api_endpoint_uses_request_region() {
+        // ImportApi must stamp the request region into the synthesized
+        // ApiEndpoint, mirroring CreateApi. A frozen us-east-1 would leak the
+        // wrong host into every client that imported against another region.
+        let s = svc();
+        let spec = r#"{"openapi":"3.0.1","info":{"title":"t","version":"1"},"paths":{"/p":{"get":{"responses":{"200":{"description":"ok"}}}}}}"#;
+        let import_body = serde_json::json!({ "Body": spec }).to_string();
+        let mut r = req("ImportApi", &import_body, &["v2", "apis"]);
+        r.region = "eu-west-1".to_string();
+        let resp = s
+            .handle_extra_action("ImportApi", &r, None, None)
+            .expect("ImportApi");
+        let b: serde_json::Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        let endpoint = b["apiEndpoint"].as_str().unwrap();
+        assert!(
+            endpoint.contains("eu-west-1"),
+            "ApiEndpoint missing request region: {endpoint}"
+        );
+        assert!(
+            !endpoint.contains("us-east-1"),
+            "ApiEndpoint leaked us-east-1: {endpoint}"
         );
     }
 

--- a/crates/fakecloud-bedrock/src/inference_profiles.rs
+++ b/crates/fakecloud-bedrock/src/inference_profiles.rs
@@ -105,7 +105,7 @@ pub(crate) fn get_inference_profile(
         "inferenceProfileId": profile_id_from_arn(&profile.inference_profile_arn),
         "inferenceProfileName": profile.inference_profile_name,
         "description": profile.description,
-        "models": profile_models(&profile.model_source),
+        "models": profile_models(&profile.model_source, &req.region),
         "status": profile.status,
         "type": profile.inference_profile_type,
         "createdAt": profile.created_at.to_rfc3339(),
@@ -160,7 +160,7 @@ pub(crate) fn list_inference_profiles(
                 "inferenceProfileId": profile_id_from_arn(&p.inference_profile_arn),
                 "inferenceProfileName": p.inference_profile_name,
                 "description": p.description,
-                "models": profile_models(&p.model_source),
+                "models": profile_models(&p.model_source, &req.region),
                 "status": p.status,
                 "type": p.inference_profile_type,
                 "createdAt": p.created_at.to_rfc3339(),
@@ -294,12 +294,12 @@ fn system_profiles(req: &AwsRequest) -> Vec<Value> {
 /// from the user-supplied `modelSource`, otherwise emit one synthesized entry
 /// pointing at a real foundation-model ARN so the response satisfies the
 /// `min: 1` length constraint on `InferenceProfileModels`.
-fn profile_models(model_source: &Value) -> Value {
+fn profile_models(model_source: &Value, region: &str) -> Value {
     if let Some(copy_from) = model_source.get("copyFrom").and_then(Value::as_str) {
         return json!([{ "modelArn": copy_from }]);
     }
     json!([{
-        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1"
+        "modelArn": format!("arn:aws:bedrock:{region}::foundation-model/amazon.titan-text-express-v1")
     }])
 }
 
@@ -436,6 +436,25 @@ mod tests {
             serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
         assert_eq!(v["inferenceProfileSummaries"].as_array().unwrap().len(), 2);
         assert!(v["nextToken"].is_string());
+    }
+
+    #[test]
+    fn fallback_model_arn_uses_request_region() {
+        // A profile created without a copyFrom modelSource synthesizes a
+        // foundation-model ARN. It must carry the request region, not a frozen
+        // us-east-1, so cross-region clients see a consistent ARN.
+        let s = shared();
+        create(&s, "p-region", false);
+        let mut r = req();
+        r.region = "eu-west-1".to_string();
+        let resp = get_inference_profile(&s, &r, "p-region").unwrap();
+        let v: Value =
+            serde_json::from_str(std::str::from_utf8(resp.body.expect_bytes()).unwrap()).unwrap();
+        let model_arn = v["models"][0]["modelArn"].as_str().unwrap();
+        assert_eq!(
+            model_arn, "arn:aws:bedrock:eu-west-1::foundation-model/amazon.titan-text-express-v1",
+            "fallback modelArn not request-scoped: {model_arn}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/cvpn.rs
+++ b/crates/fakecloud-ec2/src/service/cvpn.rs
@@ -18,7 +18,7 @@ fn status_xml(tag: &str, code: &str) -> String {
     format!("<{tag}><code>{code}</code></{tag}>")
 }
 
-fn endpoint_xml(e: &ClientVpnEndpoint, tags: &[Tag]) -> String {
+fn endpoint_xml(e: &ClientVpnEndpoint, tags: &[Tag], region: &str) -> String {
     format!(
         "{}{}{}{}{}{}<transportProtocol>{}</transportProtocol><vpnPort>443</vpnPort>{}{}",
         ec2_elem("clientVpnEndpointId", &e.id),
@@ -27,7 +27,7 @@ fn endpoint_xml(e: &ClientVpnEndpoint, tags: &[Tag]) -> String {
         ec2_elem("creationTime", FIXED_TIME),
         ec2_elem(
             "dnsName",
-            &format!("*.{}.clientvpn.us-east-1.amazonaws.com", e.id)
+            &format!("*.{}.clientvpn.{region}.amazonaws.com", e.id)
         ),
         ec2_elem("clientCidrBlock", &e.client_cidr),
         e.transport_protocol,
@@ -98,7 +98,7 @@ pub(crate) fn create_client_vpn_endpoint(
         status_xml("status", "pending-associate"),
         ec2_elem(
             "dnsName",
-            &format!("*.{id}.clientvpn.us-east-1.amazonaws.com")
+            &format!("*.{id}.clientvpn.{}.amazonaws.com", req.region)
         )
     );
     Ok(Ec2Service::respond(
@@ -139,7 +139,7 @@ pub(crate) fn describe_client_vpn_endpoints(
         .client_vpn_endpoints
         .values()
         .filter(|e| wanted.is_empty() || wanted.contains(&e.id))
-        .map(|e| endpoint_xml(e, state.tags_for(&e.id)))
+        .map(|e| endpoint_xml(e, state.tags_for(&e.id), &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -517,4 +517,51 @@ pub(crate) fn import_client_vpn_client_certificate_revocation_list(
         &req.request_id,
         &ec2_return(true),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::ec2_request;
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn dns_name_uses_request_region() {
+        let svc = Ec2Service::new();
+        // Client is in eu-west-1; the returned Client VPN DNS name host must
+        // carry that region, not a hardcoded us-east-1.
+        let mut r = ec2_request(
+            "CreateClientVpnEndpoint",
+            &[
+                (
+                    "ServerCertificateArn",
+                    "arn:aws:acm:eu-west-1:0:certificate/c",
+                ),
+                ("TransportProtocol", "udp"),
+                ("ClientCidrBlock", "10.0.0.0/22"),
+            ],
+        );
+        r.region = "eu-west-1".to_string();
+        let created = body(create_client_vpn_endpoint(&svc, &r).unwrap());
+        assert!(
+            created.contains(".clientvpn.eu-west-1.amazonaws.com"),
+            "create dnsName not request-scoped: {created}"
+        );
+        assert!(
+            !created.contains("us-east-1"),
+            "create dnsName leaked us-east-1: {created}"
+        );
+
+        // Describe emits the same regional host from endpoint_xml.
+        let mut d = ec2_request("DescribeClientVpnEndpoints", &[]);
+        d.region = "eu-west-1".to_string();
+        let desc = body(describe_client_vpn_endpoints(&svc, &d).unwrap());
+        assert!(
+            desc.contains(".clientvpn.eu-west-1.amazonaws.com"),
+            "describe dnsName not request-scoped: {desc}"
+        );
+    }
 }

--- a/crates/fakecloud-ec2/src/service/tgw_peering.rs
+++ b/crates/fakecloud-ec2/src/service/tgw_peering.rs
@@ -16,9 +16,9 @@ fn mr(req: &AwsRequest) -> Result<(), AwsServiceError> {
 
 // ---- peering attachments ----
 
-fn peering_xml(p: &TgwPeering, owner: &str) -> String {
+fn peering_xml(p: &TgwPeering, owner: &str, region: &str) -> String {
     format!(
-        "{}<requesterTgwInfo>{}{}<region>us-east-1</region></requesterTgwInfo>\
+        "{}<requesterTgwInfo>{}{}<region>{region}</region></requesterTgwInfo>\
          <accepterTgwInfo>{}{}<region>{}</region></accepterTgwInfo>\
          <status><code>available</code></status><state>{}</state>{}",
         ec2_elem("transitGatewayAttachmentId", &p.id),
@@ -61,7 +61,7 @@ pub(crate) fn create_transit_gateway_peering_attachment(
         &req.request_id,
         &format!(
             "<transitGatewayPeeringAttachment>{}</transitGatewayPeeringAttachment>",
-            peering_xml(&p, &req.account_id)
+            peering_xml(&p, &req.account_id, &req.region)
         ),
     ))
 }
@@ -106,7 +106,7 @@ fn peering_state_change(
         &req.request_id,
         &format!(
             "<transitGatewayPeeringAttachment>{}</transitGatewayPeeringAttachment>",
-            peering_xml(&p, &req.account_id)
+            peering_xml(&p, &req.account_id, &req.region)
         ),
     ))
 }
@@ -157,7 +157,7 @@ pub(crate) fn describe_transit_gateway_peering_attachments(
     let mut items: Vec<String> = state
         .tgw_peerings
         .values()
-        .map(|p| peering_xml(p, &owner))
+        .map(|p| peering_xml(p, &owner, &req.region))
         .collect();
     items.sort();
     Ok(Ec2Service::respond(
@@ -613,4 +613,53 @@ pub(crate) fn describe_transit_gateway_route_table_announcements(
         &req.request_id,
         &ec2_list("transitGatewayRouteTableAnnouncements", &items),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::ec2_request;
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn requester_tgw_info_uses_request_region() {
+        let svc = Ec2Service::new();
+        // Client operates in eu-west-1; the requester side of the peering must
+        // reflect that region, not a hardcoded us-east-1.
+        let mut r = ec2_request(
+            "CreateTransitGatewayPeeringAttachment",
+            &[
+                ("TransitGatewayId", "tgw-req"),
+                ("PeerTransitGatewayId", "tgw-peer"),
+                ("PeerAccountId", "999999999999"),
+                ("PeerRegion", "ap-south-1"),
+            ],
+        );
+        r.region = "eu-west-1".to_string();
+        let created = body(create_transit_gateway_peering_attachment(&svc, &r).unwrap());
+        assert!(
+            created.contains(
+                "<requesterTgwInfo><transitGatewayId>tgw-req</transitGatewayId>\
+                 <ownerId>000000000000</ownerId><region>eu-west-1</region></requesterTgwInfo>"
+            ),
+            "requester region not request-scoped: {created}"
+        );
+        // Accepter side keeps the explicit peer region.
+        assert!(
+            created.contains("<region>ap-south-1</region></accepterTgwInfo>"),
+            "accepter region wrong: {created}"
+        );
+
+        // Describe round-trips the same request region.
+        let mut d = ec2_request("DescribeTransitGatewayPeeringAttachments", &[]);
+        d.region = "eu-west-1".to_string();
+        let desc = body(describe_transit_gateway_peering_attachments(&svc, &d).unwrap());
+        assert!(
+            desc.contains("<region>eu-west-1</region></requesterTgwInfo>"),
+            "describe requester region not request-scoped: {desc}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-26, Family A (region-in-ARN): four handlers stamped a frozen `state.region`/hardcoded `us-east-1` into a client-visible returned ARN/URL/host instead of the request region. Mirrors the #2405/#2409 fixes.

- **apigatewayv2 `ImportApi`** (`extras.rs`): passed `region_for(aid)` (frozen `state.region`, us-east-1 fallback) into `build_api_from_spec`, which stored + returned a frozen-region `ApiEndpoint` (`https://{id}.execute-api.{region}.amazonaws.com`). Now passes `&req.region`, matching `CreateApi`. `ReimportApi` left untouched (it preserves the existing endpoint).
- **EC2 `CreateTransitGatewayPeeringAttachment` / accept/reject/delete / describe** (`tgw_peering.rs`): `<requesterTgwInfo><region>` was hardcoded `us-east-1`. Threaded a `region: &str` into `peering_xml`, passing `req.region` at all 3 call sites. Accepter side keeps its explicit `peer_region`.
- **EC2 `CreateClientVpnEndpoint` / describe** (`cvpn.rs`): DNS name host `*.{id}.clientvpn.us-east-1.amazonaws.com` was hardcoded. Threaded region into `endpoint_xml` and the create-response inline format, using `req.region`. Delete emits only a status (no host), so it needed no change.
- **Bedrock `GetInferenceProfile` / `ListInferenceProfiles`** (`inference_profiles.rs`): the synthesized fallback `modelArn` (`arn:aws:bedrock:us-east-1::foundation-model/...`) was hardcoded. Threaded region into `profile_models`, passing `req.region`.

Left by design: `SYSTEM_PROFILE_REGIONS` and `system_profile_json`'s cross-region model list (genuinely fixed multi-region routing), and `peer_region` on the accepter side (an explicit request param).

## Test plan

- New unit tests, each driving a non-default request region (`eu-west-1`) and asserting the returned value carries it, not `us-east-1`:
  - `extras::tests::import_api_endpoint_uses_request_region`
  - `service::tgw_peering::tests::requester_tgw_info_uses_request_region`
  - `service::cvpn::tests::dns_name_uses_request_region`
  - `inference_profiles::tests::fallback_model_arn_uses_request_region`
- `cargo test -p fakecloud-apigatewayv2 -p fakecloud-ec2 -p fakecloud-bedrock --lib`: 175 + 199 + 388 pass, 0 fail.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt` clean on all three crates.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes region scoping so returned ARNs/hosts use the request region instead of a frozen us-east-1. Affects API Gateway `ImportApi`, EC2 Transit Gateway peering, EC2 Client VPN, and Bedrock inference profile fallbacks.

- **Bug Fixes**
  - API Gateway v2 `ImportApi`: pass request region to `build_api_from_spec` so `apiEndpoint` is regional. `ReimportApi` unchanged.
  - EC2 `CreateTransitGatewayPeeringAttachment` (+ accept/reject/delete/describe): requester `region` now reflects the request. Accepter still uses the explicit `peerRegion`.
  - EC2 `CreateClientVpnEndpoint`/describe: DNS host now `*.{id}.clientvpn.{region}.amazonaws.com`.
  - Bedrock `GetInferenceProfile`/`ListInferenceProfiles`: synthesized fallback `modelArn` now uses the request region.

<sup>Written for commit 5ab73765ee29290b09c17434737bebff3928228d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

