### PR TITLE
fix(ec2): persist RegisterImage boot mode/root device, ModifyCapacityReservation criteria, RunInstances launch options

### DIFF
--- a/crates/fakecloud-ec2/src/service/capacity.rs
+++ b/crates/fakecloud-ec2/src/service/capacity.rs
@@ -232,6 +232,16 @@ pub(crate) fn modify_capacity_reservation(
             r.total_instance_count = c;
             r.available_instance_count = c;
         }
+        // EndDateType and InstanceMatchCriteria are validated above but were
+        // never persisted -> DescribeCapacityReservations read back the
+        // create-time values and aws_ec2_capacity_reservation drifted. Both are
+        // modifiable per AWS; honor them.
+        if let Some(t) = req.query_params.get("EndDateType") {
+            r.end_date_type = t.clone();
+        }
+        if let Some(m) = req.query_params.get("InstanceMatchCriteria") {
+            r.instance_match_criteria = m.clone();
+        }
     }
     Ok(Ec2Service::respond(
         "ModifyCapacityReservation",
@@ -742,6 +752,62 @@ mod crfleet_tests {
 
     fn body(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn modify_capacity_reservation_persists_end_date_type_and_match() {
+        // bug-audit 2026-07-28 (cycle 7) E3: ModifyCapacityReservation validated
+        // EndDateType + InstanceMatchCriteria then persisted only InstanceCount,
+        // so DescribeCapacityReservations read back the create-time values.
+        let svc = Ec2Service::new();
+        let created = body(
+            create_capacity_reservation(
+                &svc,
+                &req(
+                    "CreateCapacityReservation",
+                    &[
+                        ("InstanceType", "t3.micro"),
+                        ("InstancePlatform", "Linux/UNIX"),
+                        ("AvailabilityZone", "us-east-1a"),
+                        ("InstanceCount", "4"),
+                        ("InstanceMatchCriteria", "open"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        let id = created
+            .split("<capacityReservationId>")
+            .nth(1)
+            .unwrap()
+            .split("</capacityReservationId>")
+            .next()
+            .unwrap()
+            .to_string();
+        modify_capacity_reservation(
+            &svc,
+            &req(
+                "ModifyCapacityReservation",
+                &[
+                    ("CapacityReservationId", &id),
+                    ("EndDateType", "unlimited"),
+                    ("InstanceMatchCriteria", "targeted"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc = body(
+            describe_capacity_reservations(&svc, &req("DescribeCapacityReservations", &[]))
+                .unwrap(),
+        );
+        assert!(
+            desc.contains("<instanceMatchCriteria>targeted</instanceMatchCriteria>"),
+            "match criteria not persisted: {desc}"
+        );
+        assert!(
+            desc.contains("<endDateType>unlimited</endDateType>"),
+            "end date type not persisted: {desc}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/image.rs
+++ b/crates/fakecloud-ec2/src/service/image.rs
@@ -174,6 +174,15 @@ pub(crate) fn register_image(
     if let Some(a) = req.query_params.get("Architecture") {
         img.architecture = a.clone();
     }
+    // BootMode is validated above but was never persisted; RootDeviceName was
+    // ignored entirely -> DescribeImages read back the render defaults (uefi /
+    // /dev/xvda) and aws_ami drifted. Honor both.
+    if let Some(b) = req.query_params.get("BootMode") {
+        img.boot_mode = Some(b.clone());
+    }
+    if let Some(r) = req.query_params.get("RootDeviceName") {
+        img.root_device_name = Some(r.clone());
+    }
     let id = img.image_id.clone();
     {
         let mut accounts = svc.state.write();
@@ -1180,6 +1189,48 @@ mod tests {
         let mut i = img(None, None);
         i.image_id = id.to_string();
         state.images.insert(id.to_string(), i);
+    }
+
+    #[test]
+    fn register_image_persists_boot_mode_and_root_device() {
+        // bug-audit 2026-07-28 (cycle 7) E2: RegisterImage validated BootMode
+        // then dropped it and ignored RootDeviceName -> DescribeImages read back
+        // the render defaults (uefi / /dev/xvda) and aws_ami drifted.
+        use crate::test_support::ec2_request as req;
+        let svc = crate::service::Ec2Service::new();
+        let created = super::register_image(
+            &svc,
+            &req(
+                "RegisterImage",
+                &[
+                    ("Name", "my-ami"),
+                    ("Architecture", "arm64"),
+                    ("BootMode", "legacy-bios"),
+                    ("RootDeviceName", "/dev/sdf"),
+                ],
+            ),
+        )
+        .unwrap();
+        let cbody = String::from_utf8_lossy(created.body.expect_bytes()).to_string();
+        let id = cbody
+            .split("<imageId>")
+            .nth(1)
+            .unwrap()
+            .split("</imageId>")
+            .next()
+            .unwrap()
+            .to_string();
+        let desc =
+            super::describe_images(&svc, &req("DescribeImages", &[("ImageId", &id)])).unwrap();
+        let dbody = String::from_utf8_lossy(desc.body.expect_bytes()).to_string();
+        assert!(
+            dbody.contains("<bootMode>legacy-bios</bootMode>"),
+            "boot mode not persisted: {dbody}"
+        );
+        assert!(
+            dbody.contains("<rootDeviceName>/dev/sdf</rootDeviceName>"),
+            "root device not persisted: {dbody}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -228,6 +228,46 @@ fn reservation_xml(reservation_id: &str, owner: &str, instances: &[String]) -> S
     )
 }
 
+/// Launch-time instance options that `RunInstances` must persist. These were
+/// previously hardcoded to defaults in the instance record even when the
+/// request specified them (only the `Modify*` handlers set the struct fields),
+/// so `aws_instance` / a launch template read them back as defaults and drifted
+/// -- and they are ForceNew, so the drift never self-healed. Parsed once from
+/// the flattened request params.
+#[derive(Default)]
+struct LaunchOpts {
+    cpu_options: Option<crate::state::CpuOptions>,
+    placement_tenancy: Option<String>,
+    placement_affinity: Option<String>,
+    private_dns_hostname_type: Option<String>,
+    enable_a_record: bool,
+    enable_aaaa_record: bool,
+}
+
+fn parse_launch_opts(params: &HashMap<String, String>) -> LaunchOpts {
+    let cc = params
+        .get("CpuOptions.CoreCount")
+        .and_then(|v| v.parse::<i64>().ok());
+    let tpc = params
+        .get("CpuOptions.ThreadsPerCore")
+        .and_then(|v| v.parse::<i64>().ok());
+    LaunchOpts {
+        cpu_options: (cc.is_some() || tpc.is_some()).then(|| crate::state::CpuOptions {
+            core_count: cc.unwrap_or(1),
+            threads_per_core: tpc.unwrap_or(1),
+        }),
+        placement_tenancy: params.get("Placement.Tenancy").cloned(),
+        placement_affinity: params.get("Placement.Affinity").cloned(),
+        private_dns_hostname_type: params.get("PrivateDnsNameOptions.HostnameType").cloned(),
+        enable_a_record: params
+            .get("PrivateDnsNameOptions.EnableResourceNameDnsARecord")
+            .is_some_and(|v| v == "true"),
+        enable_aaaa_record: params
+            .get("PrivateDnsNameOptions.EnableResourceNameDnsAAAARecord")
+            .is_some_and(|v| v == "true"),
+    }
+}
+
 pub(crate) async fn run_instances(
     svc: &Ec2Service,
     req: &AwsRequest,
@@ -445,6 +485,7 @@ pub(crate) async fn run_instances(
         let mut accounts = svc.state.write();
         let state = accounts.get_or_create(&req.account_id);
         let sg_names = sg_name_map(state);
+        let launch_opts = parse_launch_opts(&req.query_params);
         for (idx, id) in ids.iter().enumerate() {
             let inst = Instance {
                 instance_id: id.clone(),
@@ -479,15 +520,20 @@ pub(crate) async fn run_instances(
                     .unwrap_or_else(|| "stop".to_string()),
                 user_data: user_data.clone().filter(|s| !s.is_empty()),
                 metadata_options: metadata_options.clone(),
-                cpu_options: None,
+                // Launch-time CpuOptions / Placement.Tenancy+Affinity /
+                // PrivateDnsNameOptions were dropped at RunInstances (only the
+                // Modify* handlers set them), so a launch template / aws_instance
+                // that specified them at creation read back defaults and drifted
+                // -- and they are ForceNew, so the drift never self-healed.
+                cpu_options: launch_opts.cpu_options.clone(),
                 bandwidth_weighting: None,
                 maintenance_options: crate::state::MaintenanceOptions::default(),
-                placement_tenancy: None,
-                placement_affinity: None,
+                placement_tenancy: launch_opts.placement_tenancy.clone(),
+                placement_affinity: launch_opts.placement_affinity.clone(),
                 placement_group_name: req.query_params.get("Placement.GroupName").cloned(),
-                private_dns_hostname_type: None,
-                enable_resource_name_dns_a_record: false,
-                enable_resource_name_dns_aaaa_record: false,
+                private_dns_hostname_type: launch_opts.private_dns_hostname_type.clone(),
+                enable_resource_name_dns_a_record: launch_opts.enable_a_record,
+                enable_resource_name_dns_aaaa_record: launch_opts.enable_aaaa_record,
             };
             crate::service::tags::apply_tag_specifications(
                 state,
@@ -2438,6 +2484,42 @@ mod modify_tests {
 
     fn body(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn parse_launch_opts_reads_cpu_tenancy_and_dns() {
+        // bug-audit 2026-07-28 (cycle 7) E4: RunInstances hardcoded these to
+        // defaults even when the request set them (only Modify* handlers did),
+        // so aws_instance drifted on ForceNew attributes. The launch path must
+        // parse them.
+        let mut p = std::collections::HashMap::new();
+        p.insert("CpuOptions.CoreCount".to_string(), "2".to_string());
+        p.insert("CpuOptions.ThreadsPerCore".to_string(), "1".to_string());
+        p.insert("Placement.Tenancy".to_string(), "dedicated".to_string());
+        p.insert(
+            "PrivateDnsNameOptions.HostnameType".to_string(),
+            "resource-name".to_string(),
+        );
+        p.insert(
+            "PrivateDnsNameOptions.EnableResourceNameDnsARecord".to_string(),
+            "true".to_string(),
+        );
+        let lo = super::parse_launch_opts(&p);
+        let cpu = lo.cpu_options.expect("cpu options parsed");
+        assert_eq!(cpu.core_count, 2);
+        assert_eq!(cpu.threads_per_core, 1);
+        assert_eq!(lo.placement_tenancy.as_deref(), Some("dedicated"));
+        assert_eq!(
+            lo.private_dns_hostname_type.as_deref(),
+            Some("resource-name")
+        );
+        assert!(lo.enable_a_record);
+        assert!(!lo.enable_aaaa_record);
+
+        // Absent -> all defaults (no phantom cpu_options struct).
+        let empty = super::parse_launch_opts(&std::collections::HashMap::new());
+        assert!(empty.cpu_options.is_none());
+        assert!(empty.placement_tenancy.is_none());
     }
 
     fn seed_instance(svc: &Ec2Service, id: &str) {


### PR DESCRIPTION
## Summary
Cycle-7 bug-hunt EC2 write-read-loss — three more accepted-then-dropped fields on the un-audited 767-op surface.

**E2** — RegisterImage validated `BootMode` then never persisted it and ignored `RootDeviceName` → DescribeImages read back the render defaults (`uefi` / `/dev/xvda`) and `aws_ami` drifted. Honor both (the Image struct already has the fields; only the register path skipped them).

**E3** — ModifyCapacityReservation validated `EndDateType` + `InstanceMatchCriteria` then persisted only InstanceCount → DescribeCapacityReservations echoed the create-time values and `aws_ec2_capacity_reservation` drifted. Both are modifiable per AWS; persist them.

**E4** — RunInstances hardcoded `cpu_options=None` / `placement_tenancy=None` / `private_dns_hostname_type=None` (only the `Modify*` handlers set these struct fields), so a launch template / `aws_instance` that specified CpuOptions, Placement.Tenancy/Affinity or PrivateDnsNameOptions at creation read back defaults — and these are ForceNew, so the drift never self-healed. Parsed at launch via a new `parse_launch_opts` helper (unit-tested Docker-free, since `run_instances` itself needs a tokio runtime + Docker).

## Test plan
- New: `register_image_persists_boot_mode_and_root_device`, `modify_capacity_reservation_persists_end_date_type_and_match`, `parse_launch_opts_reads_cpu_tenancy_and_dns`.
- `cargo nextest run -p fakecloud-ec2`: 207 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EC2 write/read loss in images, capacity reservations, and instance launches so Describe APIs return the requested values and drift is removed.

- **Bug Fixes**
  - RegisterImage: persist `BootMode` and `RootDeviceName` so DescribeImages reflects them (prevents `aws_ami` drift).
  - ModifyCapacityReservation: persist `EndDateType` and `InstanceMatchCriteria` (prevents `aws_ec2_capacity_reservation` drift).
  - RunInstances: parse and save CPU options, placement tenancy/affinity, and private DNS name options via `parse_launch_opts` (prevents `aws_instance`/launch template drift).

<sup>Written for commit 7f990af780f9377d064afd5d86d602866a879e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

