### PR TITLE
fix(cloudformation): in-place UpdateStack for CodeDeploy + ElastiCache user types (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/codedeploy.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/codedeploy.rs
@@ -12,7 +12,9 @@
 
 use serde_json::{json, Value};
 
-use super::{cfn_props_to_camel, ProvisionResult, ResourceDefinition, ResourceProvisioner};
+use super::{
+    cfn_props_to_camel, ProvisionResult, ResourceDefinition, ResourceProvisioner, StackResource,
+};
 
 impl ResourceProvisioner {
     // ----------------------------------------------------------- Application
@@ -199,6 +201,124 @@ impl ResourceProvisioner {
             "Name" => Some(dg_name.to_string()),
             _ => None,
         }
+    }
+
+    // ------------------------------------------------------- In-place updates
+
+    /// `AWS::CodeDeploy::Application` is name-keyed (stable physical id), but its
+    /// delete cascade-drops every DeploymentGroup under the app. Reprovision on a
+    /// tag edit would therefore wipe all of them. `ComputePlatform` is immutable,
+    /// so the only in-place change is tags — apply them and leave the app record
+    /// and its deployment groups intact.
+    pub(super) fn update_codedeploy_application(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let name = existing.physical_id.clone();
+        let region = &self.region;
+        let account = &self.account_id;
+
+        let mut guard = self.codedeploy_state.write();
+        let st = guard.get_or_create(account);
+        if !st.applications.contains_key(&name) {
+            return Err(format!("Application {name} not yet provisioned"));
+        }
+        let arn = format!("arn:aws:codedeploy:{region}:{account}:application:{name}");
+        let tags = cfn_tag_list_pascal(props);
+        if tags.is_empty() {
+            st.tags.remove(&arn);
+        } else {
+            st.tags.insert(arn, tags);
+        }
+        Ok(ProvisionResult::new(name))
+    }
+
+    /// `AWS::CodeDeploy::DeploymentGroup` mints a random `deploymentGroupId` at
+    /// create; reprovision churns it (breaking `GetAtt Id`). AWS
+    /// `UpdateDeploymentGroup` mutates the config in place. Rebuild the stored
+    /// group from the template but PRESERVE the existing `deploymentGroupId` and
+    /// `computePlatform`.
+    pub(super) fn update_codedeploy_deployment_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let (app, dg_name) = existing
+            .physical_id
+            .split_once('/')
+            .ok_or("AWS::CodeDeploy::DeploymentGroup physical id must be <app>/<name>")?;
+        let service_role = props
+            .get("ServiceRoleArn")
+            .and_then(Value::as_str)
+            .ok_or("AWS::CodeDeploy::DeploymentGroup requires ServiceRoleArn")?
+            .to_string();
+        let config = props
+            .get("DeploymentConfigName")
+            .and_then(Value::as_str)
+            .unwrap_or("CodeDeployDefault.OneAtATime")
+            .to_string();
+        let region = &self.region;
+        let account = &self.account_id;
+
+        let mut guard = self.codedeploy_state.write();
+        let st = guard.get_or_create(account);
+        let existing_group = st
+            .deployment_groups
+            .get(app)
+            .and_then(|g| g.get(dg_name))
+            .cloned()
+            .ok_or_else(|| format!("Deployment group {app}/{dg_name} not yet provisioned"))?;
+        let dg_id = existing_group
+            .get("deploymentGroupId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let compute = existing_group
+            .get("computePlatform")
+            .and_then(Value::as_str)
+            .unwrap_or("Server")
+            .to_string();
+
+        let mut group = match cfn_props_to_camel(props, &[]) {
+            Value::Object(m) => m,
+            _ => serde_json::Map::new(),
+        };
+        for k in [
+            "applicationName",
+            "deploymentGroupName",
+            "serviceRoleArn",
+            "deploymentConfigName",
+            "tags",
+        ] {
+            group.remove(k);
+        }
+        if let Some(v) = group.remove("eCSServices") {
+            group.insert("ecsServices".to_string(), v);
+        }
+        group.insert("applicationName".to_string(), json!(app));
+        group.insert("deploymentGroupId".to_string(), json!(dg_id.clone()));
+        group.insert("deploymentGroupName".to_string(), json!(dg_name));
+        group.insert("deploymentConfigName".to_string(), json!(config));
+        group.insert("computePlatform".to_string(), json!(compute));
+        group.insert("serviceRoleArn".to_string(), json!(service_role));
+
+        let groups = st.deployment_groups.entry(app.to_string()).or_default();
+        groups.insert(dg_name.to_string(), Value::Object(group));
+
+        let arn = format!("arn:aws:codedeploy:{region}:{account}:deploymentgroup:{app}/{dg_name}");
+        let tags = cfn_tag_list_pascal(props);
+        if tags.is_empty() {
+            st.tags.remove(&arn);
+        } else {
+            st.tags.insert(arn, tags);
+        }
+
+        Ok(ProvisionResult::new(format!("{app}/{dg_name}"))
+            .with("Id", dg_id)
+            .with("Name", dg_name))
     }
 }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/elasticache.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/elasticache.rs
@@ -202,6 +202,38 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// In-place `ModifyUser`: reprovision would reset the user's
+    /// `user_group_ids` (its membership back-references) and `password_count`.
+    /// AccessString/AuthenticationMode are the mutable properties; UserName/
+    /// Engine are immutable. Preserve arn/status/user_group_ids/password_count.
+    pub(crate) fn update_ec_user(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_id = existing.physical_id.clone();
+
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let user = state
+            .users
+            .get_mut(&user_id)
+            .ok_or_else(|| format!("User {user_id} not yet provisioned"))?;
+        if let Some(a) = props.get("AccessString").and_then(|v| v.as_str()) {
+            user.access_string = a.to_string();
+        }
+        if let Some(t) = props
+            .get("AuthenticationMode")
+            .and_then(|v| v.get("Type"))
+            .and_then(|v| v.as_str())
+        {
+            user.authentication_type = t.to_string();
+        }
+        // arn/status/user_group_ids/password_count preserved.
+        Ok(ProvisionResult::new(user_id).with("Arn", user.arn.clone()))
+    }
+
     pub(crate) fn create_ec_user_group(
         &self,
         resource: &ResourceDefinition,
@@ -251,6 +283,34 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.user_groups.remove(physical_id);
         Ok(())
+    }
+
+    /// In-place `ModifyUserGroup`: reprovision would reset the group's
+    /// `replication_groups` back-reference (the replication groups using it).
+    /// UserIds is the mutable property; Engine is immutable. Preserve
+    /// arn/status/replication_groups.
+    pub(crate) fn update_ec_user_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let user_group_id = existing.physical_id.clone();
+
+        let mut accounts = self.elasticache_state.write();
+        let state = accounts.get_or_create(&self.account_id);
+        let group = state
+            .user_groups
+            .get_mut(&user_group_id)
+            .ok_or_else(|| format!("User group {user_group_id} not yet provisioned"))?;
+        if let Some(ids) = props.get("UserIds").and_then(|v| v.as_array()) {
+            group.user_ids = ids
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+        }
+        // arn/status/replication_groups preserved.
+        Ok(ProvisionResult::new(user_group_id).with("Arn", group.arn.clone()))
     }
 
     pub(crate) fn create_ec_cache_cluster(

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1842,6 +1842,17 @@ impl ResourceProvisioner {
                 Some(self.update_timestream_database(existing, new_def)?)
             }
             "AWS::Timestream::Table" => Some(self.update_timestream_table(existing, new_def)?),
+            // In-place updates: reprovision cascade-drops the app's deployment
+            // groups / churns the deploymentGroupId / resets the ElastiCache
+            // user membership + user-group back-references.
+            "AWS::CodeDeploy::Application" => {
+                Some(self.update_codedeploy_application(existing, new_def)?)
+            }
+            "AWS::CodeDeploy::DeploymentGroup" => {
+                Some(self.update_codedeploy_deployment_group(existing, new_def)?)
+            }
+            "AWS::ElastiCache::User" => Some(self.update_ec_user(existing, new_def)?),
+            "AWS::ElastiCache::UserGroup" => Some(self.update_ec_user_group(existing, new_def)?),
             // Auto Scaling Group: mutate the stored group in place and reconcile
             // instances BY DELTA (see `update_autoscaling_group`) so a benign
             // capacity/tag/health-check change does not terminate + relaunch
@@ -4642,6 +4653,160 @@ mod tests {
             .expect("distribution still exists");
         assert_eq!(d.config.comment, "v2", "config mutated in place");
         assert!(!d.config.enabled);
+    }
+
+    #[test]
+    fn codedeploy_updates_preserve_dg_id_and_deployment_groups() {
+        // bug-audit 2026-07-27 (cycle 5): reprovision on a CodeDeploy resource
+        // churned the DeploymentGroup id (GetAtt Id) and, for the Application,
+        // cascade-dropped every deployment group under it. Updates must be in
+        // place.
+        let prov = make_provisioner();
+        let app = prov
+            .create_resource(&make_resource(
+                "AWS::CodeDeploy::Application",
+                "App",
+                serde_json::json!({"ApplicationName": "myapp", "ComputePlatform": "Server"}),
+            ))
+            .expect("app provisions");
+        let dg = prov
+            .create_resource(&make_resource(
+                "AWS::CodeDeploy::DeploymentGroup",
+                "Dg",
+                serde_json::json!({
+                    "ApplicationName": "myapp", "DeploymentGroupName": "dg1",
+                    "ServiceRoleArn": "arn:aws:iam::123456789012:role/r1"
+                }),
+            ))
+            .expect("deployment group provisions");
+        let dg_id = prov.get_att(&dg, "Id").expect("dg id");
+
+        // Update the DG service role -> deploymentGroupId (GetAtt Id) preserved.
+        prov.update_resource(
+            &dg,
+            &make_resource(
+                "AWS::CodeDeploy::DeploymentGroup",
+                "Dg",
+                serde_json::json!({
+                    "ApplicationName": "myapp", "DeploymentGroupName": "dg1",
+                    "ServiceRoleArn": "arn:aws:iam::123456789012:role/r2"
+                }),
+            ),
+        )
+        .expect("update ok")
+        .expect("updatable");
+        assert_eq!(
+            prov.get_att(&dg, "Id"),
+            Some(dg_id),
+            "deploymentGroupId preserved across update"
+        );
+
+        // Update the application (tag edit) -> the deployment group is NOT
+        // cascade-dropped.
+        prov.update_resource(
+            &app,
+            &make_resource(
+                "AWS::CodeDeploy::Application",
+                "App",
+                serde_json::json!({
+                    "ApplicationName": "myapp", "ComputePlatform": "Server",
+                    "Tags": [{"Key": "env", "Value": "prod"}]
+                }),
+            ),
+        )
+        .expect("update ok")
+        .expect("updatable");
+        let mut guard = prov.codedeploy_state.write();
+        let st = guard.get_or_create("123456789012");
+        assert!(
+            st.deployment_groups
+                .get("myapp")
+                .and_then(|g| g.get("dg1"))
+                .is_some(),
+            "deployment group preserved across application update"
+        );
+    }
+
+    #[test]
+    fn elasticache_user_updates_preserve_backrefs() {
+        // bug-audit 2026-07-27 (cycle 5): reprovision reset an ElastiCache
+        // user's membership/password back-refs and a user group's
+        // replication-group back-ref. Updates must be in place.
+        let prov = make_provisioner();
+        let user = prov
+            .create_resource(&make_resource(
+                "AWS::ElastiCache::User",
+                "U",
+                serde_json::json!({
+                    "UserId": "u1", "UserName": "user1",
+                    "AccessString": "on ~* +@all", "Engine": "redis"
+                }),
+            ))
+            .expect("user provisions");
+        let ug = prov
+            .create_resource(&make_resource(
+                "AWS::ElastiCache::UserGroup",
+                "Ug",
+                serde_json::json!({"UserGroupId": "ug1", "Engine": "redis", "UserIds": ["u1"]}),
+            ))
+            .expect("user group provisions");
+
+        // Back-references a running replication group / group membership sets.
+        {
+            let mut accounts = prov.elasticache_state.write();
+            let st = accounts.get_or_create("123456789012");
+            let u = st.users.get_mut("u1").unwrap();
+            u.password_count = 2;
+            u.user_group_ids = vec!["ug1".to_string()];
+            st.user_groups.get_mut("ug1").unwrap().replication_groups = vec!["rg1".to_string()];
+        }
+
+        prov.update_resource(
+            &user,
+            &make_resource(
+                "AWS::ElastiCache::User",
+                "U",
+                serde_json::json!({
+                    "UserId": "u1", "UserName": "user1", "AccessString": "off", "Engine": "redis"
+                }),
+            ),
+        )
+        .expect("update ok")
+        .expect("updatable");
+        prov.update_resource(
+            &ug,
+            &make_resource(
+                "AWS::ElastiCache::UserGroup",
+                "Ug",
+                serde_json::json!({
+                    "UserGroupId": "ug1", "Engine": "redis", "UserIds": ["u1", "u2"]
+                }),
+            ),
+        )
+        .expect("update ok")
+        .expect("updatable");
+
+        let mut accounts = prov.elasticache_state.write();
+        let st = accounts.get_or_create("123456789012");
+        let u = st.users.get("u1").unwrap();
+        assert_eq!(u.access_string, "off", "AccessString updated in place");
+        assert_eq!(u.password_count, 2, "password_count preserved");
+        assert_eq!(
+            u.user_group_ids,
+            vec!["ug1".to_string()],
+            "membership preserved"
+        );
+        let g = st.user_groups.get("ug1").unwrap();
+        assert_eq!(
+            g.user_ids,
+            vec!["u1".to_string(), "u2".to_string()],
+            "UserIds updated"
+        );
+        assert_eq!(
+            g.replication_groups,
+            vec!["rg1".to_string()],
+            "replication_groups back-ref preserved"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cycle-5 bug-hunt, Family B (CFN reprovision-on-in-place-change) **MED tier — the final batch of the family sweep**.

- **AWS::CodeDeploy::Application** — name-keyed, but its delete cascade-drops every DeploymentGroup under the app, so reprovision on a tag edit wiped them all. ComputePlatform is immutable, so the arm applies tags and leaves the app record + deployment groups intact.
- **AWS::CodeDeploy::DeploymentGroup** — reprovision churned the random `deploymentGroupId` (breaking `GetAtt Id`). Rebuild the stored group from the template but PRESERVE the existing `deploymentGroupId` + `computePlatform`.
- **AWS::ElastiCache::User** — reprovision reset `user_group_ids` (membership back-refs) + `password_count`. Apply AccessString/AuthenticationMode in place; preserve arn/status/user_group_ids/password_count.
- **AWS::ElastiCache::UserGroup** — reprovision reset the `replication_groups` back-ref. Apply UserIds in place; preserve arn/status/replication_groups.

(`AWS::Timestream::Database`, the remaining B5 finding, already got an in-place arm in #2420.)

This completes the **Family-B CFN reprovision-on-in-place-change sweep** for cycle 5 (AppConfig, Route53, ServiceDiscovery, Organizations, WAFv2, CloudFront, EC2 VPC/Subnet/RouteTable/SecurityGroup, CodeDeploy, ElastiCache).

## Test plan
- New regression tests: CodeDeploy DG-id + deployment-group preservation across updates; ElastiCache user/user-group back-reference preservation.
- `cargo nextest run -p fakecloud-cloudformation`: 313 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements in-place UpdateStack for CodeDeploy and ElastiCache user resources to prevent delete/recreate churn and data loss. Preserves DeploymentGroup IDs and ElastiCache back-references while allowing safe config updates.

- **Bug Fixes**
  - CodeDeploy Application: apply tag updates in place; do not cascade-drop DeploymentGroups; `ComputePlatform` remains immutable.
  - CodeDeploy DeploymentGroup: update config in place; preserve `deploymentGroupId` and `computePlatform`; maintain tags.
  - ElastiCache User: update `AccessString`/`AuthenticationMode` in place; preserve `arn`, `status`, `user_group_ids`, `password_count`.
  - ElastiCache UserGroup: update `UserIds` in place; preserve `arn`, `status`, `replication_groups`.

<sup>Written for commit a15d13b7efdb891e2c14e51ae90198205d315d82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

