### PR TITLE
fix(cloudformation): in-place UpdateStack for ACMPCA CertificateAuthority (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/acmpca.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/acmpca.rs
@@ -98,6 +98,41 @@ impl ResourceProvisioner {
             .with("CertificateSigningRequest", csr_pem))
     }
 
+    /// In-place `UpdateCertificateAuthority`. Reprovision here is CATASTROPHIC:
+    /// it churns the CA arn (dangling every Certificate/Activation/Permission and
+    /// ACM cert that references it), REGENERATES the key material + CSR, drops the
+    /// installed CA certificate and issued-cert map, and reverts an activated CA
+    /// to PENDING_CERTIFICATE. Only `RevocationConfiguration` (and Tags) are
+    /// in-place-mutable in AWS; everything else is immutable. So mutate those in
+    /// place and preserve the id, key, status, activation, and issued certs.
+    pub(super) fn update_acmpca_certificate_authority(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let arn = existing.physical_id.clone();
+
+        let mut accounts = self.acmpca_state.write();
+        let account = accounts
+            .accounts
+            .get_mut(&self.account_id)
+            .ok_or_else(|| format!("Certificate authority {arn} not yet provisioned"))?;
+        let ca = account
+            .authorities
+            .get_mut(&arn)
+            .ok_or_else(|| format!("Certificate authority {arn} not yet provisioned"))?;
+        if let Some(rc) = props.get("RevocationConfiguration") {
+            ca.revocation_configuration = Some(rc.clone());
+        }
+        ca.tags = parse_acmpca_tags(props.get("Tags"));
+        let csr = ca.csr_pem.clone();
+
+        Ok(ProvisionResult::new(arn.clone())
+            .with("Arn", arn)
+            .with("CertificateSigningRequest", csr))
+    }
+
     pub(super) fn delete_acmpca_certificate_authority(
         &self,
         physical_id: &str,

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1904,6 +1904,12 @@ impl ResourceProvisioner {
             // In-place update: reprovision would mint a new BackupPlanId and
             // drop the plan's version history + selections.
             "AWS::Backup::BackupPlan" => Some(self.update_backup_plan(existing, new_def)?),
+            // In-place update: reprovision would churn the CA arn, regenerate the
+            // key + CSR, drop the installed cert + issued certs, and revert an
+            // activated CA to PENDING_CERTIFICATE (catastrophic data loss).
+            "AWS::ACMPCA::CertificateAuthority" => {
+                Some(self.update_acmpca_certificate_authority(existing, new_def)?)
+            }
             // In-place updates: reprovision would churn the random app/env/
             // profile id and cascade-drop the nested environments, profiles,
             // hosted configuration versions and deployment history.
@@ -4807,6 +4813,68 @@ mod tests {
             vec!["rg1".to_string()],
             "replication_groups back-ref preserved"
         );
+    }
+
+    #[test]
+    fn acmpca_ca_update_preserves_key_and_activation() {
+        // bug-audit 2026-07-27 (cycle 6): reprovision on a RevocationConfiguration
+        // edit regenerated the CA key + CSR, dropped the installed cert, and
+        // reverted an activated CA to PENDING_CERTIFICATE. The update must be in
+        // place.
+        let prov = make_provisioner();
+        let ca = prov
+            .create_resource(&make_resource(
+                "AWS::ACMPCA::CertificateAuthority",
+                "CA",
+                serde_json::json!({
+                    "Type": "ROOT", "KeyAlgorithm": "RSA_2048",
+                    "SigningAlgorithm": "SHA256WITHRSA",
+                    "Subject": {"CommonName": "my-ca"}
+                }),
+            ))
+            .expect("CA provisions");
+        let arn = ca.physical_id.clone();
+
+        // Simulate activation: mark ACTIVE and capture the key/CSR.
+        let (orig_key, orig_csr) = {
+            let mut acc = prov.acmpca_state.write();
+            let a = acc.accounts.get_mut("123456789012").unwrap();
+            let rec = a.authorities.get_mut(&arn).unwrap();
+            rec.status = "ACTIVE".to_string();
+            (rec.ca_key_pem.clone(), rec.csr_pem.clone())
+        };
+
+        prov.update_resource(
+            &ca,
+            &make_resource(
+                "AWS::ACMPCA::CertificateAuthority",
+                "CA",
+                serde_json::json!({
+                    "Type": "ROOT", "KeyAlgorithm": "RSA_2048",
+                    "SigningAlgorithm": "SHA256WITHRSA",
+                    "Subject": {"CommonName": "my-ca"},
+                    "RevocationConfiguration": {"CrlConfiguration": {"Enabled": false}}
+                }),
+            ),
+        )
+        .expect("update ok")
+        .expect("updatable");
+
+        let acc = prov.acmpca_state.read();
+        let a = acc.accounts.get("123456789012").unwrap();
+        let rec = a
+            .authorities
+            .get(&arn)
+            .expect("CA still exists under its arn");
+        assert_eq!(
+            rec.status, "ACTIVE",
+            "activation preserved (not reverted to PENDING)"
+        );
+        assert_eq!(
+            rec.ca_key_pem, orig_key,
+            "key material preserved (not regenerated)"
+        );
+        assert_eq!(rec.csr_pem, orig_csr, "CSR preserved");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cycle-6 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 4. `AWS::ACMPCA::CertificateAuthority` had a create arm but **no in-place `update_*` arm**, so `UpdateStack` fell through to reprovision (delete + create) on a `RevocationConfiguration` or tag edit — both no-interruption updates in real CFN. Reprovision was **catastrophic**: it churned the CA arn (dangling every `Certificate`/`CertificateAuthorityActivation`/`Permission` and `ACM::Certificate` referencing it), **regenerated the key material + CSR**, dropped the installed CA certificate + issued-cert map, and reverted an activated CA to `PENDING_CERTIFICATE` — silently unable to issue.

`update_acmpca_certificate_authority` mutates only RevocationConfiguration + Tags in place (the sole in-place-mutable properties per AWS `UpdateCertificateAuthority`) and preserves the arn, key, CSR, status, activation, and issued certs.

## Test plan
- New regression test: an activated CA keeps its arn/key/CSR and `ACTIVE` status across a RevocationConfiguration update.
- `cargo nextest run -p fakecloud-cloudformation`: 314 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss by performing in-place updates for ACMPCA CertificateAuthority during `UpdateStack`. RevocationConfiguration and Tag edits now update the existing CA instead of reprovisioning it.

- **Bug Fixes**
  - Added in-place updater that mutates only RevocationConfiguration and Tags, preserving ARN, key, CSR, activation, and issued certs.
  - Routed `AWS::ACMPCA::CertificateAuthority` to the in-place update path to avoid delete+create on no-interruption changes.
  - Added a regression test to ensure an ACTIVE CA keeps its ARN/key/CSR after a RevocationConfiguration change.

<sup>Written for commit b2f6d2ad67215af05bd7bd50bd1f0274b17ed6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

