### PR TITLE
fix(cloudformation): persist Glue Table schema, CloudFront Distribution extras, real SFN RevisionId

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/cloudfront.rs
@@ -53,16 +53,115 @@ impl ResourceProvisioner {
         Ok(())
     }
 
+    /// Translate the CFN-flat `DistributionConfig` members that the create /
+    /// update paths would otherwise drop -- Aliases, CacheBehaviors,
+    /// CustomErrorResponses, Logging, Restrictions -- into the CloudFront wire
+    /// shape and apply them. CFN spells these as flat lists / a bare object;
+    /// the service model nests them under Quantity+Items, mirroring the Origins
+    /// translation. Only members present in the template are set, so an absent
+    /// one stays `None` (create) / is cleared on update.
+    fn apply_cfn_distribution_extras(config: &mut DistributionConfig, cfg: &serde_json::Value) {
+        // Aliases: flat ["a.example.com", ...].
+        config.aliases = cfg.get("Aliases").and_then(|v| v.as_array()).map(|arr| {
+            let cname: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            Aliases {
+                quantity: cname.len() as i32,
+                items: Some(AliasItems { cname }),
+            }
+        });
+        // CacheBehaviors: flat [{ PathPattern, ... }, ...].
+        config.cache_behaviors = cfg
+            .get("CacheBehaviors")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                let cache_behavior: Vec<CacheBehavior> = arr
+                    .iter()
+                    .filter_map(|v| serde_json::from_value(v.clone()).ok())
+                    .collect();
+                CacheBehaviors {
+                    quantity: cache_behavior.len() as i32,
+                    items: Some(CacheBehaviorItems { cache_behavior }),
+                }
+            });
+        // CustomErrorResponses: flat [{ ErrorCode, ... }, ...].
+        config.custom_error_responses = cfg
+            .get("CustomErrorResponses")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                let custom_error_response: Vec<CustomErrorResponse> = arr
+                    .iter()
+                    .filter_map(|v| serde_json::from_value(v.clone()).ok())
+                    .collect();
+                CustomErrorResponses {
+                    quantity: custom_error_response.len() as i32,
+                    items: Some(CustomErrorResponseItems {
+                        custom_error_response,
+                    }),
+                }
+            });
+        // Logging: { Bucket, IncludeCookies, Prefix } -- CFN has no Enabled, so
+        // presence of the block means logging is on.
+        config.logging = cfg
+            .get("Logging")
+            .filter(|v| v.is_object())
+            .map(|log| LoggingConfig {
+                enabled: true,
+                include_cookies: log
+                    .get("IncludeCookies")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                bucket: log
+                    .get("Bucket")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                prefix: log
+                    .get("Prefix")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        // Restrictions: { GeoRestriction: { RestrictionType, Locations: [..] } }.
+        config.restrictions = cfg
+            .get("Restrictions")
+            .and_then(|v| v.get("GeoRestriction"))
+            .map(|geo| {
+                let location: Vec<String> = geo
+                    .get("Locations")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Restrictions {
+                    geo_restriction: GeoRestriction {
+                        restriction_type: geo
+                            .get("RestrictionType")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("none")
+                            .to_string(),
+                        quantity: location.len() as i32,
+                        items: if location.is_empty() {
+                            None
+                        } else {
+                            Some(LocationList { location })
+                        },
+                    },
+                }
+            });
+    }
+
     /// Provision an `AWS::CloudFront::Distribution`. Reads
-    /// DistributionConfig.Origins/DefaultCacheBehavior/etc. and persists
-    /// a StoredDistribution in CloudFront state. CFN's Origins property
-    /// is a flat array, so we wrap it back into the wire shape with a
-    /// quantity + Items.Origin nesting.
-    /// Provision an `AWS::CloudFront::Distribution`. Reads
-    /// DistributionConfig.Origins/DefaultCacheBehavior/etc. and persists
-    /// a StoredDistribution in CloudFront state. CFN's Origins property
-    /// is a flat array, so we wrap it back into the wire shape with a
-    /// quantity + Items.Origin nesting.
+    /// DistributionConfig.Origins/DefaultCacheBehavior/etc. and persists a
+    /// StoredDistribution in CloudFront state. CFN's Origins property is a flat
+    /// array, so we wrap it back into the wire shape with a quantity +
+    /// Items.Origin nesting; `apply_cfn_distribution_extras` does the same for
+    /// Aliases / CacheBehaviors / CustomErrorResponses / Logging / Restrictions.
     pub(crate) fn create_cf_distribution(
         &self,
         resource: &ResourceDefinition,
@@ -150,6 +249,7 @@ impl ResourceProvisioner {
         config.default_root_object = default_root_object;
         config.web_acl_id = web_acl_id;
         config.viewer_certificate = viewer_certificate;
+        Self::apply_cfn_distribution_extras(&mut config, cfg);
 
         // Mint distribution id + ARN + domain in the same shape the
         // CloudFront service uses.
@@ -286,6 +386,7 @@ impl ResourceProvisioner {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
         config.viewer_certificate = viewer_certificate;
+        Self::apply_cfn_distribution_extras(&mut config, cfg);
 
         let etag_suffix: String = Uuid::new_v4()
             .simple()

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/glue.rs
@@ -171,8 +171,13 @@ impl ResourceProvisioner {
                 update_time: now,
                 last_access_time: None,
                 retention: input.get("Retention").and_then(|v| v.as_i64()).unwrap_or(0),
-                storage_descriptor: None,
-                partition_keys: Vec::new(),
+                storage_descriptor: input
+                    .get("StorageDescriptor")
+                    .and_then(fakecloud_glue::parse_storage_descriptor),
+                partition_keys: input
+                    .get("PartitionKeys")
+                    .map(fakecloud_glue::parse_columns)
+                    .unwrap_or_default(),
                 view_original_text: input
                     .get("ViewOriginalText")
                     .and_then(|v| v.as_str())
@@ -185,7 +190,10 @@ impl ResourceProvisioner {
                     .get("TableType")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string()),
-                parameters: BTreeMap::new(),
+                parameters: input
+                    .get("Parameters")
+                    .map(fakecloud_glue::parse_string_map)
+                    .unwrap_or_default(),
                 partitions: BTreeMap::new(),
             },
         );
@@ -259,8 +267,22 @@ impl ResourceProvisioner {
             .get("TableType")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // AWS UpdateTable replaces the schema-bearing members from TableInput.
+        // Apply them so a CFN update actually changes the columns/partition
+        // keys/parameters; table.partitions (separate Glue::Partition
+        // resources) are preserved.
+        table.storage_descriptor = input
+            .get("StorageDescriptor")
+            .and_then(fakecloud_glue::parse_storage_descriptor);
+        table.partition_keys = input
+            .get("PartitionKeys")
+            .map(fakecloud_glue::parse_columns)
+            .unwrap_or_default();
+        table.parameters = input
+            .get("Parameters")
+            .map(fakecloud_glue::parse_string_map)
+            .unwrap_or_default();
         table.update_time = Utc::now();
-        // table.partitions and storage_descriptor location intentionally kept.
         Ok(ProvisionResult::new(physical_id))
     }
 

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -35,7 +35,10 @@ use fakecloud_cloudfront::{
         StoredPublicKey,
     },
     model::{
-        DefaultCacheBehavior, DistributionConfig, Origin, OriginItems, Origins, ViewerCertificate,
+        AliasItems, Aliases, CacheBehavior, CacheBehaviorItems, CacheBehaviors,
+        CustomErrorResponse, CustomErrorResponseItems, CustomErrorResponses, DefaultCacheBehavior,
+        DistributionConfig, GeoRestriction, LocationList, LoggingConfig, Origin, OriginItems,
+        Origins, Restrictions, ViewerCertificate,
     },
     policies::{
         CachePolicyConfig, OriginAccessControlConfig, OriginRequestPolicyConfig,
@@ -4702,6 +4705,127 @@ mod tests {
             .expect("distribution still exists");
         assert_eq!(d.config.comment, "v2", "config mutated in place");
         assert!(!d.config.enabled);
+    }
+
+    #[test]
+    fn cloudfront_distribution_persists_aliases_and_extras() {
+        // bug-audit 2026-07-28 (cycle 7) C4: create/update read only a subset of
+        // DistributionConfig and dropped Aliases / CacheBehaviors /
+        // CustomErrorResponses / Logging / Restrictions -> custom-domain aliases
+        // + error/geo config silently vanished. They must round-trip.
+        let prov = make_provisioner();
+        let dist = prov
+            .create_resource(&make_resource(
+                "AWS::CloudFront::Distribution",
+                "D",
+                serde_json::json!({"DistributionConfig": {
+                    "Comment": "c", "Enabled": true,
+                    "Aliases": ["cdn.example.com", "www.example.com"],
+                    "Origins": [{"Id": "o1", "DomainName": "ex.com",
+                        "CustomOriginConfig": {"HTTPPort": 80, "HTTPSPort": 443,
+                            "OriginProtocolPolicy": "http-only"}}],
+                    "DefaultCacheBehavior": {"TargetOriginId": "o1", "ViewerProtocolPolicy": "allow-all"},
+                    "CustomErrorResponses": [{"ErrorCode": 404, "ResponseCode": "200",
+                        "ResponsePagePath": "/index.html"}],
+                    "Logging": {"Bucket": "logs.s3.amazonaws.com", "IncludeCookies": true, "Prefix": "cf/"},
+                    "Restrictions": {"GeoRestriction": {"RestrictionType": "whitelist",
+                        "Locations": ["US", "CA"]}}
+                }}),
+            ))
+            .expect("distribution provisions");
+        let accounts = prov.cloudfront_state.read();
+        let d = &accounts.get("000000000000").unwrap().distributions[&dist.physical_id];
+        let aliases = d.config.aliases.as_ref().expect("aliases persisted");
+        assert_eq!(aliases.quantity, 2);
+        assert_eq!(
+            aliases.items.as_ref().unwrap().cname,
+            vec!["cdn.example.com", "www.example.com"]
+        );
+        assert_eq!(
+            d.config.custom_error_responses.as_ref().unwrap().quantity,
+            1
+        );
+        assert_eq!(
+            d.config.logging.as_ref().unwrap().bucket,
+            "logs.s3.amazonaws.com"
+        );
+        let geo = &d.config.restrictions.as_ref().unwrap().geo_restriction;
+        assert_eq!(geo.restriction_type, "whitelist");
+        assert_eq!(geo.items.as_ref().unwrap().location, vec!["US", "CA"]);
+    }
+
+    #[test]
+    fn glue_table_persists_storage_descriptor_and_partition_keys() {
+        // bug-audit 2026-07-28 (cycle 7) C3: create/update hardcoded
+        // storage_descriptor=None / partition_keys=[] / parameters={} and never
+        // read TableInput.* -> a CFN-provisioned Glue table had no columns or
+        // partitions; GetTable returned an empty schema.
+        let prov = make_provisioner();
+        prov.create_resource(&make_resource(
+            "AWS::Glue::Database",
+            "DB",
+            serde_json::json!({"DatabaseInput": {"Name": "db1"}}),
+        ))
+        .expect("database provisions");
+        prov.create_resource(&make_resource(
+            "AWS::Glue::Table",
+            "T",
+            serde_json::json!({"DatabaseName": "db1", "TableInput": {
+                "Name": "t1",
+                "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"},
+                    {"Name": "name", "Type": "string"}], "Location": "s3://b/t1/"},
+                "PartitionKeys": [{"Name": "dt", "Type": "string"}],
+                "Parameters": {"classification": "parquet"}
+            }}),
+        ))
+        .expect("table provisions");
+
+        let accounts = prov.glue_state.read();
+        let db = &accounts
+            .get(&prov.account_id)
+            .unwrap()
+            .dbs_in(&prov.region)
+            .unwrap()["db1"];
+        let table = &db.tables["t1"];
+        let sd = table
+            .storage_descriptor
+            .as_ref()
+            .expect("storage descriptor persisted");
+        assert_eq!(sd.columns.len(), 2);
+        assert_eq!(sd.columns[0].name, "id");
+        assert_eq!(sd.location.as_deref(), Some("s3://b/t1/"));
+        assert_eq!(table.partition_keys.len(), 1);
+        assert_eq!(table.partition_keys[0].name, "dt");
+        assert_eq!(
+            table.parameters.get("classification").map(String::as_str),
+            Some("parquet")
+        );
+    }
+
+    #[test]
+    fn sfn_state_machine_revision_id_getatt_is_real() {
+        // bug-audit 2026-07-28 (cycle 7) C5: the StateMachineRevisionId GetAtt
+        // attribute was hardcoded "INITIAL"/"UPDATED" instead of the stored
+        // revision UUID, so a StateMachineVersion wired via
+        // !GetAtt Machine.StateMachineRevisionId stored the placeholder.
+        let prov = make_provisioner();
+        let sm = prov
+            .create_resource(&make_resource(
+                "AWS::StepFunctions::StateMachine",
+                "M",
+                serde_json::json!({
+                    "StateMachineName": "m1",
+                    "RoleArn": "arn:aws:iam::000000000000:role/r",
+                    "DefinitionString": "{\"StartAt\":\"A\",\"States\":{\"A\":{\"Type\":\"Pass\",\"End\":true}}}"
+                }),
+            ))
+            .expect("state machine provisions");
+        let rev = sm
+            .attributes
+            .get("StateMachineRevisionId")
+            .expect("revision id attribute present");
+        assert_ne!(rev, "INITIAL", "must expose the real revision id");
+        assert_eq!(rev.len(), 36, "revision id is a UUID: {rev}");
     }
 
     #[test]

--- a/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/stepfunctions.rs
@@ -53,7 +53,7 @@ impl ResourceProvisioner {
             creation_date: now,
             update_date: now,
             tags: BTreeMap::new(),
-            revision_id,
+            revision_id: revision_id.clone(),
             logging_configuration,
             tracing_configuration,
             description: String::new(),
@@ -64,10 +64,14 @@ impl ResourceProvisioner {
         let state = accounts.get_or_create(&self.account_id);
         state.state_machines.insert(arn.clone(), sm);
 
+        // Expose the real revision id (not a literal "INITIAL") so a sibling
+        // `!GetAtt Machine.StateMachineRevisionId` -- e.g. wired into an
+        // AWS::StepFunctions::StateMachineVersion -- resolves to the actual
+        // revision the state machine stores.
         Ok(ProvisionResult::new(arn.clone())
             .with("Arn", arn.clone())
             .with("Name", name)
-            .with("StateMachineRevisionId", "INITIAL"))
+            .with("StateMachineRevisionId", revision_id))
     }
 
     /// Resolve a state machine's ASL definition from any of the three
@@ -160,11 +164,12 @@ impl ResourceProvisioner {
         sm.revision_id = Uuid::new_v4().to_string();
         sm.update_date = Utc::now();
         let name = sm.name.clone();
+        let revision_id = sm.revision_id.clone();
 
         Ok(ProvisionResult::new(arn.clone())
             .with("Arn", arn)
             .with("Name", name)
-            .with("StateMachineRevisionId", "UPDATED"))
+            .with("StateMachineRevisionId", revision_id))
     }
 
     pub(super) fn delete_sfn_state_machine(&self, physical_id: &str) -> Result<(), String> {

--- a/crates/fakecloud-glue/src/lib.rs
+++ b/crates/fakecloud-glue/src/lib.rs
@@ -20,7 +20,7 @@ pub(crate) mod tail;
 mod tests;
 pub(crate) mod triggers;
 
-pub use service::GlueService;
+pub use service::{parse_columns, parse_storage_descriptor, parse_string_map, GlueService};
 pub use state::{
     Column, Database, GlueAccounts, GlueSnapshot, GlueState, Partition, SharedGlueState,
     StorageDescriptor, Table, GLUE_SNAPSHOT_SCHEMA_VERSION,

--- a/crates/fakecloud-glue/src/service.rs
+++ b/crates/fakecloud-glue/src/service.rs
@@ -761,7 +761,7 @@ fn already_exists(msg: impl Into<String>) -> AwsServiceError {
     )
 }
 
-pub(crate) fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
+pub fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
     let mut m = BTreeMap::new();
     if let Some(obj) = val.as_object() {
         for (k, v) in obj {
@@ -773,7 +773,7 @@ pub(crate) fn parse_string_map(val: &Value) -> BTreeMap<String, String> {
     m
 }
 
-fn parse_columns(val: &Value) -> Vec<Column> {
+pub fn parse_columns(val: &Value) -> Vec<Column> {
     let Some(arr) = val.as_array() else {
         return Vec::new();
     };
@@ -787,7 +787,7 @@ fn parse_columns(val: &Value) -> Vec<Column> {
         .collect()
 }
 
-pub(crate) fn parse_storage_descriptor(val: &Value) -> Option<StorageDescriptor> {
+pub fn parse_storage_descriptor(val: &Value) -> Option<StorageDescriptor> {
     if !val.is_object() {
         return None;
     }


### PR DESCRIPTION
## Summary
Cycle-7 bug-hunt CFN provisioner property-drops — a distinct cluster from the now-complete Family-B id-churn.

**C3 (MED)** — `AWS::Glue::Table` create/update hardcoded `storage_descriptor=None`, `partition_keys=[]`, `parameters={}` and never read `TableInput.StorageDescriptor`/`PartitionKeys`/`Parameters` → a CFN-provisioned table had no columns or partition keys; `GetTable` returned an empty schema. Now parses them via the Glue service's own parsers (`parse_storage_descriptor`/`parse_columns`/`parse_string_map`, now `pub`) so the provisioner and direct `CreateTable` stay identical. Update applies the new schema in place while preserving `table.partitions`.

**C4 (LOW)** — `AWS::CloudFront::Distribution` create/update read only a subset of DistributionConfig and silently dropped Aliases, CacheBehaviors, CustomErrorResponses, Logging, Restrictions → custom-domain aliases + error-page/geo config vanished. New `apply_cfn_distribution_extras` translates the CFN-flat shapes into the CloudFront Quantity+Items wire shape (mirroring the existing Origins translation); both create and update apply it.

**C5 (LOW)** — `AWS::StepFunctions::StateMachine` exposed a hardcoded `INITIAL`/`UPDATED` for the `StateMachineRevisionId` GetAtt attribute instead of the stored revision UUID, so a `StateMachineVersion` wired via `!GetAtt Machine.StateMachineRevisionId` stored the placeholder. Now returns the real revision id.

## Test plan
- New: glue table schema round-trip, distribution aliases/logging/restrictions/custom-errors persistence, sfn revision id is a real UUID.
- `cargo nextest run -p fakecloud-cloudformation -p fakecloud-glue`: 368 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CFN provisioner dropping critical properties: Glue Table schemas, CloudFront Distribution extras, and the real Step Functions RevisionId. Creates and updates now preserve schema and config so resources round‑trip correctly.

- **Bug Fixes**
  - Glue Table: Read and persist `TableInput.StorageDescriptor`, `PartitionKeys`, and `Parameters` using shared parsers; updates replace schema while keeping existing partitions.
  - CloudFront Distribution: Translate and persist `Aliases`, `CacheBehaviors`, `CustomErrorResponses`, `Logging`, and `Restrictions` into the Quantity+Items wire shape on create and update.
  - Step Functions: `GetAtt StateMachineRevisionId` returns the stored UUID instead of "INITIAL"/"UPDATED".

<sup>Written for commit ab12c448e187b49110af5160333ea069ad31094e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

