### PR TITLE
fix(cloudformation): implement Fn::GetAZs + strip Fn::Sub ${!} literal escape

### DIFF
--- a/crates/fakecloud-cloudformation/src/template/intrinsics.rs
+++ b/crates/fakecloud-cloudformation/src/template/intrinsics.rs
@@ -346,6 +346,39 @@ pub(super) fn resolve_refs_full(
                     }
                 }
             }
+            // Fn::GetAZs: the availability zones for a region. The argument is
+            // usually the empty string (meaning the stack's region), but may be
+            // an explicit region literal or `{"Ref":"AWS::Region"}`. Real CFN
+            // returns the region's AZ list; without this arm the object fell
+            // through unresolved and the ubiquitous `!Select [0, !GetAZs ""]`
+            // idiom yielded null (Select got an object, not an array). Matches
+            // DescribeAvailabilityZones' a/b/c set.
+            if let Some(azs_val) = map.get("Fn::GetAZs") {
+                let resolved = resolve_refs_full(
+                    azs_val,
+                    parameters,
+                    _resources,
+                    resource_physical_ids,
+                    resource_attributes,
+                    imports,
+                    conditions,
+                );
+                let region = match &resolved {
+                    Value::String(s) if !s.is_empty() => s.clone(),
+                    _ => parameters.get("AWS::Region").cloned().unwrap_or_default(),
+                };
+                let region = if region.is_empty() {
+                    "us-east-1".to_string()
+                } else {
+                    region
+                };
+                return Value::Array(
+                    ["a", "b", "c"]
+                        .iter()
+                        .map(|s| Value::String(format!("{region}{s}")))
+                        .collect(),
+                );
+            }
             // Fn::Select: pick element at index from an array. Args:
             // [index, list]. The list may itself be an Fn::Split / Ref.
             if let Some(sel_val) = map.get("Fn::Select") {
@@ -546,6 +579,14 @@ pub(super) fn resolve_refs_full(
                             result = result.replace(&format!("${{{logical}.{attr}}}"), value);
                         }
                     }
+                    // 6. Unescape `${!Literal}` -> `${Literal}`. `${!` is CFN's
+                    //    escape for a literal `${`, so these were deliberately
+                    //    never substituted above (the leading `!` prevents any
+                    //    key match); strip the `!` now. Without this the escape
+                    //    leaked through verbatim and corrupted IAM policy
+                    //    variables (`${!aws:username}` stayed literal instead of
+                    //    rendering `${aws:username}`).
+                    result = result.replace("${!", "${");
                     return Value::String(result);
                 }
             }

--- a/crates/fakecloud-cloudformation/src/template/mod.rs
+++ b/crates/fakecloud-cloudformation/src/template/mod.rs
@@ -817,6 +817,51 @@ Resources:
     }
 
     #[test]
+    fn fn_getazs_returns_region_azs() {
+        // bug-audit 2026-07-28 (cycle 7) C1: Fn::GetAZs was unimplemented, so
+        // the canonical `!Select [0, !GetAZs ""]` subnet idiom fed Select an
+        // object and yielded null. GetAZs must resolve to the region's AZ list.
+        let (mut p, r, ids, attrs) = empty();
+        p.insert("AWS::Region".to_string(), "us-west-2".to_string());
+        let v: Value = serde_json::from_str(r#"{"Fn::GetAZs": ""}"#).unwrap();
+        assert_eq!(
+            resolve_refs(&v, &p, &r, &ids, &attrs),
+            serde_json::json!(["us-west-2a", "us-west-2b", "us-west-2c"])
+        );
+        // The ubiquitous Select-over-GetAZs pattern now resolves.
+        let sel: Value =
+            serde_json::from_str(r#"{"Fn::Select": [1, {"Fn::GetAZs": ""}]}"#).unwrap();
+        assert_eq!(
+            resolve_refs(&sel, &p, &r, &ids, &attrs),
+            Value::String("us-west-2b".to_string())
+        );
+    }
+
+    #[test]
+    fn fn_getazs_explicit_region() {
+        let (p, r, ids, attrs) = empty();
+        let v: Value = serde_json::from_str(r#"{"Fn::GetAZs": "eu-west-1"}"#).unwrap();
+        assert_eq!(
+            resolve_refs(&v, &p, &r, &ids, &attrs),
+            serde_json::json!(["eu-west-1a", "eu-west-1b", "eu-west-1c"])
+        );
+    }
+
+    #[test]
+    fn fn_sub_unescapes_literal_variable() {
+        // bug-audit 2026-07-28 (cycle 7) C2: `${!X}` is CFN's escape for a
+        // literal `${X}` (used to protect IAM policy variables). The render loop
+        // never stripped the `!`, corrupting the policy variable. `${!X}` must
+        // render `${X}`.
+        let (p, r, ids, attrs) = empty();
+        let v: Value = serde_json::from_str(r#"{"Fn::Sub": "arn ${!aws:username} end"}"#).unwrap();
+        assert_eq!(
+            resolve_refs(&v, &p, &r, &ids, &attrs),
+            Value::String("arn ${aws:username} end".to_string())
+        );
+    }
+
+    #[test]
     fn fn_length_counts_array() {
         let (p, r, ids, attrs) = empty();
         let v: Value = serde_json::from_str(r#"{"Fn::Length": [1,2,3,4]}"#).unwrap();


### PR DESCRIPTION
## Summary
Cycle-7 bug-hunt **C1 (HIGH) + C2 (MED)**, CFN intrinsic-function fidelity.

**C1 — `Fn::GetAZs` was unimplemented.** `resolve_refs_full` had no arm for it, so `{"Fn::GetAZs":""}` returned unresolved and the ubiquitous VPC idiom `!Select [0, !GetAZs ""]` fed `Fn::Select` an object (not an array) → `Value::Null`. Every subnet/instance AZ derived from that pattern provisioned null. Now resolves to the region AZ list (a/b/c, matching `DescribeAvailabilityZones`); region comes from the GetAZs arg, else the `AWS::Region` pseudo-param, else `us-east-1`.

**C2 — `Fn::Sub` didn't strip the `${!Literal}` escape.** The ref-collection edge-detects `${!X}` and skips it, but the render loop never converted it, so `${!aws:username}` was emitted verbatim instead of `${aws:username}` — corrupting IAM policy variables in Sub-rendered policy documents. Added a final unescape step (`${!` → `${`) after all real substitutions.

## Test plan
- New: `fn_getazs_returns_region_azs` (+ Select-over-GetAZs), `fn_getazs_explicit_region`, `fn_sub_unescapes_literal_variable`.
- `cargo nextest run -p fakecloud-cloudformation`: 324 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `Fn::GetAZs` resolution and fixes `${!}` escape handling in `Fn::Sub` to align with CloudFormation. Restores valid AZ selection and corrects rendering of IAM policy variables.

- **Bug Fixes**
  - `Fn::GetAZs` now returns the region’s AZs as `[{region}a, {region}b, {region}c]`; region comes from the arg, else `AWS::Region`, else `us-east-1`. This makes `!Select [i, !GetAZs ""]` work as expected.
  - `Fn::Sub` now unescapes `${!...}` to `${...}` after substitutions, so literals like `${aws:username}` render correctly.

<sup>Written for commit faec7fdb4fd0b341648c7db87b8ba092e4b264ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

