### PR TITLE
fix(cloudformation): in-place UpdateStack for WAFv2 WebACL/IPSet/RegexPatternSet/RuleGroup (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1917,6 +1917,14 @@ impl ResourceProvisioner {
                 Some(self.update_sd_namespace(existing, new_def)?)
             }
             "AWS::ServiceDiscovery::Service" => Some(self.update_sd_service(existing, new_def)?),
+            // In-place updates: reprovision would mint a new ARN/Id, dangling
+            // WebACL rules, WebACLAssociation and CloudFront WebACLId references.
+            "AWS::WAFv2::WebACL" => Some(self.update_wafv2_web_acl(existing, new_def)?),
+            "AWS::WAFv2::IPSet" => Some(self.update_wafv2_ip_set(existing, new_def)?),
+            "AWS::WAFv2::RegexPatternSet" => {
+                Some(self.update_wafv2_regex_pattern_set(existing, new_def)?)
+            }
+            "AWS::WAFv2::RuleGroup" => Some(self.update_wafv2_rule_group(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -4370,6 +4378,86 @@ mod tests {
             n.service_count, 1,
             "service_count preserved (service not orphaned by reprovision)"
         );
+    }
+
+    #[test]
+    fn wafv2_updates_preserve_arn_and_id() {
+        // bug-audit 2026-07-27 (cycle 5): without update arms a WebACL/IPSet/etc
+        // fell through to reprovision on a rules/addresses edit, minting a new
+        // ARN/Id and dangling WebACL rules / WebACLAssociation / CloudFront
+        // WebACLId references. Updates must be in place.
+        let prov = make_provisioner();
+        let acl = prov
+            .create_resource(&make_resource(
+                "AWS::WAFv2::WebACL",
+                "Acl",
+                serde_json::json!({
+                    "Name": "a", "Scope": "REGIONAL",
+                    "DefaultAction": {"Allow": {}}, "Rules": [], "VisibilityConfig": {}
+                }),
+            ))
+            .expect("web acl provisions");
+        let acl_arn = acl.physical_id.clone();
+
+        let ipset = prov
+            .create_resource(&make_resource(
+                "AWS::WAFv2::IPSet",
+                "Ip",
+                serde_json::json!({
+                    "Name": "ip", "Scope": "REGIONAL",
+                    "IPAddressVersion": "IPV4", "Addresses": ["1.2.3.4/32"]
+                }),
+            ))
+            .expect("ip set provisions");
+        let ip_arn = ipset.physical_id.clone();
+
+        let acl_up = prov
+            .update_resource(
+                &acl,
+                &make_resource(
+                    "AWS::WAFv2::WebACL",
+                    "Acl",
+                    serde_json::json!({
+                        "Name": "a", "Scope": "REGIONAL",
+                        "DefaultAction": {"Block": {}},
+                        "Rules": [{"Name": "r1"}], "VisibilityConfig": {}
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(acl_up.physical_id, acl_arn, "WebACL ARN preserved");
+
+        let ip_up = prov
+            .update_resource(
+                &ipset,
+                &make_resource(
+                    "AWS::WAFv2::IPSet",
+                    "Ip",
+                    serde_json::json!({
+                        "Name": "ip", "Scope": "REGIONAL", "IPAddressVersion": "IPV4",
+                        "Addresses": ["5.6.7.8/32", "9.10.11.12/32"]
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(ip_up.physical_id, ip_arn, "IPSet ARN preserved");
+
+        let accounts = prov.wafv2_state.read();
+        let state = accounts.accounts.get("123456789012").unwrap();
+        let a = state
+            .web_acls
+            .get(&("REGIONAL".to_string(), "a".to_string()))
+            .unwrap();
+        assert_eq!(a.arn, acl_arn);
+        assert_eq!(a.rules.len(), 1, "WebACL rules updated in place");
+        let ip = state
+            .ip_sets
+            .get(&("REGIONAL".to_string(), "ip".to_string()))
+            .unwrap();
+        assert_eq!(ip.arn, ip_arn);
+        assert_eq!(ip.addresses.len(), 2, "IPSet addresses updated in place");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/wafv2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/wafv2.rs
@@ -507,4 +507,254 @@ impl ResourceProvisioner {
         state.associations.remove(physical_id);
         Ok(())
     }
+
+    // --- In-place updates ---
+    //
+    // WAFv2 resources are keyed by (scope, name) and their physical id is the
+    // ARN (with a random uuid), also referenced as Id/Arn by WebACL rules,
+    // WebACLAssociation and CloudFront `WebACLId`. Reprovision (delete + create)
+    // on a rules/addresses/patterns edit mints a NEW ARN/Id, dangling every
+    // reference. Name/Scope are immutable, so a change to either still forces
+    // replacement. These arms mutate the mutable config in place and bump the
+    // lock token, preserving the ARN/Id.
+
+    pub(super) fn update_wafv2_web_acl(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let updated = {
+            let mut accounts = self.wafv2_state.write();
+            let state = accounts
+                .accounts
+                .entry(self.account_id.clone())
+                .or_default();
+            match state.web_acls.get_mut(&(scope.clone(), name.clone())) {
+                Some(acl) if acl.arn == existing.physical_id => {
+                    acl.default_action = props
+                        .get("DefaultAction")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({"Allow": {}}));
+                    acl.description = props
+                        .get("Description")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    acl.rules = props
+                        .get("Rules")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    acl.visibility_config = props
+                        .get("VisibilityConfig")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({}));
+                    acl.lock_token = Uuid::new_v4().simple().to_string();
+                    Some(
+                        ProvisionResult::new(acl.arn.clone())
+                            .with("Arn", acl.arn.clone())
+                            .with("Id", acl.id.clone())
+                            .with("Name", name.clone())
+                            .with("Capacity", acl.capacity.to_string()),
+                    )
+                }
+                _ => None,
+            }
+        };
+        match updated {
+            Some(result) => Ok(result),
+            // Name/Scope changed (immutable) -> replacement.
+            None => self
+                .reprovision_resource(existing, resource)
+                .map(|o| o.unwrap_or_else(|| ProvisionResult::new(existing.physical_id.clone()))),
+        }
+    }
+
+    pub(super) fn update_wafv2_ip_set(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let updated = {
+            let mut accounts = self.wafv2_state.write();
+            let state = accounts
+                .accounts
+                .entry(self.account_id.clone())
+                .or_default();
+            match state.ip_sets.get_mut(&(scope.clone(), name.clone())) {
+                Some(set) if set.arn == existing.physical_id => {
+                    set.addresses = props
+                        .get("Addresses")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    set.description = props
+                        .get("Description")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    set.lock_token = Uuid::new_v4().simple().to_string();
+                    Some(
+                        ProvisionResult::new(set.arn.clone())
+                            .with("Arn", set.arn.clone())
+                            .with("Id", set.id.clone())
+                            .with("Name", name.clone()),
+                    )
+                }
+                _ => None,
+            }
+        };
+        match updated {
+            Some(result) => Ok(result),
+            None => self
+                .reprovision_resource(existing, resource)
+                .map(|o| o.unwrap_or_else(|| ProvisionResult::new(existing.physical_id.clone()))),
+        }
+    }
+
+    pub(super) fn update_wafv2_regex_pattern_set(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let updated = {
+            let mut accounts = self.wafv2_state.write();
+            let state = accounts
+                .accounts
+                .entry(self.account_id.clone())
+                .or_default();
+            match state
+                .regex_pattern_sets
+                .get_mut(&(scope.clone(), name.clone()))
+            {
+                Some(set) if set.arn == existing.physical_id => {
+                    set.regular_expressions = props
+                        .get("RegularExpressionList")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .map(|s| {
+                                    if let Some(s) = s.as_str() {
+                                        serde_json::json!({"RegexString": s})
+                                    } else {
+                                        s.clone()
+                                    }
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    set.description = props
+                        .get("Description")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    set.lock_token = Uuid::new_v4().simple().to_string();
+                    Some(
+                        ProvisionResult::new(set.arn.clone())
+                            .with("Arn", set.arn.clone())
+                            .with("Id", set.id.clone())
+                            .with("Name", name.clone()),
+                    )
+                }
+                _ => None,
+            }
+        };
+        match updated {
+            Some(result) => Ok(result),
+            None => self
+                .reprovision_resource(existing, resource)
+                .map(|o| o.unwrap_or_else(|| ProvisionResult::new(existing.physical_id.clone()))),
+        }
+    }
+
+    pub(super) fn update_wafv2_rule_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = props
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("Name is required")?
+            .to_string();
+        let scope = props
+            .get("Scope")
+            .and_then(|v| v.as_str())
+            .ok_or("Scope is required")?
+            .to_string();
+        let updated = {
+            let mut accounts = self.wafv2_state.write();
+            let state = accounts
+                .accounts
+                .entry(self.account_id.clone())
+                .or_default();
+            match state.rule_groups.get_mut(&(scope.clone(), name.clone())) {
+                Some(rg) if rg.arn == existing.physical_id => {
+                    rg.rules = props
+                        .get("Rules")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    rg.description = props
+                        .get("Description")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    rg.visibility_config = props
+                        .get("VisibilityConfig")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({}));
+                    rg.lock_token = Uuid::new_v4().simple().to_string();
+                    Some(
+                        ProvisionResult::new(rg.arn.clone())
+                            .with("Arn", rg.arn.clone())
+                            .with("Id", rg.id.clone())
+                            .with("Name", name.clone())
+                            .with("Capacity", rg.capacity.to_string()),
+                    )
+                }
+                _ => None,
+            }
+        };
+        match updated {
+            Some(result) => Ok(result),
+            None => self
+                .reprovision_resource(existing, resource)
+                .map(|o| o.unwrap_or_else(|| ProvisionResult::new(existing.physical_id.clone()))),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3d. WAFv2 resources are keyed by `(scope, name)`; their physical id is the ARN (with a random uuid), also exposed as Id/Arn and referenced by WebACL rules, `AWS::WAFv2::WebACLAssociation` and CloudFront `WebACLId`. Without an in-place `update_*` arm, `UpdateStack` fell through to reprovision (delete + create) on a rules/addresses/patterns edit, minting a **new ARN/Id** and dangling every reference.

- **WebACL** — update DefaultAction/Description/Rules/VisibilityConfig in place.
- **IPSet** — update Addresses/Description in place.
- **RegexPatternSet** — update RegularExpressionList/Description in place.
- **RuleGroup** — update Rules/Description/VisibilityConfig in place.

All bump the lock token and preserve the ARN/Id. Name/Scope are immutable → a change to either still falls back to replacement. Same fix pattern as #2420/#2423/#2425/#2426.

Remaining Family-B types (CloudFront Distribution, EC2 VPC/Subnet/SG/RouteTable, + MED tier: CodeDeploy, ElastiCache User/UserGroup) follow in later PRs.

## Test plan
- New regression test: WebACL rules + IPSet addresses updates keep their ARN.
- `cargo nextest run -p fakecloud-cloudformation`: 307 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents reprovision and broken references by adding in-place updates for WAFv2 resources. WebACL, IPSet, RegexPatternSet, and RuleGroup now keep their ARN/Id during UpdateStack.

- **Bug Fixes**
  - In-place updates for `AWS::WAFv2::{WebACL, IPSet, RegexPatternSet, RuleGroup}`; preserve ARN/Id and bump lock token. Name/Scope changes still trigger replacement.
  - Updated fields: WebACL (DefaultAction, Description, Rules, VisibilityConfig); IPSet (Addresses, Description); RegexPatternSet (RegularExpressionList, Description); RuleGroup (Rules, Description, VisibilityConfig).
  - Regression test verifies ARNs are preserved on WebACL rule and IPSet address edits.

<sup>Written for commit 8685157492d9456bd041403b051eaa4a20fc5f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

