### PR TITLE
fix(eks,neptune,memorydb,opensearch): refresh stale engine-version catalogs

### DIFF
--- a/crates/fakecloud-eks/src/eks_helpers.rs
+++ b/crates/fakecloud-eks/src/eks_helpers.rs
@@ -1190,6 +1190,26 @@ pub(crate) fn cluster_version_catalog(cluster_type: &str) -> Vec<Value> {
             "standard_support",
             false,
         ),
+        (
+            "1.33",
+            "1.33.0",
+            "eks.3",
+            "2025-05-28",
+            "2026-07-28",
+            "2027-07-28",
+            "standard_support",
+            false,
+        ),
+        (
+            "1.34",
+            "1.34.0",
+            "eks.1",
+            "2025-11-11",
+            "2027-01-11",
+            "2028-01-11",
+            "standard_support",
+            false,
+        ),
     ];
     ROWS.iter()
         .map(

--- a/crates/fakecloud-memorydb/src/service.rs
+++ b/crates/fakecloud-memorydb/src/service.rs
@@ -1702,6 +1702,7 @@ impl MemoryDbService {
             { "Engine": "redis", "EngineVersion": "7.1", "EnginePatchVersion": "7.1.1", "ParameterGroupFamily": "memorydb_redis7" },
             { "Engine": "redis", "EngineVersion": "6.2", "EnginePatchVersion": "6.2.6", "ParameterGroupFamily": "memorydb_redis6" },
             { "Engine": "valkey", "EngineVersion": "7.2", "EnginePatchVersion": "7.2.0", "ParameterGroupFamily": "memorydb_valkey7" },
+            { "Engine": "valkey", "EngineVersion": "8.0", "EnginePatchVersion": "8.0.0", "ParameterGroupFamily": "memorydb_valkey8" },
         ]);
         ok(json!({ "EngineVersions": versions, "NextToken": Value::Null }))
     }

--- a/crates/fakecloud-neptune/src/service.rs
+++ b/crates/fakecloud-neptune/src/service.rs
@@ -2385,10 +2385,17 @@ impl NeptuneService {
         &self,
         req: &AwsRequest,
     ) -> Result<AwsResponse, AwsServiceError> {
+        // Newer majors are APPENDED (not prepended) so `DescribeDBEngineVersions`
+        // with `DefaultOnly=true` (which returns the first entry) keeps resolving
+        // to the established default rather than a brand-new major — see the RDS
+        // engine-major lesson.
         let versions = [
             ("1.2.1.0", "neptune1.2"),
             ("1.3.0.0", "neptune1.3"),
             ("1.3.2.1", "neptune1.3"),
+            ("1.4.1.0", "neptune1.4"),
+            ("1.4.2.0", "neptune1.4"),
+            ("1.4.5.0", "neptune1.4"),
         ];
         let inner: String = versions
             .iter()

--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -3498,7 +3498,15 @@ fn instance_type_names() -> Vec<&'static str> {
 fn versions(api: Api) -> Vec<&'static str> {
     match api {
         Api::Es => vec!["7.10", "7.9", "6.8"],
-        Api::OpenSearch => vec!["OpenSearch_2.11", "OpenSearch_2.9", "Elasticsearch_7.10"],
+        Api::OpenSearch => vec![
+            "OpenSearch_2.19",
+            "OpenSearch_2.17",
+            "OpenSearch_2.15",
+            "OpenSearch_2.13",
+            "OpenSearch_2.11",
+            "OpenSearch_2.9",
+            "Elasticsearch_7.10",
+        ],
     }
 }
 


### PR DESCRIPTION
## Summary
Cycle-6 bug-hunt: hand-maintained `Describe*Versions`/`ListVersions` catalogs had rotted behind current AWS, so terraform data-source lookups for a current version resolved empty and errored the plan. **Creates are NOT gated on these lists**, so this is purely data-source staleness (no apply-reject).

- **eks** — `DescribeClusterVersions` add 1.33 + 1.34 (were topping at 1.32). Appended as `defaultVersion=false` so the default stays 1.31 (no tfacc default-resolution break).
- **neptune** — `DescribeDBEngineVersions` add the 1.4.x line (1.4.1.0/1.4.2.0/1.4.5.0); **appended** after 1.3.2.1 so `DefaultOnly=true` (first entry) keeps the established default (per the RDS engine-major lesson).
- **memorydb** — `DescribeEngineVersions` add valkey 8.0 (ElastiCache already lists it).
- **opensearch** — `ListVersions` add OpenSearch 2.13/2.15/2.17/2.19.

## Test plan
- `cargo nextest run` eks/neptune/memorydb/opensearch: 157 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- Data-only refresh; the tfacc eks/neptune data-source shards validate the lookups in CI.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh engine-version catalogs for EKS, Neptune, MemoryDB, and OpenSearch so Terraform data-source lookups resolve current versions instead of failing. Data-only change; no API updates.

- **Bug Fixes**
  - eks: added 1.33 and 1.34; appended as non-default (default stays 1.31).
  - neptune: added 1.4.1.0, 1.4.2.0, 1.4.5.0; appended to preserve DefaultOnly behavior.
  - memorydb: added valkey 8.0.
  - opensearch: added 2.13, 2.15, 2.17, 2.19.

<sup>Written for commit d7e706d4f81320449d0b9c9fd56d6edd64c0d32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

