### PR TITLE
fix(cloudformation): in-place UpdateStack for Organizations OU/Account/Policy (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1925,6 +1925,18 @@ impl ResourceProvisioner {
                 Some(self.update_wafv2_regex_pattern_set(existing, new_def)?)
             }
             "AWS::WAFv2::RuleGroup" => Some(self.update_wafv2_rule_group(existing, new_def)?),
+            // In-place updates: reprovision churns the random org id (breaking
+            // every Ref/attachment) and, for Account, mints a whole new member
+            // account while closing the old one.
+            "AWS::Organizations::OrganizationalUnit" => {
+                Some(self.update_organization_unit(existing, new_def)?)
+            }
+            "AWS::Organizations::Account" => {
+                Some(self.update_organization_account(existing, new_def)?)
+            }
+            "AWS::Organizations::Policy" => {
+                Some(self.update_organization_policy(existing, new_def)?)
+            }
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -4458,6 +4470,113 @@ mod tests {
             .unwrap();
         assert_eq!(ip.arn, ip_arn);
         assert_eq!(ip.addresses.len(), 2, "IPSet addresses updated in place");
+    }
+
+    #[test]
+    fn organizations_updates_are_in_place_not_reprovisioned() {
+        // bug-audit 2026-07-27 (cycle 5): without update arms these fell through
+        // to reprovision, churning the OU/policy id (dangling attachments) and
+        // minting a brand-new member account. Updates must be in place.
+        let prov = make_provisioner();
+        prov.create_resource(&make_resource(
+            "AWS::Organizations::Organization",
+            "Org",
+            serde_json::json!({"FeatureSet": "ALL"}),
+        ))
+        .expect("org provisions");
+        let root_id = {
+            let g = prov.organizations_state.read();
+            g.as_ref().unwrap().root_id.clone()
+        };
+
+        let ou = prov
+            .create_resource(&make_resource(
+                "AWS::Organizations::OrganizationalUnit",
+                "OU",
+                serde_json::json!({"Name": "team", "ParentId": root_id}),
+            ))
+            .expect("ou provisions");
+        let ou_id = ou.physical_id.clone();
+
+        let policy = prov
+            .create_resource(&make_resource(
+                "AWS::Organizations::Policy",
+                "Pol",
+                serde_json::json!({"Name": "p1", "Content": "{}", "TargetIds": [ou_id]}),
+            ))
+            .expect("policy provisions");
+        let pol_id = policy.physical_id.clone();
+
+        let acct = prov
+            .create_resource(&make_resource(
+                "AWS::Organizations::Account",
+                "Acc",
+                serde_json::json!({"AccountName": "dev", "Email": "dev@example.com"}),
+            ))
+            .expect("account provisions");
+        let acct_id = acct.physical_id.clone();
+
+        // OU rename: id preserved.
+        let ou_up = prov
+            .update_resource(
+                &ou,
+                &make_resource(
+                    "AWS::Organizations::OrganizationalUnit",
+                    "OU",
+                    serde_json::json!({"Name": "team-renamed", "ParentId": root_id}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(ou_up.physical_id, ou_id, "OU id preserved");
+
+        // Policy content change: id preserved, still attached to the OU.
+        let pol_up = prov
+            .update_resource(
+                &policy,
+                &make_resource(
+                    "AWS::Organizations::Policy",
+                    "Pol",
+                    serde_json::json!({"Name": "p1", "Content": "{\"v\":2}", "TargetIds": [ou_id]}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(pol_up.physical_id, pol_id, "policy id preserved");
+
+        // Account tag edit: must NOT mint a new member account.
+        let acct_up = prov
+            .update_resource(
+                &acct,
+                &make_resource(
+                    "AWS::Organizations::Account",
+                    "Acc",
+                    serde_json::json!({
+                        "AccountName": "dev",
+                        "Email": "dev@example.com",
+                        "Tags": [{"Key": "env", "Value": "dev"}]
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(
+            acct_up.physical_id, acct_id,
+            "account id preserved (not a new member account)"
+        );
+
+        let g = prov.organizations_state.read();
+        let org = g.as_ref().unwrap();
+        assert_eq!(org.ous.get(&ou_id).unwrap().name, "team-renamed");
+        assert_eq!(org.policies.get(&pol_id).unwrap().content, "{\"v\":2}");
+        assert!(
+            org.attachments
+                .get(&ou_id)
+                .map(|s| s.contains(&pol_id))
+                .unwrap_or(false),
+            "policy still attached to the OU after the in-place update"
+        );
+        assert!(org.accounts.contains_key(&acct_id), "same account persists");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/organizations.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/organizations.rs
@@ -352,4 +352,181 @@ impl ResourceProvisioner {
         }
         Ok(())
     }
+
+    // -------------------------------------------------- In-place updates
+    //
+    // Reprovision (delete + create) on an Organizations resource churns its
+    // random id (breaking every `Ref`/attachment that stored it) and, for
+    // Account, mints an entirely new 12-digit member account while closing the
+    // old one -- catastrophic. AWS updates all of these in place. These arms
+    // mutate the stored record, preserving the id and attachments.
+
+    pub(crate) fn update_organization_unit(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        let ou = org
+            .ous
+            .get_mut(&id)
+            .ok_or_else(|| format!("Organizational unit {id} not yet provisioned"))?;
+        // Name is the only in-place-mutable OU property; id/arn/parent_id and
+        // the OU's policy attachments are preserved.
+        ou.name = name.clone();
+        let arn = ou.arn.clone();
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("Arn", arn)
+            .with("Name", name))
+    }
+
+    pub(crate) fn update_organization_account(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let account_id = existing.physical_id.clone();
+        let parent_ids: Vec<String> = props
+            .get("ParentIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags: Vec<(String, String)> = props
+            .get("Tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let k = t.get("Key").and_then(|v| v.as_str())?;
+                        let val = t.get("Value").and_then(|v| v.as_str()).unwrap_or("");
+                        Some((k.to_string(), val.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        // AccountName/Email are immutable; do NOT mint a new account. Move to a
+        // new parent if ParentIds changed and refresh tags in place.
+        if !org.accounts.contains_key(&account_id) {
+            return Err(format!("Account {account_id} not yet provisioned"));
+        }
+        if let Some(parent) = parent_ids.first() {
+            let source = org
+                .accounts
+                .get(&account_id)
+                .map(|a| a.parent_id.clone())
+                .unwrap_or_else(|| org.root_id.clone());
+            if parent != &source {
+                org.move_account(&account_id, &source, parent)
+                    .map_err(|e| format!("Failed to move account to parent {parent}: {e:?}"))?;
+            }
+        }
+        // Tags are replaced wholesale to match the desired CFN state.
+        org.set_resource_tags(&account_id, &tags);
+
+        let acct = org
+            .accounts
+            .get(&account_id)
+            .ok_or_else(|| format!("Account {account_id} vanished during update"))?;
+        Ok(ProvisionResult::new(account_id.clone())
+            .with("AccountId", account_id.clone())
+            .with("AccountName", acct.name.clone())
+            .with("Email", acct.email.clone())
+            .with("Arn", acct.arn.clone())
+            .with("JoinedMethod", acct.joined_method.clone())
+            .with("JoinedTimestamp", acct.joined_timestamp.to_rfc3339())
+            .with("Status", acct.status.clone()))
+    }
+
+    pub(crate) fn update_organization_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&resource.logical_id)
+            .to_string();
+        let description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let content = props
+            .get("Content")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    serde_json::to_string(v).unwrap_or_default()
+                }
+            })
+            .unwrap_or_default();
+        let target_ids: Vec<String> = props
+            .get("TargetIds")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut org_lock = self.organizations_state.write();
+        let org = org_lock
+            .as_mut()
+            .ok_or_else(|| "Organization not yet created".to_string())?;
+        let arn = {
+            let policy = org
+                .policies
+                .get_mut(&id)
+                .ok_or_else(|| format!("Policy {id} not yet provisioned"))?;
+            // Name/Description/Content update in place; id/arn/type preserved.
+            policy.name = name.clone();
+            policy.description = description;
+            policy.content = content;
+            policy.arn.clone()
+        };
+        // Reconcile attachments to the desired TargetIds: detach from all
+        // targets, then attach to the requested set (preserves the policy id).
+        for attachments in org.attachments.values_mut() {
+            attachments.remove(&id);
+        }
+        for target in target_ids {
+            org.attachments
+                .entry(target)
+                .or_default()
+                .insert(id.clone());
+        }
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("Id", id)
+            .with("Arn", arn)
+            .with("Name", name))
+    }
 }


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3b. These Organizations types had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on any property or tag edit:

- **AWS::Organizations::OrganizationalUnit** — reprovision churned the `ou-` id (dangling its policy attachments, orphaning child accounts/OUs). Update Name in place; preserve id/arn/attachments.
- **AWS::Organizations::Account** — reprovision minted a brand-new 12-digit member account and closed the old one (catastrophic for anything scoped to the account id). Update in place: move to a new ParentId if changed + refresh tags, never re-create. AccountName/Email are immutable.
- **AWS::Organizations::Policy** — reprovision churned the `p-` id and dropped attachments. Update Name/Description/Content in place and reconcile attachments to the desired TargetIds; preserve id/arn/type.

Same fix pattern as #2420/#2423. Remaining Family-B types (CloudFront Distribution, EC2 VPC/Subnet/SG/RouteTable, ServiceDiscovery, WAFv2, + MED tier) follow in later PRs.

## Test plan
- New regression test: OU rename, policy content change (attachment preserved), account tag edit — all keep their physical id (no reprovision).
- `cargo nextest run -p fakecloud-cloudformation`: 304 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UpdateStack to update AWS Organizations resources in place, avoiding reprovisioning and data loss. OU renames, account parent/tag changes, and policy edits now preserve ids and attachments.

- **Bug Fixes**
  - `AWS::Organizations::OrganizationalUnit`: Update Name in place; keep id/arn and policy attachments.
  - `AWS::Organizations::Account`: Move to a new parent when changed and refresh tags; never recreate. AccountName/Email remain immutable.
  - `AWS::Organizations::Policy`: Update Name/Description/Content in place; reconcile attachments to desired TargetIds; preserve id/arn/type.

<sup>Written for commit 97de4517b0e1cf8f9af413a49b8f3648e92b00a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

