### PR TITLE
fix(cloudformation): in-place UpdateStack for Route53Resolver ResolverRule + FirewallDomainList (no id churn)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1931,6 +1931,14 @@ impl ResourceProvisioner {
             "AWS::Route53::HealthCheck" => {
                 Some(self.update_route53_health_check(existing, new_def)?)
             }
+            // In-place updates: reprovision would churn the random rslvr-* id,
+            // dangling sibling associations / rules that reference it.
+            "AWS::Route53Resolver::ResolverRule" => {
+                Some(self.update_r53r_resolver_rule(existing, new_def)?)
+            }
+            "AWS::Route53Resolver::FirewallDomainList" => {
+                Some(self.update_r53r_firewall_domain_list(existing, new_def)?)
+            }
             // In-place updates: reprovision would churn the ns-/srv- id and drop
             // a namespace's services / a service's registered instances.
             "AWS::ServiceDiscovery::HttpNamespace"
@@ -4954,6 +4962,78 @@ mod tests {
             "config updated in place"
         );
         assert_eq!(rec.version, 2, "version bumped");
+    }
+
+    #[test]
+    fn route53resolver_updates_preserve_ids() {
+        // bug-audit 2026-07-27 (cycle 6): reprovision churned the random rslvr-*
+        // id, dangling sibling associations/rules. Updates must be in place.
+        let prov = make_provisioner();
+        let rule = prov
+            .create_resource(&make_resource(
+                "AWS::Route53Resolver::ResolverRule",
+                "RR",
+                serde_json::json!({
+                    "RuleType": "FORWARD", "DomainName": "ex.com.", "Name": "r1",
+                    "TargetIps": [{"Ip": "10.0.0.2", "Port": 53}]
+                }),
+            ))
+            .expect("resolver rule provisions");
+        let rule_id = rule.physical_id.clone();
+        let rule_up = prov
+            .update_resource(
+                &rule,
+                &make_resource(
+                    "AWS::Route53Resolver::ResolverRule",
+                    "RR",
+                    serde_json::json!({
+                        "RuleType": "FORWARD", "DomainName": "ex.com.", "Name": "r1-renamed",
+                        "TargetIps": [{"Ip": "10.0.0.3", "Port": 53}, {"Ip": "10.0.0.4", "Port": 53}]
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(rule_up.physical_id, rule_id, "resolver rule id preserved");
+
+        let fdl = prov
+            .create_resource(&make_resource(
+                "AWS::Route53Resolver::FirewallDomainList",
+                "FDL",
+                serde_json::json!({"Name": "dl", "Domains": ["a.com."]}),
+            ))
+            .expect("firewall domain list provisions");
+        let fdl_id = fdl.physical_id.clone();
+        let fdl_up = prov
+            .update_resource(
+                &fdl,
+                &make_resource(
+                    "AWS::Route53Resolver::FirewallDomainList",
+                    "FDL",
+                    serde_json::json!({"Name": "dl", "Domains": ["b.com.", "c.com."]}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(
+            fdl_up.physical_id, fdl_id,
+            "firewall domain list id preserved"
+        );
+
+        let mut st = prov.route53resolver_state.write();
+        let acc = st.account_mut("123456789012");
+        let r = acc.rules.get(&rule_id).expect("rule preserved");
+        assert_eq!(
+            r.name.as_deref(),
+            Some("r1-renamed"),
+            "name updated in place"
+        );
+        assert_eq!(r.target_ips.len(), 2, "target ips updated in place");
+        assert_eq!(
+            acc.firewall_domains.get(&fdl_id).map(|d| d.len()),
+            Some(2),
+            "domains updated in place"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
@@ -409,6 +409,77 @@ impl ResourceProvisioner {
         Ok(out)
     }
 
+    /// In-place `UpdateResolverRule`: reprovision would churn the random
+    /// rslvr-rr- id, dangling every `AWS::Route53Resolver::ResolverRuleAssociation`
+    /// that stored it. Name/TargetIps/ResolverEndpointId are the mutable
+    /// properties; RuleType/DomainName are immutable. Preserve id/arn/creation.
+    pub(super) fn update_r53r_resolver_rule(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let target_ips: Vec<TargetAddress> = props
+            .get("TargetIps")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .map(|t| TargetAddress {
+                        ip: t.get("Ip").and_then(|v| v.as_str()).map(String::from),
+                        port: Some(t.get("Port").and_then(|v| v.as_i64()).unwrap_or(53)),
+                        ipv6: t.get("Ipv6").and_then(|v| v.as_str()).map(String::from),
+                        protocol: t.get("Protocol").and_then(|v| v.as_str()).map(String::from),
+                        server_name_indication: t
+                            .get("ServerNameIndication")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let name = props.get("Name").and_then(|v| v.as_str()).map(String::from);
+        let resolver_endpoint_id = props
+            .get("ResolverEndpointId")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let target_ips_att =
+            serde_json::to_string(&target_ips).unwrap_or_else(|_| "[]".to_string());
+
+        let tags = self.r53r_tags(props);
+        let (arn, domain_name) = {
+            let mut st = self.route53resolver_state.write();
+            let acc = st.account_mut(&self.account_id);
+            let rule = acc
+                .rules
+                .get_mut(&id)
+                .ok_or_else(|| format!("Resolver rule {id} not yet provisioned"))?;
+            rule.name = name.clone();
+            rule.target_ips = target_ips;
+            rule.resolver_endpoint_id = resolver_endpoint_id.clone();
+            rule.modification_time = now_rfc3339();
+            let arn = rule.arn.clone();
+            let domain_name = rule.domain_name.clone();
+            if tags.is_empty() {
+                acc.tags.remove(&arn);
+            } else {
+                acc.tags.insert(arn.clone(), tags);
+            }
+            (arn, domain_name)
+        };
+
+        let mut out = ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("ResolverRuleId", id)
+            .with("Name", name.unwrap_or_default())
+            .with("DomainName", domain_name.unwrap_or_default())
+            .with("TargetIps", target_ips_att);
+        if let Some(ep) = resolver_endpoint_id {
+            out = out.with("ResolverEndpointId", ep);
+        }
+        Ok(out)
+    }
+
     pub(super) fn delete_r53r_resolver_rule(&self, physical_id: &str) -> Result<(), String> {
         let mut st = self.route53resolver_state.write();
         if let Some(acc) = st.accounts.get_mut(&self.account_id) {
@@ -613,6 +684,54 @@ impl ResourceProvisioner {
                 acc.tags.insert(arn.clone(), tags);
             }
         }
+        Ok(ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("Id", id))
+    }
+
+    /// In-place update: reprovision would churn the random rslvr-fdl- id,
+    /// dangling every FirewallRule that references this domain list. Name/Domains
+    /// are the mutable properties (UpdateFirewallDomains); preserve id/arn.
+    pub(super) fn update_r53r_firewall_domain_list(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let name = props.get("Name").and_then(|v| v.as_str());
+        let domains: Vec<String> = props
+            .get("Domains")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let tags = self.r53r_tags(props);
+
+        let mut st = self.route53resolver_state.write();
+        let acc = st.account_mut(&self.account_id);
+        let arn = {
+            let list = acc
+                .firewall_domain_lists
+                .get_mut(&id)
+                .ok_or_else(|| format!("Firewall domain list {id} not yet provisioned"))?;
+            if let Some(n) = name {
+                list.name = n.to_string();
+            }
+            list.domain_count = domains.len() as i64;
+            list.modification_time = now_rfc3339();
+            list.arn.clone()
+        };
+        acc.firewall_domains.insert(id.clone(), domains);
+        if tags.is_empty() {
+            acc.tags.remove(&arn);
+        } else {
+            acc.tags.insert(arn.clone(), tags);
+        }
+
         Ok(ProvisionResult::new(id.clone())
             .with("Arn", arn)
             .with("Id", id))


### PR DESCRIPTION
## Summary
Cycle-6 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 4c. These Route53Resolver types mint random `rslvr-*` ids referenced by sibling associations, but had no in-place update arm, so a config edit reprovisioned and churned the id — dangling the referencing resources.

- **AWS::Route53Resolver::ResolverRule** — reprovision churned the `rslvr-rr-` id, dangling every ResolverRuleAssociation. Update Name/TargetIps/ResolverEndpointId in place (RuleType/DomainName immutable); preserve id/arn/creation.
- **AWS::Route53Resolver::FirewallDomainList** — reprovision churned the `rslvr-fdl-` id, dangling every FirewallRule referencing it. Update Name/Domains in place; preserve id/arn.

Remaining Route53Resolver types (ResolverEndpoint, QueryLoggingConfig, FirewallRuleGroup) + the CloudFront policy family follow in later PRs.

## Test plan
- New regression test: both keep their id and apply the config change in place.
- `cargo nextest run -p fakecloud-cloudformation`: 317 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add in-place updates for AWS::Route53Resolver::ResolverRule and AWS::Route53Resolver::FirewallDomainList to stop rslvr-* ID churn on config edits. This prevents dangling associations and rules.

- **Bug Fixes**
  - ResolverRule: update Name, TargetIps, ResolverEndpointId in place; keep id/arn/creation; RuleType and DomainName remain immutable.
  - FirewallDomainList: update Name and Domains in place; keep id/arn.

<sup>Written for commit 6b55cc70e956ae40762159f87ea864967c6c16bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

