### PR TITLE
fix(sns,kinesis,dynamodb,route53): resume pagination past a deleted marker

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -205,7 +205,7 @@ impl DynamoDbService {
         // For GSI queries the start key contains both index keys and table PK, so
         // we must match on ALL of them to find the exact item.
         if let Some(ref start_key) = exclusive_start_key {
-            if let Some(pos) = matched.iter().position(|item| {
+            let matches_start = |item: &&HashMap<String, AttributeValue>| {
                 let index_match =
                     item_matches_key(item, start_key, &hash_key_name, range_key_name.as_deref());
                 if is_gsi_query {
@@ -219,8 +219,22 @@ impl DynamoDbService {
                 } else {
                     index_match
                 }
-            }) {
+            };
+            if let Some(pos) = matched.iter().position(&matches_start) {
                 matched = matched.split_off(pos + 1);
+            } else if let Some(rk) = range_key_name.as_deref() {
+                // The ExclusiveStartKey item was deleted between pages. `matched`
+                // is sorted by the range key in the scan direction, so resume by
+                // order — drop every item at-or-before the start key's range
+                // value — instead of leaving the full list, which would restart
+                // at page 1 (a non-terminating delete-drain loop).
+                let sk_rv = start_key.get(rk).cloned();
+                let before = matched.partition_point(|item| {
+                    let ord = compare_attribute_values(item.get(rk), sk_rv.as_ref());
+                    let ord = if scan_forward { ord } else { ord.reverse() };
+                    ord != std::cmp::Ordering::Greater
+                });
+                matched = matched.split_off(before);
             }
         }
 
@@ -501,6 +515,12 @@ impl DynamoDbService {
                 item_matches_key(item, start_key, &hash_key_name, range_key_name.as_deref())
             }) {
                 matched = matched.split_off(pos + 1);
+            } else {
+                // The start-key item was deleted between pages. A Scan's result
+                // order is storage/segment order, NOT sorted by the key, so we
+                // cannot resume by ordering; terminate this segment (empty page)
+                // rather than leave the full list and re-deliver from the top.
+                matched.clear();
             }
         }
 

--- a/crates/fakecloud-kinesis/src/service.rs
+++ b/crates/fakecloud-kinesis/src/service.rs
@@ -1555,12 +1555,13 @@ impl KinesisService {
 
         let next_token = body["NextToken"].as_str();
         if let Some(token) = next_token {
-            if let Some(pos) = consumers
-                .iter()
-                .position(|c| c["ConsumerName"].as_str() == Some(token))
-            {
-                consumers = consumers.split_off(pos + 1);
-            }
+            // Resume strictly after the token (the last ConsumerName of the
+            // previous page). `partition_point` on the name-sorted vec is robust
+            // to that consumer having been deregistered between pages: a plain
+            // `position(== token)` would return None and leave the full list in
+            // place, re-delivering page 1 (a non-terminating loop).
+            let pos = consumers.partition_point(|c| c["ConsumerName"].as_str() <= Some(token));
+            consumers = consumers.split_off(pos);
         }
 
         let has_more = consumers.len() > max_results;

--- a/crates/fakecloud-route53/src/service/traffic_policies.rs
+++ b/crates/fakecloud-route53/src/service/traffic_policies.rs
@@ -611,7 +611,18 @@ impl Route53Service {
             .map(|a| a.traffic_policy_instances.values().cloned().collect())
             .unwrap_or_default();
         drop(state);
-        instances.sort_by(|a, b| a.id.cmp(&b.id));
+        // Sort by the same (hostedZoneId, name, type) tuple that the pagination
+        // markers carry — the cursor key must match the sort key so the resume
+        // below is a strictly-greater seek, not an exact-position lookup that
+        // restarts at page 1 when the marker item was deleted between pages.
+        let tuple = |i: &StoredTrafficPolicyInstance| {
+            (
+                i.hosted_zone_id.clone(),
+                i.name.clone(),
+                i.traffic_policy_type.clone(),
+            )
+        };
+        instances.sort_by_key(|a| tuple(a));
         // Honor incoming pagination markers. Without consuming
         // `hostedzoneidmarker` / `trafficpolicyinstancenamemarker` /
         // `trafficpolicyinstancetypemarker`, follow-up pages
@@ -634,15 +645,11 @@ impl Route53Service {
         let start = if hz_marker.is_empty() && name_marker.is_empty() && type_marker.is_empty() {
             0
         } else {
-            instances
-                .iter()
-                .position(|i| {
-                    i.hosted_zone_id == hz_marker
-                        && i.name == name_marker
-                        && i.traffic_policy_type == type_marker
-                })
-                .map(|p| p + 1)
-                .unwrap_or(0)
+            // Resume strictly after the marker tuple. `partition_point` on the
+            // tuple-sorted vec advances correctly even if the marker instance was
+            // deleted between pages.
+            let marker = (hz_marker, name_marker, type_marker);
+            instances.partition_point(|i| tuple(i) <= marker)
         };
         let slice: Vec<&StoredTrafficPolicyInstance> =
             instances.iter().skip(start).take(max_items).collect();

--- a/crates/fakecloud-sns/src/service_platform.rs
+++ b/crates/fakecloud-sns/src/service_platform.rs
@@ -485,10 +485,15 @@ fn paginate_sns_members(
 ) -> (String, Option<String>) {
     use base64::Engine;
     items.sort_by(|a, b| a.0.cmp(&b.0));
+    // Resume at the first key >= the token key. `partition_point` (items are
+    // sorted by key) makes this robust to the token'd item having been deleted
+    // between pages: a plain `position(== key)` would return None and restart
+    // at page 1 (a non-terminating delete-drain loop). The token points at the
+    // first key of the next page, so the resume is inclusive.
     let start = next_token
         .and_then(|t| base64::engine::general_purpose::STANDARD.decode(t).ok())
         .and_then(|b| String::from_utf8(b).ok())
-        .and_then(|key| items.iter().position(|(k, _)| *k == key))
+        .map(|key| items.partition_point(|(k, _)| k.as_str() < key.as_str()))
         .unwrap_or(0);
     let end = (start + SNS_LIST_PAGE_SIZE).min(items.len());
     let next = if end < items.len() {
@@ -535,5 +540,28 @@ mod pagination_tests {
         let (page, tok) = paginate_sns_members(items(10), None);
         assert_eq!(page.matches("<member>").count(), 10);
         assert!(tok.is_none());
+    }
+
+    #[test]
+    fn resumes_past_a_deleted_marker_item() {
+        // bug-audit 2026-07-27 (cycle 5): the token points at the first key of
+        // the next page (item 100). If that item is deleted between pages, a
+        // `position(== key)` resume returned None and restarted at page 1 (a
+        // non-terminating delete-drain loop). The `partition_point` resume must
+        // advance to the next surviving key instead.
+        let (_page1, tok1) = paginate_sns_members(items(150), None);
+        let tok1 = tok1.expect("first page truncated");
+
+        // Drop the item the token points at (arn-0100) plus a few after it.
+        let mut remaining = items(150);
+        remaining.retain(|(k, _)| !matches!(k.as_str(), "arn-0100" | "arn-0101" | "arn-0102"));
+
+        let (page2, tok2) = paginate_sns_members(remaining, Some(&tok1));
+        // Must resume at the first surviving key >= arn-0100 (arn-0103), NOT
+        // restart at arn-0000.
+        assert!(page2.contains("<member>103</member>"));
+        assert!(!page2.contains("<member>0</member>"));
+        assert!(!page2.contains("<member>99</member>"));
+        assert!(tok2.is_none());
     }
 }


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family P (pagination restart-page-1) sibling sweep — five more List/Describe handlers restart at page 1 (or re-deliver the full result set) when the item a pagination token points at is deleted between pages, producing a non-terminating delete-drain loop. Same class and fix pattern as the merged #2406/#2419 sweeps.

- **SNS** `ListPlatformApplications` / `ListEndpointsByPlatformApplication` — token = first key of next page; `partition_point` (first key ≥ token) instead of `position(== key).unwrap_or(0)`.
- **Kinesis** `ListStreamConsumers` — token = last ConsumerName of prev page; strictly-greater `partition_point` instead of a no-else `position` that left the full list.
- **DynamoDB** `Query` — keep the exact ExclusiveStartKey fast path (zero behavior change when the item exists); on a deleted marker resume by range-key order, scan-direction aware.
- **DynamoDB** `Scan` — storage/segment order isn't key-sorted, so terminate the segment (empty page) on a deleted start key rather than restart from the top.
- **Route53** `ListTrafficPolicyInstances` — sort by the `(hostedZoneId, name, type)` marker tuple the cursor carries (was sorting by `id`) and resume strictly-greater, matching the correct sibling traffic-policy ops.

All #2406/#2419 sites were re-verified correct (no regression).

## Test plan
- New unit regression test for the SNS paginator (`resumes_past_a_deleted_marker_item`).
- `cargo nextest run` for sns/kinesis/dynamodb/route53: 857 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- DynamoDB Query/Scan, Kinesis, Route53 handler paths covered by existing conformance/e2e suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination across `fakecloud-sns`, `fakecloud-kinesis`, `fakecloud-dynamodb`, and `fakecloud-route53` so pages resume past a deleted marker instead of restarting at page 1. Prevents non-terminating delete-drain loops when items disappear between pages.

- **Bug Fixes**
  - `fakecloud-sns`: ListPlatformApplications/ListEndpointsByPlatformApplication now resume at the first key ≥ token using partition_point.
  - `fakecloud-kinesis`: ListStreamConsumers resumes strictly after the last ConsumerName via partition_point, handling deregistered consumers.
  - `fakecloud-dynamodb`: Query keeps the exact ExclusiveStartKey when present; if deleted, resumes by range-key in the scan direction. Scan returns an empty page if the start key was deleted, since results aren’t key-sorted.
  - `fakecloud-route53`: ListTrafficPolicyInstances sorts by (hostedZoneId, name, type) and resumes strictly greater on that tuple.

<sup>Written for commit a713b230f6d3836918706790021ffb7cad93425c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

