### PR TITLE
fix(cloudformation,tfacc): in-place UpdateStack for ServiceDiscovery; serialize autoscaling tfacc shard

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1909,6 +1909,14 @@ impl ResourceProvisioner {
             // servers and wipe every record set stored inside the zone. Name is
             // immutable, so a name change still falls back to replacement.
             "AWS::Route53::HostedZone" => Some(self.update_route53_hosted_zone(existing, new_def)?),
+            // In-place updates: reprovision would churn the ns-/srv- id and drop
+            // a namespace's services / a service's registered instances.
+            "AWS::ServiceDiscovery::HttpNamespace"
+            | "AWS::ServiceDiscovery::PublicDnsNamespace"
+            | "AWS::ServiceDiscovery::PrivateDnsNamespace" => {
+                Some(self.update_sd_namespace(existing, new_def)?)
+            }
+            "AWS::ServiceDiscovery::Service" => Some(self.update_sd_service(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -4285,6 +4293,82 @@ mod tests {
         assert_ne!(
             after_name.physical_id, zid,
             "a Name change replaces the zone (new id)"
+        );
+    }
+
+    #[test]
+    fn servicediscovery_updates_preserve_instances_and_ids() {
+        // bug-audit 2026-07-27 (cycle 5): without update arms a namespace/service
+        // fell through to reprovision on a Description edit, churning the ns-/srv-
+        // id and dropping the namespace's services / the service's registered
+        // instances.
+        let prov = make_provisioner();
+        let ns = prov
+            .create_resource(&make_resource(
+                "AWS::ServiceDiscovery::HttpNamespace",
+                "NS",
+                serde_json::json!({"Name": "myns", "Description": "v1"}),
+            ))
+            .expect("namespace provisions");
+        let ns_id = ns.physical_id.clone();
+        let svc = prov
+            .create_resource(&make_resource(
+                "AWS::ServiceDiscovery::Service",
+                "Svc",
+                serde_json::json!({"Name": "mysvc", "NamespaceId": ns_id, "Description": "v1"}),
+            ))
+            .expect("service provisions");
+        let svc_id = svc.physical_id.clone();
+
+        // Simulate registered instances on the service.
+        {
+            let mut accounts = prov.servicediscovery_state.write();
+            let state = accounts.get_or_create("123456789012");
+            state.services.get_mut(&svc_id).unwrap().instance_count = 3;
+        }
+
+        let svc_up = prov
+            .update_resource(
+                &svc,
+                &make_resource(
+                    "AWS::ServiceDiscovery::Service",
+                    "Svc",
+                    serde_json::json!({"Name": "mysvc", "NamespaceId": ns_id, "Description": "v2"}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(svc_up.physical_id, svc_id, "service id preserved");
+
+        let ns_up = prov
+            .update_resource(
+                &ns,
+                &make_resource(
+                    "AWS::ServiceDiscovery::HttpNamespace",
+                    "NS",
+                    serde_json::json!({"Name": "myns", "Description": "v2"}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(ns_up.physical_id, ns_id, "namespace id preserved");
+
+        let accounts = prov.servicediscovery_state.read();
+        let state = accounts.get("123456789012").unwrap();
+        let s = state.services.get(&svc_id).expect("service still exists");
+        assert_eq!(s.description.as_deref(), Some("v2"));
+        assert_eq!(
+            s.instance_count, 3,
+            "registered instances preserved across the in-place update"
+        );
+        let n = state
+            .namespaces
+            .get(&ns_id)
+            .expect("namespace still exists");
+        assert_eq!(n.description.as_deref(), Some("v2"));
+        assert_eq!(
+            n.service_count, 1,
+            "service_count preserved (service not orphaned by reprovision)"
         );
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/servicediscovery.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/servicediscovery.rs
@@ -17,7 +17,7 @@ use fakecloud_servicediscovery::{
     Namespace, Service,
 };
 
-use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource};
 
 /// A lowercase alphanumeric fragment of the requested length, seeded from a
 /// random uuid's hex (which is alphanumeric). Mirrors the shape the direct
@@ -332,6 +332,88 @@ impl ResourceProvisioner {
             }
         }
         Ok(())
+    }
+
+    // --- In-place updates ---
+    //
+    // Namespaces and services own contained state (a namespace's service_count,
+    // a service's registered instances) and mint random ids referenced by their
+    // children. Reprovision (delete + create) on a Description/DnsConfig/tag edit
+    // would churn the ns-/srv- id -- orphaning every service under a namespace,
+    // wiping every registered instance under a service -- so mutate in place.
+
+    /// Handles all three CFN namespace types (Http/PublicDns/PrivateDns). AWS
+    /// `UpdateNamespace` mutates the Description in place (and the SOA TTL for
+    /// DNS namespaces); id, arn, service_count, hosted zone and VPC are kept.
+    pub(super) fn update_sd_namespace(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let mut accounts = self.servicediscovery_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let ns = state
+            .namespaces
+            .get_mut(&id)
+            .ok_or_else(|| format!("Namespace {id} not yet provisioned"))?;
+        ns.description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        // DNS namespaces: refresh the SOA TTL; HTTP namespaces have no `dns`.
+        if let Some(dns) = ns.dns.as_mut() {
+            dns.soa_ttl = sd_soa_ttl(props);
+        }
+        let arn = ns.arn.clone();
+        let hosted_zone_id = ns.dns.as_ref().map(|d| d.hosted_zone_id.clone());
+
+        let mut result = ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("Id", id);
+        if let Some(hz) = hosted_zone_id {
+            result = result.with("HostedZoneId", hz);
+        }
+        Ok(result)
+    }
+
+    /// AWS `UpdateService` mutates Description / DnsConfig / HealthCheckConfig in
+    /// place; the registered instances, instance_count, namespace and id are
+    /// preserved (reprovision would wipe the instances and churn the srv- id).
+    pub(super) fn update_sd_service(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let mut accounts = self.servicediscovery_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let svc = state
+            .services
+            .get_mut(&id)
+            .ok_or_else(|| format!("Service {id} not yet provisioned"))?;
+        svc.description = props
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        if let Some(dns) = props.get("DnsConfig") {
+            svc.dns_config = Some(parse_dns_config(dns));
+        }
+        if let Some(hc) = props.get("HealthCheckConfig") {
+            svc.health_check_config = Some(parse_health_check(hc));
+        }
+        // instances / instance_count / instances_revision / namespace_id kept.
+        let arn = svc.arn.clone();
+        let name = svc.name.clone();
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("Id", id)
+            .with("Name", name))
     }
 }
 

--- a/crates/fakecloud-tfacc/src/lib.rs
+++ b/crates/fakecloud-tfacc/src/lib.rs
@@ -229,7 +229,11 @@ pub struct GoTestRunner<'a> {
 /// Other services have no such heavy per-test load, so parallel-4 is fine.
 fn parallelism_for(service: &str) -> u32 {
     match service {
-        "pipes" | "kinesisanalyticsv2" => 1,
+        // `autoscaling` drives multi-step create/update/delete lifecycle waiters
+        // (launch config -> ASG -> instance settle) that, four-at-a-time on a
+        // 2-core runner, starve the shared fakecloud server enough to wedge the
+        // whole shard to the 60-min job cap under load. Run it serially.
+        "pipes" | "kinesisanalyticsv2" | "autoscaling" => 1,
         _ => 4,
     }
 }


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3c.

**ServiceDiscovery (Cloud Map)** types had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on any property/tag edit — churning the random `ns-`/`srv-` id and dropping contained state:
- **AWS::ServiceDiscovery::{Http,PublicDns,PrivateDns}Namespace** — update Description (and DNS SOA TTL) in place; preserve id/arn/service_count/hosted-zone/vpc (reprovision orphaned every service under the namespace).
- **AWS::ServiceDiscovery::Service** — update Description/DnsConfig/HealthCheckConfig in place; preserve id/arn and the registered instances + instance_count (reprovision wiped them).

**Also (CI reliability):** run the `autoscaling` tfacc shard serially (`parallelism_for` → 1). Its create/update/delete lifecycle waiters, four-at-a-time on a 2-core runner under concurrent-PR load, starve the shared fakecloud server and wedge the shard to the 60-min job cap (observed repeatedly this cycle — it timed out/straggled on #2420 and #2423). Same escape hatch `pipes`/`kinesisanalyticsv2` already use.

Remaining Family-B types (CloudFront Distribution, EC2 VPC/Subnet/SG/RouteTable, WAFv2, + MED tier) follow in later PRs.

## Test plan
- New regression test: SD namespace/service Description updates keep their id and preserve service_count / registered instances.
- `cargo nextest run -p fakecloud-cloudformation`: 306 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean (cloudformation + tfacc).
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add in-place UpdateStack handling for Cloud Map namespaces and services to prevent replacements that churn `ns-`/`srv-` ids and drop state. Also runs the `autoscaling` `tfacc` shard serially to reduce CI timeouts.

- **Bug Fixes**
  - `fakecloud-cloudformation`: In-place updates for `AWS::ServiceDiscovery::{Http,PublicDns,PrivateDns}Namespace` (Description, DNS SOA TTL). Preserve id/arn/hosted zone/VPC/service_count.
  - `fakecloud-cloudformation`: In-place updates for `AWS::ServiceDiscovery::Service` (Description, DnsConfig, HealthCheckConfig). Preserve id/arn/name and registered instances/instance_count.
  - Added regression test to confirm ids and counts are preserved.

<sup>Written for commit bb46fe1fb5d280d8e7e68940fba3db7dfd0d4907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

