### PR TITLE
fix(cognito): apply pre-token overrides to auth flows

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/admin.rs
+++ b/crates/fakecloud-cognito/src/service/auth/admin.rs
@@ -78,7 +78,7 @@ impl CognitoService {
         })
     }
 
-    pub(super) fn admin_auth_verify(
+    pub(super) async fn admin_auth_verify(
         &self,
         input: &AdminAuthInput,
         region: &str,
@@ -91,122 +91,162 @@ impl CognitoService {
             &input.password,
         )?;
 
+        // Resolve everything the token grant needs under the state lock, then
+        // release the guard (it is not `Send` and must not be held across the
+        // trigger `await` below). Challenge/error outcomes return early.
+        let (sub, user_attrs, account_id, pool_signing_owned, claims) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
+
+            let user = state
+                .users
+                .get(&input.pool_id)
+                .and_then(|users| users.get(&input.username))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "UserNotFoundException",
+                        "User does not exist.",
+                    )
+                })?;
+
+            let password_matches = match (&user.password, &user.temporary_password) {
+                (Some(p), _) if p == &input.password => true,
+                (_, Some(tp)) if tp == &input.password => true,
+                _ => false,
+            };
+            if !password_matches {
+                state.auth_events.push(AuthEvent {
+                    event_id: Uuid::new_v4().to_string(),
+                    event_type: "SIGN_IN_FAILURE".to_string(),
+                    username: input.username.clone(),
+                    user_pool_id: input.pool_id.clone(),
+                    client_id: Some(input.client_id.clone()),
+                    timestamp: Utc::now(),
+                    success: false,
+                    feedback_value: None,
+                });
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Incorrect username or password.",
+                ));
+            }
+
+            if user.user_status == user_status::FORCE_CHANGE_PASSWORD {
+                let session = Uuid::new_v4().to_string();
+                state.sessions.insert(
+                    session.clone(),
+                    SessionData {
+                        user_pool_id: input.pool_id.clone(),
+                        username: input.username.clone(),
+                        client_id: input.client_id.clone(),
+                        challenge_name: "NEW_PASSWORD_REQUIRED".to_string(),
+                        challenge_results: vec![],
+                        challenge_metadata: None,
+                    },
+                );
+                return Ok(AdminAuthOutcome::NewPasswordRequired { session });
+            }
+
+            let sub = user.sub.clone();
+            let user_attrs = triggers::collect_user_attributes(user);
+            let account_id = state.account_id.clone();
+
+            // Enforce a second factor before minting tokens (fixes the
+            // AdminInitiateAuth MFA bypass). Compute the decision + delivery
+            // destination while `user` is still borrowed, then drop the borrow so
+            // the challenge session can be inserted.
+            let mfa_challenge = state
+                .user_pools
+                .get(&input.pool_id)
+                .and_then(|pool| super::required_mfa_challenge(pool, user));
+            let mfa_phone = user
+                .attributes
+                .iter()
+                .find(|a| a.name == "phone_number")
+                .map(|a| a.value.clone());
+            if let Some(challenge_name) = mfa_challenge {
+                let sms_destination = mfa_phone.as_deref().map(super::mask_phone);
+                // For SMS_MFA the code is stored on the session; the admin path does
+                // not dispatch it here (SNS delivery must not run under the state
+                // write lock), but the challenge is still enforced.
+                let sms_code = (challenge_name == "SMS_MFA").then(generate_confirmation_code);
+                let session = Uuid::new_v4().to_string();
+                state.sessions.insert(
+                    session.clone(),
+                    SessionData {
+                        user_pool_id: input.pool_id.clone(),
+                        username: input.username.clone(),
+                        client_id: input.client_id.clone(),
+                        challenge_name: challenge_name.to_string(),
+                        challenge_results: vec![],
+                        challenge_metadata: sms_code,
+                    },
+                );
+                return Ok(AdminAuthOutcome::MfaChallenge {
+                    challenge_name,
+                    session,
+                    sms_destination,
+                });
+            }
+
+            let pool_signing_owned = state.user_pools.get(&input.pool_id).and_then(|pool| {
+                pool.signing_key_pem
+                    .as_ref()
+                    .zip(pool.signing_kid.as_ref())
+                    .map(|(p, k)| (p.clone(), k.clone()))
+            });
+            let claims = crate::service::token_claims_for(
+                state,
+                &input.pool_id,
+                &input.username,
+                &input.client_id,
+            );
+
+            (sub, user_attrs, account_id, pool_signing_owned, claims)
+        };
+
+        // Real Cognito fires the PreTokenGeneration trigger on AdminInitiateAuth
+        // token grants too; apply any claim/group/scope overrides it returns.
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = triggers::get_trigger_arn(
+                &self.state,
+                &input.pool_id,
+                TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = triggers::build_trigger_event(
+                    TriggerSource::TokenGenerationAuthentication,
+                    &input.pool_id,
+                    Some(&input.client_id),
+                    &input.username,
+                    &user_attrs,
+                    region,
+                    &account_id,
+                );
+                triggers::invoke_trigger(ctx, &function_arn, &event).await
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
-
-        let user = state
-            .users
-            .get(&input.pool_id)
-            .and_then(|users| users.get(&input.username))
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "UserNotFoundException",
-                    "User does not exist.",
-                )
-            })?;
-
-        let password_matches = match (&user.password, &user.temporary_password) {
-            (Some(p), _) if p == &input.password => true,
-            (_, Some(tp)) if tp == &input.password => true,
-            _ => false,
-        };
-        if !password_matches {
-            state.auth_events.push(AuthEvent {
-                event_id: Uuid::new_v4().to_string(),
-                event_type: "SIGN_IN_FAILURE".to_string(),
-                username: input.username.clone(),
-                user_pool_id: input.pool_id.clone(),
-                client_id: Some(input.client_id.clone()),
-                timestamp: Utc::now(),
-                success: false,
-                feedback_value: None,
-            });
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Incorrect username or password.",
-            ));
-        }
-
-        if user.user_status == user_status::FORCE_CHANGE_PASSWORD {
-            let session = Uuid::new_v4().to_string();
-            state.sessions.insert(
-                session.clone(),
-                SessionData {
-                    user_pool_id: input.pool_id.clone(),
-                    username: input.username.clone(),
-                    client_id: input.client_id.clone(),
-                    challenge_name: "NEW_PASSWORD_REQUIRED".to_string(),
-                    challenge_results: vec![],
-                    challenge_metadata: None,
-                },
-            );
-            return Ok(AdminAuthOutcome::NewPasswordRequired { session });
-        }
-
-        let sub = user.sub.clone();
-
-        // Enforce a second factor before minting tokens (fixes the
-        // AdminInitiateAuth MFA bypass). Compute the decision + delivery
-        // destination while `user` is still borrowed, then drop the borrow so
-        // the challenge session can be inserted.
-        let mfa_challenge = state
-            .user_pools
-            .get(&input.pool_id)
-            .and_then(|pool| super::required_mfa_challenge(pool, user));
-        let mfa_phone = user
-            .attributes
-            .iter()
-            .find(|a| a.name == "phone_number")
-            .map(|a| a.value.clone());
-        if let Some(challenge_name) = mfa_challenge {
-            let sms_destination = mfa_phone.as_deref().map(super::mask_phone);
-            // For SMS_MFA the code is stored on the session; the admin path does
-            // not dispatch it here (SNS delivery must not run under the state
-            // write lock), but the challenge is still enforced.
-            let sms_code = (challenge_name == "SMS_MFA").then(generate_confirmation_code);
-            let session = Uuid::new_v4().to_string();
-            state.sessions.insert(
-                session.clone(),
-                SessionData {
-                    user_pool_id: input.pool_id.clone(),
-                    username: input.username.clone(),
-                    client_id: input.client_id.clone(),
-                    challenge_name: challenge_name.to_string(),
-                    challenge_results: vec![],
-                    challenge_metadata: sms_code,
-                },
-            );
-            return Ok(AdminAuthOutcome::MfaChallenge {
-                challenge_name,
-                session,
-                sms_destination,
-            });
-        }
-
-        let pool_signing_owned = state.user_pools.get(&input.pool_id).and_then(|pool| {
-            pool.signing_key_pem
-                .as_ref()
-                .zip(pool.signing_kid.as_ref())
-                .map(|(p, k)| (p.clone(), k.clone()))
-        });
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let claims = crate::service::token_claims_for(
-            state,
-            &input.pool_id,
-            &input.username,
-            &input.client_id,
-        );
-        let tokens = generate_tokens(
+        let tokens = crate::service::generate_tokens_with_overrides(
             &input.pool_id,
             &input.client_id,
             &sub,
             &input.username,
             region,
             signing,
+            None,
+            None,
+            pretoken_response.as_ref(),
             &claims,
         );
 

--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -14,8 +14,14 @@ impl CognitoService {
         region: &str,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
+        let accounts = self.state.read();
+        let state = accounts.get(&req.account_id).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ResourceNotFoundException",
+                "User pool does not exist.",
+            )
+        })?;
         let user = state
             .users
             .get(pool_id)
@@ -28,18 +34,64 @@ impl CognitoService {
                 )
             })?;
 
+        let user_attributes = triggers::collect_user_attributes(user);
         let sub = user.sub.clone();
+        let account_id = state.account_id.clone();
         let pool_signing_owned = state.user_pools.get(pool_id).and_then(|pool| {
             pool.signing_key_pem
                 .as_ref()
                 .zip(pool.signing_kid.as_ref())
                 .map(|(p, k)| (p.clone(), k.clone()))
         });
+        drop(accounts);
+
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = triggers::get_trigger_arn(
+                &self.state,
+                pool_id,
+                TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = triggers::build_trigger_event(
+                    TriggerSource::TokenGenerationAuthentication,
+                    pool_id,
+                    Some(client_id),
+                    username,
+                    &user_attributes,
+                    region,
+                    &account_id,
+                );
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(triggers::invoke_trigger(
+                        ctx,
+                        &function_arn,
+                        &event,
+                    ))
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
         let claims = crate::service::token_claims_for(state, pool_id, username, client_id);
-        let tokens = generate_tokens(pool_id, client_id, &sub, username, region, signing, &claims);
+        let tokens = crate::service::generate_tokens_with_overrides(
+            pool_id,
+            client_id,
+            &sub,
+            username,
+            region,
+            signing,
+            None,
+            None,
+            pretoken_response.as_ref(),
+            &claims,
+        );
 
         state.refresh_tokens.insert(
             tokens.refresh_token.clone(),

--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -159,6 +159,7 @@ impl CognitoService {
         match challenge_name {
             "NEW_PASSWORD_REQUIRED" => {
                 self.respond_new_password_required(client_id, session, body, req)
+                    .await
             }
             "PASSWORD_VERIFIER" => self.respond_password_verifier(client_id, session, body, req),
             "SELECT_CHALLENGE" => self.respond_select_challenge(client_id, session, body, req),
@@ -725,7 +726,7 @@ impl CognitoService {
         }
     }
 
-    pub(super) fn respond_new_password_required(
+    pub(super) async fn respond_new_password_required(
         &self,
         client_id: &str,
         session: &str,
@@ -751,77 +752,130 @@ impl CognitoService {
                 )
             })?;
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
+        // Validate + rotate the password and gather token inputs under the state
+        // lock, then release the guard (it is not `Send` and must not be held
+        // across the trigger `await` below).
+        let (sub, username, user_attributes, pool_id, account_id, region, pool_signing_owned) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
 
-        let session_data = state.sessions.remove(session).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid session.",
-            )
-        })?;
-
-        if session_data.client_id != client_id
-            || session_data.challenge_name != "NEW_PASSWORD_REQUIRED"
-        {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid session.",
-            ));
-        }
-
-        let password_policy = state
-            .user_pools
-            .get(&session_data.user_pool_id)
-            .ok_or_else(|| {
+            let session_data = state.sessions.remove(session).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
-                    "ResourceNotFoundException",
-                    "User pool does not exist.",
-                )
-            })?
-            .policies
-            .password_policy
-            .clone();
-        validate_password(new_password, &password_policy)?;
-
-        let region = state.region.clone();
-
-        let user = state
-            .users
-            .get_mut(&session_data.user_pool_id)
-            .and_then(|users| users.get_mut(&session_data.username))
-            .ok_or_else(|| {
-                AwsServiceError::aws_error(
-                    StatusCode::BAD_REQUEST,
-                    "UserNotFoundException",
-                    "User does not exist.",
+                    "NotAuthorizedException",
+                    "Invalid session.",
                 )
             })?;
 
-        user.password = Some(new_password.to_string());
-        user.temporary_password = None;
-        user.user_status = user_status::CONFIRMED.to_string();
-        user.user_last_modified_date = Utc::now();
+            if session_data.client_id != client_id
+                || session_data.challenge_name != "NEW_PASSWORD_REQUIRED"
+            {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid session.",
+                ));
+            }
 
-        let sub = user.sub.clone();
-        let username = user.username.clone();
-        let pool_id = session_data.user_pool_id.clone();
+            let password_policy = state
+                .user_pools
+                .get(&session_data.user_pool_id)
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "ResourceNotFoundException",
+                        "User pool does not exist.",
+                    )
+                })?
+                .policies
+                .password_policy
+                .clone();
+            validate_password(new_password, &password_policy)?;
 
-        let pool_signing_owned = state.user_pools.get(&pool_id).and_then(|pool| {
-            pool.signing_key_pem
-                .as_ref()
-                .zip(pool.signing_kid.as_ref())
-                .map(|(p, k)| (p.clone(), k.clone()))
-        });
+            let region = state.region.clone();
+
+            let user = state
+                .users
+                .get_mut(&session_data.user_pool_id)
+                .and_then(|users| users.get_mut(&session_data.username))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "UserNotFoundException",
+                        "User does not exist.",
+                    )
+                })?;
+
+            user.password = Some(new_password.to_string());
+            user.temporary_password = None;
+            user.user_status = user_status::CONFIRMED.to_string();
+            user.user_last_modified_date = Utc::now();
+
+            let sub = user.sub.clone();
+            let username = user.username.clone();
+            let user_attributes = triggers::collect_user_attributes(user);
+            let pool_id = session_data.user_pool_id.clone();
+            let account_id = state.account_id.clone();
+
+            let pool_signing_owned = state.user_pools.get(&pool_id).and_then(|pool| {
+                pool.signing_key_pem
+                    .as_ref()
+                    .zip(pool.signing_kid.as_ref())
+                    .map(|(p, k)| (p.clone(), k.clone()))
+            });
+            (
+                sub,
+                username,
+                user_attributes,
+                pool_id,
+                account_id,
+                region,
+                pool_signing_owned,
+            )
+        };
+
+        // NEW_PASSWORD_REQUIRED completion issues tokens, so real Cognito fires
+        // the PreTokenGeneration trigger here too; apply any overrides it returns.
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = triggers::get_trigger_arn(
+                &self.state,
+                &pool_id,
+                TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = triggers::build_trigger_event(
+                    TriggerSource::TokenGenerationAuthentication,
+                    &pool_id,
+                    Some(client_id),
+                    &username,
+                    &user_attributes,
+                    &region,
+                    &account_id,
+                );
+                triggers::invoke_trigger(ctx, &function_arn, &event).await
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
         let claims = crate::service::token_claims_for(state, &pool_id, &username, client_id);
-        let tokens = generate_tokens(
-            &pool_id, client_id, &sub, &username, &region, signing, &claims,
+        let tokens = crate::service::generate_tokens_with_overrides(
+            &pool_id,
+            client_id,
+            &sub,
+            &username,
+            &region,
+            signing,
+            None,
+            None,
+            pretoken_response.as_ref(),
+            &claims,
         );
 
         state.refresh_tokens.insert(
@@ -1049,13 +1103,15 @@ impl CognitoService {
         }
 
         if issue_tokens {
-            return self.custom_challenge_issue_tokens(
-                &pool_id,
-                &session_client_id,
-                &username,
-                &region,
-                req,
-            );
+            return self
+                .custom_challenge_issue_tokens(
+                    &pool_id,
+                    &session_client_id,
+                    &username,
+                    &region,
+                    req,
+                )
+                .await;
         }
 
         let next_challenge_name = define_response["response"]["challengeName"]
@@ -1130,7 +1186,7 @@ impl CognitoService {
     /// Mint and persist tokens for a CUSTOM_CHALLENGE round whose final
     /// DefineAuthChallenge response set `issueTokens: true`. Mirrors the
     /// success-path bookkeeping that USER_PASSWORD_AUTH does.
-    pub(super) fn custom_challenge_issue_tokens(
+    pub(super) async fn custom_challenge_issue_tokens(
         &self,
         pool_id: &str,
         client_id: &str,
@@ -1138,32 +1194,85 @@ impl CognitoService {
         region: &str,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
-        let user = state
-            .users
-            .get(pool_id)
-            .and_then(|users| users.get(username))
-            .ok_or_else(|| {
+        // Resolve everything under the state lock, then release the guard (it is
+        // not `Send` and must not be held across the trigger `await` below).
+        let (user_attributes, sub, account_id, pool_signing_owned) = {
+            let accounts = self.state.read();
+            let state = accounts.get(&req.account_id).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
-                    "NotAuthorizedException",
-                    "User does not exist.",
+                    "ResourceNotFoundException",
+                    "User pool does not exist.",
                 )
             })?;
+            let user = state
+                .users
+                .get(pool_id)
+                .and_then(|users| users.get(username))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotAuthorizedException",
+                        "User does not exist.",
+                    )
+                })?;
 
-        let sub = user.sub.clone();
-        let pool_signing_owned = state.user_pools.get(pool_id).and_then(|pool| {
-            pool.signing_key_pem
-                .as_ref()
-                .zip(pool.signing_kid.as_ref())
-                .map(|(p, k)| (p.clone(), k.clone()))
-        });
+            let user_attributes = triggers::collect_user_attributes(user);
+            let sub = user.sub.clone();
+            let account_id = state.account_id.clone();
+            let pool_signing_owned = state.user_pools.get(pool_id).and_then(|pool| {
+                pool.signing_key_pem
+                    .as_ref()
+                    .zip(pool.signing_kid.as_ref())
+                    .map(|(p, k)| (p.clone(), k.clone()))
+            });
+            (user_attributes, sub, account_id, pool_signing_owned)
+        };
+
+        // A multi-round CUSTOM_AUTH flow fires PreTokenGeneration once the final
+        // challenge resolves with issueTokens:true — apply its overrides, matching
+        // the first-call custom-auth path.
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = triggers::get_trigger_arn(
+                &self.state,
+                pool_id,
+                TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = triggers::build_trigger_event(
+                    TriggerSource::TokenGenerationAuthentication,
+                    pool_id,
+                    Some(client_id),
+                    username,
+                    &user_attributes,
+                    region,
+                    &account_id,
+                );
+                triggers::invoke_trigger(ctx, &function_arn, &event).await
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
         let claims = crate::service::token_claims_for(state, pool_id, username, client_id);
-        let tokens = generate_tokens(pool_id, client_id, &sub, username, region, signing, &claims);
+        let tokens = crate::service::generate_tokens_with_overrides(
+            pool_id,
+            client_id,
+            &sub,
+            username,
+            region,
+            signing,
+            None,
+            None,
+            pretoken_response.as_ref(),
+            &claims,
+        );
 
         state.refresh_tokens.insert(
             tokens.refresh_token.clone(),

--- a/crates/fakecloud-cognito/src/service/auth/challenges.rs
+++ b/crates/fakecloud-cognito/src/service/auth/challenges.rs
@@ -6,7 +6,7 @@ impl CognitoService {
     /// Mint and persist tokens for a CUSTOM_AUTH flow that DefineAuthChallenge
     /// resolved with `issueTokens: true` on the very first call (no challenge
     /// round-trip needed).
-    pub(super) fn custom_auth_issue_tokens(
+    pub(super) async fn custom_auth_issue_tokens(
         &self,
         pool_id: &str,
         client_id: &str,
@@ -14,36 +14,40 @@ impl CognitoService {
         region: &str,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
-        let accounts = self.state.read();
-        let state = accounts.get(&req.account_id).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "ResourceNotFoundException",
-                "User pool does not exist.",
-            )
-        })?;
-        let user = state
-            .users
-            .get(pool_id)
-            .and_then(|users| users.get(username))
-            .ok_or_else(|| {
+        // Resolve everything under the state lock, then release the guard (it is
+        // not `Send` and must not be held across the trigger `await` below).
+        let (user_attributes, sub, account_id, pool_signing_owned) = {
+            let accounts = self.state.read();
+            let state = accounts.get(&req.account_id).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
-                    "NotAuthorizedException",
-                    "Incorrect username or password.",
+                    "ResourceNotFoundException",
+                    "User pool does not exist.",
                 )
             })?;
+            let user = state
+                .users
+                .get(pool_id)
+                .and_then(|users| users.get(username))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotAuthorizedException",
+                        "Incorrect username or password.",
+                    )
+                })?;
 
-        let user_attributes = triggers::collect_user_attributes(user);
-        let sub = user.sub.clone();
-        let account_id = state.account_id.clone();
-        let pool_signing_owned = state.user_pools.get(pool_id).and_then(|pool| {
-            pool.signing_key_pem
-                .as_ref()
-                .zip(pool.signing_kid.as_ref())
-                .map(|(p, k)| (p.clone(), k.clone()))
-        });
-        drop(accounts);
+            let user_attributes = triggers::collect_user_attributes(user);
+            let sub = user.sub.clone();
+            let account_id = state.account_id.clone();
+            let pool_signing_owned = state.user_pools.get(pool_id).and_then(|pool| {
+                pool.signing_key_pem
+                    .as_ref()
+                    .zip(pool.signing_kid.as_ref())
+                    .map(|(p, k)| (p.clone(), k.clone()))
+            });
+            (user_attributes, sub, account_id, pool_signing_owned)
+        };
 
         let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
             if let Some(function_arn) = triggers::get_trigger_arn(
@@ -60,13 +64,7 @@ impl CognitoService {
                     region,
                     &account_id,
                 );
-                tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(triggers::invoke_trigger(
-                        ctx,
-                        &function_arn,
-                        &event,
-                    ))
-                })
+                triggers::invoke_trigger(ctx, &function_arn, &event).await
             } else {
                 None
             }
@@ -161,10 +159,17 @@ impl CognitoService {
                 self.respond_new_password_required(client_id, session, body, req)
                     .await
             }
-            "PASSWORD_VERIFIER" => self.respond_password_verifier(client_id, session, body, req),
-            "SELECT_CHALLENGE" => self.respond_select_challenge(client_id, session, body, req),
+            "PASSWORD_VERIFIER" => {
+                self.respond_password_verifier(client_id, session, body, req)
+                    .await
+            }
+            "SELECT_CHALLENGE" => {
+                self.respond_select_challenge(client_id, session, body, req)
+                    .await
+            }
             "SOFTWARE_TOKEN_MFA" | "SMS_MFA" | "MFA_SETUP" => {
                 self.respond_mfa_challenge(challenge_name, client_id, session, body, req)
+                    .await
             }
             "CUSTOM_CHALLENGE" => {
                 self.respond_custom_challenge(client_id, session, body, req)
@@ -288,7 +293,7 @@ impl CognitoService {
     /// `SOFTWARE_TOKEN_MFA` (RFC 6238 TOTP), `SMS_MFA` (the code dispatched at
     /// challenge time) and `MFA_SETUP` (the user must have associated + verified
     /// a software token via this session first).
-    pub(super) fn respond_mfa_challenge(
+    pub(super) async fn respond_mfa_challenge(
         &self,
         challenge_name: &str,
         client_id: &str,
@@ -396,6 +401,7 @@ impl CognitoService {
                 .remove(session);
         }
         self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
+            .await
     }
 
     /// Record a failed MFA attempt in the auth-event log for introspection.
@@ -465,7 +471,7 @@ impl CognitoService {
     /// `RespondToAuthChallenge(ChallengeName=PASSWORD_VERIFIER)`: verify the
     /// client's SRP6a proof against the handshake stashed at InitiateAuth time
     /// and, on success, mint real tokens. Reuses the shared token issuer.
-    pub(super) fn respond_password_verifier(
+    pub(super) async fn respond_password_verifier(
         &self,
         client_id: &str,
         session: &str,
@@ -602,13 +608,14 @@ impl CognitoService {
         }
 
         self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
+            .await
     }
 
     /// `RespondToAuthChallenge(ChallengeName=SELECT_CHALLENGE)` for the
     /// `USER_AUTH` flow: the client's `ANSWER` picks a challenge. `PASSWORD_SRP`
     /// kicks off the SRP handshake (reusing the shared builder); `PASSWORD`
     /// verifies the password directly and mints tokens.
-    pub(super) fn respond_select_challenge(
+    pub(super) async fn respond_select_challenge(
         &self,
         client_id: &str,
         session: &str,
@@ -717,6 +724,7 @@ impl CognitoService {
                     return Ok(resp);
                 }
                 self.custom_auth_issue_tokens(&pool_id, client_id, &username, &region, req)
+                    .await
             }
             other => Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -991,7 +991,9 @@ impl CognitoService {
         }
 
         if issue_tokens {
-            return self.custom_auth_issue_tokens(pool_id, client_id, username, &region, req);
+            return self
+                .custom_auth_issue_tokens(pool_id, client_id, username, &region, req)
+                .await;
         }
 
         let challenge_name = define_response["response"]["challengeName"]

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -59,7 +59,7 @@ impl CognitoService {
             }
         }
 
-        let tokens = match self.admin_auth_verify(&input, &lookup.region, req)? {
+        let tokens = match self.admin_auth_verify(&input, &lookup.region, req).await? {
             AdminAuthOutcome::NewPasswordRequired { session } => {
                 return Ok(AwsResponse::ok_json(json!({
                     "ChallengeName": "NEW_PASSWORD_REQUIRED",
@@ -1100,75 +1100,97 @@ impl CognitoService {
                 )
             })?;
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
+        // Resolve everything under the state lock, then release the guard (it is
+        // not `Send` and must not be held across the trigger `await` below).
+        let (
+            token_pool_id,
+            token_username,
+            region,
+            account_id,
+            user_attrs,
+            sub,
+            pool_signing_owned,
+            claims,
+        ) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
 
-        let token_data = state.refresh_tokens.get(refresh_token).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid refresh token.",
-            )
-        })?;
-
-        if token_data.client_id != client_id {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid refresh token.",
-            ));
-        }
-
-        // Enforce the app client's RefreshTokenValidity: an expired refresh
-        // token can no longer mint access tokens (L2). Previously the token was
-        // honored forever.
-        let refresh_validity_secs = state
-            .user_pool_clients
-            .get(client_id)
-            .map(crate::service::refresh_token_validity_secs)
-            .unwrap_or(30 * 86400);
-        let age = Utc::now()
-            .signed_duration_since(token_data.issued_at)
-            .num_seconds();
-        if refresh_validity_secs > 0 && age >= refresh_validity_secs {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Refresh Token has expired.",
-            ));
-        }
-
-        let token_pool_id = token_data.user_pool_id.clone();
-        let token_username = token_data.username.clone();
-
-        let user = state
-            .users
-            .get(&token_pool_id)
-            .and_then(|users| users.get(&token_username))
-            .ok_or_else(|| {
+            let token_data = state.refresh_tokens.get(refresh_token).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotAuthorizedException",
-                    "User does not exist.",
+                    "Invalid refresh token.",
                 )
             })?;
 
-        let region = state.region.clone();
-        let account_id = state.account_id.clone();
-        let user_attrs = triggers::collect_user_attributes(user);
-        let sub = user.sub.clone();
-        let pool_signing_owned = state.user_pools.get(&token_pool_id).and_then(|pool| {
-            pool.signing_key_pem
-                .as_ref()
-                .zip(pool.signing_kid.as_ref())
-                .map(|(p, k)| (p.clone(), k.clone()))
-        });
+            if token_data.client_id != client_id {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid refresh token.",
+                ));
+            }
+
+            // Enforce the app client's RefreshTokenValidity: an expired refresh
+            // token can no longer mint access tokens (L2). Previously the token was
+            // honored forever.
+            let refresh_validity_secs = state
+                .user_pool_clients
+                .get(client_id)
+                .map(crate::service::refresh_token_validity_secs)
+                .unwrap_or(30 * 86400);
+            let age = Utc::now()
+                .signed_duration_since(token_data.issued_at)
+                .num_seconds();
+            if refresh_validity_secs > 0 && age >= refresh_validity_secs {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Refresh Token has expired.",
+                ));
+            }
+
+            let token_pool_id = token_data.user_pool_id.clone();
+            let token_username = token_data.username.clone();
+
+            let user = state
+                .users
+                .get(&token_pool_id)
+                .and_then(|users| users.get(&token_username))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotAuthorizedException",
+                        "User does not exist.",
+                    )
+                })?;
+
+            let region = state.region.clone();
+            let account_id = state.account_id.clone();
+            let user_attrs = triggers::collect_user_attributes(user);
+            let sub = user.sub.clone();
+            let pool_signing_owned = state.user_pools.get(&token_pool_id).and_then(|pool| {
+                pool.signing_key_pem
+                    .as_ref()
+                    .zip(pool.signing_kid.as_ref())
+                    .map(|(p, k)| (p.clone(), k.clone()))
+            });
+            let claims =
+                crate::service::token_claims_for(state, &token_pool_id, &token_username, client_id);
+            (
+                token_pool_id,
+                token_username,
+                region,
+                account_id,
+                user_attrs,
+                sub,
+                pool_signing_owned,
+                claims,
+            )
+        };
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let claims =
-            crate::service::token_claims_for(state, &token_pool_id, &token_username, client_id);
-        drop(accounts);
 
         let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
             if let Some(function_arn) = triggers::get_trigger_arn(
@@ -1187,13 +1209,7 @@ impl CognitoService {
                 );
                 let started = std::time::Instant::now();
                 let invoked_at = chrono::Utc::now();
-                let raw_response = tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(triggers::invoke_trigger(
-                        ctx,
-                        &function_arn,
-                        &event,
-                    ))
-                });
+                let raw_response = triggers::invoke_trigger(ctx, &function_arn, &event).await;
                 let duration_ms = started.elapsed().as_millis() as u64;
                 record_pre_token_gen_invocation(
                     &self.state,

--- a/crates/fakecloud-cognito/src/service/auth/initiate.rs
+++ b/crates/fakecloud-cognito/src/service/auth/initiate.rs
@@ -180,6 +180,7 @@ impl CognitoService {
             }
             "REFRESH_TOKEN_AUTH" | "REFRESH_TOKEN" => {
                 self.initiate_refresh_token_auth(&body, client_id, &explicit_auth_flows, req)
+                    .await
             }
             other => Err(AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
@@ -724,7 +725,7 @@ impl CognitoService {
             return Ok(resp);
         }
 
-        let pretoken_overrides = if let Some(ctx) = self.delivery_ctx.as_ref() {
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
             if let Some(function_arn) = triggers::get_trigger_arn(
                 &self.state,
                 pool_id,
@@ -743,10 +744,6 @@ impl CognitoService {
                 let invoked_at = chrono::Utc::now();
                 let raw_response = triggers::invoke_trigger(ctx, &function_arn, &event).await;
                 let duration_ms = started.elapsed().as_millis() as u64;
-                let overrides = raw_response
-                    .as_ref()
-                    .and_then(|resp| resp.get("response").cloned());
-
                 record_pre_token_gen_invocation(
                     &self.state,
                     &req.account_id,
@@ -761,7 +758,7 @@ impl CognitoService {
                     duration_ms,
                 );
 
-                overrides
+                raw_response
             } else {
                 None
             }
@@ -783,7 +780,7 @@ impl CognitoService {
             signing,
             None,
             None,
-            pretoken_overrides.as_ref(),
+            pretoken_response.as_ref(),
             &claims,
         );
 
@@ -1066,7 +1063,7 @@ impl CognitoService {
         Ok(AwsResponse::ok_json(response))
     }
 
-    pub(super) fn initiate_refresh_token_auth(
+    pub(super) async fn initiate_refresh_token_auth(
         &self,
         body: &Value,
         client_id: &str,
@@ -1157,6 +1154,8 @@ impl CognitoService {
             })?;
 
         let region = state.region.clone();
+        let account_id = state.account_id.clone();
+        let user_attrs = triggers::collect_user_attributes(user);
         let sub = user.sub.clone();
         let pool_signing_owned = state.user_pools.get(&token_pool_id).and_then(|pool| {
             pool.signing_key_pem
@@ -1169,16 +1168,70 @@ impl CognitoService {
             .map(|(p, k)| (p.as_str(), k.as_str()));
         let claims =
             crate::service::token_claims_for(state, &token_pool_id, &token_username, client_id);
-        let tokens = generate_tokens(
+        drop(accounts);
+
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = triggers::get_trigger_arn(
+                &self.state,
+                &token_pool_id,
+                TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = triggers::build_trigger_event(
+                    TriggerSource::TokenGenerationAuthentication,
+                    &token_pool_id,
+                    Some(client_id),
+                    &token_username,
+                    &user_attrs,
+                    &region,
+                    &account_id,
+                );
+                let started = std::time::Instant::now();
+                let invoked_at = chrono::Utc::now();
+                let raw_response = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(triggers::invoke_trigger(
+                        ctx,
+                        &function_arn,
+                        &event,
+                    ))
+                });
+                let duration_ms = started.elapsed().as_millis() as u64;
+                record_pre_token_gen_invocation(
+                    &self.state,
+                    &req.account_id,
+                    &token_pool_id,
+                    &region,
+                    &account_id,
+                    &token_username,
+                    &function_arn,
+                    &event,
+                    raw_response.as_ref(),
+                    invoked_at,
+                    duration_ms,
+                );
+
+                raw_response
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let tokens = crate::service::generate_tokens_with_overrides(
             &token_pool_id,
             client_id,
             &sub,
             &token_username,
             &region,
             signing,
+            None,
+            None,
+            pretoken_response.as_ref(),
             &claims,
         );
 
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         state.access_tokens.insert(
             tokens.access_token.clone(),
             AccessTokenData {

--- a/crates/fakecloud-cognito/src/service/auth/mod.rs
+++ b/crates/fakecloud-cognito/src/service/auth/mod.rs
@@ -15,8 +15,8 @@ use crate::triggers::{self, TriggerSource};
 use crate::user_status;
 
 use super::{
-    ensure_user_pool_exists, generate_confirmation_code, generate_tokens, parse_user_attributes,
-    require_str, validate_password, CognitoService, TokenSet,
+    ensure_user_pool_exists, generate_confirmation_code, parse_user_attributes, require_str,
+    validate_password, CognitoService, TokenSet,
 };
 
 struct AdminAuthInput {

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -654,7 +654,7 @@ impl CognitoService {
         Ok(AwsResponse::ok_json(json!({})))
     }
 
-    pub(super) fn get_tokens_from_refresh_token(
+    pub(super) async fn get_tokens_from_refresh_token(
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
@@ -665,66 +665,119 @@ impl CognitoService {
         let _client_secret = body["ClientSecret"].as_str();
         let _device_key = body["DeviceKey"].as_str();
 
-        let mut accounts = self.state.write();
-        let state = accounts.get_or_create(&req.account_id);
+        // Resolve everything under the state lock, then release the guard (it is
+        // not `Send` and must not be held across the trigger `await` below).
+        let (pool_id, username, sub, region, user_attrs, account_id, pool_signing_owned, claims) = {
+            let mut accounts = self.state.write();
+            let state = accounts.get_or_create(&req.account_id);
 
-        // Validate client exists
-        if !state.user_pool_clients.contains_key(client_id) {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "InvalidParameterException",
-                format!("Client {client_id} does not exist."),
-            ));
-        }
+            // Validate client exists
+            if !state.user_pool_clients.contains_key(client_id) {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidParameterException",
+                    format!("Client {client_id} does not exist."),
+                ));
+            }
 
-        let token_data = state.refresh_tokens.get(refresh_token).ok_or_else(|| {
-            AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid refresh token.",
-            )
-        })?;
-
-        // Verify client matches
-        if token_data.client_id != client_id {
-            return Err(AwsServiceError::aws_error(
-                StatusCode::BAD_REQUEST,
-                "NotAuthorizedException",
-                "Invalid refresh token.",
-            ));
-        }
-
-        let pool_id = token_data.user_pool_id.clone();
-        let username = token_data.username.clone();
-
-        // Find user to get sub
-        let user = state
-            .users
-            .get(pool_id.as_str())
-            .and_then(|users| users.get(username.as_str()))
-            .ok_or_else(|| {
+            let token_data = state.refresh_tokens.get(refresh_token).ok_or_else(|| {
                 AwsServiceError::aws_error(
                     StatusCode::BAD_REQUEST,
                     "NotAuthorizedException",
-                    "User not found.",
+                    "Invalid refresh token.",
                 )
             })?;
 
-        let sub = user.sub.clone();
-        let region = state.region.clone();
+            // Verify client matches
+            if token_data.client_id != client_id {
+                return Err(AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "NotAuthorizedException",
+                    "Invalid refresh token.",
+                ));
+            }
 
-        let pool_signing_owned = state.user_pools.get(&pool_id).and_then(|pool| {
-            pool.signing_key_pem
-                .as_ref()
-                .zip(pool.signing_kid.as_ref())
-                .map(|(p, k)| (p.clone(), k.clone()))
-        });
+            let pool_id = token_data.user_pool_id.clone();
+            let username = token_data.username.clone();
+
+            // Find user to get sub
+            let user = state
+                .users
+                .get(pool_id.as_str())
+                .and_then(|users| users.get(username.as_str()))
+                .ok_or_else(|| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "NotAuthorizedException",
+                        "User not found.",
+                    )
+                })?;
+
+            let sub = user.sub.clone();
+            let user_attrs = crate::triggers::collect_user_attributes(user);
+            let region = state.region.clone();
+            let account_id = state.account_id.clone();
+
+            let pool_signing_owned = state.user_pools.get(&pool_id).and_then(|pool| {
+                pool.signing_key_pem
+                    .as_ref()
+                    .zip(pool.signing_kid.as_ref())
+                    .map(|(p, k)| (p.clone(), k.clone()))
+            });
+            let claims = super::token_claims_for(state, &pool_id, &username, client_id);
+            (
+                pool_id,
+                username,
+                sub,
+                region,
+                user_attrs,
+                account_id,
+                pool_signing_owned,
+                claims,
+            )
+        };
+
+        // GetTokensFromRefreshToken issues fresh tokens, so real Cognito fires
+        // the PreTokenGeneration trigger here too; apply any overrides it returns.
+        let pretoken_response = if let Some(ctx) = self.delivery_ctx.as_ref() {
+            if let Some(function_arn) = crate::triggers::get_trigger_arn(
+                &self.state,
+                &pool_id,
+                crate::triggers::TriggerSource::TokenGenerationAuthentication,
+            ) {
+                let event = crate::triggers::build_trigger_event(
+                    crate::triggers::TriggerSource::TokenGenerationAuthentication,
+                    &pool_id,
+                    Some(client_id),
+                    &username,
+                    &user_attrs,
+                    &region,
+                    &account_id,
+                );
+                crate::triggers::invoke_trigger(ctx, &function_arn, &event).await
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut accounts = self.state.write();
+        let state = accounts.get_or_create(&req.account_id);
         let signing = pool_signing_owned
             .as_ref()
             .map(|(p, k)| (p.as_str(), k.as_str()));
-        let claims = super::token_claims_for(state, &pool_id, &username, client_id);
-        let tokens = super::generate_tokens(
-            &pool_id, client_id, &sub, &username, &region, signing, &claims,
+        let tokens = super::generate_tokens_with_overrides(
+            &pool_id,
+            client_id,
+            &sub,
+            &username,
+            &region,
+            signing,
+            None,
+            None,
+            pretoken_response.as_ref(),
+            &claims,
         );
 
         let rotation_enabled = state

--- a/crates/fakecloud-cognito/src/service/misc.rs
+++ b/crates/fakecloud-cognito/src/service/misc.rs
@@ -667,7 +667,25 @@ impl CognitoService {
 
         // Resolve everything under the state lock, then release the guard (it is
         // not `Send` and must not be held across the trigger `await` below).
-        let (pool_id, username, sub, region, user_attrs, account_id, pool_signing_owned, claims) = {
+        //
+        // Refresh-token rotation (when enabled) MUST be atomic with validation:
+        // the old token is validated and — in the same critical section, before
+        // the guard is released for the trigger `await` — swapped out for a freshly
+        // minted one. The new token's VALUE does not depend on the trigger result
+        // (only the access/id token claims do), so generating it here lets a
+        // concurrent replay of the same old token fail validation (it has already
+        // been removed), preserving single-use / replay detection.
+        let (
+            pool_id,
+            username,
+            sub,
+            region,
+            user_attrs,
+            account_id,
+            pool_signing_owned,
+            claims,
+            rotated_refresh,
+        ) = {
             let mut accounts = self.state.write();
             let state = accounts.get_or_create(&req.account_id);
 
@@ -725,6 +743,33 @@ impl CognitoService {
                     .map(|(p, k)| (p.clone(), k.clone()))
             });
             let claims = super::token_claims_for(state, &pool_id, &username, client_id);
+
+            let rotation_enabled = state
+                .user_pool_clients
+                .get(client_id)
+                .and_then(|c| c.refresh_token_rotation.as_ref())
+                .map(|r| r.feature.eq_ignore_ascii_case("ENABLED"))
+                .unwrap_or(false);
+
+            // Atomic swap: mint the replacement and invalidate the old token while
+            // still holding the write guard, so a concurrent replay of the same old
+            // token can no longer validate.
+            let rotated_refresh = if rotation_enabled {
+                let new_token = format!("rt-{}", Uuid::new_v4());
+                state.refresh_tokens.insert(
+                    new_token.clone(),
+                    RefreshTokenData {
+                        user_pool_id: pool_id.clone(),
+                        username: username.clone(),
+                        client_id: client_id.to_string(),
+                        issued_at: Utc::now(),
+                    },
+                );
+                state.refresh_tokens.remove(refresh_token);
+                Some(new_token)
+            } else {
+                None
+            };
             (
                 pool_id,
                 username,
@@ -734,6 +779,7 @@ impl CognitoService {
                 account_id,
                 pool_signing_owned,
                 claims,
+                rotated_refresh,
             )
         };
 
@@ -780,31 +826,9 @@ impl CognitoService {
             &claims,
         );
 
-        let rotation_enabled = state
-            .user_pool_clients
-            .get(client_id)
-            .and_then(|c| c.refresh_token_rotation.as_ref())
-            .map(|r| r.feature.eq_ignore_ascii_case("ENABLED"))
-            .unwrap_or(false);
-
+        // Rotation (validate + swap) already happened atomically under the scope-1
+        // write guard; here we only persist the freshly minted access token.
         let now = Utc::now();
-        let rotated_refresh = if rotation_enabled {
-            let new_token = format!("rt-{}", Uuid::new_v4());
-            state.refresh_tokens.insert(
-                new_token.clone(),
-                RefreshTokenData {
-                    user_pool_id: pool_id.clone(),
-                    username: username.clone(),
-                    client_id: client_id.to_string(),
-                    issued_at: now,
-                },
-            );
-            state.refresh_tokens.remove(refresh_token);
-            Some(new_token)
-        } else {
-            None
-        };
-
         state.access_tokens.insert(
             tokens.access_token.clone(),
             AccessTokenData {

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -462,7 +462,7 @@ impl AwsService for CognitoService {
             "ListDevices" => self.list_devices(&req),
             "UpdateDeviceStatus" => self.update_device_status(&req),
             "RevokeToken" => self.revoke_token(&req),
-            "GetTokensFromRefreshToken" => self.get_tokens_from_refresh_token(&req),
+            "GetTokensFromRefreshToken" => self.get_tokens_from_refresh_token(&req).await,
             "TagResource" => self.tag_resource(&req),
             "UntagResource" => self.untag_resource(&req),
             "ListTagsForResource" => self.list_tags_for_resource(&req),

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -2119,8 +2119,11 @@ fn generate_tokens_with_overrides(
     //   }
     // Real Cognito also accepts the v1 flat `claimsOverrideDetails` shape.
     if let Some(ov) = overrides {
-        let v2 = &ov["claimsAndScopeOverrideDetails"];
-        let v1 = &ov["claimsOverrideDetails"];
+        // Lambda triggers return the full Cognito event, whose override data
+        // is nested under `response`; retain support for direct override data.
+        let response = ov.get("response").unwrap_or(ov);
+        let v2 = &response["claimsAndScopeOverrideDetails"];
+        let v1 = &response["claimsOverrideDetails"];
         let id_block = if !v2.is_null() {
             &v2["idTokenGeneration"]
         } else {

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -7952,6 +7952,42 @@ fn pretoken_v1_claims_override_details_shape() {
 }
 
 #[test]
+fn pretoken_lambda_response_applies_v1_group_overrides_to_access_tokens() {
+    use crate::service::generate_tokens_with_overrides;
+    use base64::Engine;
+
+    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let lambda_response = serde_json::json!({
+        "response": {
+            "claimsOverrideDetails": {
+                "groupOverrideDetails": {"groupsToOverride": ["{\\\"id\\\":1}"]},
+            }
+        }
+    });
+
+    let tokens = generate_tokens_with_overrides(
+        "us-east-1_abc",
+        "client1",
+        "sub-1",
+        "alice",
+        "us-east-1",
+        None,
+        None,
+        None,
+        Some(&lambda_response),
+        &crate::service::TokenClaims::default(),
+    );
+
+    let parts: Vec<&str> = tokens.access_token.split('.').collect();
+    let access_payload: serde_json::Value =
+        serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap();
+    assert_eq!(
+        access_payload["cognito:groups"],
+        serde_json::json!(["{\\\"id\\\":1}"])
+    );
+}
+
+#[test]
 fn get_signing_certificate_returns_real_x509_matching_pool_jwt_key() {
     use base64::Engine;
     let (svc, pool_id) = setup_svc_with_pool();

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -7209,7 +7209,7 @@ fn get_tokens_from_refresh_token_unknown_client_errors() {
     let (svc, _) = make_svc();
     let body = json!({"RefreshToken": "rt", "ClientId": "nope"});
     let req = make_req("GetTokensFromRefreshToken", &body.to_string());
-    assert!(svc.get_tokens_from_refresh_token(&req).is_err());
+    assert!(block_on(svc.get_tokens_from_refresh_token(&req)).is_err());
 }
 
 #[test]
@@ -7219,7 +7219,7 @@ fn get_tokens_from_refresh_token_invalid_refresh_token() {
     let client_id = create_client(&svc, &pool_id);
     let body = json!({"RefreshToken": "bogus", "ClientId": client_id});
     let req = make_req("GetTokensFromRefreshToken", &body.to_string());
-    assert!(svc.get_tokens_from_refresh_token(&req).is_err());
+    assert!(block_on(svc.get_tokens_from_refresh_token(&req)).is_err());
 }
 
 #[test]
@@ -7245,7 +7245,7 @@ fn get_tokens_from_refresh_token_client_mismatch_errors() {
     }
     let body = json!({"RefreshToken": rt, "ClientId": client_b});
     let req = make_req("GetTokensFromRefreshToken", &body.to_string());
-    assert!(svc.get_tokens_from_refresh_token(&req).is_err());
+    assert!(block_on(svc.get_tokens_from_refresh_token(&req)).is_err());
 }
 
 #[test]
@@ -7270,7 +7270,7 @@ fn get_tokens_from_refresh_token_returns_new_tokens() {
     }
     let body = json!({"RefreshToken": rt, "ClientId": client_id});
     let req = make_req("GetTokensFromRefreshToken", &body.to_string());
-    let resp = svc.get_tokens_from_refresh_token(&req).unwrap();
+    let resp = block_on(svc.get_tokens_from_refresh_token(&req)).unwrap();
     let b = resp_json(&resp);
     assert!(b["AuthenticationResult"]["AccessToken"].as_str().is_some());
     assert!(b["AuthenticationResult"]["IdToken"].as_str().is_some());
@@ -7985,6 +7985,169 @@ fn pretoken_lambda_response_applies_v1_group_overrides_to_access_tokens() {
         access_payload["cognito:groups"],
         serde_json::json!(["{\\\"id\\\":1}"])
     );
+}
+
+/// A mock Lambda that drives the CUSTOM_AUTH challenge triggers to completion and
+/// returns PreTokenGeneration overrides, switching on the event's `triggerSource`.
+struct SwitchingTriggerLambda;
+
+impl fakecloud_core::delivery::LambdaDelivery for SwitchingTriggerLambda {
+    fn invoke_lambda(
+        &self,
+        _function_arn: &str,
+        payload: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, String>> + Send>> {
+        let event: Value = serde_json::from_str(payload).unwrap_or_else(|_| json!({}));
+        let src = event["triggerSource"].as_str().unwrap_or("").to_string();
+        let resp = if src.contains("VerifyAuthChallenge") {
+            json!({"response": {"answerCorrect": true}})
+        } else if src.contains("DefineAuthChallenge") {
+            json!({"response": {"issueTokens": true, "failAuthentication": false}})
+        } else if src.contains("TokenGeneration") {
+            json!({"response": {
+                "claimsAndScopeOverrideDetails": {
+                    "idTokenGeneration": {"claimsToAddOrOverride": {"tenant": "acme"}},
+                    "accessTokenGeneration": {"claimsToAddOrOverride": {"tenant": "acme"}},
+                    "groupOverrideDetails": {"groupsToOverride": ["pretoken-admins"]},
+                }
+            }})
+        } else {
+            // PreAuthentication and other gate triggers: a non-None response means
+            // "allow", so return an empty (echoed) response.
+            json!({"response": {}})
+        };
+        let bytes = serde_json::to_vec(&resp).unwrap();
+        Box::pin(async move { Ok(bytes) })
+    }
+}
+
+/// Build a service whose delivery bus invokes [`SwitchingTriggerLambda`].
+fn svc_with_pretoken_lambda() -> (CognitoService, crate::state::SharedCognitoState) {
+    let state = std::sync::Arc::new(parking_lot::RwLock::new(
+        fakecloud_core::multi_account::MultiAccountState::new(
+            "123456789012",
+            "us-east-1",
+            "http://localhost:4569",
+        ),
+    ));
+    let bus = std::sync::Arc::new(
+        fakecloud_core::delivery::DeliveryBus::new()
+            .with_lambda(std::sync::Arc::new(SwitchingTriggerLambda)),
+    );
+    let ctx = triggers::CognitoDeliveryContext::new(bus);
+    let svc = CognitoService::new(state.clone()).with_delivery(ctx);
+    (svc, state)
+}
+
+/// Point the pool's LambdaConfig at the (mock) trigger functions.
+fn set_lambda_config(state: &crate::state::SharedCognitoState, pool_id: &str, config: Value) {
+    let mut w = state.write();
+    let st = w.default_mut();
+    st.user_pools.get_mut(pool_id).unwrap().lambda_config = Some(config);
+}
+
+/// Decode the `.` -separated JWT's claims (second segment) into JSON.
+fn decode_jwt_claims(token: &str) -> Value {
+    use base64::Engine;
+    let b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let parts: Vec<&str> = token.split('.').collect();
+    serde_json::from_slice(&b64url.decode(parts[1]).unwrap()).unwrap()
+}
+
+#[test]
+fn admin_initiate_auth_applies_pretoken_overrides_to_access_token() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "alice");
+    set_user_password(&svc, &pool_id, "alice", "P@ssw0rd!");
+    set_lambda_config(
+        &state,
+        &pool_id,
+        json!({"PreTokenGeneration": "arn:aws:lambda:us-east-1:123456789012:function:pretoken"}),
+    );
+
+    let body = json!({
+        "UserPoolId": pool_id,
+        "ClientId": client_id,
+        "AuthFlow": "ADMIN_NO_SRP_AUTH",
+        "AuthParameters": {"USERNAME": "alice", "PASSWORD": "P@ssw0rd!"},
+    });
+    let req = make_req("AdminInitiateAuth", &body.to_string());
+    let resp = block_on(svc.admin_initiate_auth(&req)).unwrap();
+    let b = resp_json(&resp);
+    let access = b["AuthenticationResult"]["AccessToken"].as_str().unwrap();
+    let claims = decode_jwt_claims(access);
+
+    // These only appear if AdminInitiateAuth routed token generation through the
+    // PreTokenGeneration override path — reverting to plain `generate_tokens`
+    // would drop both (the user has no real group membership or `tenant` claim).
+    assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
+    assert_eq!(claims["tenant"], "acme");
+}
+
+#[test]
+fn custom_challenge_completion_applies_pretoken_overrides_to_access_token() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let body = json!({
+        "UserPoolId": pool_id,
+        "ClientName": "cc-client",
+        "ExplicitAuthFlows": ["ALLOW_CUSTOM_AUTH"],
+    });
+    let req = make_req("CreateUserPoolClient", &body.to_string());
+    let client_id = resp_json(&svc.create_user_pool_client(&req).unwrap())["UserPoolClient"]
+        ["ClientId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    admin_create_user_helper(&svc, &pool_id, "bob");
+    set_user_password(&svc, &pool_id, "bob", "P@ssw0rd!");
+    set_lambda_config(
+        &state,
+        &pool_id,
+        json!({
+            "DefineAuthChallenge": "arn:aws:lambda:us-east-1:123456789012:function:define",
+            "VerifyAuthChallengeResponse": "arn:aws:lambda:us-east-1:123456789012:function:verify",
+            "PreTokenGeneration": "arn:aws:lambda:us-east-1:123456789012:function:pretoken",
+        }),
+    );
+
+    // Seed a pending CUSTOM_CHALLENGE round; the mock's VerifyAuthChallenge marks
+    // the answer correct and DefineAuthChallenge resolves with issueTokens:true.
+    let session = "cc-session".to_string();
+    {
+        let mut w = state.write();
+        let st = w.default_mut();
+        st.sessions.insert(
+            session.clone(),
+            SessionData {
+                user_pool_id: pool_id.clone(),
+                username: "bob".to_string(),
+                client_id: client_id.clone(),
+                challenge_name: "CUSTOM_CHALLENGE".to_string(),
+                challenge_results: vec![],
+                challenge_metadata: None,
+            },
+        );
+    }
+
+    let body = json!({
+        "ClientId": client_id,
+        "ChallengeName": "CUSTOM_CHALLENGE",
+        "Session": session,
+        "ChallengeResponses": {"ANSWER": "correct"},
+    });
+    let req = make_req("RespondToAuthChallenge", &body.to_string());
+    let resp = block_on(svc.respond_to_auth_challenge(&req)).unwrap();
+    let b = resp_json(&resp);
+    let access = b["AuthenticationResult"]["AccessToken"].as_str().unwrap();
+    let claims = decode_jwt_claims(access);
+
+    // These only appear if the CUSTOM_CHALLENGE completion path routed token
+    // generation through the PreTokenGeneration override path.
+    assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
+    assert_eq!(claims["tenant"], "acme");
 }
 
 #[test]

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -7276,6 +7276,65 @@ fn get_tokens_from_refresh_token_returns_new_tokens() {
     assert!(b["AuthenticationResult"]["IdToken"].as_str().is_some());
 }
 
+/// Fix 2 regression guard: with refresh-token rotation ENABLED, the old token is
+/// single-use. The validate + rotation-swap happens atomically under the scope-1
+/// write guard (before the guard is released for the trigger await), so the OLD
+/// token is invalidated synchronously on first use — a concurrent replay of the
+/// same old token can no longer validate. Here we assert the synchronous
+/// invalidation: a second call with the old token fails, and the returned new
+/// token works.
+#[test]
+fn get_tokens_from_refresh_token_rotation_makes_old_token_single_use() {
+    let (svc, state) = make_svc();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "rox");
+    let rt_old = "rt-old".to_string();
+    {
+        let mut st = state.write();
+        let acct = st.get_or_create("123456789012");
+        // Enable rotation on the client.
+        acct.user_pool_clients
+            .get_mut(&client_id)
+            .unwrap()
+            .refresh_token_rotation = Some(crate::state::RefreshTokenRotationConfig {
+            feature: "ENABLED".to_string(),
+            retry_grace_period_seconds: None,
+        });
+        acct.refresh_tokens.insert(
+            rt_old.clone(),
+            crate::state::RefreshTokenData {
+                user_pool_id: pool_id.clone(),
+                username: "rox".to_string(),
+                client_id: client_id.clone(),
+                issued_at: chrono::Utc::now(),
+            },
+        );
+    }
+
+    // First use rotates: a fresh refresh token comes back.
+    let body = json!({"RefreshToken": rt_old, "ClientId": client_id});
+    let req = make_req("GetTokensFromRefreshToken", &body.to_string());
+    let resp = block_on(svc.get_tokens_from_refresh_token(&req)).unwrap();
+    let b = resp_json(&resp);
+    let rt_new = b["AuthenticationResult"]["RefreshToken"]
+        .as_str()
+        .expect("rotation returns a new refresh token")
+        .to_string();
+    assert_ne!(rt_new, "rt-old");
+
+    // The old token is now single-use: replaying it is rejected (it was removed
+    // synchronously in the same critical section as validation).
+    let body = json!({"RefreshToken": "rt-old", "ClientId": client_id});
+    let req = make_req("GetTokensFromRefreshToken", &body.to_string());
+    assert!(block_on(svc.get_tokens_from_refresh_token(&req)).is_err());
+
+    // The newly issued token works.
+    let body = json!({"RefreshToken": rt_new, "ClientId": client_id});
+    let req = make_req("GetTokensFromRefreshToken", &body.to_string());
+    assert!(block_on(svc.get_tokens_from_refresh_token(&req)).is_ok());
+}
+
 // ── Branding + WebAuthn extra coverage (branding.rs) ──────────────
 
 fn issue_at(
@@ -8146,6 +8205,63 @@ fn custom_challenge_completion_applies_pretoken_overrides_to_access_token() {
 
     // These only appear if the CUSTOM_CHALLENGE completion path routed token
     // generation through the PreTokenGeneration override path.
+    assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
+    assert_eq!(claims["tenant"], "acme");
+}
+
+/// Fix 1 regression guard: `custom_auth_issue_tokens` used to invoke the
+/// PreTokenGeneration trigger via `block_in_place`/`Handle::block_on`, which
+/// PANICS on a current-thread tokio runtime (exactly what the `block_on` test
+/// harness uses). Driving a custom-auth issueTokens path (the SELECT_CHALLENGE
+/// PASSWORD answer) WITH a configured PreTokenGeneration trigger must complete
+/// without panicking and must apply the trigger's claim overrides.
+#[test]
+fn custom_auth_issue_tokens_applies_pretoken_overrides_on_current_thread_runtime() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "cara");
+    set_user_password(&svc, &pool_id, "cara", "P@ssw0rd!");
+    set_lambda_config(
+        &state,
+        &pool_id,
+        json!({"PreTokenGeneration": "arn:aws:lambda:us-east-1:123456789012:function:pretoken"}),
+    );
+
+    // Seed a SELECT_CHALLENGE session; answering with PASSWORD verifies the
+    // password directly and mints tokens via `custom_auth_issue_tokens`.
+    let session = "sc-session".to_string();
+    {
+        let mut w = state.write();
+        let st = w.default_mut();
+        st.sessions.insert(
+            session.clone(),
+            SessionData {
+                user_pool_id: pool_id.clone(),
+                username: "cara".to_string(),
+                client_id: client_id.clone(),
+                challenge_name: "SELECT_CHALLENGE".to_string(),
+                challenge_results: vec![],
+                challenge_metadata: None,
+            },
+        );
+    }
+
+    let body = json!({
+        "ClientId": client_id,
+        "ChallengeName": "SELECT_CHALLENGE",
+        "Session": session,
+        "ChallengeResponses": {"ANSWER": "PASSWORD", "PASSWORD": "P@ssw0rd!"},
+    });
+    let req = make_req("RespondToAuthChallenge", &body.to_string());
+    // Would PANIC before the async conversion (block_on == current-thread runtime).
+    let resp = block_on(svc.respond_to_auth_challenge(&req)).unwrap();
+    let b = resp_json(&resp);
+    let access = b["AuthenticationResult"]["AccessToken"].as_str().unwrap();
+    let claims = decode_jwt_claims(access);
+
+    // Present only if the token-minting path routed through the PreTokenGeneration
+    // override path (the user has no real group membership or `tenant` claim).
     assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
     assert_eq!(claims["tenant"], "acme");
 }


### PR DESCRIPTION
## Why

Pre-token Lambda overrides were dropped from access tokens issued by SRP, refresh-token, and custom-auth flows. Applications that depend on `cognito:groups` then reject otherwise successful sign-ins.

## How

- Preserve the complete Lambda event response when merging v1/v2 overrides.
- Apply pre-token generation to SRP, custom-auth, and refresh-token token issuance.
- Add regression coverage for v1 group overrides in access tokens.

## Type

- [x] Bug fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Pre Token Generation Lambda overrides across all auth flows (SRP/ADMIN_NO_SRP, custom-auth first-call and multi-round, NEW_PASSWORD_REQUIRED, refresh). Also makes refresh-token rotation atomic to prevent replay and converts remaining paths to async to avoid block_in_place panics.

- **Bug Fixes**
  - Route `AdminInitiateAuth`, `CUSTOM_AUTH` (first-call and multi-round completion), `NEW_PASSWORD_REQUIRED` completion, and `GetTokensFromRefreshToken` through `generate_tokens_with_overrides`.
  - Accept Lambda responses nested under `response` and merge v1/v2 claim overrides for groups and claims.
  - Make refresh-token rotation atomic (old token becomes single-use); add regression tests for admin-initiate/custom-challenge overrides and rotation.

- **Refactors**
  - Convert custom-auth issuance/completion, AdminInitiateAuth, NEW_PASSWORD_REQUIRED, and refresh-token issuance to async and release the state lock before awaiting triggers to avoid `block_in_place` panics (works on current-thread runtimes).

<sup>Written for commit 46dc9df64edb63f164fbf590dc05ffd775e1f84b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

