### PR TITLE
fix(cloudformation): in-place UpdateStack for CloudFront Distribution (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
@@ -204,6 +204,116 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// In-place `UpdateDistribution`. Reprovision would mint a NEW distribution
+    /// id + `*.cloudfront.net` domain + ARN, breaking `Ref` (id), `GetAtt
+    /// DomainName` and any Route53 alias record pointing at the old domain --
+    /// the single most-referenced CloudFront attribute. AWS updates nearly the
+    /// entire DistributionConfig in place, so rebuild the config and swap it into
+    /// the stored distribution, preserving id/arn/domain and the (immutable)
+    /// caller reference, and bump the ETag.
+    pub(crate) fn update_cf_distribution(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("DistributionConfig")
+            .ok_or_else(|| "DistributionConfig is required".to_string())?;
+
+        let origin_entries: Vec<Origin> = cfg
+            .get("Origins")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| "DistributionConfig.Origins is required".to_string())?
+            .iter()
+            .map(|o| {
+                serde_json::from_value::<Origin>(o.clone())
+                    .map_err(|e| format!("Invalid Origin entry: {e}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if origin_entries.is_empty() {
+            return Err("DistributionConfig.Origins must contain at least one origin".to_string());
+        }
+        let origins = Origins {
+            quantity: origin_entries.len() as i32,
+            items: Some(OriginItems {
+                origin: origin_entries,
+            }),
+        };
+
+        let dcb_value = cfg
+            .get("DefaultCacheBehavior")
+            .ok_or_else(|| "DistributionConfig.DefaultCacheBehavior is required".to_string())?;
+        let default_cache_behavior: DefaultCacheBehavior =
+            serde_json::from_value(dcb_value.clone())
+                .map_err(|e| format!("Invalid DefaultCacheBehavior: {e}"))?;
+
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let enabled = cfg.get("Enabled").and_then(|v| v.as_bool()).unwrap_or(true);
+        let viewer_certificate: Option<ViewerCertificate> = cfg
+            .get("ViewerCertificate")
+            .map(|v| serde_json::from_value(v.clone()))
+            .transpose()
+            .map_err(|e| format!("Invalid ViewerCertificate: {e}"))?;
+
+        let mut config = DistributionConfig {
+            caller_reference: String::new(), // preserved from the stored config below
+            comment,
+            enabled,
+            origins,
+            default_cache_behavior,
+            ..Default::default()
+        };
+        config.price_class = cfg
+            .get("PriceClass")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        config.http_version = cfg
+            .get("HttpVersion")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        config.is_ipv6_enabled = cfg.get("IPV6Enabled").and_then(|v| v.as_bool());
+        config.default_root_object = cfg
+            .get("DefaultRootObject")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        config.web_acl_id = cfg
+            .get("WebACLId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        config.viewer_certificate = viewer_certificate;
+
+        let etag_suffix: String = Uuid::new_v4()
+            .simple()
+            .to_string()
+            .chars()
+            .take(7)
+            .collect::<String>()
+            .to_uppercase();
+
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let dist = state
+            .distributions
+            .get_mut(&existing.physical_id)
+            .ok_or_else(|| format!("Distribution {} not yet provisioned", existing.physical_id))?;
+        // CallerReference is immutable across an update; keep the stored one.
+        config.caller_reference = dist.config.caller_reference.clone();
+        dist.config = config;
+        dist.status = "InProgress".to_string();
+        dist.last_modified_time = Utc::now();
+        dist.etag = format!("E{etag_suffix}");
+
+        Ok(ProvisionResult::new(dist.id.clone())
+            .with("Id", dist.id.clone())
+            .with("DomainName", dist.domain_name.clone())
+            .with("Arn", dist.arn.clone()))
+    }
+
     pub(crate) fn create_cf_origin_access_control(
         &self,
         resource: &ResourceDefinition,

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1937,6 +1937,11 @@ impl ResourceProvisioner {
             "AWS::Organizations::Policy" => {
                 Some(self.update_organization_policy(existing, new_def)?)
             }
+            // In-place update: reprovision would mint a new distribution id +
+            // domain + ARN, breaking Ref/GetAtt DomainName and Route53 aliases.
+            "AWS::CloudFront::Distribution" => {
+                Some(self.update_cf_distribution(existing, new_def)?)
+            }
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -4577,6 +4582,59 @@ mod tests {
             "policy still attached to the OU after the in-place update"
         );
         assert!(org.accounts.contains_key(&acct_id), "same account persists");
+    }
+
+    #[test]
+    fn cloudfront_distribution_update_is_in_place() {
+        // bug-audit 2026-07-27 (cycle 5): without an update arm a Distribution
+        // fell through to reprovision on any config edit, minting a new id +
+        // *.cloudfront.net domain + ARN and breaking Ref/GetAtt DomainName and
+        // Route53 aliases. The update must mutate the config in place.
+        let prov = make_provisioner();
+        let cfg = |comment: &str, enabled: bool| {
+            serde_json::json!({"DistributionConfig": {
+                "Comment": comment, "Enabled": enabled,
+                "Origins": [{
+                    "Id": "o1", "DomainName": "ex.com",
+                    "CustomOriginConfig": {
+                        "HTTPPort": 80, "HTTPSPort": 443,
+                        "OriginProtocolPolicy": "http-only"
+                    }
+                }],
+                "DefaultCacheBehavior": {
+                    "TargetOriginId": "o1", "ViewerProtocolPolicy": "allow-all"
+                }
+            }})
+        };
+        let dist = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::Distribution",
+                "D",
+                cfg("v1", true),
+            ))
+            .expect("distribution provisions");
+        let id = dist.physical_id.clone();
+
+        let up = prov
+            .update_resource(
+                &dist,
+                &make_resource("AWS::CloudFront::Distribution", "D", cfg("v2", false)),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(
+            up.physical_id, id,
+            "distribution id preserved (not reprovisioned)"
+        );
+
+        let accounts = prov.cloudfront_state.read();
+        let state = accounts.get("000000000000").unwrap();
+        let d = state
+            .distributions
+            .get(&id)
+            .expect("distribution still exists");
+        assert_eq!(d.config.comment, "v2", "config mutated in place");
+        assert!(!d.config.enabled);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3e. `AWS::CloudFront::Distribution` had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on any config edit (Comment/Enabled/Origins/PriceClass/DefaultRootObject/WebACLId/...) — minting a **new distribution id + `*.cloudfront.net` domain + ARN**. That breaks `Ref` (the id), `GetAtt DomainName` (the most-referenced CloudFront attribute) and every Route53 alias record pointing at the old domain.

`update_cf_distribution` rebuilds the DistributionConfig from the template and swaps it into the stored distribution, preserving the id/arn/domain and the immutable CallerReference, resetting Status to `InProgress` and bumping the ETag — matching AWS `UpdateDistribution`.

Remaining Family-B types (EC2 VPC/Subnet/SG/RouteTable HIGH, + MED tier: CodeDeploy App/DG, ElastiCache User/UserGroup, Timestream Database) follow in later PRs.

## Test plan
- New regression test: a Comment/Enabled edit keeps the distribution id and mutates config in place.
- `cargo nextest run -p fakecloud-cloudformation`: 309 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable in-place updates for `AWS::CloudFront::Distribution` to prevent replacement on config changes. Edits now mutate the existing distribution and preserve the id, domain, and ARN, matching AWS `UpdateDistribution`.

- **Bug Fixes**
  - Added `update_cf_distribution` to rebuild and swap `DistributionConfig` in place (preserves id/domain/ARN and immutable CallerReference; sets Status to `InProgress`; bumps ETag).
  - Routed `UpdateStack` for `AWS::CloudFront::Distribution` to the new in-place handler.
  - Added a regression test: changing Comment/Enabled keeps the same distribution id and updates config in place.

<sup>Written for commit 8b32acf10a86fcbbb86d3884064cdcf60c63cc50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

