### PR TITLE
fix(cloudformation): in-place UpdateStack for IAM/Cognito/Backup/Timestream stateful types (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/backup.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/backup.rs
@@ -205,6 +205,74 @@ impl ResourceProvisioner {
             .with("VersionId", version))
     }
 
+    /// In-place `UpdateStack` for an `AWS::Backup::BackupPlan`. Mutates the
+    /// stored `PlanRecord` in place instead of the reprovision fallback's
+    /// delete+recreate. `delete_backup_plan` removes the plan and re-create
+    /// mints a fresh `BackupPlanId`, dropping the plan's `versions` history and
+    /// every `selection` attached to it (`AWS::Backup::BackupSelection` /
+    /// direct `CreateBackupSelection`). Mirroring the direct `UpdateBackupPlan`
+    /// handler, this applies the new `BackupPlan` body, appends a new version,
+    /// and preserves the plan id, `arn`, `creation_date`, `versions` history and
+    /// `selections`.
+    pub(super) fn update_backup_plan(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let plan_src = props
+            .get("BackupPlan")
+            .filter(|v| v.is_object())
+            .ok_or("AWS::Backup::BackupPlan requires BackupPlan")?;
+        let plan_name = plan_src
+            .get("BackupPlanName")
+            .and_then(Value::as_str)
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let plan = normalize_backup_plan(plan_src);
+        let advanced = plan_src
+            .get("AdvancedBackupSettings")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new()));
+
+        let now = chrono::Utc::now();
+        let version = uuid::Uuid::new_v4().simple().to_string();
+
+        let mut guard = self.backup_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        let arn = {
+            let record = st
+                .plans
+                .get_mut(&id)
+                .ok_or_else(|| format!("Backup plan {id} not yet provisioned"))?;
+            // Mutate the plan body + advanced settings, append a version.
+            // `id`, `arn`, `creation_date`, `selections` are preserved.
+            record.plan = plan;
+            record.advanced_backup_settings = advanced;
+            record.version_id = version.clone();
+            record.versions.push(PlanVersion {
+                version_id: version.clone(),
+                creation_date: now,
+                deletion_date: None,
+                plan_name,
+            });
+            record.arn.clone()
+        };
+        // Tags are replaced wholesale on update, matching CFN tag semantics.
+        let tags = tag_map(props.get("BackupPlanTags"));
+        if tags.is_empty() {
+            st.tags.remove(&arn);
+        } else {
+            st.tags.insert(arn.clone(), tags);
+        }
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("BackupPlanArn", arn)
+            .with("BackupPlanId", id)
+            .with("VersionId", version))
+    }
+
     pub(super) fn delete_backup_plan(&self, physical_id: &str) -> Result<(), String> {
         let mut guard = self.backup_state.write();
         let st = guard.get_or_create(&self.account_id);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cognito.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cognito.rs
@@ -584,6 +584,96 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(identity_pool_id.clone()).with("Name", identity_pool_id))
     }
 
+    /// In-place `UpdateStack` for an `AWS::Cognito::IdentityPool`. Mutates the
+    /// stored `IdentityPool` record instead of the reprovision fallback's
+    /// delete+recreate. `delete_cognito_identity_pool` mints a brand-new pool id
+    /// (`<region>:<uuid>`) on recreate AND cascade-drops every
+    /// `identity_pool_role_attachment` tied to the pool, so a benign name/tag
+    /// change would churn the physical id and silently wipe the separately-
+    /// managed role attachment. This applies the mutable properties in place and
+    /// preserves the pool id, `creation_date`, and the untouched role
+    /// attachments.
+    pub(super) fn update_cognito_identity_pool(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let pool_id = &existing.physical_id;
+
+        let mut accounts = self.cognito_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let pool = state
+            .identity_pools
+            .get_mut(pool_id)
+            .ok_or_else(|| format!("Identity pool {pool_id} not yet provisioned"))?;
+
+        if let Some(name) = props.get("IdentityPoolName").and_then(|v| v.as_str()) {
+            pool.identity_pool_name = name.to_string();
+        }
+        if let Some(b) = props
+            .get("AllowUnauthenticatedIdentities")
+            .and_then(|v| v.as_bool())
+        {
+            pool.allow_unauthenticated_identities = b;
+        }
+        if let Some(b) = props.get("AllowClassicFlow").and_then(|v| v.as_bool()) {
+            pool.allow_classic_flow = b;
+        }
+        if let Some(dp) = props.get("DeveloperProviderName").and_then(|v| v.as_str()) {
+            pool.developer_provider_name = Some(dp.to_string());
+        }
+        if let Some(providers) = props
+            .get("CognitoIdentityProviders")
+            .and_then(|v| v.as_array())
+        {
+            pool.cognito_identity_providers = providers
+                .iter()
+                .filter_map(|p| {
+                    let obj = p.as_object()?;
+                    Some(CognitoIdentityProvider {
+                        provider_name: obj
+                            .get("ProviderName")
+                            .and_then(|v| v.as_str())?
+                            .to_string(),
+                        client_id: obj.get("ClientId").and_then(|v| v.as_str())?.to_string(),
+                        server_side_token_check: obj
+                            .get("ServerSideTokenCheck")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                    })
+                })
+                .collect();
+        }
+        if props.get("OpenIdConnectProviderARNs").is_some() {
+            pool.open_id_connect_provider_arns =
+                parse_cognito_string_array(props.get("OpenIdConnectProviderARNs"));
+        }
+        if props.get("SamlProviderARNs").is_some() {
+            pool.saml_provider_arns = parse_cognito_string_array(props.get("SamlProviderARNs"));
+        }
+        if let Some(m) = props
+            .get("SupportedLoginProviders")
+            .and_then(|v| v.as_object())
+        {
+            pool.supported_login_providers = m
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect();
+        }
+        if let Some(v) = props.get("CognitoStreams") {
+            pool.cognito_streams = Some(v.clone());
+        }
+        if let Some(v) = props.get("PushSync") {
+            pool.push_sync = Some(v.clone());
+        }
+        if props.get("IdentityPoolTags").is_some() {
+            pool.identity_pool_tags = parse_cognito_tags(props.get("IdentityPoolTags"));
+        }
+
+        Ok(ProvisionResult::new(pool_id.clone()).with("Name", pool_id.clone()))
+    }
+
     pub(super) fn delete_cognito_identity_pool(&self, physical_id: &str) -> Result<(), String> {
         let mut accounts = self.cognito_state.write();
         let state = accounts.get_or_create(&self.account_id);

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/iam.rs
@@ -450,6 +450,86 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// Apply a CFN property update to an existing IAM user in place. Without a
+    /// dedicated arm the reprovision fallback would `delete_iam_user` +
+    /// re-create, which mints a new `user_id`, WIPES every `access_key` the user
+    /// held, and strips the user from every group. This mutates the stored user
+    /// in place — refreshing tags, permissions boundary, inline `Policies` and
+    /// attached `ManagedPolicyArns` (the template is authoritative for the
+    /// policy sets), and additively applying any `Groups` — while preserving the
+    /// physical id (user name), `user_id`, `arn`, the user's `access_keys`, and
+    /// pre-existing (externally-added) group memberships. A changed `UserName`
+    /// is a replacement handled by the reprovision path, not here.
+    pub(super) fn update_iam_user(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_name = existing.physical_id.clone();
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+
+        let arn = {
+            let user = state
+                .users
+                .get_mut(&user_name)
+                .ok_or_else(|| format!("IAM user {user_name} not yet provisioned"))?;
+            if props.get("Tags").is_some() {
+                user.tags = parse_iam_tags(props.get("Tags"));
+            }
+            if let Some(pb) = props.get("PermissionsBoundary").and_then(|v| v.as_str()) {
+                user.permissions_boundary = Some(pb.to_string());
+            }
+            user.arn.clone()
+        };
+
+        // Inline policies — replace the whole set with the template's.
+        if let Some(policies) = props.get("Policies").and_then(|v| v.as_array()) {
+            let inline = state
+                .user_inline_policies
+                .entry(user_name.clone())
+                .or_default();
+            inline.clear();
+            for p in policies {
+                if let (Some(n), Some(doc)) = (
+                    p.get("PolicyName").and_then(|v| v.as_str()),
+                    p.get("PolicyDocument"),
+                ) {
+                    let document = if doc.is_string() {
+                        doc.as_str().unwrap_or("").to_string()
+                    } else {
+                        serde_json::to_string(doc).unwrap_or_default()
+                    };
+                    inline.insert(n.to_string(), document);
+                }
+            }
+        }
+        // Attached managed policies — replace the set with the template's.
+        if let Some(arns) = props.get("ManagedPolicyArns").and_then(|v| v.as_array()) {
+            let attached: Vec<String> = arns
+                .iter()
+                .filter_map(|a| a.as_str().map(String::from))
+                .collect();
+            state.user_policies.insert(user_name.clone(), attached);
+        }
+        // Group memberships — additive, so externally-managed memberships (a
+        // direct AddUserToGroup / UserToGroupAddition resource) survive.
+        if let Some(groups) = props.get("Groups").and_then(|v| v.as_array()) {
+            for g in groups {
+                if let Some(g_name) = g.as_str() {
+                    if let Some(group) = state.groups.get_mut(g_name) {
+                        if !group.members.iter().any(|m| m == &user_name) {
+                            group.members.push(user_name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ProvisionResult::new(user_name).with("Arn", arn))
+    }
+
     pub(super) fn create_iam_group(
         &self,
         resource: &ResourceDefinition,
@@ -517,6 +597,58 @@ impl ResourceProvisioner {
             },
         );
 
+        Ok(ProvisionResult::new(group_name).with("Arn", arn))
+    }
+
+    /// Apply a CFN property update to an existing IAM group in place. Without a
+    /// dedicated arm the reprovision fallback would `delete_iam_group` +
+    /// re-create, dropping every membership added out-of-band (a direct
+    /// AddUserToGroup / `AWS::IAM::UserToGroupAddition` resource) and churning
+    /// the `group_id`. This refreshes the inline `Policies` and attached
+    /// `ManagedPolicyArns` (the template is authoritative for the policy sets)
+    /// while preserving the physical id (group name), `group_id`, `arn`, and the
+    /// group's `members`. A changed `GroupName` is a replacement handled by the
+    /// reprovision path, not here.
+    pub(super) fn update_iam_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let group_name = existing.physical_id.clone();
+        let mut accounts = self.iam_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let group = state
+            .groups
+            .get_mut(&group_name)
+            .ok_or_else(|| format!("IAM group {group_name} not yet provisioned"))?;
+
+        // Inline policies — replace the whole set with the template's.
+        if let Some(policies) = props.get("Policies").and_then(|v| v.as_array()) {
+            group.inline_policies.clear();
+            for p in policies {
+                if let (Some(n), Some(doc)) = (
+                    p.get("PolicyName").and_then(|v| v.as_str()),
+                    p.get("PolicyDocument"),
+                ) {
+                    let document = if doc.is_string() {
+                        doc.as_str().unwrap_or("").to_string()
+                    } else {
+                        serde_json::to_string(doc).unwrap_or_default()
+                    };
+                    group.inline_policies.insert(n.to_string(), document);
+                }
+            }
+        }
+        // Attached managed policies — replace the set with the template's.
+        if let Some(arns) = props.get("ManagedPolicyArns").and_then(|v| v.as_array()) {
+            group.attached_policies = arns
+                .iter()
+                .filter_map(|a| a.as_str().map(String::from))
+                .collect();
+        }
+
+        let arn = group.arn.clone();
         Ok(ProvisionResult::new(group_name).with("Arn", arn))
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1625,6 +1625,12 @@ impl ResourceProvisioner {
             "AWS::IAM::Role" => Some(self.update_iam_role(existing, new_def)?),
             "AWS::IAM::Policy" => Some(self.update_iam_policy(existing, new_def)?),
             "AWS::IAM::ManagedPolicy" => Some(self.update_iam_policy(existing, new_def)?),
+            // In-place update: the reprovision fallback (delete + create) would
+            // wipe the user's access keys / churn the user id (User) or drop
+            // out-of-band group memberships (Group). See `update_iam_user` /
+            // `update_iam_group`.
+            "AWS::IAM::User" => Some(self.update_iam_user(existing, new_def)?),
+            "AWS::IAM::Group" => Some(self.update_iam_group(existing, new_def)?),
             "AWS::ApiGateway::RestApi" => Some(self.update_apigw_rest_api(existing, new_def)?),
             "AWS::ApiGateway::Resource" => Some(self.update_apigw_resource(existing, new_def)?),
             "AWS::ApiGateway::Method" => Some(self.update_apigw_method(existing, new_def)?),
@@ -1743,6 +1749,11 @@ impl ResourceProvisioner {
             "AWS::Cognito::UserPoolClient" => {
                 Some(self.update_cognito_user_pool_client(existing, new_def)?)
             }
+            // In-place update: reprovision would mint a new `<region>:<uuid>`
+            // pool id and cascade-drop the pool's role attachment.
+            "AWS::Cognito::IdentityPool" => {
+                Some(self.update_cognito_identity_pool(existing, new_def)?)
+            }
             "AWS::RDS::DBInstance" => Some(self.update_rds_db_instance(existing, new_def)?),
             "AWS::S3::Bucket" => Some(self.update_s3_bucket(existing, new_def)?),
             "AWS::S3::BucketPolicy" => Some(self.update_s3_bucket_policy(existing, new_def)?),
@@ -1827,6 +1838,9 @@ impl ResourceProvisioner {
             // that a reprovision (delete+create) would silently wipe.
             "AWS::Glue::Database" => Some(self.update_glue_database(existing, new_def)?),
             "AWS::Glue::Table" => Some(self.update_glue_table(existing, new_def)?),
+            "AWS::Timestream::Database" => {
+                Some(self.update_timestream_database(existing, new_def)?)
+            }
             "AWS::Timestream::Table" => Some(self.update_timestream_table(existing, new_def)?),
             // Auto Scaling Group: mutate the stored group in place and reconcile
             // instances BY DELTA (see `update_autoscaling_group`) so a benign
@@ -1876,6 +1890,9 @@ impl ResourceProvisioner {
                 Some(self.update_firehose_delivery_stream(existing, new_def)?)
             }
             "AWS::Backup::BackupVault" => Some(self.update_backup_vault(existing, new_def)?),
+            // In-place update: reprovision would mint a new BackupPlanId and
+            // drop the plan's version history + selections.
+            "AWS::Backup::BackupPlan" => Some(self.update_backup_plan(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/timestream.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/timestream.rs
@@ -67,6 +67,50 @@ impl ResourceProvisioner {
             .with("DatabaseName", name))
     }
 
+    /// In-place `UpdateStack` for an `AWS::Timestream::Database`. Mutates the
+    /// stored `Database` record instead of the reprovision fallback's
+    /// delete+recreate. The database's tables and their ingested records live in
+    /// separate maps keyed by `<db>|<table>` and survive a database
+    /// delete+recreate, but the recreated `Database` resets `table_count` to 0 —
+    /// so `DescribeDatabase` would report 0 tables while the tables still exist.
+    /// This applies the mutable `KmsKeyId` (and tags) in place and preserves the
+    /// database identity (`arn`, `creation_time`) and its `table_count`. Real
+    /// AWS `UpdateDatabase` only mutates the KMS key.
+    pub(super) fn update_timestream_database(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+
+        let mut guard = self.timestream_state.write();
+        let data = guard.get_or_create(&self.account_id);
+        let arn = {
+            let db = data
+                .databases
+                .get_mut(&name)
+                .ok_or_else(|| format!("Database {name} not yet provisioned"))?;
+            if let Some(kms) = props.get("KmsKeyId").and_then(Value::as_str) {
+                db.kms_key_id = Some(kms.to_string());
+            }
+            db.last_updated_time = now_epoch();
+            // `table_count`, `arn`, `creation_time` are preserved.
+            db.arn.clone()
+        };
+        // Tags are replaced wholesale on update, matching CFN tag semantics.
+        let tags = string_tag_map(props.get("Tags"));
+        if tags.is_empty() {
+            data.tags.remove(&arn);
+        } else {
+            data.tags.insert(arn.clone(), tags);
+        }
+
+        Ok(ProvisionResult::new(name.clone())
+            .with("Arn", arn)
+            .with("DatabaseName", name))
+    }
+
     pub(super) fn delete_timestream_database(&self, physical_id: &str) -> Result<(), String> {
         let mut guard = self.timestream_state.write();
         let data = guard.get_or_create(&self.account_id);

--- a/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
+++ b/crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs
@@ -22,6 +22,7 @@
 
 mod helpers;
 
+use aws_sdk_cloudformation::types::Capability;
 use helpers::TestServer;
 
 async fn wait_for_status(server: &TestServer, stack: &str, want: &str) {
@@ -722,5 +723,293 @@ async fn cfn_update_backup_vault_is_in_place() {
         tags.tags().and_then(|t| t.get("env")).map(String::as_str),
         Some("prod"),
         "the mutable tag change should have been applied in place"
+    );
+}
+
+// --- AWS::IAM::User -------------------------------------------------------
+//
+// Without an in-place arm the reprovision fallback would `delete_iam_user` +
+// re-create on a benign tag change: that WIPES every access key the user held
+// and mints a new `user_id`. This asserts an out-of-band access key and the
+// stable `user_id` both survive a tag-only `UpdateStack`.
+
+const USER_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Worker": {
+      "Type": "AWS::IAM::User",
+      "Properties": {
+        "UserName": "cfn-preserve-worker",
+        "Tags": [{"Key": "env", "Value": "staging"}]
+      }
+    }
+  }
+}"#;
+
+// Identical except the tag value staging -> prod (a mutable, in-place change).
+const USER_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Worker": {
+      "Type": "AWS::IAM::User",
+      "Properties": {
+        "UserName": "cfn-preserve-worker",
+        "Tags": [{"Key": "env", "Value": "prod"}]
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn cfn_update_iam_user_preserves_access_keys() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let iam = server.iam_client().await;
+
+    cfn.create_stack()
+        .stack_name("user-preserve")
+        .template_body(USER_TEMPLATE_V1)
+        .capabilities(Capability::CapabilityNamedIam)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "user-preserve", "CREATE_COMPLETE").await;
+
+    // The server-minted user id is the user's stable identity; a delete+recreate
+    // would mint a new one.
+    let before = iam
+        .get_user()
+        .user_name("cfn-preserve-worker")
+        .send()
+        .await
+        .expect("get_user before");
+    let user_id_before = before.user().expect("user").user_id().to_string();
+
+    // Out-of-band: mint an access key the template never carries. A
+    // delete+recreate would wipe it.
+    let key = iam
+        .create_access_key()
+        .user_name("cfn-preserve-worker")
+        .send()
+        .await
+        .expect("create_access_key");
+    let access_key_id = key
+        .access_key()
+        .expect("access key")
+        .access_key_id()
+        .to_string();
+
+    // Change a mutable property (a tag value). Pre-fix this delete+recreated the
+    // user, wiping the access key and minting a new user id.
+    cfn.update_stack()
+        .stack_name("user-preserve")
+        .template_body(USER_TEMPLATE_V2)
+        .capabilities(Capability::CapabilityNamedIam)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "user-preserve", "UPDATE_COMPLETE").await;
+
+    // The user id is unchanged -> in-place, not a destructive recreate.
+    let after = iam
+        .get_user()
+        .user_name("cfn-preserve-worker")
+        .send()
+        .await
+        .expect("get_user after");
+    assert_eq!(
+        after.user().expect("user").user_id(),
+        user_id_before,
+        "user id must be stable across an in-place update; a recreate would mint a new one"
+    );
+
+    // The out-of-band access key survived the update.
+    let keys = iam
+        .list_access_keys()
+        .user_name("cfn-preserve-worker")
+        .send()
+        .await
+        .expect("list_access_keys");
+    assert!(
+        keys.access_key_metadata()
+            .iter()
+            .any(|k| k.access_key_id() == Some(access_key_id.as_str())),
+        "the out-of-band access key must survive an in-place IAM user update; a reprovision would have wiped it"
+    );
+
+    // ...and the tag change was actually applied.
+    let tags = iam
+        .list_user_tags()
+        .user_name("cfn-preserve-worker")
+        .send()
+        .await
+        .expect("list_user_tags");
+    assert_eq!(
+        tags.tags()
+            .iter()
+            .find(|t| t.key() == "env")
+            .map(|t| t.value()),
+        Some("prod"),
+        "the mutable tag change should have been applied in place"
+    );
+}
+
+// --- AWS::Cognito::IdentityPool -------------------------------------------
+//
+// Without an in-place arm the reprovision fallback would
+// `delete_cognito_identity_pool` + re-create on a benign name change: that
+// mints a brand-new `<region>:<uuid>` pool id AND cascade-drops the pool's
+// separately-managed role attachment. This asserts the pool id stays stable and
+// an out-of-band role attachment survives a name-only `UpdateStack`.
+
+const POOL_TEMPLATE_V1: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Pool": {
+      "Type": "AWS::Cognito::IdentityPool",
+      "Properties": {
+        "IdentityPoolName": "cfn_preserve_pool_v1",
+        "AllowUnauthenticatedIdentities": true
+      }
+    }
+  },
+  "Outputs": {
+    "PoolId": {"Value": {"Ref": "Pool"}}
+  }
+}"#;
+
+// Identical except the pool name is bumped (a mutable, in-place change).
+const POOL_TEMPLATE_V2: &str = r#"{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Pool": {
+      "Type": "AWS::Cognito::IdentityPool",
+      "Properties": {
+        "IdentityPoolName": "cfn_preserve_pool_v2",
+        "AllowUnauthenticatedIdentities": true
+      }
+    }
+  },
+  "Outputs": {
+    "PoolId": {"Value": {"Ref": "Pool"}}
+  }
+}"#;
+
+async fn stack_output(server: &TestServer, stack: &str, key: &str) -> String {
+    let cfn = server.cloudformation_client().await;
+    let out = cfn
+        .describe_stacks()
+        .stack_name(stack)
+        .send()
+        .await
+        .expect("describe_stacks");
+    out.stacks()
+        .first()
+        .expect("stack")
+        .outputs()
+        .iter()
+        .find(|o| o.output_key() == Some(key))
+        .and_then(|o| o.output_value())
+        .unwrap_or_else(|| panic!("output {key} not found"))
+        .to_string()
+}
+
+#[tokio::test]
+async fn cfn_update_cognito_identity_pool_preserves_role_attachment() {
+    let server = TestServer::start().await;
+    let cfn = server.cloudformation_client().await;
+    let cognito_identity = server.cognito_identity_client().await;
+    let iam = server.iam_client().await;
+
+    // A role to attach to the pool out-of-band.
+    let trust_doc = r#"{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"Federated": "cognito-identity.amazonaws.com"},
+            "Action": "sts:AssumeRoleWithWebIdentity"
+        }]
+    }"#;
+    let role = iam
+        .create_role()
+        .role_name("CfnPreservePoolUnauthRole")
+        .assume_role_policy_document(trust_doc)
+        .send()
+        .await
+        .expect("create unauth role");
+    let role_arn = role.role().unwrap().arn().to_string();
+
+    cfn.create_stack()
+        .stack_name("pool-preserve")
+        .template_body(POOL_TEMPLATE_V1)
+        .send()
+        .await
+        .expect("create_stack");
+    wait_for_status(&server, "pool-preserve", "CREATE_COMPLETE").await;
+
+    let pool_id = stack_output(&server, "pool-preserve", "PoolId").await;
+    assert!(
+        pool_id.contains(':'),
+        "identity pool id should be `<region>:<uuid>`: {pool_id}"
+    );
+
+    // Out-of-band: attach roles to the pool (a separate SetIdentityPoolRoles
+    // record). A delete+recreate would cascade-drop this attachment.
+    use std::collections::HashMap;
+    let mut roles = HashMap::new();
+    roles.insert("authenticated".to_string(), role_arn.clone());
+    roles.insert("unauthenticated".to_string(), role_arn.clone());
+    cognito_identity
+        .set_identity_pool_roles()
+        .identity_pool_id(&pool_id)
+        .set_roles(Some(roles))
+        .send()
+        .await
+        .expect("set identity pool roles");
+
+    // Change a mutable property (the pool name). Pre-fix this delete+recreated
+    // the pool, minting a new id and dropping the role attachment.
+    cfn.update_stack()
+        .stack_name("pool-preserve")
+        .template_body(POOL_TEMPLATE_V2)
+        .send()
+        .await
+        .expect("update_stack");
+    wait_for_status(&server, "pool-preserve", "UPDATE_COMPLETE").await;
+
+    // The pool id is unchanged -> in-place, not a destructive recreate.
+    let pool_id_after = stack_output(&server, "pool-preserve", "PoolId").await;
+    assert_eq!(
+        pool_id_after, pool_id,
+        "identity pool id must be stable across an in-place update; a recreate would mint a new `<region>:<uuid>`"
+    );
+
+    // The name change was actually applied.
+    let described = cognito_identity
+        .describe_identity_pool()
+        .identity_pool_id(&pool_id)
+        .send()
+        .await
+        .expect("describe identity pool");
+    assert_eq!(
+        described.identity_pool_name(),
+        "cfn_preserve_pool_v2",
+        "the mutable name change should have been applied in place"
+    );
+
+    // The out-of-band role attachment survived the update.
+    let got_roles = cognito_identity
+        .get_identity_pool_roles()
+        .identity_pool_id(&pool_id)
+        .send()
+        .await
+        .expect("get identity pool roles");
+    assert_eq!(
+        got_roles
+            .roles()
+            .and_then(|m| m.get("unauthenticated"))
+            .map(String::as_str),
+        Some(role_arn.as_str()),
+        "the out-of-band role attachment must survive an in-place identity pool update; a reprovision would have cascade-dropped it"
     );
 }


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-26 Family B (CFN reprovision-on-update data loss). `update_resource`'s `_ => reprovision_resource` fallback (delete + create) still fired for several stateful types lacking an in-place `update_*` arm, churning the physical id and dropping separately-managed contained state. This adds dedicated in-place arms for the remaining offenders and wires them into the `update_resource` match before the `_ =>` fallthrough. A changed Name/identity property remains a replacement (still handled by the reprovision path); an in-place update keeps the existing physical id and all contained collections.

### Arms added — what each preserves

- **`AWS::IAM::User`** (`update_iam_user`): preserves the physical id (user name), `user_id`, `arn`, and the user's `access_keys` + pre-existing (out-of-band) group memberships. Refreshes tags, permissions boundary, inline `Policies` and attached `ManagedPolicyArns`; applies `Groups` additively. Reprovision would have wiped every access key and minted a new `user_id`.
- **`AWS::IAM::Group`** (`update_iam_group`): preserves the physical id (group name), `group_id`, `arn`, and `members` (memberships added out-of-band via `AWS::IAM::UserToGroupAddition` / direct `AddUserToGroup`). Refreshes inline `Policies` and attached `ManagedPolicyArns`. Reprovision would have dropped those memberships.
- **`AWS::Cognito::IdentityPool`** (`update_cognito_identity_pool`): preserves the `<region>:<uuid>` pool id, `creation_date`, and the pool's separately-managed role attachment. Applies name / auth flags / providers / tags in place. Reprovision would have minted a new pool id and cascade-dropped the role attachment.
- **`AWS::Backup::BackupPlan`** (`update_backup_plan`): preserves `BackupPlanId`, `arn`, `creation_date`, the `versions` history and attached `selections`. Mirrors the direct `UpdateBackupPlan` handler (applies the new plan body + appends a new version). Reprovision would have minted a new `BackupPlanId` and dropped versions/selections.
- **`AWS::Timestream::Database`** (`update_timestream_database`): preserves `arn`, `creation_time`, and `table_count`. Applies the mutable `KmsKeyId` (+ tags) in place. Reprovision reset `table_count` to 0 while the tables/records survived in their own maps, desyncing `DescribeDatabase`.

## Test plan

- `cargo build -p fakecloud-cloudformation` — green.
- `cargo clippy -p fakecloud-cloudformation --all-targets -- -D warnings` — clean.
- `cargo test -p fakecloud-cloudformation` — 303 passed.
- New e2e tests in `crates/fakecloud-e2e/tests/cloudformation_update_preserves_stateful.rs`:
  - `cfn_update_iam_user_preserves_access_keys` — an out-of-band `AccessKey` and the stable `user_id` both survive a tag-only `UpdateStack`.
  - `cfn_update_cognito_identity_pool_preserves_role_attachment` — the pool id stays stable and an out-of-band role attachment survives a name-only `UpdateStack`.
  - `cargo test -p fakecloud-e2e --no-run --test cloudformation_update_preserves_stateful` compiles; both new tests plus `cfn_update_backup_vault_is_in_place` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CloudFormation now updates IAM User/Group, Cognito IdentityPool, Backup BackupPlan, and Timestream Database in place. This prevents delete+recreate on benign changes and preserves IDs and external state.

- **Bug Fixes**
  - IAM User: updates tags, permissions boundary, inline/managed policies, and additive group memberships in place. Preserves username, user_id, arn, and existing access keys. Name changes still replace.
  - IAM Group: updates inline/managed policies in place. Preserves group name, group_id, arn, and members. Name changes still replace.
  - Cognito IdentityPool: updates name, flags, providers, and tags in place. Preserves pool id and role attachments.
  - Backup BackupPlan: mirrors UpdateBackupPlan (apply new plan body/tags, append version). Preserves BackupPlanId, arn, version history, and selections.
  - Timestream Database: updates KmsKeyId and tags in place. Preserves arn, creation time, and table_count.
  - Added e2e tests to confirm IAM access keys and identity pool role attachments survive updates; tests pass.

<sup>Written for commit b2b643a697849d9c6f373f46af3e4a1ff14cc315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

