### PR TITLE
fix(rds): unbreak the local postgres image build; publish postgres 18

### DIFF
--- a/.github/workflows/docker-rds-images.yml
+++ b/.github/workflows/docker-rds-images.yml
@@ -50,6 +50,7 @@ jobs:
           - { engine: postgres, version: "15", build_arg: "PG_VERSION" }
           - { engine: postgres, version: "16", build_arg: "PG_VERSION" }
           - { engine: postgres, version: "17", build_arg: "PG_VERSION" }
+          - { engine: postgres, version: "18", build_arg: "PG_VERSION" }
           # MySQL majors. 5.7 is excluded — Oracle ended community
           # support in October 2023 and the image base no longer ships
           # the build deps we'd need to compile the UDF.
@@ -135,6 +136,7 @@ jobs:
           - { engine: postgres, version: "15" }
           - { engine: postgres, version: "16" }
           - { engine: postgres, version: "17" }
+          - { engine: postgres, version: "18" }
           - { engine: mysql, version: "8.0" }
           - { engine: mariadb, version: "10.6" }
           - { engine: mariadb, version: "10.11" }
@@ -226,6 +228,7 @@ jobs:
           - { engine: postgres, version: "15" }
           - { engine: postgres, version: "16" }
           - { engine: postgres, version: "17" }
+          - { engine: postgres, version: "18" }
           - { engine: mysql, version: "8.0" }
           - { engine: mariadb, version: "10.6" }
           - { engine: mariadb, version: "10.11" }

--- a/crates/fakecloud-rds/assets/postgres/Dockerfile
+++ b/crates/fakecloud-rds/assets/postgres/Dockerfile
@@ -5,8 +5,14 @@
 # tries to pull that tag first and falls back to building from this
 # Dockerfile locally when the pull fails (dev / unreleased / airgapped).
 # PG_VERSION must sit before the first FROM so its substitution is
-# available across all stages. Inside each stage it has to be
-# re-declared (Dockerfile spec) for `RUN`/`COPY` references to expand.
+# available there. Do NOT re-declare it inside the postgres stage: that
+# image already sets `ENV PG_VERSION=<major>.<minor>-<n>.pgdg<rel>` (e.g.
+# 18.4-1.pgdg13+1), and the legacy builder resolves the ENV ahead of the
+# ARG, so `postgresql-plpython3-${PG_VERSION}` becomes the full Debian
+# version string and apt exits 100. BuildKit prefers the ARG and hides
+# the clash, but fakecloud shells out to whatever `docker` it finds —
+# in-container CLIs usually have no buildx and fall back to the legacy
+# builder. Use the base image's own PG_MAJOR after FROM instead.
 ARG PG_VERSION=16
 
 # Rebuild `gosu` from source with current Go to eliminate the upstream
@@ -19,7 +25,6 @@ ENV CGO_ENABLED=0
 RUN go install -ldflags='-s -w' github.com/tianon/gosu@v0.0.0-20250923190938-6456aaa0f3c8
 
 FROM postgres:${PG_VERSION}
-ARG PG_VERSION
 
 COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
 RUN chmod 0755 /usr/local/bin/gosu
@@ -32,11 +37,11 @@ RUN chmod 0755 /usr/local/bin/gosu
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
-        postgresql-plpython3-${PG_VERSION} \
+        postgresql-plpython3-${PG_MAJOR} \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY aws_commons.control aws_commons--1.1.sql aws_commons--1.0--1.1.sql \
      aws_lambda.control aws_lambda--1.0.sql \
      aws_s3.control aws_s3--1.0.sql \
-     /usr/share/postgresql/${PG_VERSION}/extension/
+     /usr/share/postgresql/${PG_MAJOR}/extension/


### PR DESCRIPTION
`ensure_postgres_image` pulls the prebuilt tag and falls back to `docker build` when that fails. The docs call the build path the one for dev, unreleased and airgapped setups, and `FAKECLOUD_REBUILD_POSTGRES_IMAGE=1` takes it on purpose. That build has never worked.

The `postgres` image sets `ENV PG_VERSION=18.4-1.pgdg13+1`, and the Dockerfile re-declared `ARG PG_VERSION` after `FROM` so `RUN` and `COPY` could reach it. BuildKit resolves the ARG first, which is why CI stayed green. The legacy builder resolves the ENV first:

    E: Couldn't find any package by glob 'postgresql-plpython3-18.4-1.pgdg13+1'
    The command '/bin/sh -c apt-get update ...' returned a non-zero code: 100

fakecloud shells out to whatever `docker` binary it finds, and an in-container CLI usually ships without buildx — so the legacy builder is what users get. The failure is quiet: the half-created instance is dropped from state, and `DescribeDBInstances` answers `DBInstanceNotFound` with no hint that an image build died.

Postgres 18 is where this shows up today. `default_engine_versions` advertises `18.0`, `validate_create_request` accepts any `18.x`, and `default_parameter_groups` seeds `postgres18`, but the image workflow stops at 17, so no `fakecloud-postgres:18-*` tag has ever been published and every postgres 18 instance goes straight into the broken fallback.

## Fix

- Drop the post-`FROM` `ARG PG_VERSION` and use the base image's own `PG_MAJOR` for the package name and the extension directory. Nothing after `FROM` reads `PG_VERSION` now, so the ENV has nothing to shadow. The pre-`FROM` ARG still feeds the image tag, so the `--build-arg` contract and the Rust call site stay as they are.
- Add postgres 18 to the `build`, `merge` and `scan` job matrices in `docker-rds-images.yml`.
- mysql and mariadb never reference their arg after `FROM`, so they need no change.

## Tests

No unit test can reach this — the failure lives inside `docker build`. The workflow's `pull_request` trigger is paths-filtered on `crates/fakecloud-rds/assets/postgres/**`, so this PR runs the dry-run build for both arches, 18 included.

Checked by hand on the Dockerfile as committed. `DOCKER_BUILDKIT=0 docker build` for majors 16, 17 and 18 exits 0, where 18 exited 100 before; BuildKit still exits 0 for all three. Each image carries the 7 `aws_*` extension files and `postgresql-plpython3`.

End to end against a Docker build of this branch, with every local postgres 18 image removed first so the fallback had to run:

    Prebuilt postgres image not available, falling back to local build tag=...:18-0.44.5
    Building fakecloud-postgres image locally (first use can take ~60s)

`create-db-instance --engine postgres --engine-version 18.0` then reached `available`, and `psql` against the endpoint reports `PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1)` with `aws_commons`, `aws_lambda` and `plpython3u` installed. `cargo test -p fakecloud-rds` (276 passed), clippy with `-D warnings` and `cargo fmt --check` are clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local `postgres` image build used by the fallback path and publishes `postgres` 18 images. This lets Postgres 18 DB instances build and run in dev/airgapped setups without BuildKit.

- **Bug Fixes**
  - Stop redeclaring `ARG PG_VERSION` after `FROM`; use base image `PG_MAJOR` for `postgresql-plpython3` and extension paths to avoid apt failures with legacy Docker.
  - Add `postgres` 18 to build, manifest-merge, and verify matrices in `.github/workflows/docker-rds-images.yml`.
  - `mysql` and `mariadb` require no changes.

<sup>Written for commit 8b459894920bbe9fa22750e666e96b7bce0d7e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


