### PR TITLE
fix(cloudformation): in-place UpdateStack for CloudFront KeyGroup/PublicKey/Function/OAC + Route53Resolver ResolverEndpoint (no id churn)

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
@@ -927,4 +927,199 @@ impl ResourceProvisioner {
         p.last_modified_time = Utc::now();
         Ok(ProvisionResult::new(id.clone()).with("Id", id))
     }
+
+    pub(crate) fn update_cf_origin_access_control(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("OriginAccessControlConfig")
+            .ok_or("OriginAccessControlConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("OriginAccessControlConfig.Name is required")?
+            .to_string();
+        let signing_protocol = cfg
+            .get("SigningProtocol")
+            .and_then(|v| v.as_str())
+            .unwrap_or("sigv4")
+            .to_string();
+        let signing_behavior = cfg
+            .get("SigningBehavior")
+            .and_then(|v| v.as_str())
+            .unwrap_or("always")
+            .to_string();
+        let origin_type = cfg
+            .get("OriginAccessControlOriginType")
+            .and_then(|v| v.as_str())
+            .ok_or("OriginAccessControlConfig.OriginAccessControlOriginType is required")?
+            .to_string();
+        let description = cfg
+            .get("Description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let oac = state
+            .origin_access_controls
+            .get_mut(&id)
+            .ok_or_else(|| format!("Origin access control {id} not yet provisioned"))?;
+        oac.config = OriginAccessControlConfig {
+            name,
+            description,
+            signing_protocol,
+            signing_behavior,
+            origin_access_control_origin_type: origin_type,
+        };
+        oac.etag = etag;
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    pub(crate) fn update_cf_public_key(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("PublicKeyConfig")
+            .ok_or("PublicKeyConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("PublicKeyConfig.Name is required")?
+            .to_string();
+        let encoded_key = cfg
+            .get("EncodedKey")
+            .and_then(|v| v.as_str())
+            .ok_or("PublicKeyConfig.EncodedKey is required")?
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let pk = state
+            .public_keys
+            .get_mut(&id)
+            .ok_or_else(|| format!("Public key {id} not yet provisioned"))?;
+        // CallerReference is immutable in CloudFront; preserve the stored one.
+        let caller_reference = pk.config.caller_reference.clone();
+        pk.config = PublicKeyConfig {
+            caller_reference,
+            name,
+            encoded_key,
+            comment,
+        };
+        pk.etag = etag;
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    pub(crate) fn update_cf_key_group(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let cfg = resource
+            .properties
+            .get("KeyGroupConfig")
+            .ok_or("KeyGroupConfig is required")?;
+        let name = cfg
+            .get("Name")
+            .and_then(|v| v.as_str())
+            .ok_or("KeyGroupConfig.Name is required")?
+            .to_string();
+        let items: Vec<String> = cfg
+            .get("Items")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let kg = state
+            .key_groups
+            .get_mut(&id)
+            .ok_or_else(|| format!("Key group {id} not yet provisioned"))?;
+        kg.config = KeyGroupConfig {
+            name,
+            items: KeyGroupItems { public_key: items },
+            comment,
+        };
+        kg.etag = etag;
+        kg.last_modified_time = Utc::now();
+        Ok(ProvisionResult::new(id.clone()).with("Id", id))
+    }
+
+    pub(crate) fn update_cf_function(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        let props = &resource.properties;
+        let function_code = props
+            .get("FunctionCode")
+            .and_then(|v| v.as_str())
+            .ok_or("FunctionCode is required")?
+            .to_string();
+        let cfg = props
+            .get("FunctionConfig")
+            .ok_or("FunctionConfig is required")?;
+        let runtime = cfg
+            .get("Runtime")
+            .and_then(|v| v.as_str())
+            .unwrap_or("cloudfront-js-2.0")
+            .to_string();
+        let comment = cfg
+            .get("Comment")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let etag = format!("E{}", fakecloud_core::ids::short_id(7).to_uppercase());
+
+        // Functions are keyed by Name (== physical id). Name is the resource
+        // identifier, so an in-place update mutates the dev-stage code + config
+        // and preserves the ARN Ref/GetAtt targets. A Name change would fall
+        // back to replacement through the generic path.
+        let id = existing.physical_id.clone();
+        let mut accounts = self.cloudfront_state.write();
+        let state = accounts.entry("000000000000");
+        let func = state
+            .functions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Function {id} not yet provisioned"))?;
+        func.config = FunctionConfig {
+            comment,
+            runtime,
+            key_value_store_associations: func.config.key_value_store_associations.clone(),
+        };
+        func.function_code = function_code;
+        func.status = "UNPUBLISHED".to_string();
+        func.stage = "DEVELOPMENT".to_string();
+        func.etag = etag;
+        func.last_modified_time = Utc::now();
+        let function_arn = func.function_arn.clone();
+        Ok(ProvisionResult::new(id.clone())
+            .with("FunctionARN", function_arn)
+            .with("Stage", "DEVELOPMENT"))
+    }
 }

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -1933,6 +1933,9 @@ impl ResourceProvisioner {
             }
             // In-place updates: reprovision would churn the random rslvr-* id,
             // dangling sibling associations / rules that reference it.
+            "AWS::Route53Resolver::ResolverEndpoint" => {
+                Some(self.update_r53r_resolver_endpoint(existing, new_def)?)
+            }
             "AWS::Route53Resolver::ResolverRule" => {
                 Some(self.update_r53r_resolver_rule(existing, new_def)?)
             }
@@ -1987,6 +1990,15 @@ impl ResourceProvisioner {
             "AWS::CloudFront::ResponseHeadersPolicy" => {
                 Some(self.update_cf_response_headers_policy(existing, new_def)?)
             }
+            // In-place updates: reprovision would churn the random id these
+            // types mint, dangling a Distribution's TrustedKeyGroups /
+            // FunctionAssociations / OAC reference or a KeyGroup's key-id list.
+            "AWS::CloudFront::OriginAccessControl" => {
+                Some(self.update_cf_origin_access_control(existing, new_def)?)
+            }
+            "AWS::CloudFront::PublicKey" => Some(self.update_cf_public_key(existing, new_def)?),
+            "AWS::CloudFront::KeyGroup" => Some(self.update_cf_key_group(existing, new_def)?),
+            "AWS::CloudFront::Function" => Some(self.update_cf_function(existing, new_def)?),
             // In-place updates: reprovision would churn the vpc-/subnet-/rtb- id
             // and orphan every child/sibling that references it (subnets, SGs,
             // route tables, routes, associations, instances, ENIs).
@@ -5212,6 +5224,179 @@ mod tests {
                 .clone()),
             Some("allViewer".to_string()),
             "origin request policy config updated in place"
+        );
+    }
+
+    #[test]
+    fn cloudfront_keygroup_family_updates_preserve_ids() {
+        // bug-audit 2026-07-27 (cycle 6) tail: KeyGroup / PublicKey / Function /
+        // OriginAccessControl mint a random id referenced by a Distribution's
+        // TrustedKeyGroups / FunctionAssociations / OAC. A config edit must
+        // update in place, not churn the id.
+        let prov = make_provisioner();
+
+        let pk = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::PublicKey",
+                "PK",
+                serde_json::json!({"PublicKeyConfig": {"Name": "pk", "EncodedKey": "-----KEY-----",
+                    "CallerReference": "cr-1", "Comment": "v1"}}),
+            ))
+            .expect("public key provisions");
+        let pk_id = pk.physical_id.clone();
+        let pk_up = prov
+            .update_resource(
+                &pk,
+                &make_resource(
+                    "AWS::CloudFront::PublicKey",
+                    "PK",
+                    serde_json::json!({"PublicKeyConfig": {"Name": "pk", "EncodedKey": "-----KEY-----",
+                        "CallerReference": "cr-1", "Comment": "v2"}}),
+                ),
+            )
+            .expect("pk update ok")
+            .expect("updatable");
+        assert_eq!(pk_up.physical_id, pk_id, "public key id preserved");
+
+        let kg = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::KeyGroup",
+                "KG",
+                serde_json::json!({"KeyGroupConfig": {"Name": "kg", "Items": [pk_id.clone()]}}),
+            ))
+            .expect("key group provisions");
+        let kg_id = kg.physical_id.clone();
+        let kg_up = prov
+            .update_resource(
+                &kg,
+                &make_resource(
+                    "AWS::CloudFront::KeyGroup",
+                    "KG",
+                    serde_json::json!({"KeyGroupConfig": {"Name": "kg2", "Items": [pk_id.clone()]}}),
+                ),
+            )
+            .expect("kg update ok")
+            .expect("updatable");
+        assert_eq!(kg_up.physical_id, kg_id, "key group id preserved");
+
+        let oac = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::OriginAccessControl",
+                "OAC",
+                serde_json::json!({"OriginAccessControlConfig": {"Name": "oac",
+                    "OriginAccessControlOriginType": "s3", "SigningBehavior": "always",
+                    "SigningProtocol": "sigv4"}}),
+            ))
+            .expect("oac provisions");
+        let oac_id = oac.physical_id.clone();
+        let oac_up = prov
+            .update_resource(
+                &oac,
+                &make_resource(
+                    "AWS::CloudFront::OriginAccessControl",
+                    "OAC",
+                    serde_json::json!({"OriginAccessControlConfig": {"Name": "oac",
+                        "OriginAccessControlOriginType": "s3", "SigningBehavior": "never",
+                        "SigningProtocol": "sigv4"}}),
+                ),
+            )
+            .expect("oac update ok")
+            .expect("updatable");
+        assert_eq!(oac_up.physical_id, oac_id, "oac id preserved");
+
+        let func = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::Function",
+                "FN",
+                serde_json::json!({"Name": "fn1", "FunctionCode": "function handler(){}",
+                    "FunctionConfig": {"Runtime": "cloudfront-js-2.0", "Comment": "v1"}}),
+            ))
+            .expect("function provisions");
+        let fn_id = func.physical_id.clone();
+        let fn_up = prov
+            .update_resource(
+                &func,
+                &make_resource(
+                    "AWS::CloudFront::Function",
+                    "FN",
+                    serde_json::json!({"Name": "fn1", "FunctionCode": "function handler(){return 2;}",
+                        "FunctionConfig": {"Runtime": "cloudfront-js-2.0", "Comment": "v2"}}),
+                ),
+            )
+            .expect("fn update ok")
+            .expect("updatable");
+        assert_eq!(fn_up.physical_id, fn_id, "function id preserved");
+
+        let accounts = prov.cloudfront_state.read();
+        let state = accounts.get("000000000000").unwrap();
+        assert_eq!(
+            state
+                .public_keys
+                .get(&pk_id)
+                .and_then(|p| p.config.comment.clone()),
+            Some("v2".to_string()),
+            "public key comment updated in place"
+        );
+        assert_eq!(
+            state.key_groups.get(&kg_id).map(|g| g.config.name.clone()),
+            Some("kg2".to_string()),
+            "key group name updated in place"
+        );
+        assert_eq!(
+            state
+                .origin_access_controls
+                .get(&oac_id)
+                .map(|o| o.config.signing_behavior.clone()),
+            Some("never".to_string()),
+            "oac signing behavior updated in place"
+        );
+        assert_eq!(
+            state.functions.get(&fn_id).map(|f| f.function_code.clone()),
+            Some("function handler(){return 2;}".to_string()),
+            "function code updated in place"
+        );
+    }
+
+    #[test]
+    fn route53resolver_endpoint_update_preserves_id() {
+        // bug-audit 2026-07-27 (cycle 6) tail: reprovision churned the
+        // rslvr-*-id that sibling ResolverRule.ResolverEndpointId references.
+        // Name/Protocols edits must apply in place.
+        let prov = make_provisioner();
+        let ep = prov
+            .create_resource(&make_resource(
+                "AWS::Route53Resolver::ResolverEndpoint",
+                "EP",
+                serde_json::json!({"Direction": "OUTBOUND", "Name": "ep1",
+                    "SecurityGroupIds": ["sg-1"],
+                    "IpAddresses": [{"SubnetId": "subnet-1", "Ip": "10.0.0.5"}]}),
+            ))
+            .expect("endpoint provisions");
+        let ep_id = ep.physical_id.clone();
+        let ep_up = prov
+            .update_resource(
+                &ep,
+                &make_resource(
+                    "AWS::Route53Resolver::ResolverEndpoint",
+                    "EP",
+                    serde_json::json!({"Direction": "OUTBOUND", "Name": "ep2",
+                        "SecurityGroupIds": ["sg-1"],
+                        "Protocols": ["Do53", "DoH"],
+                        "IpAddresses": [{"SubnetId": "subnet-1", "Ip": "10.0.0.5"}]}),
+                ),
+            )
+            .expect("endpoint update ok")
+            .expect("updatable");
+        assert_eq!(ep_up.physical_id, ep_id, "resolver endpoint id preserved");
+
+        let st = prov.route53resolver_state.read();
+        let acc = st.accounts.get(&prov.account_id).unwrap();
+        let rec = acc.endpoints.get(&ep_id).unwrap();
+        assert_eq!(rec.endpoint.name.as_deref(), Some("ep2"), "name updated");
+        assert_eq!(
+            rec.endpoint.protocols,
+            vec!["Do53".to_string(), "DoH".to_string()],
+            "protocols updated in place"
         );
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/route53resolver.rs
@@ -317,6 +317,83 @@ impl ResourceProvisioner {
             .with("Name", name_att))
     }
 
+    pub(super) fn update_r53r_resolver_endpoint(
+        &self,
+        existing: &StackResource,
+        resource: &ResourceDefinition,
+    ) -> Result<ProvisionResult, String> {
+        // In-place mutate the fields AWS's UpdateResolverEndpoint touches
+        // (Name / ResolverEndpointType / Protocols / PreferredInstanceType +
+        // the metric/DNS64 toggles). Direction, SecurityGroupIds, IpAddresses
+        // and the host VPC are immutable/replace-only, so preserve them along
+        // with the id/arn — reprovision would churn the rslvr-*-id that sibling
+        // ResolverRule.ResolverEndpointId / associations reference.
+        let props = &resource.properties;
+        let id = existing.physical_id.clone();
+        let name = props.get("Name").and_then(|v| v.as_str()).map(String::from);
+        let tags = self.r53r_tags(props);
+        let (arn, ip_count, direction, host_vpc) = {
+            let mut st = self.route53resolver_state.write();
+            let acc = st.account_mut(&self.account_id);
+            let rec = acc
+                .endpoints
+                .get_mut(&id)
+                .ok_or_else(|| format!("Resolver endpoint {id} not yet provisioned"))?;
+            rec.endpoint.name = name.clone();
+            if let Some(t) = props.get("ResolverEndpointType").and_then(|v| v.as_str()) {
+                rec.endpoint.resolver_endpoint_type = t.to_string();
+            }
+            if let Some(p) = props.get("Protocols").and_then(|v| v.as_array()) {
+                rec.endpoint.protocols = p
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+            }
+            if let Some(v) = props.get("PreferredInstanceType").and_then(|v| v.as_str()) {
+                rec.endpoint.preferred_instance_type = Some(v.to_string());
+            }
+            if let Some(b) = props.get("Dns64Enabled").and_then(|v| v.as_bool()) {
+                rec.endpoint.dns64_enabled = Some(b);
+            }
+            if let Some(b) = props
+                .get("Ipv6InternetAccessEnabled")
+                .and_then(|v| v.as_bool())
+            {
+                rec.endpoint.ipv6_internet_access_enabled = Some(b);
+            }
+            if let Some(b) = props
+                .get("RniEnhancedMetricsEnabled")
+                .and_then(|v| v.as_bool())
+            {
+                rec.endpoint.rni_enhanced_metrics_enabled = Some(b);
+            }
+            if let Some(b) = props
+                .get("TargetNameServerMetricsEnabled")
+                .and_then(|v| v.as_bool())
+            {
+                rec.endpoint.target_name_server_metrics_enabled = Some(b);
+            }
+            rec.endpoint.modification_time = now_rfc3339();
+            let arn = rec.endpoint.arn.clone();
+            let ip_count = rec.endpoint.ip_address_count;
+            let direction = rec.endpoint.direction.clone();
+            let host_vpc = rec.endpoint.host_vpc_id.clone();
+            if tags.is_empty() {
+                acc.tags.remove(&arn);
+            } else {
+                acc.tags.insert(arn.clone(), tags);
+            }
+            (arn, ip_count, direction, host_vpc)
+        };
+        Ok(ProvisionResult::new(id.clone())
+            .with("Arn", arn)
+            .with("ResolverEndpointId", id)
+            .with("IpAddressCount", ip_count.to_string())
+            .with("Direction", direction)
+            .with("HostVPCId", host_vpc)
+            .with("Name", name.unwrap_or_default()))
+    }
+
     pub(super) fn delete_r53r_resolver_endpoint(&self, physical_id: &str) -> Result<(), String> {
         let mut st = self.route53resolver_state.write();
         if let Some(acc) = st.accounts.get_mut(&self.account_id) {


### PR DESCRIPTION
## Summary
Final tail of the cycle-6 CFN reprovision-on-in-place-change (Family B) sweep. Each of these types mints a random id a sibling resource stores as a back-reference:

- **CloudFront PublicKey** (`K…`) -> KeyGroup.Items
- **CloudFront KeyGroup** (`KG…`) -> Distribution TrustedKeyGroups
- **CloudFront Function** (fn name) -> Distribution DefaultCacheBehavior.FunctionAssociations
- **CloudFront OriginAccessControl** -> Origin.OriginAccessControlId
- **Route53Resolver ResolverEndpoint** (`rslvr-*`) -> ResolverRule.ResolverEndpointId / associations

Without an in-place update arm, a config edit fell through to `reprovision`, churning the id and dangling the back-reference (the referencing resource isn't re-run in the same stack update). AWS updates each in place, so rebuild the config, preserve the id, bump the ETag/modification time. ResolverEndpoint mutates only the `UpdateResolverEndpoint`-mutable fields (Name/ResolverEndpointType/Protocols/PreferredInstanceType + metric toggles) and preserves the immutable Direction/SecurityGroupIds/IpAddresses/HostVPCId.

Completes the CFN id-churn family — no reprovision-fallthrough id-minting CFN types remain.

## Test plan
- New regression tests: `cloudfront_keygroup_family_updates_preserve_ids`, `route53resolver_endpoint_update_preserves_id` — ids preserved + config applied.
- `cargo nextest run -p fakecloud-cloudformation`: 321 passed, 0 failed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface -> no SDK/doc changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements in-place UpdateStack for CloudFront KeyGroup/PublicKey/Function/OriginAccessControl and Route53Resolver ResolverEndpoint. Prevents ID churn and dangling back-references on config changes.

- **Bug Fixes**
  - `AWS::CloudFront::PublicKey`: updates `PublicKeyConfig` in place; preserves `K…` id and caller reference; bumps ETag.
  - `AWS::CloudFront::KeyGroup`: updates `KeyGroupConfig` in place; preserves `KG…` id; bumps ETag/last modified.
  - `AWS::CloudFront::Function`: updates code and `FunctionConfig` for the same Name; preserves id/ARN; sets stage to DEVELOPMENT and status to UNPUBLISHED; bumps ETag/last modified.
  - `AWS::CloudFront::OriginAccessControl`: updates config in place; preserves id; bumps ETag.
  - `AWS::Route53Resolver::ResolverEndpoint`: updates allowed fields (`Name`, `ResolverEndpointType`, `Protocols`, `PreferredInstanceType`, metric toggles); preserves Direction/SecurityGroupIds/IpAddresses/HostVPCId and `rslvr-*` id; updates tags and modification time.

<sup>Written for commit cb7d07dddc83156065daccf823fec5e743f3c25b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

