### PR TITLE
fix(cloudformation): in-place UpdateStack for EC2 InternetGateway + Route53 HealthCheck (no data loss)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/ec2.rs
@@ -389,6 +389,19 @@ impl ResourceProvisioner {
         Ok(ProvisionResult::new(id.clone()).with("RouteTableId", id))
     }
 
+    /// An internet gateway's only property is `Tags` (in-place in AWS), and the
+    /// internal EC2 dispatch has no standalone CreateTags. The point of the arm
+    /// is to AVOID reprovision, which would churn the igw-id and orphan every
+    /// `VPCGatewayAttachment` + route that references it. Preserve the id.
+    pub(super) fn update_ec2_internet_gateway(
+        &self,
+        existing: &StackResource,
+        _resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let id = existing.physical_id.clone();
+        Ok(ProvisionResult::new(id.clone()).with("InternetGatewayId", id))
+    }
+
     /// In-place `AWS::EC2::SecurityGroup` update. Reprovision would churn the
     /// sg id -- breaking every `Ref`/`SourceSecurityGroupId` that stored it and
     /// dropping the group's rules -- and `GroupDescription`/`GroupName`/`VpcId`

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1926,6 +1926,11 @@ impl ResourceProvisioner {
             // servers and wipe every record set stored inside the zone. Name is
             // immutable, so a name change still falls back to replacement.
             "AWS::Route53::HostedZone" => Some(self.update_route53_hosted_zone(existing, new_def)?),
+            // In-place update: reprovision would churn the random HealthCheckId,
+            // dangling every RecordSet that references it for failover routing.
+            "AWS::Route53::HealthCheck" => {
+                Some(self.update_route53_health_check(existing, new_def)?)
+            }
             // In-place updates: reprovision would churn the ns-/srv- id and drop
             // a namespace's services / a service's registered instances.
             "AWS::ServiceDiscovery::HttpNamespace"
@@ -1966,6 +1971,9 @@ impl ResourceProvisioner {
             "AWS::EC2::Subnet" => Some(self.update_ec2_subnet(existing, new_def)?),
             "AWS::EC2::RouteTable" => Some(self.update_ec2_route_table(existing, new_def)?),
             "AWS::EC2::SecurityGroup" => Some(self.update_ec2_security_group(existing, new_def)?),
+            "AWS::EC2::InternetGateway" => {
+                Some(self.update_ec2_internet_gateway(existing, new_def)?)
+            }
             // No dedicated in-place update arm for this type. Real
             // CloudFormation, lacking an in-place mutator for a changed
             // property, falls back to REPLACEMENT: it deletes the old backing
@@ -4875,6 +4883,77 @@ mod tests {
             "key material preserved (not regenerated)"
         );
         assert_eq!(rec.csr_pem, orig_csr, "CSR preserved");
+    }
+
+    #[test]
+    fn ec2_internet_gateway_update_preserves_id() {
+        // bug-audit 2026-07-27 (cycle 6): a tag-only edit reprovisioned the IGW,
+        // churning the igw-id and orphaning VPCGatewayAttachment + routes.
+        let prov = make_provisioner();
+        let igw = prov
+            .create_resource(&make_resource(
+                "AWS::EC2::InternetGateway",
+                "IGW",
+                serde_json::json!({}),
+            ))
+            .expect("igw provisions");
+        let id = igw.physical_id.clone();
+        let up = prov
+            .update_resource(
+                &igw,
+                &make_resource(
+                    "AWS::EC2::InternetGateway",
+                    "IGW",
+                    serde_json::json!({"Tags": [{"Key": "env", "Value": "prod"}]}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(up.physical_id, id, "internet gateway id preserved");
+    }
+
+    #[test]
+    fn route53_health_check_update_preserves_id() {
+        // bug-audit 2026-07-27 (cycle 6): a HealthCheckConfig edit reprovisioned
+        // the health check, churning the HealthCheckId that RecordSets store for
+        // failover routing.
+        let prov = make_provisioner();
+        let hc = prov
+            .create_resource(&make_resource(
+                "AWS::Route53::HealthCheck",
+                "HC",
+                serde_json::json!({"HealthCheckConfig": {
+                    "Type": "HTTP", "ResourcePath": "/a",
+                    "FullyQualifiedDomainName": "ex.com", "Port": 80
+                }}),
+            ))
+            .expect("health check provisions");
+        let id = hc.physical_id.clone();
+        prov.update_resource(
+            &hc,
+            &make_resource(
+                "AWS::Route53::HealthCheck",
+                "HC",
+                serde_json::json!({"HealthCheckConfig": {
+                    "Type": "HTTP", "ResourcePath": "/b",
+                    "FullyQualifiedDomainName": "ex.com", "Port": 80
+                }}),
+            ),
+        )
+        .expect("update ok")
+        .expect("updatable");
+        let accounts = prov.route53_state.read();
+        let state = accounts.get("000000000000").unwrap();
+        let rec = state
+            .health_checks
+            .get(&id)
+            .expect("health check preserved");
+        assert_eq!(
+            rec.config.resource_path.as_deref(),
+            Some("/b"),
+            "config updated in place"
+        );
+        assert_eq!(rec.version, 2, "version bumped");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route.rs
@@ -316,14 +316,70 @@ impl ResourceProvisioner {
         let cfg_value = props
             .get("HealthCheckConfig")
             .ok_or("HealthCheckConfig is required")?;
+        let cfg = self.build_health_check_config(cfg_value)?;
 
+        let id = Uuid::new_v4().to_string();
+        let hc = StoredHealthCheck {
+            id: id.clone(),
+            caller_reference: format!("cfn-{}", resource.logical_id),
+            version: 1,
+            config: cfg,
+            created_time: Utc::now(),
+            status: fakecloud_route53::HealthCheckStatus::Success,
+            last_failure_reason: None,
+        };
+
+        let mut accounts = self.route53_state.write();
+        // Route53 is a global service in fakecloud; all entries share the
+        // default account bucket so SDK reads land on the same data.
+        let state = accounts.entry("000000000000");
+        state.health_checks.insert(id.clone(), hc);
+
+        Ok(ProvisionResult::new(id.clone()).with("HealthCheckId", id))
+    }
+
+    /// In-place `UpdateHealthCheck`: reprovision would churn the random
+    /// HealthCheckId (dangling every `AWS::Route53::RecordSet` that stored it for
+    /// failover routing) and reset the version/status. AWS mutates the config in
+    /// place, so rebuild the config and swap it into the stored health check,
+    /// preserving the id/caller reference/created time and bumping the version.
+    pub(super) fn update_route53_health_check(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg_value = resource
+            .properties
+            .get("HealthCheckConfig")
+            .ok_or("HealthCheckConfig is required")?;
+        let cfg = self.build_health_check_config(cfg_value)?;
+        let id = existing.physical_id.clone();
+
+        let mut accounts = self.route53_state.write();
+        let state = accounts.entry("000000000000");
+        let hc = state
+            .health_checks
+            .get_mut(&id)
+            .ok_or_else(|| format!("Health check {id} not yet provisioned"))?;
+        hc.config = cfg;
+        hc.version += 1;
+        // id / caller_reference / created_time / status preserved.
+
+        Ok(ProvisionResult::new(id.clone()).with("HealthCheckId", id))
+    }
+
+    /// Parse an `AWS::Route53::HealthCheck` `HealthCheckConfig` block into the
+    /// route53 model (shared by the create + in-place update arms).
+    fn build_health_check_config(
+        &self,
+        cfg_value: &serde_json::Value,
+    ) -> Result<HealthCheckConfig, String> {
         let health_check_type = cfg_value
             .get("Type")
             .and_then(|v| v.as_str())
             .ok_or("HealthCheckConfig.Type is required")?
             .to_string();
-
-        let cfg = HealthCheckConfig {
+        Ok(HealthCheckConfig {
             ip_address: cfg_value
                 .get("IPAddress")
                 .and_then(|v| v.as_str())
@@ -413,26 +469,7 @@ impl ResourceProvisioner {
                 .get("RoutingControlArn")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-        };
-
-        let id = Uuid::new_v4().to_string();
-        let hc = StoredHealthCheck {
-            id: id.clone(),
-            caller_reference: format!("cfn-{}", resource.logical_id),
-            version: 1,
-            config: cfg,
-            created_time: Utc::now(),
-            status: fakecloud_route53::HealthCheckStatus::Success,
-            last_failure_reason: None,
-        };
-
-        let mut accounts = self.route53_state.write();
-        // Route53 is a global service in fakecloud; all entries share the
-        // default account bucket so SDK reads land on the same data.
-        let state = accounts.entry("000000000000");
-        state.health_checks.insert(id.clone(), hc);
-
-        Ok(ProvisionResult::new(id.clone()).with("HealthCheckId", id))
+        })
     }
 
     pub(super) fn delete_route53_health_check(&self, physical_id: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary
Cycle-6 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 4b.

- **AWS::EC2::InternetGateway** — a missed sibling of the v0.44.6 EC2-networking sweep. Its only property is Tags (in-place in AWS), but with no update arm a tag-only edit reprovisioned and churned the `igw-` id, orphaning every VPCGatewayAttachment + route referencing it. Added a no-op-preserve-id arm (the internal EC2 dispatch has no standalone CreateTags; the point is to avoid reprovision), matching `update_ec2_route_table`.
- **AWS::Route53::HealthCheck** — `HealthCheckConfig` is in-place-updatable via `UpdateHealthCheck`, but with no update arm a benign config edit reprovisioned, churning the random HealthCheckId that `AWS::Route53::RecordSet` stores for failover routing (and resetting version/status). Extracted the config parse into a shared helper + added an in-place update arm that rebuilds the config, preserves id/caller-reference/created-time, and bumps the version.

Remaining Family-B: Route53Resolver family + CloudFront policy family follow next.

## Test plan
- New regression tests: IGW + HealthCheck updates keep their id (HealthCheck also applies the config change + bumps version).
- `cargo nextest run -p fakecloud-cloudformation`: 316 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable in-place updates for EC2 InternetGateway and Route53 HealthCheck to avoid replacements and ID churn, preventing broken attachments, routes, and failover records. HealthCheck config changes now apply in place and bump the version.

- **Bug Fixes**
  - AWS::EC2::InternetGateway: tag-only updates now preserve the InternetGatewayId to prevent orphaned VPCGatewayAttachment and routes.
  - AWS::Route53::HealthCheck: apply HealthCheckConfig via in-place update, preserving HealthCheckId/caller reference/created time and bumping version (shared config parser added).

<sup>Written for commit 6e962cd550471919d26ba70fa2e96e8de58da7a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

