### PR TITLE
fix(cloudformation): in-place UpdateStack for EC2 VPC/Subnet/RouteTable (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -301,6 +301,94 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone()).with("RouteTableId", id))
     }
 
+    // --- In-place updates ---
+    //
+    // These VPC networking resources mint an id (`vpc-`/`subnet-`/`rtb-`) that
+    // every child and sibling references via `Ref` (subnets, security groups,
+    // route tables, routes, associations, instances, ENIs). Reprovision
+    // (delete + create) on a mutable-attribute or tag edit churns that id and
+    // orphans all of them. AWS applies these changes in place. The update arms
+    // re-dispatch the specific Modify* EC2 call against the EXISTING id and
+    // return it unchanged.
+
+    /// `EnableDnsSupport`/`EnableDnsHostnames` are in-place (ModifyVpcAttribute)
+    /// in AWS; `CidrBlock`/`InstanceTenancy` are immutable. Preserve the vpc id.
+    pub(super) fn update_ec2_vpc(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        let dns_support = prop_bool(props, "EnableDnsSupport");
+        let dns_hostnames = prop_bool(props, "EnableDnsHostnames");
+        if dns_support.is_some() || dns_hostnames.is_some() {
+            let mut mp = HashMap::new();
+            mp.insert("VpcId".to_string(), id.clone());
+            if let Some(v) = dns_support {
+                mp.insert("EnableDnsSupport.Value".to_string(), v.to_string());
+            }
+            if let Some(v) = dns_hostnames {
+                mp.insert("EnableDnsHostnames.Value".to_string(), v.to_string());
+            }
+            self.ec2_dispatch("ModifyVpcAttribute", mp)?;
+        }
+
+        let cidr = prop_str(props, "CidrBlock").unwrap_or("").to_string();
+        Ok(ProvisionResult::new(id.clone())
+            .with("VpcId", id)
+            .with("CidrBlock", cidr))
+    }
+
+    /// `MapPublicIpOnLaunch` is in-place (ModifySubnetAttribute) in AWS;
+    /// `CidrBlock`/`AvailabilityZone`/`VpcId` are immutable. Preserve the subnet
+    /// id.
+    pub(super) fn update_ec2_subnet(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        if let Some(v) = prop_bool(props, "MapPublicIpOnLaunch") {
+            let mut mp = HashMap::new();
+            mp.insert("SubnetId".to_string(), id.clone());
+            mp.insert("MapPublicIpOnLaunch.Value".to_string(), v.to_string());
+            self.ec2_dispatch("ModifySubnetAttribute", mp)?;
+        }
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("SubnetId", id)
+            .with(
+                "AvailabilityZone",
+                prop_str(props, "AvailabilityZone")
+                    .unwrap_or("")
+                    .to_string(),
+            )
+            .with("VpcId", prop_str(props, "VpcId").unwrap_or("").to_string())
+            .with(
+                "CidrBlock",
+                prop_str(props, "CidrBlock").unwrap_or("").to_string(),
+            ))
+    }
+
+    /// A route table has no in-place-mutable property (routes are separate
+    /// `AWS::EC2::Route` resources; tags are re-applied by the create-time
+    /// TagSpecification path, not a standalone CreateTags the internal EC2
+    /// dispatch supports). The whole point of the arm is to AVOID reprovision,
+    /// which would churn the rtb id and orphan every Route /
+    /// SubnetRouteTableAssociation child. So preserve the id and report success.
+    pub(super) fn update_ec2_route_table(
+        &self,
+        existing: &StackResource,
+        _resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let id = existing.physical_id.clone();
+        Ok(ProvisionResult::new(id.clone()).with("RouteTableId", id))
+    }
+
     /// `AWS::EC2::Instance` — create a REAL control-plane instance synchronously
     /// (so `Ref` resolves to the `i-...` id and `Fn::GetAtt`
     /// PrivateIp/PublicIp/AvailabilityZone resolve during provisioning), then

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1942,6 +1942,12 @@ impl ResourceProvisioner {
             "AWS::CloudFront::Distribution" => {
                 Some(self.update_cf_distribution(existing, new_def)?)
             }
+            // In-place updates: reprovision would churn the vpc-/subnet-/rtb- id
+            // and orphan every child/sibling that references it (subnets, SGs,
+            // route tables, routes, associations, instances, ENIs).
+            "AWS::EC2::VPC" => Some(self.update_ec2_vpc(existing, new_def)?),
+            "AWS::EC2::Subnet" => Some(self.update_ec2_subnet(existing, new_def)?),
+            "AWS::EC2::RouteTable" => Some(self.update_ec2_route_table(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -5004,6 +5010,96 @@ mod tests {
         // Delete routes through the real handler.
         prov.delete_resource(&subnet).expect("subnet deletes");
         prov.delete_resource(&vpc).expect("vpc deletes");
+    }
+
+    #[test]
+    fn ec2_networking_updates_preserve_ids() {
+        // bug-audit 2026-07-27 (cycle 5): without update arms a VPC/Subnet/
+        // RouteTable fell through to reprovision on a mutable-attribute or tag
+        // edit, churning the id and orphaning every child/sibling that
+        // referenced it. Updates must be in place (same id).
+        let prov = make_provisioner();
+        let vpc = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::VPC",
+                "Vpc",
+                serde_json::json!({ "CidrBlock": "10.2.0.0/16" }),
+            ))
+            .expect("VPC provisions");
+        let vpc_id = vpc.physical_id.clone();
+
+        let subnet = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::Subnet",
+                "Subnet",
+                serde_json::json!({ "VpcId": vpc_id, "CidrBlock": "10.2.1.0/24" }),
+            ))
+            .expect("subnet provisions");
+        let subnet_id = subnet.physical_id.clone();
+
+        let rtb = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::RouteTable",
+                "Rtb",
+                serde_json::json!({ "VpcId": vpc_id }),
+            ))
+            .expect("route table provisions");
+        let rtb_id = rtb.physical_id.clone();
+
+        // VPC: enable DNS hostnames in place -> same vpc id.
+        let vpc_up = prov
+            .update_resource(
+                &vpc,
+                &make_resource(
+                    "AWS::EC2::VPC",
+                    "Vpc",
+                    serde_json::json!({ "CidrBlock": "10.2.0.0/16", "EnableDnsHostnames": true }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(vpc_up.physical_id, vpc_id, "VPC id preserved");
+
+        // Subnet: flip MapPublicIpOnLaunch in place -> same subnet id.
+        let subnet_up = prov
+            .update_resource(
+                &subnet,
+                &make_resource(
+                    "AWS::EC2::Subnet",
+                    "Subnet",
+                    serde_json::json!({
+                        "VpcId": vpc_id, "CidrBlock": "10.2.1.0/24",
+                        "MapPublicIpOnLaunch": true
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(subnet_up.physical_id, subnet_id, "subnet id preserved");
+
+        // RouteTable: a tag edit must not reprovision (would orphan routes) ->
+        // same rtb id.
+        let rtb_up = prov
+            .update_resource(
+                &rtb,
+                &make_resource(
+                    "AWS::EC2::RouteTable",
+                    "Rtb",
+                    serde_json::json!({
+                        "VpcId": vpc_id, "Tags": [{"Key": "env", "Value": "prod"}]
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(rtb_up.physical_id, rtb_id, "route table id preserved");
+
+        // All three still exist under their original ids in EC2 state.
+        let ec2 = prov.ec2_state.read();
+        let acct = ec2.get("123456789012").unwrap();
+        assert!(acct.vpcs.contains_key(&vpc_id));
+        assert!(acct.subnets.contains_key(&subnet_id));
+        assert!(acct.route_tables.contains_key(&rtb_id));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3f. These VPC networking types had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on a mutable-attribute or tag edit — churning the `vpc-`/`subnet-`/`rtb-` id and orphaning every child/sibling that references it via `Ref` (subnets, security groups, route tables, routes, associations, instances, ENIs).

- **AWS::EC2::VPC** — apply `EnableDnsSupport`/`EnableDnsHostnames` via ModifyVpcAttribute against the existing vpc id (CidrBlock/InstanceTenancy immutable).
- **AWS::EC2::Subnet** — apply `MapPublicIpOnLaunch` via ModifySubnetAttribute against the existing subnet id (CidrBlock/AvailabilityZone/VpcId immutable).
- **AWS::EC2::RouteTable** — no in-place-mutable property (routes are separate `AWS::EC2::Route` resources); the arm preserves the rtb id instead of reprovisioning, which would orphan every Route/SubnetRouteTableAssociation child.

Tag re-application on update is intentionally omitted: the internal EC2 provision dispatch has no standalone `CreateTags` (create applies tags via the TagSpecification path), and tags are not the data-loss concern — id churn is.

`AWS::EC2::SecurityGroup` (needs a DescribeSecurityGroups → Revoke → Authorize rule reconciliation) follows in its own PR, along with the remaining MED-tier types (CodeDeploy App/DG, ElastiCache User/UserGroup, Timestream Database).

## Test plan
- New regression test: VPC/Subnet/RouteTable updates all keep their id (no reprovision).
- `cargo nextest run -p fakecloud-cloudformation`: 310 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent data loss by making CloudFormation updates for `AWS::EC2::VPC`, `AWS::EC2::Subnet`, and `AWS::EC2::RouteTable` happen in place. `UpdateStack` no longer reprovisions these, so IDs and dependencies stay intact.

- **Bug Fixes**
  - Added update arms:
    - VPC: apply `EnableDnsSupport`/`EnableDnsHostnames` via `ModifyVpcAttribute` (preserve VPC ID).
    - Subnet: apply `MapPublicIpOnLaunch` via `ModifySubnetAttribute` (preserve Subnet ID).
    - RouteTable: preserve ID; no reprovision on tag/property edits.
  - Added regression test ensuring IDs are unchanged after updates.
  - No API changes; tags are not reapplied on update by design.

<sup>Written for commit 79c90b2fb47f92a7d82f121fa655c3d07975e11d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

