### PR TITLE
chore(release): bump workspace to v0.44.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-account"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acm"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-acmpca"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-amplify"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigateway"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-apigatewayv2"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appconfig"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-application-autoscaling"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-appsync"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-athena"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-autoscaling"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-aws"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-backup"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-batch"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-bedrock-agent-runtime"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ce"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudcontrol"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudformation"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudfront"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudtrail"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cloudwatch"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeartifact"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codebuild"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codecommit"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codeconnections"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codedeploy"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-codepipeline"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-cognito"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-comprehend"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-config"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-conformance-macros"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-core"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dms"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-docdb"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dsql"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-dynamodb"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-e2e"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ec2"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecr"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ecs"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-efs"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eks"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticache"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elasticbeanstalk"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-elbv2"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-emr"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-eventbridge"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-firehose"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-fis"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glacier"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-glue"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5853,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iam"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-identitystore"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iot"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iotdata"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-iotwireless"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-k8s"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kafka"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5995,7 +5995,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesis"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kinesisanalyticsv2"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-kms"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lakeformation"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-lambda"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-logs"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-managedblockchain"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6166,7 +6166,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mediaconvert"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6186,7 +6186,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-memorydb"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mq"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6229,7 +6229,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-mwaa"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-neptune"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-opensearch"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-organizations"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-parity"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-persistence"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pinpoint"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6365,7 +6365,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-pipes"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ram"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6429,7 +6429,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-rds-data"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-redshift"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6470,7 +6470,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6490,7 +6490,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-resource-groups-tagging"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6508,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-route53resolver"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6557,7 +6557,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "aws-smithy-eventstream",
@@ -6594,7 +6594,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-s3tables"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6614,7 +6614,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sagemaker"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6632,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-scheduler"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6655,7 +6655,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sdk"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "percent-encoding",
  "reqwest",
@@ -6666,7 +6666,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-secretsmanager"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-serverlessrepo"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6709,7 +6709,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-servicediscovery"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ses"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-shield"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sns"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-sqs"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssm"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-ssoadmin"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-stepfunctions"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-support"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-swf"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6934,7 +6934,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-testkit"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -7004,7 +7004,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-textract"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7023,7 +7023,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-tfacc"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "fakecloud-testkit",
  "tokio",
@@ -7031,7 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-timestream"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transcribe"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7071,7 +7071,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-transfer"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-translate"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-verifiedpermissions"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-wafv2"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7158,7 +7158,7 @@ dependencies = [
 
 [[package]]
 name = "fakecloud-xray"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/faiscadev/fakecloud"
 homepage = "https://fakecloud.dev"
 rust-version = "1.94"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies]
 cedar-policy = "4"
@@ -118,387 +118,387 @@ features = [ "json", "multipart",]
 
 [workspace.dependencies.fakecloud-core]
 path = "crates/fakecloud-core"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-aws]
 path = "crates/fakecloud-aws"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-sqs]
 path = "crates/fakecloud-sqs"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-shield]
 path = "crates/fakecloud-shield"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-sns]
 path = "crates/fakecloud-sns"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-eventbridge]
 path = "crates/fakecloud-eventbridge"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ec2]
 path = "crates/fakecloud-ec2"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-iam]
 path = "crates/fakecloud-iam"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-organizations]
 path = "crates/fakecloud-organizations"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ssm]
 path = "crates/fakecloud-ssm"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-s3]
 path = "crates/fakecloud-s3"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-dynamodb]
 path = "crates/fakecloud-dynamodb"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-lambda]
 path = "crates/fakecloud-lambda"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-k8s]
 path = "crates/fakecloud-k8s"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-secretsmanager]
 path = "crates/fakecloud-secretsmanager"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-logs]
 path = "crates/fakecloud-logs"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-kms]
 path = "crates/fakecloud-kms"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-cloudformation]
 path = "crates/fakecloud-cloudformation"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-cloudcontrol]
 path = "crates/fakecloud-cloudcontrol"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ses]
 path = "crates/fakecloud-ses"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-cognito]
 path = "crates/fakecloud-cognito"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-kinesis]
 path = "crates/fakecloud-kinesis"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-rds]
 path = "crates/fakecloud-rds"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-rds-data]
 path = "crates/fakecloud-rds-data"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-cloudtrail]
 path = "crates/fakecloud-cloudtrail"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ce]
 path = "crates/fakecloud-ce"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-codeconnections]
 path = "crates/fakecloud-codeconnections"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-dms]
 path = "crates/fakecloud-dms"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-docdb]
 path = "crates/fakecloud-docdb"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-neptune]
 path = "crates/fakecloud-neptune"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-textract]
 path = "crates/fakecloud-textract"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-transcribe]
 path = "crates/fakecloud-transcribe"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-translate]
 path = "crates/fakecloud-translate"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-swf]
 path = "crates/fakecloud-swf"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-pinpoint]
 path = "crates/fakecloud-pinpoint"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-timestream]
 path = "crates/fakecloud-timestream"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-transfer]
 path = "crates/fakecloud-transfer"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-dsql]
 path = "crates/fakecloud-dsql"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-resource-groups]
 path = "crates/fakecloud-resource-groups"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-resource-groups-tagging]
 path = "crates/fakecloud-resource-groups-tagging"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-elasticbeanstalk]
 path = "crates/fakecloud-elasticbeanstalk"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-elasticache]
 path = "crates/fakecloud-elasticache"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-eks]
 path = "crates/fakecloud-eks"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-glacier]
 path = "crates/fakecloud-glacier"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-appconfig]
 path = "crates/fakecloud-appconfig"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-backup]
 path = "crates/fakecloud-backup"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ram]
 path = "crates/fakecloud-ram"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-s3tables]
 path = "crates/fakecloud-s3tables"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-lakeformation]
 path = "crates/fakecloud-lakeformation"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-codebuild]
 path = "crates/fakecloud-codebuild"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-codecommit]
 path = "crates/fakecloud-codecommit"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-codedeploy]
 path = "crates/fakecloud-codedeploy"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-codepipeline]
 path = "crates/fakecloud-codepipeline"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-codeartifact]
 path = "crates/fakecloud-codeartifact"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-efs]
 path = "crates/fakecloud-efs"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-mq]
 path = "crates/fakecloud-mq"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-kafka]
 path = "crates/fakecloud-kafka"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-fis]
 path = "crates/fakecloud-fis"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-emr]
 path = "crates/fakecloud-emr"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-mwaa]
 path = "crates/fakecloud-mwaa"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-opensearch]
 path = "crates/fakecloud-opensearch"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-memorydb]
 path = "crates/fakecloud-memorydb"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-kinesisanalyticsv2]
 path = "crates/fakecloud-kinesisanalyticsv2"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-servicediscovery]
 path = "crates/fakecloud-servicediscovery"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ecr]
 path = "crates/fakecloud-ecr"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ecs]
 path = "crates/fakecloud-ecs"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-elbv2]
 path = "crates/fakecloud-elbv2"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-cloudfront]
 path = "crates/fakecloud-cloudfront"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-route53]
 path = "crates/fakecloud-route53"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-route53resolver]
 path = "crates/fakecloud-route53resolver"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-account]
 path = "crates/fakecloud-account"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-identitystore]
 path = "crates/fakecloud-identitystore"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-ssoadmin]
 path = "crates/fakecloud-ssoadmin"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-verifiedpermissions]
 path = "crates/fakecloud-verifiedpermissions"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-acm]
 path = "crates/fakecloud-acm"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-acmpca]
 path = "crates/fakecloud-acmpca"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-config]
 path = "crates/fakecloud-config"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-firehose]
 path = "crates/fakecloud-firehose"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-glue]
 path = "crates/fakecloud-glue"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-cloudwatch]
 path = "crates/fakecloud-cloudwatch"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-application-autoscaling]
 path = "crates/fakecloud-application-autoscaling"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-autoscaling]
 path = "crates/fakecloud-autoscaling"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-batch]
 path = "crates/fakecloud-batch"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-pipes]
 path = "crates/fakecloud-pipes"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-wafv2]
 path = "crates/fakecloud-wafv2"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-athena]
 path = "crates/fakecloud-athena"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-redshift]
 path = "crates/fakecloud-redshift"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-stepfunctions]
 path = "crates/fakecloud-stepfunctions"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-scheduler]
 path = "crates/fakecloud-scheduler"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-apigateway]
 path = "crates/fakecloud-apigateway"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-apigatewayv2]
 path = "crates/fakecloud-apigatewayv2"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-bedrock]
 path = "crates/fakecloud-bedrock"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-bedrock-agent]
 path = "crates/fakecloud-bedrock-agent"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-bedrock-agent-runtime]
 path = "crates/fakecloud-bedrock-agent-runtime"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-sdk]
 path = "crates/fakecloud-sdk"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-persistence]
 path = "crates/fakecloud-persistence"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.kube]
 version = "0.95"
@@ -511,49 +511,49 @@ features = ["latest"]
 
 [workspace.dependencies.fakecloud-xray]
 path = "crates/fakecloud-xray"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-amplify]
 path = "crates/fakecloud-amplify"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-appsync]
 path = "crates/fakecloud-appsync"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-mediaconvert]
 path = "crates/fakecloud-mediaconvert"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-serverlessrepo]
 path = "crates/fakecloud-serverlessrepo"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-iot]
 path = "crates/fakecloud-iot"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-iotdata]
 path = "crates/fakecloud-iotdata"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-iotwireless]
 path = "crates/fakecloud-iotwireless"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-sagemaker]
 path = "crates/fakecloud-sagemaker"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-managedblockchain]
 path = "crates/fakecloud-managedblockchain"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-comprehend]
 path = "crates/fakecloud-comprehend"
-version = "0.44.5"
+version = "0.44.6"
 
 [workspace.dependencies.fakecloud-support]
 path = "crates/fakecloud-support"
-version = "0.44.5"
+version = "0.44.6"
 

--- a/sdks/dotnet/src/FakeCloud/FakeCloud.csproj
+++ b/sdks/dotnet/src/FakeCloud/FakeCloud.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>FakeCloud</AssemblyName>
 
     <PackageId>FakeCloud</PackageId>
-    <Version>0.44.5</Version>
+    <Version>0.44.6</Version>
     <Authors>fakecloud contributors</Authors>
     <Description>C#/.NET client SDK for fakecloud, a local AWS cloud emulator. Provides typed access to the fakecloud introspection and simulation API for test assertions.</Description>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -12,7 +12,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    testImplementation("dev.fakecloud:fakecloud:0.44.5")
+    testImplementation("dev.fakecloud:fakecloud:0.44.6")
 }
 ```
 
@@ -22,7 +22,7 @@ Maven:
 <dependency>
     <groupId>dev.fakecloud</groupId>
     <artifactId>fakecloud</artifactId>
-    <version>0.44.5</version>
+    <version>0.44.6</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -394,7 +394,7 @@ import dev.fakecloud.Types.BedrockResponseRule;
 import java.util.List;
 
 FakeCloud fc = new FakeCloud();
-String modelId = "anthropic.claude-3-haiku-20.44.57-v1:0";
+String modelId = "anthropic.claude-3-haiku-20.44.67-v1:0";
 
 // beforeEach
 fc.reset();

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "dev.fakecloud"
-version = "0.44.5"
+version = "0.44.6"
 
 repositories {
     mavenCentral()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fakecloud"
-version = "0.44.5"
+version = "0.44.6"
 description = "Python SDK for fakecloud — local AWS cloud emulator"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakecloud",
-  "version": "0.44.5",
+  "version": "0.44.6",
   "description": "Client SDK for fakecloud — local AWS cloud emulator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release v0.44.6 — cycle-5 bug-hunt sweep (all bug fixes, patch bump).

Merged since v0.44.5:
- **Family P (pagination):** #2422 SNS/Kinesis/DynamoDB Query+Scan/Route53 resume-past-deleted-marker
- **Family B (CFN reprovision-on-in-place-change), full sweep:** #2423 AppConfig+Route53 HostedZone · #2425 Organizations OU/Account/Policy · #2426 ServiceDiscovery (+ autoscaling tfacc serialize) · #2428 WAFv2 WebACL/IPSet/RegexPatternSet/RuleGroup · #2430 CloudFront Distribution · #2431 EC2 VPC/Subnet/RouteTable · #2433 EC2 SecurityGroup · #2435 CodeDeploy + ElastiCache User/UserGroup
- **Tier-1 misc:** #2424 kinesisanalyticsv2 UTF-8 panic, MSK Kafka 3.9, RDS DBSubnetGroup request-region AZs, Redshift integration status

## Test plan
- Version bump only; CI validates the pin bumps.
- publish-crates.sh --check: 109 crates, dependency order valid.
- No new crates since v0.44.5, so no publish-list change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump workspace and SDK packages to v0.44.6 to ship the cycle-5 bug-fix sweep. No functional changes; version updates only.

- **Dependencies**
  - Bumped all `fakecloud-*` crates to `0.44.6` in Cargo files.
  - Updated SDK versions: .NET (`FakeCloud.csproj`), Java (`build.gradle.kts` and README), Python (`pyproject.toml`), TypeScript (`package.json`).
  - No new crates; publish list unchanged.

<sup>Written for commit 974aec915f4419606157b07387929cd0138dc46f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

