### PR TITLE
fix(cloudformation): in-place UpdateStack for Route53Resolver FirewallRuleGroup + QueryLoggingConfig (no id churn)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1939,6 +1939,12 @@ impl ResourceProvisioner {
             "AWS::Route53Resolver::FirewallDomainList" => {
                 Some(self.update_r53r_firewall_domain_list(existing, new_def)?)
             }
+            "AWS::Route53Resolver::ResolverQueryLoggingConfig" => {
+                Some(self.update_r53r_query_log_config(existing, new_def)?)
+            }
+            "AWS::Route53Resolver::FirewallRuleGroup" => {
+                Some(self.update_r53r_firewall_rule_group(existing, new_def)?)
+            }
             // In-place updates: reprovision would churn the ns-/srv- id and drop
             // a namespace's services / a service's registered instances.
             "AWS::ServiceDiscovery::HttpNamespace"
@@ -5033,6 +5039,95 @@ mod tests {
             acc.firewall_domains.get(&fdl_id).map(|d| d.len()),
             Some(2),
             "domains updated in place"
+        );
+    }
+
+    #[test]
+    fn route53resolver_rulegroup_and_querylog_updates_preserve_ids() {
+        // bug-audit 2026-07-27 (cycle 6): reprovision churned the rslvr-frg-/
+        // rslvr-qlc- id (dangling associations) and dropped the rule group's
+        // inline rules / the query-log config's association_count.
+        let prov = make_provisioner();
+        let frg = prov
+            .create_resource(&make_resource(
+                "AWS::Route53Resolver::FirewallRuleGroup",
+                "FRG",
+                serde_json::json!({
+                    "Name": "g1",
+                    "FirewallRules": [{"Priority": 10, "Action": "ALLOW", "FirewallDomainListId": "rslvr-fdl-x"}]
+                }),
+            ))
+            .expect("firewall rule group provisions");
+        let frg_id = frg.physical_id.clone();
+        let frg_up = prov
+            .update_resource(
+                &frg,
+                &make_resource(
+                    "AWS::Route53Resolver::FirewallRuleGroup",
+                    "FRG",
+                    serde_json::json!({
+                        "Name": "g1-renamed",
+                        "FirewallRules": [
+                            {"Priority": 10, "Action": "ALLOW", "FirewallDomainListId": "rslvr-fdl-x"},
+                            {"Priority": 20, "Action": "BLOCK", "FirewallDomainListId": "rslvr-fdl-y"}
+                        ]
+                    }),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(
+            frg_up.physical_id, frg_id,
+            "firewall rule group id preserved"
+        );
+
+        let qlc = prov
+            .create_resource(&make_resource(
+                "AWS::Route53Resolver::ResolverQueryLoggingConfig",
+                "QLC",
+                serde_json::json!({"Name": "q1", "DestinationArn": "arn:aws:s3:::b"}),
+            ))
+            .expect("query log config provisions");
+        let qlc_id = qlc.physical_id.clone();
+        {
+            let mut st = prov.route53resolver_state.write();
+            let acc = st.account_mut("123456789012");
+            acc.query_log_configs
+                .get_mut(&qlc_id)
+                .unwrap()
+                .association_count = 3;
+        }
+        let qlc_up = prov
+            .update_resource(
+                &qlc,
+                &make_resource(
+                    "AWS::Route53Resolver::ResolverQueryLoggingConfig",
+                    "QLC",
+                    serde_json::json!({"Name": "q1", "DestinationArn": "arn:aws:s3:::b",
+                        "Tags": [{"Key": "env", "Value": "prod"}]}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(qlc_up.physical_id, qlc_id, "query log config id preserved");
+
+        let mut st = prov.route53resolver_state.write();
+        let acc = st.account_mut("123456789012");
+        assert_eq!(
+            acc.firewall_rules.get(&frg_id).map(|r| r.len()),
+            Some(2),
+            "rule group inline rules updated in place"
+        );
+        assert_eq!(
+            acc.firewall_rule_groups.get(&frg_id).map(|g| g.rule_count),
+            Some(2)
+        );
+        assert_eq!(
+            acc.query_log_configs
+                .get(&qlc_id)
+                .map(|c| c.association_count),
+            Some(3),
+            "association_count preserved (not reset by reprovision)"
         );
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
@@ -583,6 +583,28 @@ impl ResourceProvisioner {
             .with("Id", id))
     }
 
+    /// In-place update: `ResolverQueryLoggingConfig` has no mutable property
+    /// other than tags, but reprovision would churn the random rslvr-qlc- id
+    /// (dangling its associations) and reset `association_count`. Preserve the id.
+    pub(super) fn update_r53r_query_log_config(
+        &self,
+        existing: &StackResource,
+        _resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let id = existing.physical_id.clone();
+        let arn = {
+            let st = self.route53resolver_state.read();
+            st.accounts
+                .get(&self.account_id)
+                .and_then(|a| a.query_log_configs.get(&id))
+                .map(|c| c.arn.clone())
+                .ok_or_else(|| format!("Query log config {id} not yet provisioned"))?
+        };
+        Ok(ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("Id", id))
+    }
+
     pub(super) fn delete_r53r_query_log_config(&self, physical_id: &str) -> Result<(), String> {
         let mut st = self.route53resolver_state.write();
         if let Some(acc) = st.accounts.get_mut(&self.account_id) {
@@ -839,6 +861,102 @@ impl ResourceProvisioner {
                 acc.tags.insert(arn.clone(), tags);
             }
         }
+        Ok(ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("Id", id)
+            .with("RuleCount", rule_count.to_string()))
+    }
+
+    /// In-place update: reprovision would churn the random rslvr-frg- id
+    /// (dangling every FirewallRuleGroupAssociation) and drop the group's inline
+    /// rules. Rebuild the rules from the template + update Name in place, and
+    /// preserve the id/arn.
+    pub(super) fn update_r53r_firewall_rule_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let name = props.get("Name").and_then(|v| v.as_str());
+        let mut rules = Vec::new();
+        for r in props
+            .get("FirewallRules")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+        {
+            rules.push(FirewallRule {
+                firewall_rule_group_id: id.clone(),
+                firewall_domain_list_id: r
+                    .get("FirewallDomainListId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                name: r
+                    .get("Name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                priority: r.get("Priority").and_then(|v| v.as_i64()).unwrap_or(100),
+                action: r
+                    .get("Action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("ALLOW")
+                    .to_string(),
+                block_response: r
+                    .get("BlockResponse")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                block_override_domain: r
+                    .get("BlockOverrideDomain")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                block_override_dns_type: r
+                    .get("BlockOverrideDnsType")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                block_override_ttl: r.get("BlockOverrideTtl").and_then(|v| v.as_i64()),
+                creator_request_id: id.clone(),
+                creation_time: now_rfc3339(),
+                modification_time: now_rfc3339(),
+                firewall_domain_redirection_action: None,
+                qtype: r.get("Qtype").and_then(|v| v.as_str()).map(String::from),
+                dns_threat_protection: r
+                    .get("DnsThreatProtection")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                confidence_threshold: r
+                    .get("ConfidenceThreshold")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                firewall_rule_type: r.get("FirewallRuleType").filter(|v| !v.is_null()).cloned(),
+                firewall_threat_protection_id: None,
+            });
+        }
+        let rule_count = rules.len() as i64;
+        let tags = self.r53r_tags(props);
+
+        let mut st = self.route53resolver_state.write();
+        let acc = st.account_mut(&self.account_id);
+        let arn = {
+            let group = acc
+                .firewall_rule_groups
+                .get_mut(&id)
+                .ok_or_else(|| format!("Firewall rule group {id} not yet provisioned"))?;
+            if let Some(n) = name {
+                group.name = n.to_string();
+            }
+            group.rule_count = rule_count;
+            group.modification_time = now_rfc3339();
+            group.arn.clone()
+        };
+        acc.firewall_rules.insert(id.clone(), rules);
+        if tags.is_empty() {
+            acc.tags.remove(&arn);
+        } else {
+            acc.tags.insert(arn.clone(), tags);
+        }
+
         Ok(ProvisionResult::new(id.clone())
             .with("Arn", arn)
             .with("Id", id)


### PR DESCRIPTION
## Summary
Cycle-6 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 4d.

- **AWS::Route53Resolver::FirewallRuleGroup** — reprovision churned the random `rslvr-frg-` id (dangling every FirewallRuleGroupAssociation) and dropped the group's inline rules. Rebuild the rules from the template + update Name in place; preserve id/arn.
- **AWS::Route53Resolver::ResolverQueryLoggingConfig** — no in-place-mutable property other than tags, but reprovision churned the random `rslvr-qlc-` id (dangling its associations) and reset `association_count`. No-op-preserve-id arm.

Remaining CFN id-churn tail: Route53Resolver ResolverEndpoint + the CloudFront policy family, in the next PR.

## Test plan
- New regression test: both keep their id; the rule group applies the new rules and the query-log config keeps its association_count.
- `cargo nextest run -p fakecloud-cloudformation`: 318 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UpdateStack now updates Route53Resolver `FirewallRuleGroup` and `ResolverQueryLoggingConfig` in place to stop random ID churn. This preserves associations and applies rule changes without reprovision.

- **Bug Fixes**
  - `AWS::Route53Resolver::FirewallRuleGroup`: Rebuilds `FirewallRules` from the template and updates `Name` in place; keeps `rslvr-frg-` id/arn and associations; updates `RuleCount` and tags.
  - `AWS::Route53Resolver::ResolverQueryLoggingConfig`: No-op update (except tags) that keeps `rslvr-qlc-` id/arn and preserves `association_count` and associations.
  - Added a regression test to confirm IDs are stable and state is preserved.

<sup>Written for commit 124de4607e825f2a821d777961c1108e2b6859a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

