### PR TITLE
fix(lambda): preserve native Docker host alias

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -165,7 +165,8 @@ impl HostNetworking {
     /// Resolve networking for `cli`, reading `FAKECLOUD_IN_CONTAINER` from
     /// the process environment.
     pub fn detect(cli: &str) -> Self {
-        let (host_alias, add_host_arg) = resolve_host_alias(cli);
+        let (host_alias, mut add_host_arg) = resolve_host_alias(cli);
+        add_host_arg = preserve_native_host_alias(add_host_arg, host_alias_resolves(&host_alias));
         let sibling_host =
             resolve_sibling_host(&host_alias, std::env::var("FAKECLOUD_IN_CONTAINER").ok());
         Self {
@@ -183,6 +184,23 @@ impl HostNetworking {
             argv.push("--add-host".to_string());
             argv.push(arg.clone());
         }
+    }
+}
+
+fn host_alias_resolves(host_alias: &str) -> bool {
+    std::net::ToSocketAddrs::to_socket_addrs(&(host_alias, 0)).is_ok()
+}
+
+fn preserve_native_host_alias(
+    add_host_arg: Option<String>,
+    host_alias_resolves: bool,
+) -> Option<String> {
+    if add_host_arg.is_some() && host_alias_resolves {
+        // Docker Desktop-style runtimes provide this alias natively.
+        // Passing --add-host would replace that working mapping.
+        None
+    } else {
+        add_host_arg
     }
 }
 
@@ -351,6 +369,33 @@ mod tests {
         // way docker must get an explicit --add-host.
         assert!(add_host.is_some());
         assert!(add_host.unwrap().starts_with("host.docker.internal:"));
+    }
+
+    #[test]
+    fn native_host_alias_prevents_docker_add_host_override() {
+        let add_host =
+            preserve_native_host_alias(Some("host.docker.internal:host-gateway".to_string()), true);
+
+        assert_eq!(add_host, None);
+    }
+
+    #[test]
+    fn unresolved_host_alias_keeps_docker_add_host() {
+        let add_host = preserve_native_host_alias(
+            Some("host.docker.internal:host-gateway".to_string()),
+            false,
+        );
+
+        assert_eq!(
+            add_host.as_deref(),
+            Some("host.docker.internal:host-gateway")
+        );
+    }
+
+    #[test]
+    fn absent_docker_add_host_remains_absent() {
+        assert_eq!(preserve_native_host_alias(None, true), None);
+        assert_eq!(preserve_native_host_alias(None, false), None);
     }
 
     #[test]

--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -166,7 +166,20 @@ impl HostNetworking {
     /// the process environment.
     pub fn detect(cli: &str) -> Self {
         let (host_alias, mut add_host_arg) = resolve_host_alias(cli);
-        add_host_arg = preserve_native_host_alias(add_host_arg, host_alias_resolves(&host_alias));
+        // A resolving `host.docker.internal` is only trustworthy evidence that
+        // the runtime provides the alias natively (and will inject it into
+        // sibling containers too) when fakecloud is itself containerized:
+        // Docker-Desktop-class runtimes inject the alias into CONTAINERS, never
+        // onto the host. On a bare native-Linux host a resolving alias is
+        // spurious (a hijacking NXDOMAIN resolver, a stray /etc/hosts entry, or
+        // a wildcard search domain), so suppressing the bridge --add-host there
+        // would break the host route sibling containers need. Gate the
+        // suppression on the in-container signal to avoid that regression.
+        let in_container = in_container_mode(std::env::var("FAKECLOUD_IN_CONTAINER").ok());
+        add_host_arg = preserve_native_host_alias(
+            add_host_arg,
+            in_container && host_alias_resolves(&host_alias),
+        );
         let sibling_host =
             resolve_sibling_host(&host_alias, std::env::var("FAKECLOUD_IN_CONTAINER").ok());
         Self {
@@ -187,17 +200,44 @@ impl HostNetworking {
     }
 }
 
+/// How long to wait for the blocking `getaddrinfo` in [`host_alias_resolves`]
+/// before giving up and returning `false`. `getaddrinfo` has no timeout of its
+/// own, and a slow or unreachable DNS server would otherwise block a runtime
+/// thread at startup (this runs inside runtime constructors under
+/// `#[tokio::main]`). Bounding it — same tradeoff as [`CLI_PROBE_TIMEOUT`] —
+/// turns "DNS wedged" into "alias doesn't resolve", the safe default that keeps
+/// the `--add-host` bridge mapping.
+pub const HOST_ALIAS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// True when `host_alias` resolves via the process resolver. The `getaddrinfo`
+/// call is blocking with no timeout of its own, so it runs on a spawned thread
+/// bounded by [`HOST_ALIAS_RESOLVE_TIMEOUT`]; on timeout we return `false` (the
+/// safe default that keeps `--add-host`). A leaked resolver thread on timeout
+/// is acceptable — same tradeoff as [`probe_cli`].
 fn host_alias_resolves(host_alias: &str) -> bool {
-    std::net::ToSocketAddrs::to_socket_addrs(&(host_alias, 0)).is_ok()
+    let (tx, rx) = std::sync::mpsc::channel();
+    let alias = host_alias.to_string();
+    std::thread::spawn(move || {
+        let resolves = std::net::ToSocketAddrs::to_socket_addrs(&(alias.as_str(), 0)).is_ok();
+        let _ = tx.send(resolves);
+    });
+    rx.recv_timeout(HOST_ALIAS_RESOLVE_TIMEOUT).unwrap_or(false)
 }
 
 fn preserve_native_host_alias(
     add_host_arg: Option<String>,
-    host_alias_resolves: bool,
+    should_suppress: bool,
 ) -> Option<String> {
-    if add_host_arg.is_some() && host_alias_resolves {
-        // Docker Desktop-style runtimes provide this alias natively.
-        // Passing --add-host would replace that working mapping.
+    if add_host_arg.is_some() && should_suppress {
+        // Suppress the injected `--add-host host.docker.internal:<vm-bridge-ip>`
+        // only when fakecloud is containerized AND the alias already resolves
+        // (see the gate in `detect`). In that case a Docker-Desktop-class
+        // runtime provides `host.docker.internal` natively inside every sibling
+        // container, pointing at the real host; injecting the VM bridge-gateway
+        // IP would shadow it and break the host route. On a bare host — where a
+        // hijacking resolver can make the alias resolve spuriously — the caller
+        // passes `false` here so native Linux docker keeps the bridge mapping
+        // it genuinely needs.
         None
     } else {
         add_host_arg
@@ -246,14 +286,21 @@ pub fn resolve_host_alias(cli: &str) -> (String, Option<String>) {
 /// - anything else, including `None` -> fakecloud runs on the host,
 ///   siblings live on `127.0.0.1:<port>`.
 pub fn resolve_sibling_host(host_alias: &str, env_value: Option<String>) -> String {
-    let in_container = env_value
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    if in_container {
+    if in_container_mode(env_value) {
         host_alias.to_string()
     } else {
         "127.0.0.1".to_string()
     }
+}
+
+/// Parse the `FAKECLOUD_IN_CONTAINER` signal: `Some("1")` or a case-insensitive
+/// `Some("true")` mean fakecloud is running inside a container; anything else,
+/// including `None`, means it runs on the host. Single source of truth for the
+/// parse so `detect`'s native-alias gate and `resolve_sibling_host` can't drift.
+fn in_container_mode(env_value: Option<String>) -> bool {
+    env_value
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 /// Hostnames fakecloud's bundled ECR/OCI registry can be addressed by from a
@@ -396,6 +443,57 @@ mod tests {
     fn absent_docker_add_host_remains_absent() {
         assert_eq!(preserve_native_host_alias(None, true), None);
         assert_eq!(preserve_native_host_alias(None, false), None);
+    }
+
+    #[test]
+    fn in_container_mode_parses_truthy_values() {
+        assert!(in_container_mode(Some("1".to_string())));
+        assert!(in_container_mode(Some("true".to_string())));
+        assert!(in_container_mode(Some("True".to_string())));
+        assert!(in_container_mode(Some("TRUE".to_string())));
+    }
+
+    #[test]
+    fn in_container_mode_rejects_falsey_and_absent() {
+        assert!(!in_container_mode(None));
+        assert!(!in_container_mode(Some(String::new())));
+        assert!(!in_container_mode(Some("0".to_string())));
+        assert!(!in_container_mode(Some("false".to_string())));
+        assert!(!in_container_mode(Some("yes".to_string())));
+    }
+
+    #[test]
+    fn native_alias_gate_suppresses_only_in_container() {
+        // The gate `detect` computes: `in_container && host_alias_resolves`.
+        let add_host = || Some("host.docker.internal:172.17.0.1".to_string());
+
+        // In-container + resolves -> Desktop-class runtime provides the alias
+        // natively in siblings; drop the shadowing bridge mapping.
+        let in_container = true;
+        let resolves = true;
+        assert_eq!(
+            preserve_native_host_alias(add_host(), in_container && resolves),
+            None,
+        );
+
+        // NOT in-container (bare host) + resolves -> the resolving alias is
+        // spurious (hijacking resolver / stray hosts entry). Native Linux docker
+        // needs the bridge mapping; must NOT drop it. Regression guard.
+        let in_container = false;
+        let resolves = true;
+        assert_eq!(
+            preserve_native_host_alias(add_host(), in_container && resolves).as_deref(),
+            Some("host.docker.internal:172.17.0.1"),
+        );
+
+        // In-container + does NOT resolve -> nothing native to preserve; keep
+        // the injected mapping.
+        let in_container = true;
+        let resolves = false;
+        assert_eq!(
+            preserve_native_host_alias(add_host(), in_container && resolves).as_deref(),
+            Some("host.docker.internal:172.17.0.1"),
+        );
     }
 
     #[test]

--- a/crates/fakecloud-lambda/src/runtime/docker.rs
+++ b/crates/fakecloud-lambda/src/runtime/docker.rs
@@ -46,6 +46,10 @@ pub struct DockerBackend {
     /// not `127.0.0.1:<port>`. Set via the `FAKECLOUD_IN_CONTAINER=1`
     /// env var baked into the published image (issue #1539 Bug 4).
     sibling_host: String,
+    /// Registry host used by the Docker daemon when pulling fakecloud ECR
+    /// images. This is separate from `sibling_host`: Docker Desktop and
+    /// OrbStack accept the local HTTP registry only over loopback.
+    registry_host: String,
     /// Isolated DOCKER_CONFIG dir with Basic auth for `127.0.0.1:<port>`.
     /// Lets `docker pull` talk to fakecloud ECR without mutating the user's
     /// `~/.docker/config.json`.
@@ -77,6 +81,8 @@ impl DockerBackend {
             add_host_arg: net.add_host_arg,
             server_port,
             sibling_host: net.sibling_host,
+            registry_host: std::env::var("FAKECLOUD_ECR_REGISTRY_HOST")
+                .unwrap_or_else(|_| "127.0.0.1".to_string()),
             docker_config,
         })
     }
@@ -108,15 +114,12 @@ impl DockerBackend {
             RuntimeError::ContainerStartFailed("PackageType=Image function has no ImageUri".into())
         })?;
 
-        // Point the registry host at `sibling_host` (not a bare
-        // `127.0.0.1`): when fakecloud runs in a container the daemon and
-        // the spawned sibling reach fakecloud's published registry port via
-        // `host.docker.internal`, since `127.0.0.1` is the host loopback
-        // from the daemon's view (issue #1539, bug 0.8). On the host,
-        // `sibling_host` is `127.0.0.1`, unchanged.
+        // Docker pulls through the host daemon. Unlike the Lambda callback
+        // path, local ECR must use the loopback registry on Docker Desktop
+        // and OrbStack because it is served over HTTP.
         let local_pull_uri = fakecloud_core::ecr_uri::translate_to_local_at(
             image,
-            &self.sibling_host,
+            &self.registry_host,
             self.server_port,
         );
         let pull_uri = local_pull_uri.as_deref().unwrap_or(image);
@@ -495,7 +498,7 @@ impl LambdaBackend for DockerBackend {
         // back to the URI as-is for public-ECR / Docker Hub / Quay images.
         let local_uri = fakecloud_core::ecr_uri::translate_to_local_at(
             image,
-            &self.sibling_host,
+            &self.registry_host,
             self.server_port,
         );
         let pull_uri = local_uri.as_deref().unwrap_or(image);

--- a/crates/fakecloud-lambda/src/service/invoke.rs
+++ b/crates/fakecloud-lambda/src/service/invoke.rs
@@ -163,7 +163,7 @@ impl LambdaService {
             }
         };
 
-        if func.code_zip.is_none() {
+        if func.code_zip.is_none() && func.package_type != "Image" {
             return Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "InvalidParameterValueException",

--- a/crates/fakecloud-server/src/lambda_delivery.rs
+++ b/crates/fakecloud-server/src/lambda_delivery.rs
@@ -97,7 +97,7 @@ impl LambdaDelivery for LambdaDeliveryImpl {
                 });
             }
 
-            if func.code_zip.is_none() {
+            if func.code_zip.is_none() && func.package_type != "Image" {
                 return Err(format!(
                     "Function {function_name} has no deployment package"
                 ));


### PR DESCRIPTION
## Why

Docker Desktop-style runtimes provide `host.docker.internal` natively. Fakecloud's injected `--add-host` mapping could replace that working route, preventing Lambda containers from reaching host services. Image-backed Lambda pulls also need to use the host loopback registry rather than the Lambda callback hostname.

## How

- Preserve an already-resolvable native Docker host alias instead of replacing it.
- Use a dedicated loopback host for local ECR image pulls.
- Permit image-package Lambda functions to invoke without a ZIP deployment package.

## Type

- [x] Bug fix
