### PR TITLE
fix(cloudformation): in-place UpdateStack for AppConfig + Route53 HostedZone (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/appconfig.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/appconfig.rs
@@ -12,10 +12,10 @@
 
 use serde_json::Value;
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 use fakecloud_appconfig::state::{
-    application_arn, environment_arn, profile_arn, ApplicationRecord, EnvironmentRecord,
-    ProfileRecord,
+    application_arn, environment_arn, profile_arn, AppConfigState, ApplicationRecord,
+    EnvironmentRecord, ProfileRecord,
 };
 
 impl ResourceProvisioner {
@@ -228,10 +228,138 @@ impl ResourceProvisioner {
         }
         None
     }
+
+    // ---------------------------------------------------- In-place updates
+    //
+    // AppConfig applications/environments/profiles own nested state
+    // (environments, profiles, experiments, deployment history, hosted
+    // configuration versions) keyed inside the parent record, and their ids
+    // are randomly minted. Reprovisioning (delete + create) on an in-place
+    // property change (Name/Description/... or a tag edit) would drop all of
+    // that and churn the id, dangling every child CFN resource and `Ref`.
+    // These arms mutate the stored record in place, preserving the id and all
+    // contained state (matching AWS `Update*` semantics).
+
+    pub(super) fn update_appconfig_application(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let arn = application_arn(&self.region, &self.account_id, &id);
+
+        let mut guard = self.appconfig_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        {
+            let record = st
+                .applications
+                .get_mut(&id)
+                .ok_or_else(|| format!("Application {id} not yet provisioned"))?;
+            if let Some(name) = props.get("Name").and_then(Value::as_str) {
+                record.name = name.to_string();
+            }
+            record.description = opt_str(props, "Description");
+            // environments / profiles / experiments preserved.
+        }
+        apply_tags(st, &arn, props.get("Tags"));
+
+        Ok(ProvisionResult::new(id.clone()).with("ApplicationId", id))
+    }
+
+    pub(super) fn update_appconfig_environment(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let (app_id, env_id) = existing
+            .physical_id
+            .split_once('|')
+            .ok_or("AWS::AppConfig::Environment physical id must be <appId>|<envId>")?;
+        let arn = environment_arn(&self.region, &self.account_id, app_id, env_id);
+
+        let mut guard = self.appconfig_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        {
+            let app = st
+                .applications
+                .get_mut(app_id)
+                .ok_or_else(|| format!("Application {app_id} not yet provisioned"))?;
+            let record = app
+                .environments
+                .get_mut(env_id)
+                .ok_or_else(|| format!("Environment {env_id} not yet provisioned"))?;
+            if let Some(name) = props.get("Name").and_then(Value::as_str) {
+                record.name = name.to_string();
+            }
+            record.description = opt_str(props, "Description");
+            if let Some(monitors) = props.get("Monitors") {
+                record.monitors = monitors.clone();
+            }
+            // deployments / next_deployment_number / state preserved.
+        }
+        apply_tags(st, &arn, props.get("Tags"));
+
+        Ok(ProvisionResult::new(existing.physical_id.clone()).with("EnvironmentId", env_id))
+    }
+
+    pub(super) fn update_appconfig_configuration_profile(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let (app_id, profile_id) = existing.physical_id.split_once('|').ok_or(
+            "AWS::AppConfig::ConfigurationProfile physical id must be <appId>|<profileId>",
+        )?;
+        let arn = profile_arn(&self.region, &self.account_id, app_id, profile_id);
+
+        let mut guard = self.appconfig_state.write();
+        let st = guard.get_or_create(&self.account_id);
+        {
+            let app = st
+                .applications
+                .get_mut(app_id)
+                .ok_or_else(|| format!("Application {app_id} not yet provisioned"))?;
+            let record = app
+                .profiles
+                .get_mut(profile_id)
+                .ok_or_else(|| format!("ConfigurationProfile {profile_id} not yet provisioned"))?;
+            if let Some(name) = props.get("Name").and_then(Value::as_str) {
+                record.name = name.to_string();
+            }
+            record.description = opt_str(props, "Description");
+            if let Some(uri) = props.get("LocationUri").and_then(Value::as_str) {
+                record.location_uri = uri.to_string();
+            }
+            record.retrieval_role_arn = opt_str(props, "RetrievalRoleArn");
+            if let Some(validators) = props.get("Validators") {
+                record.validators = validators.clone();
+            }
+            record.kms_key_identifier = opt_str(props, "KmsKeyIdentifier");
+            // hosted_versions / next_version_number / type preserved.
+        }
+        apply_tags(st, &arn, props.get("Tags"));
+
+        Ok(ProvisionResult::new(existing.physical_id.clone())
+            .with("ConfigurationProfileId", profile_id))
+    }
 }
 
 fn opt_str(props: &Value, key: &str) -> Option<String> {
     props.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+/// Replace an ARN's tag set wholesale from CFN `Tags` (matching CFN tag update
+/// semantics): empty/absent clears the entry, otherwise it overwrites.
+fn apply_tags(st: &mut AppConfigState, arn: &str, tags_val: Option<&Value>) {
+    let tags = tag_map(tags_val);
+    if tags.is_empty() {
+        st.tags.remove(arn);
+    } else {
+        st.tags.insert(arn.to_string(), tags);
+    }
 }
 
 /// Convert CFN `Tags` (`[{Key,Value}]`) into the AppConfig `TagMap`.

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1893,6 +1893,22 @@ impl ResourceProvisioner {
             // In-place update: reprovision would mint a new BackupPlanId and
             // drop the plan's version history + selections.
             "AWS::Backup::BackupPlan" => Some(self.update_backup_plan(existing, new_def)?),
+            // In-place updates: reprovision would churn the random app/env/
+            // profile id and cascade-drop the nested environments, profiles,
+            // hosted configuration versions and deployment history.
+            "AWS::AppConfig::Application" => {
+                Some(self.update_appconfig_application(existing, new_def)?)
+            }
+            "AWS::AppConfig::Environment" => {
+                Some(self.update_appconfig_environment(existing, new_def)?)
+            }
+            "AWS::AppConfig::ConfigurationProfile" => {
+                Some(self.update_appconfig_configuration_profile(existing, new_def)?)
+            }
+            // In-place comment update: reprovision would churn the zone id + name
+            // servers and wipe every record set stored inside the zone. Name is
+            // immutable, so a name change still falls back to replacement.
+            "AWS::Route53::HostedZone" => Some(self.update_route53_hosted_zone(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -4149,6 +4165,126 @@ mod tests {
             alarm.threshold_metric_id.as_deref(),
             Some("ad2"),
             "ThresholdMetricId refreshed on update"
+        );
+    }
+
+    #[test]
+    fn appconfig_application_update_preserves_children_and_id() {
+        // bug-audit 2026-07-27 (cycle 5): without an in-place update arm an
+        // AppConfig application fell through to reprovision (delete + create) on
+        // any property or tag edit, churning the random app id and dropping the
+        // nested environments/profiles. The update arm must mutate in place.
+        let prov = make_provisioner();
+        let app = prov
+            .create_resource(&make_resource(
+                "AWS::AppConfig::Application",
+                "App",
+                serde_json::json!({
+                    "Name": "my-app",
+                    "Description": "v1",
+                    "Tags": [{"Key": "env", "Value": "dev"}]
+                }),
+            ))
+            .expect("app provisions");
+        let app_id = app.physical_id.clone();
+
+        let env = prov
+            .create_resource(&make_resource(
+                "AWS::AppConfig::Environment",
+                "Env",
+                serde_json::json!({"ApplicationId": app_id, "Name": "prod"}),
+            ))
+            .expect("env provisions");
+        assert!(env.physical_id.starts_with(&format!("{app_id}|")));
+
+        let updated = prov
+            .update_resource(
+                &app,
+                &make_resource(
+                    "AWS::AppConfig::Application",
+                    "App",
+                    serde_json::json!({
+                        "Name": "my-app",
+                        "Description": "v2",
+                        "Tags": [{"Key": "env", "Value": "prod"}]
+                    }),
+                ),
+            )
+            .expect("update succeeds")
+            .expect("AWS::AppConfig::Application is updatable");
+        assert_eq!(
+            updated.physical_id, app_id,
+            "application id preserved (not churned by reprovision)"
+        );
+
+        let g = prov.appconfig_state.read();
+        let st = g.get("123456789012").unwrap();
+        let record = st
+            .applications
+            .get(&app_id)
+            .expect("application still exists under its original id");
+        assert_eq!(record.description.as_deref(), Some("v2"));
+        assert_eq!(
+            record.environments.len(),
+            1,
+            "child environment preserved across the in-place update"
+        );
+    }
+
+    #[test]
+    fn route53_hosted_zone_comment_update_is_in_place_but_name_change_replaces() {
+        // bug-audit 2026-07-27 (cycle 5): reprovision on a comment/tag edit would
+        // churn the zone id + name servers and wipe every record set. A comment
+        // change must be in-place (id preserved); a Name change (immutable) must
+        // still replace.
+        let prov = make_provisioner();
+        let zone = prov
+            .create_resource(&make_resource(
+                "AWS::Route53::HostedZone",
+                "Z",
+                serde_json::json!({"Name": "example.com", "HostedZoneConfig": {"Comment": "v1"}}),
+            ))
+            .expect("zone provisions");
+        let zid = zone.physical_id.clone();
+
+        // Comment-only change: in place, same id.
+        let after_comment = prov
+            .update_resource(
+                &zone,
+                &make_resource(
+                    "AWS::Route53::HostedZone",
+                    "Z",
+                    serde_json::json!({"Name": "example.com", "HostedZoneConfig": {"Comment": "v2"}}),
+                ),
+            )
+            .expect("update succeeds")
+            .expect("updatable");
+        assert_eq!(
+            after_comment.physical_id, zid,
+            "comment update keeps zone id"
+        );
+        {
+            let accounts = prov.route53_state.read();
+            let state = accounts.get("000000000000").unwrap();
+            let z = state.hosted_zones.get(&zid).expect("zone preserved");
+            assert_eq!(z.comment.as_deref(), Some("v2"));
+        }
+
+        // Name change: immutable -> replacement mints a new id.
+        let after_name = prov
+            .update_resource(
+                &after_comment,
+                &make_resource(
+                    "AWS::Route53::HostedZone",
+                    "Z",
+                    serde_json::json!({"Name": "renamed.com", "HostedZoneConfig": {"Comment": "v2"}}),
+                ),
+            )
+            .expect("update succeeds")
+            .expect("updatable");
+        assert_ne!(
+            after_name.physical_id, zid,
+            "a Name change replaces the zone (new id)"
         );
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route.rs
@@ -91,6 +91,63 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// In-place update for `AWS::Route53::HostedZone`. AWS only supports an
+    /// in-place mutation of the comment (`UpdateHostedZoneComment`); `Name` is
+    /// immutable and a change forces replacement. Reprovisioning on a comment
+    /// (or tag) edit would churn the zone id + 4 name servers AND wipe every
+    /// record set (both `AWS::Route53::RecordSet` children and runtime
+    /// `ChangeResourceRecordSets` records) stored inside the zone. So mutate the
+    /// comment in place when the name is unchanged, preserving the record sets;
+    /// fall back to replacement only when the (immutable) name actually changes.
+    pub(super) fn update_route53_hosted_zone(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let normalized_name = if name.ends_with('.') {
+            name.clone()
+        } else {
+            format!("{name}.")
+        };
+        let comment = props
+            .get("HostedZoneConfig")
+            .and_then(|v| v.get("Comment"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let in_place = {
+            let mut accounts = self.route53_state.write();
+            let state = accounts.entry("000000000000");
+            match state.hosted_zones.get_mut(&existing.physical_id) {
+                Some(z) if z.name == normalized_name => {
+                    z.comment = comment; // record sets / id / name servers preserved
+                    let id = z.id.clone();
+                    let name_servers = z.name_servers.clone();
+                    let mut result = ProvisionResult::new(id.clone()).with("Id", id);
+                    for (i, ns) in name_servers.iter().enumerate() {
+                        result = result.with(&format!("NameServers.{i}"), ns.clone());
+                    }
+                    result = result.with("NameServers", name_servers.join(","));
+                    Some(result)
+                }
+                _ => None,
+            }
+        };
+        match in_place {
+            Some(result) => Ok(result),
+            // Name changed (immutable) or zone missing: AWS replaces the zone.
+            None => self.reprovision_resource(existing, resource).map(|opt| {
+                opt.unwrap_or_else(|| ProvisionResult::new(existing.physical_id.clone()))
+            }),
+        }
+    }
+
     pub(super) fn create_route53_record_set(
         &self,
         resource: &ResourceDefinition,


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3a. These types had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on any property change. Because `Tags` is a property on all of them, a **tag-only edit alone** triggered the destructive replacement: a new random physical id (breaking `Ref`/`GetAtt` and every child resource) plus a cascade-drop of state contained inside the record.

- **AWS::AppConfig::Application** — mutate Name/Description in place; preserve nested environments/profiles/experiments (were dropped + app id churned).
- **AWS::AppConfig::Environment** — mutate Name/Description/Monitors in place; preserve deployment history.
- **AWS::AppConfig::ConfigurationProfile** — mutate Name/Description/LocationUri/RetrievalRoleArn/Validators/KmsKeyIdentifier in place; preserve hosted configuration versions.
- **AWS::Route53::HostedZone** — `UpdateHostedZoneComment` is the only in-place mutation AWS supports; mutate the comment in place (preserving all record sets, id, name servers). Name is immutable → a Name change still replaces.

Tags replaced wholesale on update (CFN semantics). Same fix pattern as #2420. Remaining Family-B types (CloudFront Distribution, EC2 VPC/Subnet/SG/RouteTable, Orgs Account/OU, ServiceDiscovery, WAFv2, + MED tier) follow in later PRs.

## Test plan
- New regression tests: AppConfig application update preserves the child environment + id; Route53 comment update is in-place (id kept) while a Name change replaces.
- `cargo nextest run -p fakecloud-cloudformation`: 305 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface (behavior-only fix) → no SDK/doc/metadata changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents destructive replacements by adding in-place UpdateStack support for AppConfig and Route53 HostedZone. Tag-only or minor edits no longer churn IDs or wipe nested state; HostedZone only replaces on Name change.

- **Bug Fixes**
  - AppConfig Application, Environment, ConfigurationProfile: mutate supported fields in place (e.g., Name, Description, Monitors, LocationUri, RetrievalRoleArn, Validators, KmsKeyIdentifier). Preserve physical IDs and nested state; tags overwrite wholesale per CFN semantics.
  - Route53 HostedZone: update Comment in place, preserving zone ID, name servers, and record sets. Name remains immutable and triggers replacement if changed.

<sup>Written for commit 2d76e2525b9946b2355d311720975356c1c4e62e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

