### PR TITLE
fix(dotnet): bump FakeCloud.csproj to 0.44.8 (release version parity)

### DIFF
--- a/sdks/dotnet/src/FakeCloud/FakeCloud.csproj
+++ b/sdks/dotnet/src/FakeCloud/FakeCloud.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>FakeCloud</AssemblyName>
 
     <PackageId>FakeCloud</PackageId>
-    <Version>0.44.7</Version>
+    <Version>0.44.8</Version>
     <Authors>fakecloud contributors</Authors>
     <Description>C#/.NET client SDK for fakecloud, a local AWS cloud emulator. Provides typed access to the fakecloud introspection and simulation API for test assertions.</Description>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
The v0.44.8 release bump missed `sdks/dotnet/src/FakeCloud/FakeCloud.csproj` (`<Version>` stayed 0.44.7), so `release.yml`'s **Publish NuGet** job failed its tag-vs-csproj guard: `Tag v0.44.8 does not match FakeCloud.csproj version 0.44.7`. The .NET SDK (7th SDK, #2393) was added after the release bump-list was last revised, so its version file wasn't in the swept set.

This brings `csproj` to 0.44.8 so main matches the released workspace version and the **next** release publishes .NET correctly. The v0.44.8 tag is frozen at the old csproj, so .NET publishing resumes at the next version; the other six registries published 0.44.8 normally.

Follow-up (outside this PR): the `fc-release` skill's canonical bump list is updated to include the dotnet csproj so this can't recur.

## Test plan
- Version-string-only change; no code. release-tooling / CI green.
- Confirms `sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p'` now yields 0.44.8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `sdks/dotnet/src/FakeCloud/FakeCloud.csproj` version to 0.44.8 to match the v0.44.8 release and satisfy the tag-vs-csproj check. Ensures the .NET SDK publishes correctly on the next release.

<sup>Written for commit 1091fb873fe156be2be6db3d25c029ab4cc66e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

