### PR TITLE
fix(iam,kms,route53,wafv2,bedrock): pagination resumes past a deleted marker (sibling sweep)

### DIFF
--- a/crates/fakecloud-bedrock/src/async_invoke.rs
+++ b/crates/fakecloud-bedrock/src/async_invoke.rs
@@ -170,12 +170,18 @@ pub(crate) fn list_async_invokes(
         .collect();
     items.sort_by_key(|i| std::cmp::Reverse(i.submit_time));
 
+    // The list is sorted by Reverse(submit_time) but the cursor is an
+    // invocation_arn, so it is not a sortable total order — resume by finding
+    // the marker's position in the current order and starting after it. A
+    // missing marker (its invocation was deleted between pages) falls back to
+    // `items.len()` (terminate) rather than 0, so the pager never restarts at
+    // page 1.
     let start = if let Some(token) = next_token {
         items
             .iter()
             .position(|inv| inv.invocation_arn.as_str() == token.as_str())
             .map(|p| p + 1)
-            .unwrap_or(0)
+            .unwrap_or(items.len())
     } else {
         0
     };

--- a/crates/fakecloud-iam/src/iam_service/groups.rs
+++ b/crates/fakecloud-iam/src/iam_service/groups.rs
@@ -125,13 +125,19 @@ impl IamService {
             .iter()
             .filter_map(|uname| state.users.get(uname))
             .collect();
+        // Members are held in membership (insertion) order, not sorted by
+        // user_name, so the cursor is not a sortable total order — resume by
+        // finding the marker's position in the current order and starting
+        // after it. A deleted marker falls back to `resolved.len()` (terminate)
+        // rather than 0, so the pager never restarts at page 1.
         let start_idx = marker
             .as_ref()
-            .and_then(|m| {
+            .map(|m| {
                 resolved
                     .iter()
                     .position(|u| u.user_name == *m)
                     .map(|p| p + 1)
+                    .unwrap_or(resolved.len())
             })
             .unwrap_or(0);
         let rest = resolved.get(start_idx..).unwrap_or(&[]);
@@ -256,14 +262,18 @@ impl IamService {
         }
         groups.sort_by(|a, b| a.group_name.cmp(&b.group_name));
 
-        // Marker-based pagination: resume after the marked item.
+        // Marker-based pagination. The list is sorted by group_name and the
+        // marker is the last group_name of the previous page, so resume at the
+        // first group strictly greater than the marker. A strict `>` keeps the
+        // pager moving forward even when the marked group was deleted between
+        // pages (a plain "find marker, start after" would restart at page 1).
         let start_idx = marker
             .as_ref()
-            .and_then(|m| {
+            .map(|m| {
                 groups
                     .iter()
-                    .position(|g| g.group_name == *m)
-                    .map(|p| p + 1)
+                    .position(|g| g.group_name > *m)
+                    .unwrap_or(groups.len())
             })
             .unwrap_or(0);
         let page = groups.get(start_idx..).unwrap_or(&[]);

--- a/crates/fakecloud-iam/src/iam_service/roles.rs
+++ b/crates/fakecloud-iam/src/iam_service/roles.rs
@@ -249,13 +249,17 @@ impl IamService {
         }
         roles.sort_by(|a, b| a.role_name.cmp(&b.role_name));
 
-        // Apply marker-based pagination (start after the marker item)
+        // Apply marker-based pagination. The list is sorted by role_name and
+        // the marker is the last role_name of the previous page, so resume at
+        // the first role strictly greater than the marker. Using a strict `>`
+        // (rather than "find the marker, start after it") means a marker whose
+        // role was deleted between pages still resumes forward instead of
+        // restarting at page 1.
         let start_idx = if let Some(ref m) = marker {
             roles
                 .iter()
-                .position(|r| r.role_name == *m)
-                .map(|pos| pos + 1)
-                .unwrap_or(0)
+                .position(|r| r.role_name > *m)
+                .unwrap_or(roles.len())
         } else {
             0
         };

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -92,6 +92,67 @@ fn list_roles_rejects_non_numeric_max_items() {
 }
 
 #[test]
+fn list_roles_resumes_past_deleted_marker() {
+    // bug-hunt 2026-07-26 Family P: a delete-as-you-go pager must keep moving
+    // forward when the marker role is deleted between pages. Resuming with a
+    // strict `role_name > marker` (rather than "find the marker, start after
+    // it, else restart at 0") guarantees no page-1 repeat.
+    let svc = make_service();
+    let trust = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+    // Put the roles under a dedicated path so PathPrefix isolates them from the
+    // pre-seeded service-linked roles.
+    for i in 0..5 {
+        svc.create_role(&make_request(
+            "CreateRole",
+            vec![
+                ("RoleName", &format!("role-{i}")),
+                ("Path", "/testp/"),
+                ("AssumeRolePolicyDocument", trust),
+            ],
+        ))
+        .unwrap();
+    }
+
+    // Page 1: MaxItems=2 -> role-0, role-1; marker = role-1.
+    let resp = svc
+        .list_roles(&make_request(
+            "ListRoles",
+            vec![("PathPrefix", "/testp/"), ("MaxItems", "2")],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(body.contains("<RoleName>role-0</RoleName>"));
+    assert!(body.contains("<RoleName>role-1</RoleName>"));
+    assert!(body.contains("<IsTruncated>true</IsTruncated>"));
+    let marker = extract_xml_value(&body, "Marker");
+    assert_eq!(marker, "role-1");
+
+    // Delete the marker role between pages.
+    svc.delete_role(&make_request("DeleteRole", vec![("RoleName", "role-1")]))
+        .unwrap();
+
+    // Page 2: resume from the (now-deleted) marker. Must advance to role-2,
+    // role-3 -- never restart at role-0.
+    let resp = svc
+        .list_roles(&make_request(
+            "ListRoles",
+            vec![
+                ("PathPrefix", "/testp/"),
+                ("MaxItems", "2"),
+                ("Marker", &marker),
+            ],
+        ))
+        .unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+    assert!(
+        !body.contains("<RoleName>role-0</RoleName>"),
+        "page 2 must not repeat page 1 after the marker was deleted, got: {body}"
+    );
+    assert!(body.contains("<RoleName>role-2</RoleName>"));
+    assert!(body.contains("<RoleName>role-3</RoleName>"));
+}
+
+#[test]
 fn list_policies_rejects_non_numeric_max_items() {
     let svc = make_service();
     let req = make_request("ListPolicies", vec![("MaxItems", "notanumber")]);

--- a/crates/fakecloud-iam/src/iam_service/users.rs
+++ b/crates/fakecloud-iam/src/iam_service/users.rs
@@ -745,12 +745,15 @@ impl IamService {
             .unwrap_or_default();
         keys.sort_by(|a, b| a.access_key_id.cmp(&b.access_key_id));
 
-        // Apply marker-based pagination (start after the marker item)
+        // Apply marker-based pagination. Keys are sorted by access_key_id and
+        // the marker is the last access_key_id of the previous page, so resume
+        // at the first key strictly greater than the marker. A strict `>` keeps
+        // the pager moving forward even when the marked key was deleted between
+        // pages (a plain "find marker, start after" would restart at page 1).
         let start_idx = if let Some(ref m) = marker {
             keys.iter()
-                .position(|k| k.access_key_id == *m)
-                .map(|pos| pos + 1)
-                .unwrap_or(0)
+                .position(|k| k.access_key_id > *m)
+                .unwrap_or(keys.len())
         } else {
             0
         };

--- a/crates/fakecloud-kms/src/service_custom_store.rs
+++ b/crates/fakecloud-kms/src/service_custom_store.rs
@@ -449,12 +449,17 @@ impl KmsService {
             }
         }
 
+        // Stores are sorted by custom_key_store_id and the marker is the last
+        // id of the previous page, so resume at the first store strictly
+        // greater than the marker. A strict `>` keeps the pager moving forward
+        // even when the marked store was deleted between pages (a plain "find
+        // marker, start after" would restart at page 1).
         let start = marker
-            .and_then(|m| {
+            .map(|m| {
                 stores
                     .iter()
-                    .position(|s| s.custom_key_store_id == m)
-                    .map(|p| p + 1)
+                    .position(|s| s.custom_key_store_id.as_str() > m)
+                    .unwrap_or(stores.len())
             })
             .unwrap_or(0);
 

--- a/crates/fakecloud-route53/src/service/cidr.rs
+++ b/crates/fakecloud-route53/src/service/cidr.rs
@@ -198,14 +198,17 @@ impl Route53Service {
             .get("nexttoken")
             .cloned()
             .unwrap_or_default();
+        // Collections are sorted by id and the token is the last id of the
+        // previous page, so resume at the first collection strictly greater
+        // than the token. A strict `>` keeps the pager moving forward even when
+        // the token's collection was deleted between pages.
         let start = if nexttoken.is_empty() {
             0
         } else {
             colls
                 .iter()
-                .position(|c| c.id == nexttoken)
-                .map(|p| p + 1)
-                .unwrap_or(0)
+                .position(|c| c.id > nexttoken)
+                .unwrap_or(colls.len())
         };
         let slice: Vec<&StoredCidrCollection> = colls.iter().skip(start).take(max_items).collect();
         let next = if start + slice.len() < colls.len() {
@@ -260,14 +263,17 @@ impl Route53Service {
             .get("nexttoken")
             .cloned()
             .unwrap_or_default();
+        // Location names are sorted and the token is the last name of the
+        // previous page, so resume at the first name strictly greater than the
+        // token. A strict `>` keeps the pager moving forward even when the
+        // token's location was deleted between pages.
         let start = if nexttoken.is_empty() {
             0
         } else {
             names
                 .iter()
-                .position(|n| n == &nexttoken)
-                .map(|p| p + 1)
-                .unwrap_or(0)
+                .position(|n| n > &nexttoken)
+                .unwrap_or(names.len())
         };
         let slice: Vec<&String> = names.iter().skip(start).take(max_items).collect();
         let next = if start + slice.len() < names.len() {
@@ -338,6 +344,11 @@ impl Route53Service {
             let cidr = after.strip_prefix(':')?;
             Some((loc, cidr))
         }
+        // The cursor here is a compound (location, cidr) token, not a single
+        // sortable key, so resume by finding the marker's position in the
+        // current order and starting after it. A missing marker (its block was
+        // deleted between pages) falls back to `blocks.len()` (terminate)
+        // rather than 0, so the pager never restarts at page 1.
         let start = if nexttoken.is_empty() {
             0
         } else if let Some((loc, cidr)) = decode_token(&nexttoken) {
@@ -345,13 +356,13 @@ impl Route53Service {
                 .iter()
                 .position(|(n, b)| n == loc && b == cidr)
                 .map(|p| p + 1)
-                .unwrap_or(0)
+                .unwrap_or(blocks.len())
         } else {
             blocks
                 .iter()
                 .position(|(_, b)| b == &nexttoken)
                 .map(|p| p + 1)
-                .unwrap_or(0)
+                .unwrap_or(blocks.len())
         };
         let slice: Vec<&(String, String)> = blocks.iter().skip(start).take(max_items).collect();
         let next = if start + slice.len() < blocks.len() {

--- a/crates/fakecloud-wafv2/src/service/logging.rs
+++ b/crates/fakecloud-wafv2/src/service/logging.rs
@@ -103,13 +103,19 @@ impl Wafv2Service {
             let b_arn = b.get("ResourceArn").and_then(Value::as_str).unwrap_or("");
             a_arn.cmp(b_arn)
         });
+        // Configs are sorted by ResourceArn and the marker is the last
+        // ResourceArn of the previous page, so resume at the first config
+        // strictly greater than the marker. A strict `>` keeps the pager moving
+        // forward even when the marked config was deleted between pages (a plain
+        // "find marker, start after" would restart at page 1).
         let start = if next_marker.is_empty() {
             0
         } else {
             all.iter()
-                .position(|c| c.get("ResourceArn").and_then(Value::as_str) == Some(next_marker))
-                .map(|p| p + 1)
-                .unwrap_or(0)
+                .position(|c| {
+                    c.get("ResourceArn").and_then(Value::as_str).unwrap_or("") > next_marker
+                })
+                .unwrap_or(all.len())
         };
         let page: Vec<Value> = all.iter().skip(start).take(limit).cloned().collect();
         let next = if start + page.len() < all.len() {


### PR DESCRIPTION
## Summary

bug-hunt 2026-07-26 Family P (pagination restart-page-1) -- completes the #2406 sweep.

The marker-resume idiom `list.iter().position(|x| key(x) == marker).map(|p| p+1).unwrap_or(0)` restarts at page 1 when the marker item was deleted between pages (`.unwrap_or(0)`), so a delete-as-you-go pager never terminates. #2406 fixed several IAM/KMS ops via a strictly-greater resume; these siblings were missed. Each site was read for its sort order + marker emission to pick the correct form:

Strictly-greater `> marker` (list already sorted by the cursor key, so a deleted marker still resumes exactly where it should):
- IAM `ListRoles` (sorted by role_name)
- IAM `ListGroups` (group_name)
- IAM `ListAccessKeys` (access_key_id)
- KMS `ListCustomKeyStores` (custom_key_store_id)
- Route53 `ListCidrCollections` (id) and `ListCidrLocations` (location name)
- WAFv2 `ListLoggingConfigurations` (ResourceArn)

Minimal `unwrap_or(0)` -> `unwrap_or(len)` (cursor is not a sortable total order, so a plain `>` would skip/reorder; keep the position-lookup but terminate on a deleted marker instead of restarting):
- IAM `GetGroup` member-users (members held in insertion order, cursor is user_name)
- Route53 `ListCidrBlocks` (compound `(location, cidr)` token)
- Bedrock `ListAsyncInvokes` (list sorted by `Reverse(submit_time)`, cursor is invocation_arn)

WAFv2 `ListMobileSdkReleases` was already correct (uses an `Option`-based start that yields an empty page on an unknown marker) and was left unchanged.

## Test plan
- New unit test `list_roles_resumes_past_deleted_marker`: create N>limit roles, page once (MaxItems=2), delete the marker role, page again -- asserts page 2 advances to role-2/role-3 and never repeats role-0 (no page-1 restart).
- `cargo build` + `cargo clippy --all-targets -D warnings` + `cargo fmt` on fakecloud-iam, fakecloud-kms, fakecloud-route53, fakecloud-wafv2, fakecloud-bedrock: all clean.
- Full test suites for the five touched crates: all green (iam, kms 223, route53 83+51, wafv2, bedrock).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pagination so it resumes past a deleted marker instead of restarting at page 1, preventing loops and ensuring forward progress in IAM, KMS, Route53, WAFv2, and Bedrock. Also adds a unit test to cover the deleted-marker case.

- **Bug Fixes**
  - Use strict-greater resume for sorted lists: IAM ListRoles, ListGroups, ListAccessKeys; KMS ListCustomKeyStores; Route53 ListCidrCollections, ListCidrLocations; WAFv2 ListLoggingConfigurations.
  - For non-total cursors, treat a missing marker as end (no restart): IAM GetGroup members, Route53 ListCidrBlocks, Bedrock ListAsyncInvokes.
  - Added unit test list_roles_resumes_past_deleted_marker; all touched crate tests pass.

<sup>Written for commit 0edf56c31dd096e6529015395ac315a3b094cdcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

