### PR TITLE
fix(sns): apply exists:false + String.Array semantics inside $or filter policies

### DIFF
--- a/crates/fakecloud-sns/src/helpers.rs
+++ b/crates/fakecloud-sns/src/helpers.rs
@@ -768,6 +768,53 @@ pub(crate) fn validate_sms_endpoint(endpoint: &str) -> Result<(), AwsServiceErro
     Ok(())
 }
 
+/// Match a single filter-policy key's rule set against the message attributes,
+/// applying the full MessageAttributes-scope semantics: `exists:false` on an
+/// absent attribute, per-element matching for a `String.Array` attribute, and
+/// type-aware numeric matching. Shared by the top-level policy loop and the
+/// `$or` alternatives so both paths behave identically (before this existed the
+/// `$or` branch only did a plain string+typed lookup and silently dropped
+/// messages that should have matched via `exists:false` or a `String.Array`).
+fn attr_key_matches(
+    allowed_values: &Value,
+    key: &str,
+    message_attributes: &BTreeMap<String, MessageAttribute>,
+) -> bool {
+    // A non-array rule imposes no constraint (mirrors the loop's `continue`).
+    let allowed = match allowed_values.as_array() {
+        Some(arr) => arr,
+        None => return true,
+    };
+    let msg_attr = match message_attributes.get(key) {
+        Some(a) => a,
+        // Absent attribute matches only an explicit `exists:false`.
+        None => {
+            return allowed.iter().any(|v| {
+                v.as_object()
+                    .and_then(|o| o.get("exists"))
+                    .and_then(|e| e.as_bool())
+                    == Some(false)
+            });
+        }
+    };
+    let attr_value = msg_attr.string_value.as_deref().unwrap_or("");
+    let is_numeric_type = msg_attr.data_type == "Number";
+    // String.Array: match if any element satisfies the rule set.
+    if msg_attr.data_type.starts_with("String.Array") {
+        if let Ok(arr) = serde_json::from_str::<Vec<Value>>(attr_value) {
+            return arr.iter().any(|elem| {
+                let elem_str = match elem {
+                    Value::String(s) => s.clone(),
+                    Value::Number(n) => n.to_string(),
+                    _ => elem.to_string(),
+                };
+                check_filter_values(allowed, &elem_str)
+            });
+        }
+    }
+    check_filter_values_typed(allowed, attr_value, Some(is_numeric_type))
+}
+
 /// Check if a message's attributes match the subscription's FilterPolicy.
 pub(crate) fn matches_filter_policy(
     sub: &SnsSubscription,
@@ -796,35 +843,16 @@ pub(crate) fn matches_filter_policy(
 
     // MessageAttributes scope
     for (attr_name, allowed_values) in &filter {
-        // Handle $or operator
+        // $or: at least one alternative (a mini filter policy) must match, each
+        // evaluated through the same per-key semantics as a top-level key.
         if attr_name == "$or" {
             if let Some(or_conditions) = allowed_values.as_array() {
                 let any_match = or_conditions.iter().any(|condition| {
-                    if let Some(cond_obj) = condition.as_object() {
-                        let cond_map: HashMap<String, Value> = cond_obj
+                    condition.as_object().is_some_and(|cond_obj| {
+                        cond_obj
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect();
-                        // Each condition in $or is a mini filter policy
-                        cond_map.iter().all(|(key, vals)| {
-                            if let Some(arr) = vals.as_array() {
-                                if let Some(msg_attr) = message_attributes.get(key) {
-                                    let val = msg_attr.string_value.as_deref().unwrap_or("");
-                                    // Type-aware, matching the non-$or path: a
-                                    // numeric filter must not match a string
-                                    // attribute (and vice versa).
-                                    let is_numeric_type = msg_attr.data_type == "Number";
-                                    check_filter_values_typed(arr, val, Some(is_numeric_type))
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            }
-                        })
-                    } else {
-                        false
-                    }
+                            .all(|(key, vals)| attr_key_matches(vals, key, message_attributes))
+                    })
                 });
                 if !any_match {
                     return false;
@@ -833,50 +861,7 @@ pub(crate) fn matches_filter_policy(
             }
         }
 
-        let allowed = match allowed_values.as_array() {
-            Some(arr) => arr,
-            None => continue,
-        };
-
-        let msg_attr = match message_attributes.get(attr_name) {
-            Some(a) => a,
-            None => {
-                let has_exists_false = allowed.iter().any(|v| {
-                    v.as_object()
-                        .and_then(|o| o.get("exists"))
-                        .and_then(|e| e.as_bool())
-                        == Some(false)
-                });
-                if has_exists_false {
-                    continue;
-                }
-                return false;
-            }
-        };
-
-        let attr_value = msg_attr.string_value.as_deref().unwrap_or("");
-        let is_numeric_type = msg_attr.data_type == "Number";
-
-        // Handle String.Array data type: parse the JSON array and check each element
-        if msg_attr.data_type.starts_with("String.Array") || msg_attr.data_type == "String.Array" {
-            if let Ok(arr) = serde_json::from_str::<Vec<Value>>(attr_value) {
-                let any_match = arr.iter().any(|elem| {
-                    let elem_str = match elem {
-                        Value::String(s) => s.clone(),
-                        Value::Number(n) => n.to_string(),
-                        _ => elem.to_string(),
-                    };
-                    check_filter_values(allowed, &elem_str)
-                });
-                if !any_match {
-                    return false;
-                }
-                continue;
-            }
-        }
-
-        let matched = check_filter_values_typed(allowed, attr_value, Some(is_numeric_type));
-        if !matched {
+        if !attr_key_matches(allowed_values, attr_name, message_attributes) {
             return false;
         }
     }
@@ -1690,6 +1675,45 @@ mod filter_consistency_tests {
         let mut string_attrs = BTreeMap::new();
         string_attrs.insert("price".to_string(), str_attr("100"));
         assert!(!matches_filter_policy(&sub, &string_attrs, ""));
+    }
+
+    #[test]
+    fn or_branch_applies_exists_false_and_string_array() {
+        // bug-audit 2026-07-28 (cycle 7) S1: the $or branch resolved each key
+        // only via a plain get()+typed check, so it dropped messages that match
+        // via `exists:false` (absent attr) or a String.Array element. Both must
+        // work identically to the top-level path.
+
+        // exists:false alternative — message has no `x`, should match.
+        let policy = json!({ "$or": [ { "x": [{"exists": false}] }, { "y": ["b"] } ] });
+        let sub = sub_with_filter(policy);
+        let mut attrs = BTreeMap::new();
+        attrs.insert("y".to_string(), str_attr("a")); // y != "b", but x is absent
+        assert!(
+            matches_filter_policy(&sub, &attrs, ""),
+            "absent x should satisfy exists:false alternative"
+        );
+
+        // String.Array alternative — `tags` is a String.Array containing "red".
+        let policy2 = json!({ "$or": [ { "tags": ["red"] }, { "kind": ["z"] } ] });
+        let sub2 = sub_with_filter(policy2);
+        let arr_attr = MessageAttribute {
+            data_type: "String.Array".to_string(),
+            string_value: Some(r#"["red","blue"]"#.to_string()),
+            binary_value: None,
+        };
+        let mut attrs2 = BTreeMap::new();
+        attrs2.insert("tags".to_string(), arr_attr);
+        assert!(
+            matches_filter_policy(&sub2, &attrs2, ""),
+            "String.Array element `red` should satisfy the $or alternative"
+        );
+
+        // Negative control: neither alternative satisfied -> no match.
+        let mut attrs3 = BTreeMap::new();
+        attrs3.insert("y".to_string(), str_attr("a"));
+        attrs3.insert("x".to_string(), str_attr("present")); // x exists -> exists:false fails
+        assert!(!matches_filter_policy(&sub, &attrs3, ""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cycle-7 bug-hunt **S1 (MED)**. In the default MessageAttributes scope, the `$or` branch of `matches_filter_policy` resolved each alternative key only via `message_attributes.get(key)` + a plain typed check: it hard-failed an absent attribute and fed a `String.Array` attribute value (raw JSON-array string) straight into the matcher. So it silently **dropped** messages that should have matched an `$or` alternative via `exists:false` (attribute absent) or a `String.Array` element — both of which the top-level (non-`$or`) path already handled on a separate code path.

## Fix
Extract the full per-key semantics (`exists:false` on absent attr, `String.Array` per-element match, type-aware numeric) into a shared `attr_key_matches()` and route **both** the top-level loop and every `$or` alternative through it, so the two paths behave identically.

## Test plan
- New `or_branch_applies_exists_false_and_string_array`: `$or` with an `exists:false` alternative (absent attr) and a `String.Array` alternative both deliver, plus a negative control. Existing `or_branch_is_type_aware` still passes.
- `cargo nextest run -p fakecloud-sns`: 231 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No API surface change → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SNS filter policy `$or` evaluation to match top-level semantics: supports `exists:false` for missing attributes and per-element matching for `String.Array`, preventing valid messages from being dropped.

- **Bug Fixes**
  - Introduced shared `attr_key_matches()` and used it in both the top-level and `$or` paths of `matches_filter_policy`.
  - Applies `exists:false` on absent attrs, per-element `String.Array` matching, and type-aware numeric checks in `$or`.
  - Added `or_branch_applies_exists_false_and_string_array` test; no API or docs changes.

<sup>Written for commit 69da0361df4fc1eef96e8941a2bfb508023a3e5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

