### PR TITLE
fix(kinesisanalyticsv2,kafka,rds,redshift): panic-safe truncation, MSK 3.9, request-region subnet AZs, integration status

### DIFF
--- a/crates/fakecloud-kafka/src/shared.rs
+++ b/crates/fakecloud-kafka/src/shared.rs
@@ -89,6 +89,8 @@ pub fn cluster_name_from_arn(arn: &str) -> Option<&str> {
 /// by an exact `version` (e.g. `2.4.1.1`) and reads its `status` -- resolves,
 /// and so a cluster can be created at, and upgraded between, any of these.
 pub const KAFKA_VERSIONS: &[&str] = &[
+    "3.9.x.kraft",
+    "3.9.x",
     "3.8.x.kraft",
     "3.8.x",
     "3.7.x.kraft",

--- a/crates/fakecloud-kinesisanalyticsv2/src/runtime/mod.rs
+++ b/crates/fakecloud-kinesisanalyticsv2/src/runtime/mod.rs
@@ -616,8 +616,14 @@ fn sanitize(s: &str) -> String {
         .unwrap_or("")
         .replace(|c: char| c.is_control(), " ");
     let line = line.trim();
-    if line.len() > 300 {
-        format!("{}...", &line[..300])
+    // Truncate by characters, not bytes: a byte slice `&line[..300]` panics
+    // ("byte index 300 is not a char boundary") when index 300 lands inside a
+    // multibyte UTF-8 char, which survives the control-char filter above. A
+    // backend/daemon error line echoing a submitted (multibyte) name/SQL could
+    // hit this and drop the request connection instead of returning an error.
+    if line.chars().count() > 300 {
+        let truncated: String = line.chars().take(300).collect();
+        format!("{truncated}...")
     } else {
         line.to_string()
     }
@@ -626,6 +632,17 @@ fn sanitize(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sanitize_truncates_multibyte_without_panicking() {
+        // bug-audit 2026-07-27 (cycle 5): a byte slice `&line[..300]` panicked
+        // when byte 300 landed mid-char. A long line of multibyte chars whose
+        // 300th byte is inside a char must truncate cleanly, not panic.
+        let line = "é".repeat(400); // 2 bytes each -> 800 bytes, 400 chars
+        let out = sanitize(&line);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().filter(|&c| c == 'é').count(), 300);
+    }
 
     #[test]
     fn alloc_free_port_returns_a_usable_port() {

--- a/crates/fakecloud-rds/src/service/subnet_groups.rs
+++ b/crates/fakecloud-rds/src/service/subnet_groups.rs
@@ -45,7 +45,11 @@ impl RdsService {
         // unrelated subnets.
         let mut subnet_availability_zones: Vec<String> = Vec::with_capacity(subnet_ids.len());
         let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
-        let region = &state.region;
+        // Use the request's SigV4 region (as the returned ARN does), not the
+        // server's frozen startup region: a client in eu-west-1 must not get
+        // subnet AZ names like `us-east-1a` alongside a `...:rds:eu-west-1:...`
+        // ARN.
+        let region = request.region.as_str();
         for sid in &subnet_ids {
             let next = seen.len();
             let idx = *seen.entry(sid.as_str()).or_insert(next);
@@ -204,7 +208,9 @@ impl RdsService {
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&request.account_id);
 
-        let region = state.region.clone();
+        // Request-scope region for AZ names (matches the group's ARN), not the
+        // server's frozen startup region.
+        let region = request.region.clone();
 
         let subnet_group = state
             .subnet_groups

--- a/crates/fakecloud-redshift/src/service/access.rs
+++ b/crates/fakecloud-redshift/src/service/access.rs
@@ -878,7 +878,13 @@ impl RedshiftService {
             integration_name: name,
             source_arn: param(req, "SourceArn").unwrap_or_default(),
             target_arn: param(req, "TargetArn").unwrap_or_default(),
-            status: "creating".to_string(),
+            // Terminal `active` at create: there is no backing zero-ETL data
+            // plane to settle, and DescribeIntegrations has no lazy transition,
+            // so leaving `creating` here would hang terraform's
+            // aws_redshift_integration create-waiter (polls for `active`) until a
+            // silent ~60m timeout. Matches how redshift clusters/event
+            // subscriptions are created in a terminal state.
+            status: "active".to_string(),
             create_time: Utc::now(),
             description: param(req, "Description"),
             kms_key_id: param(req, "KMSKeyId"),


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt Tier-1 miscellany (four independent fixes):

- **kinesisanalyticsv2** — `sanitize()` truncated a backend/daemon error line with a byte slice `&line[..300]`, panicking *"byte index 300 is not a char boundary"* when byte 300 landed inside a multibyte UTF-8 char (the control-char filter leaves multibyte intact) → dropped request connection. Truncate by chars.
- **kafka** — add Apache Kafka `3.9.x` / `3.9.x.kraft` to `KAFKA_VERSIONS` (MSK has GA'd them). Without it the `aws_msk_kafka_version` data source resolved empty for a 3.9-pinned config → terraform plan error. (`CreateCluster` was never gated on the list, so cluster creation already worked.)
- **rds** — `CreateDBSubnetGroup`/`ModifyDBSubnetGroup` built subnet `AvailabilityZone` names from the server's frozen startup region while the group ARN used the request region; a non-default-region client got `us-east-1a` next to an `eu-west-1` ARN. Use `request.region` for both.
- **redshift** — `CreateIntegration` recorded `Status=creating` with no lazy settle, so `DescribeIntegrations` never advanced to `active` and terraform's `aws_redshift_integration` create-waiter hung to a silent ~60m timeout. Record `active` at create (no backing data plane; matches how clusters/event subscriptions are created).

## Test plan
- New regression test for the multibyte `sanitize` truncation.
- `cargo nextest run` kinesisanalyticsv2/kafka/rds/redshift: all green (345 + sanitize).
- clippy `--all-targets -D warnings` + fmt clean.
- RDS AZ change only differs for non-default-region clients; e2e defaults to us-east-1 so AZ names are unchanged there (no regression). No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four Tier‑1 issues: panic-safe log truncation, MSK `3.9.x` support, correct RDS subnet AZ region, and immediate-active Redshift integrations. Prevents dropped requests, Terraform plan errors, and long waiter hangs.

- **Bug Fixes**
  - `kinesisanalyticsv2`: truncate error lines by characters (not bytes) to avoid UTF‑8 boundary panics.
  - `kafka`: add `3.9.x` and `3.9.x.kraft` to `KAFKA_VERSIONS` so `aws_msk_kafka_version` resolves for 3.9.
  - `rds`: build subnet `AvailabilityZone` names from the request region to match the group ARN.
  - `redshift`: set integrations to `active` at create so `DescribeIntegrations` reflects readiness and `aws_redshift_integration` waits do not hang.

<sup>Written for commit 2e3a0ab93aa166ce79b11bf20a93e7a2441dfb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

