### PR TITLE
fix(cloudformation): in-place UpdateStack for EC2 SecurityGroup (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -389,6 +389,66 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone()).with("RouteTableId", id))
     }
 
+    /// In-place `AWS::EC2::SecurityGroup` update. Reprovision would churn the
+    /// sg id -- breaking every `Ref`/`SourceSecurityGroupId` that stored it and
+    /// dropping the group's rules -- and `GroupDescription`/`GroupName`/`VpcId`
+    /// are all immutable anyway, so replacement would fail on those. Preserve
+    /// the sg id and reconcile the inline ingress/egress rules in place.
+    pub(super) fn update_ec2_security_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+
+        self.reconcile_sg_rules(&id, props, "SecurityGroupIngress", false)?;
+        self.reconcile_sg_rules(&id, props, "SecurityGroupEgress", true)?;
+
+        Ok(ProvisionResult::new(id.clone())
+            .with("GroupId", id)
+            .with("VpcId", prop_str(props, "VpcId").unwrap_or("").to_string()))
+    }
+
+    /// Reconcile one rule direction to the template's desired set. A direction
+    /// is only touched when the template specifies it INLINE (revoke the
+    /// group's current rules in that direction, then authorize the template's)
+    /// -- when the property is absent the rules are left alone, since they may
+    /// be managed by separate `AWS::EC2::SecurityGroupIngress`/`Egress`
+    /// resources whose state must not be wiped by this update.
+    fn reconcile_sg_rules(
+        &self,
+        group_id: &str,
+        props: &Value,
+        prop_key: &str,
+        is_egress: bool,
+    ) -> Result<(), String> {
+        let Some(rules) = props.get(prop_key).and_then(|v| v.as_array()) else {
+            return Ok(());
+        };
+
+        // Revoke the group's current rules in this direction. The internal EC2
+        // provision dispatch has no Revoke action, so drop them directly in
+        // state (equivalent to a revoke-all for the direction the template
+        // manages inline), then authorize the desired set via the real handler.
+        {
+            let mut accounts = self.ec2_state.write();
+            let state = accounts.get_or_create(&self.account_id);
+            if let Some(sg) = state.security_groups.get_mut(group_id) {
+                sg.rules.retain(|r| r.is_egress != is_egress);
+            }
+        }
+        if !rules.is_empty() {
+            let action = if is_egress {
+                "AuthorizeSecurityGroupEgress"
+            } else {
+                "AuthorizeSecurityGroupIngress"
+            };
+            self.ec2_dispatch(action, sg_rule_params(group_id, rules))?;
+        }
+        Ok(())
+    }
+
     /// `AWS::EC2::Instance` — create a REAL control-plane instance synchronously
     /// (so `Ref` resolves to the `i-...` id and `Fn::GetAtt`
     /// PrivateIp/PublicIp/AvailabilityZone resolve during provisioning), then

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1948,6 +1948,7 @@ impl ResourceProvisioner {
             "AWS::EC2::VPC" => Some(self.update_ec2_vpc(existing, new_def)?),
             "AWS::EC2::Subnet" => Some(self.update_ec2_subnet(existing, new_def)?),
             "AWS::EC2::RouteTable" => Some(self.update_ec2_route_table(existing, new_def)?),
+            "AWS::EC2::SecurityGroup" => Some(self.update_ec2_security_group(existing, new_def)?),
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -5100,6 +5101,67 @@ mod tests {
         assert!(acct.vpcs.contains_key(&vpc_id));
         assert!(acct.subnets.contains_key(&subnet_id));
         assert!(acct.route_tables.contains_key(&rtb_id));
+    }
+
+    #[test]
+    fn ec2_security_group_update_reconciles_rules_in_place() {
+        // bug-audit 2026-07-27 (cycle 5): without an update arm a SecurityGroup
+        // fell through to reprovision on a rule edit, churning the sg id
+        // (breaking Ref/SourceSecurityGroupId references) and dropping rules.
+        // The update must keep the id and reconcile the inline rules in place.
+        let prov = make_provisioner();
+        let vpc = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::VPC",
+                "Vpc",
+                serde_json::json!({ "CidrBlock": "10.3.0.0/16" }),
+            ))
+            .expect("VPC provisions");
+        let sg = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::SecurityGroup",
+                "Sg",
+                serde_json::json!({
+                    "GroupDescription": "test", "VpcId": vpc.physical_id,
+                    "SecurityGroupIngress": [
+                        {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIp": "0.0.0.0/0"}
+                    ]
+                }),
+            ))
+            .expect("SG provisions");
+        let sg_id = sg.physical_id.clone();
+
+        // Replace the ingress rule (port 22 -> 443).
+        let up = prov
+            .update_resource(
+                &sg,
+                &make_resource(
+                    "AWS::EC2::SecurityGroup",
+                    "Sg",
+                    serde_json::json!({
+                        "GroupDescription": "test", "VpcId": vpc.physical_id,
+                        "SecurityGroupIngress": [
+                            {"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "CidrIp": "0.0.0.0/0"}
+                        ]
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(up.physical_id, sg_id, "security group id preserved");
+
+        let ec2 = prov.ec2_state.read();
+        let acct = ec2.get("123456789012").unwrap();
+        let g = acct.security_groups.get(&sg_id).expect("SG still exists");
+        let ingress: Vec<_> = g.rules.iter().filter(|r| !r.is_egress).collect();
+        assert!(
+            ingress.iter().any(|r| r.from_port == 443),
+            "new rule authorized in place"
+        );
+        assert!(
+            !ingress.iter().any(|r| r.from_port == 22),
+            "old rule revoked in place"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 3g. `AWS::EC2::SecurityGroup` had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on an ingress/egress rule edit — churning the sg id (breaking every `Ref` and `SourceSecurityGroupId` that stored it, plus separately-managed `SecurityGroupIngress`/`Egress` resources targeting it) and dropping the group's rules. GroupDescription/GroupName/VpcId are immutable anyway, so replacement would also fail on those.

`update_ec2_security_group` preserves the sg id and reconciles the inline rules in place: for each direction the template specifies inline, revoke the group's current rules in that direction, then authorize the desired set. **A direction the template does NOT specify is left untouched**, so rules owned by separate `AWS::EC2::SecurityGroupIngress`/`Egress` resources are not wiped. (The revoke is a direct state removal because the internal EC2 provision dispatch exposes no Revoke action; the authorize goes through the real handler.)

Completes the EC2-networking Family-B sweep (VPC/Subnet/RouteTable shipped in #2431). Remaining Family-B: MED tier (CodeDeploy App/DG, ElastiCache User/UserGroup, Timestream Database) follows next.

## Test plan
- New regression test: replacing an ingress rule keeps the sg id and swaps the rule in place.
- `cargo nextest run -p fakecloud-cloudformation`: 311 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-place `UpdateStack` for `AWS::EC2::SecurityGroup` so rule edits no longer replace the group, preventing ID churn and rule loss.

- **Bug Fixes**
  - Implemented `update_ec2_security_group` and wired it into the update dispatcher to reconcile inline ingress/egress rules in place.
  - Keeps `GroupId` stable; for each specified direction, revokes current rules then authorizes the desired set; leaves unspecified directions untouched to avoid wiping separately managed `SecurityGroupIngress`/`Egress`.
  - Added a regression test to verify ID preservation and rule swap; no API or migration changes.

<sup>Written for commit dbe74dfd4052f7f115a82ca27e2f44b94410c1d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

