### PR TITLE
fix(cloudformation): in-place UpdateStack for CloudFront Cache/OriginRequest/ResponseHeaders policies (no id churn)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
@@ -756,4 +756,175 @@ impl ResourceProvisioner {
         state.response_headers_policies.remove(physical_id);
         Ok(())
     }
+
+    // --- In-place policy updates ---
+    //
+    // These policies mint a random id that a Distribution stores via
+    // DefaultCacheBehavior.{CachePolicyId,OriginRequestPolicyId,
+    // ResponseHeadersPolicyId}. Reprovision on a config edit churns the id and
+    // dangles that reference (the Distribution is not re-run in the same update).
+    // AWS updates the policy in place (UpdateCachePolicy etc.), so rebuild the
+    // config, preserve the id, and bump the ETag.
+
+    pub(crate) fn update_cf_cache_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("CachePolicyConfig")
+            .ok_or("CachePolicyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("CachePolicyConfig.Name is required")?
+            .to_string();
+        let min_ttl = cfg
+            .get("MinTTL")
+            .and_then(|v| {
+                v.as_i64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            })
+            .unwrap_or(0);
+        let default_ttl = cfg.get("DefaultTTL").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        });
+        let max_ttl = cfg.get("MaxTTL").and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        });
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let p = state
+            .cache_policies
+            .get_mut(&id)
+            .ok_or_else(|| format!("Cache policy {id} not yet provisioned"))?;
+        p.config = CachePolicyConfig {
+            comment,
+            name,
+            default_ttl,
+            max_ttl,
+            min_ttl,
+            parameters_in_cache_key_and_forwarded_to_origin: None,
+        };
+        p.etag = etag;
+        p.last_modified_time = Utc::now();
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    pub(crate) fn update_cf_origin_request_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("OriginRequestPolicyConfig")
+            .ok_or("OriginRequestPolicyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("OriginRequestPolicyConfig.Name is required")?
+            .to_string();
+        let header_behavior = cfg
+            .get("HeadersConfig")
+            .and_then(|v| v.get("HeaderBehavior"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none")
+            .to_string();
+        let cookie_behavior = cfg
+            .get("CookiesConfig")
+            .and_then(|v| v.get("CookieBehavior"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none")
+            .to_string();
+        let query_string_behavior = cfg
+            .get("QueryStringsConfig")
+            .and_then(|v| v.get("QueryStringBehavior"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("none")
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let p = state
+            .origin_request_policies
+            .get_mut(&id)
+            .ok_or_else(|| format!("Origin request policy {id} not yet provisioned"))?;
+        p.config = OriginRequestPolicyConfig {
+            comment,
+            name,
+            headers_config: OriginRequestPolicyHeadersConfig {
+                header_behavior,
+                headers: None,
+            },
+            cookies_config: OriginRequestPolicyCookiesConfig {
+                cookie_behavior,
+                cookies: None,
+            },
+            query_strings_config: OriginRequestPolicyQueryStringsConfig {
+                query_string_behavior,
+                query_strings: None,
+            },
+        };
+        p.etag = etag;
+        p.last_modified_time = Utc::now();
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    pub(crate) fn update_cf_response_headers_policy(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("ResponseHeadersPolicyConfig")
+            .ok_or("ResponseHeadersPolicyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("ResponseHeadersPolicyConfig.Name is required")?
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let p = state
+            .response_headers_policies
+            .get_mut(&id)
+            .ok_or_else(|| format!("Response headers policy {id} not yet provisioned"))?;
+        p.config = ResponseHeadersPolicyConfig {
+            comment,
+            name,
+            cors_config: None,
+            security_headers_config: None,
+            server_timing_headers_config: None,
+            custom_headers_config: None,
+            remove_headers_config: None,
+        };
+        p.etag = etag;
+        p.last_modified_time = Utc::now();
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1978,6 +1978,15 @@ impl ResourceProvisioner {
             "AWS::CloudFront::Distribution" => {
                 Some(self.update_cf_distribution(existing, new_def)?)
             }
+            // In-place updates: reprovision would churn the random policy id that
+            // a Distribution stores as DefaultCacheBehavior.*PolicyId.
+            "AWS::CloudFront::CachePolicy" => Some(self.update_cf_cache_policy(existing, new_def)?),
+            "AWS::CloudFront::OriginRequestPolicy" => {
+                Some(self.update_cf_origin_request_policy(existing, new_def)?)
+            }
+            "AWS::CloudFront::ResponseHeadersPolicy" => {
+                Some(self.update_cf_response_headers_policy(existing, new_def)?)
+            }
             // In-place updates: reprovision would churn the vpc-/subnet-/rtb- id
             // and orphan every child/sibling that references it (subnets, SGs,
             // route tables, routes, associations, instances, ENIs).
@@ -5128,6 +5137,81 @@ mod tests {
                 .map(|c| c.association_count),
             Some(3),
             "association_count preserved (not reset by reprovision)"
+        );
+    }
+
+    #[test]
+    fn cloudfront_policy_updates_preserve_ids() {
+        // bug-audit 2026-07-27 (cycle 6): reprovision churned the random policy id
+        // that a Distribution stores as DefaultCacheBehavior.*PolicyId. Updates
+        // must be in place.
+        let prov = make_provisioner();
+        let cp = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::CachePolicy",
+                "CP",
+                serde_json::json!({"CachePolicyConfig": {"Name": "cp", "MinTTL": 100}}),
+            ))
+            .expect("cache policy provisions");
+        let cp_id = cp.physical_id.clone();
+        let cp_up = prov
+            .update_resource(
+                &cp,
+                &make_resource(
+                    "AWS::CloudFront::CachePolicy",
+                    "CP",
+                    serde_json::json!({"CachePolicyConfig": {"Name": "cp", "MinTTL": 200}}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(cp_up.physical_id, cp_id, "cache policy id preserved");
+
+        let orp = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::OriginRequestPolicy",
+                "ORP",
+                serde_json::json!({"OriginRequestPolicyConfig": {"Name": "orp",
+                    "HeadersConfig": {"HeaderBehavior": "none"},
+                    "CookiesConfig": {"CookieBehavior": "none"},
+                    "QueryStringsConfig": {"QueryStringBehavior": "none"}}}),
+            ))
+            .expect("origin request policy provisions");
+        let orp_id = orp.physical_id.clone();
+        let orp_up = prov
+            .update_resource(
+                &orp,
+                &make_resource(
+                    "AWS::CloudFront::OriginRequestPolicy",
+                    "ORP",
+                    serde_json::json!({"OriginRequestPolicyConfig": {"Name": "orp",
+                        "HeadersConfig": {"HeaderBehavior": "allViewer"},
+                        "CookiesConfig": {"CookieBehavior": "none"},
+                        "QueryStringsConfig": {"QueryStringBehavior": "none"}}}),
+                ),
+            )
+            .expect("update ok")
+            .expect("updatable");
+        assert_eq!(
+            orp_up.physical_id, orp_id,
+            "origin request policy id preserved"
+        );
+
+        let accounts = prov.cloudfront_state.read();
+        let state = accounts.get("000000000000").unwrap();
+        assert_eq!(
+            state.cache_policies.get(&cp_id).map(|p| p.config.min_ttl),
+            Some(200),
+            "cache policy config updated in place"
+        );
+        assert_eq!(
+            state.origin_request_policies.get(&orp_id).map(|p| p
+                .config
+                .headers_config
+                .header_behavior
+                .clone()),
+            Some("allViewer".to_string()),
+            "origin request policy config updated in place"
         );
     }
 


### PR DESCRIPTION
## Summary
Cycle-6 bug-hunt, Family B (CFN reprovision-on-in-place-change) round 4e. These CloudFront policies mint a random id (`CP…`/`ORP…`/`RHP…`) that a Distribution stores as `DefaultCacheBehavior.{CachePolicyId,OriginRequestPolicyId,ResponseHeadersPolicyId}`. Without an in-place update arm, a config edit reprovisioned and churned the id, dangling that reference (the Distribution isn't re-run in the same stack update). AWS updates the policy in place, so rebuild the config, preserve the id, and bump the ETag.

- **AWS::CloudFront::CachePolicy**
- **AWS::CloudFront::OriginRequestPolicy**
- **AWS::CloudFront::ResponseHeadersPolicy**

Remaining CloudFront id-churn types (KeyGroup, PublicKey, Function, OriginAccessControl) + Route53Resolver ResolverEndpoint are the last niche carry-over.

## Test plan
- New regression test: cache + origin-request policy updates keep their id and apply the config change.
- `cargo nextest run -p fakecloud-cloudformation`: 319 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CloudFront policy updates to run in-place so policy IDs don’t churn and Distribution references stay valid. Matches AWS behavior by rebuilding the config, keeping the same ID, and bumping the ETag.

- **Bug Fixes**
  - In-place UpdateStack for `AWS::CloudFront::CachePolicy`, `AWS::CloudFront::OriginRequestPolicy`, and `AWS::CloudFront::ResponseHeadersPolicy`.
  - Preserves policy Id on config changes; updates config, ETag, and LastModifiedTime.
  - Adds a regression test to ensure IDs are preserved and changes apply.

<sup>Written for commit 744b6d57ea66f705c2c190915ac1e5ddfbc82116. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

