### PR TITLE
fix(cognito): apply Pre Token Generation trigger to hosted-UI OAuth grants

### DIFF
--- a/crates/fakecloud-cognito/src/service/auth/mod.rs
+++ b/crates/fakecloud-cognito/src/service/auth/mod.rs
@@ -175,7 +175,7 @@ impl CognitoService {}
 /// `claims_added` / `claims_overridden` / `group_overrides` instead of
 /// having to walk the raw Lambda response themselves.
 #[allow(clippy::too_many_arguments)]
-fn record_pre_token_gen_invocation(
+pub(crate) fn record_pre_token_gen_invocation(
     state: &SharedCognitoState,
     account_id_key: &str,
     pool_id: &str,

--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1983,6 +1983,11 @@ fn inject_identity_claims(map: &mut serde_json::Map<String, Value>, attributes: 
 ///
 /// `claims` carries the signed-in user's attributes + group memberships and
 /// the client's token-validity config; see [`TokenClaims`].
+/// Convenience wrapper for the no-scope / no-override case. Only the tests
+/// mint tokens without scope/overrides now — every production caller (the
+/// OAuth grants and the InitiateAuth flows) goes through
+/// [`generate_tokens_with_overrides`] directly.
+#[cfg(test)]
 fn generate_tokens(
     pool_id: &str,
     client_id: &str,
@@ -1992,33 +1997,14 @@ fn generate_tokens(
     signing: Option<(&str, &str)>,
     claims: &TokenClaims,
 ) -> TokenSet {
-    generate_tokens_with_scope(
-        pool_id, client_id, sub, username, region, signing, None, None, claims,
-    )
-}
-
-/// Like [`generate_tokens`] but lets callers stamp custom `scope` and
-/// `nonce` claims into the issued tokens — used by the
-/// `authorization_code` grant which carries the scopes and nonce the
-/// user originally consented to at `/oauth2/authorize`.
-#[allow(clippy::too_many_arguments)]
-fn generate_tokens_with_scope(
-    pool_id: &str,
-    client_id: &str,
-    sub: &str,
-    username: &str,
-    region: &str,
-    signing: Option<(&str, &str)>,
-    scope: Option<&str>,
-    nonce: Option<&str>,
-    claims: &TokenClaims,
-) -> TokenSet {
     generate_tokens_with_overrides(
-        pool_id, client_id, sub, username, region, signing, scope, nonce, None, claims,
+        pool_id, client_id, sub, username, region, signing, None, None, None, claims,
     )
 }
 
-/// Like [`generate_tokens_with_scope`] but accepts a
+/// Like [`generate_tokens`] but also accepts optional `scope` / `nonce`
+/// claims (the `authorization_code` and implicit grants carry the scopes and
+/// nonce the user consented to at `/oauth2/authorize`) and a
 /// `claimsAndScopeOverrideDetails`-shaped JSON value from a
 /// PreTokenGeneration trigger response.
 ///
@@ -2473,11 +2459,85 @@ impl OAuthTokenResponse {
 /// are present, AWS treats the Basic header as authoritative and fails
 /// on conflict; we follow the same rule here.
 /// `region` is the AWS region used for the JWT `iss` claim.
+/// Invoke the PreTokenGeneration Lambda trigger for a hosted-UI OAuth grant
+/// and return its `response` overrides `Value`, or `None` when fakecloud has
+/// no delivery context, the user can't be resolved, or the pool has no trigger
+/// configured -- in which case token issuance is unchanged. Mirrors the
+/// InitiateAuth pre-token block in `service/auth/initiate.rs` so hosted-UI
+/// grants apply `cognito:groups` and claim overrides like the API auth flows,
+/// and records the invocation for introspection. The read lock that resolves
+/// the user is released before the trigger `await`.
+async fn oauth_pre_token_overrides(
+    state: &SharedCognitoState,
+    delivery_ctx: Option<&CognitoDeliveryContext>,
+    pool_id: &str,
+    client_id: &str,
+    username: &str,
+) -> Option<Value> {
+    let ctx = delivery_ctx?;
+    let (account_id_key, account_id, event_region, user_attrs) = {
+        let mas = state.read();
+        let mut found = None;
+        for (key, account) in mas.iter() {
+            if let Some(user) = account
+                .users
+                .get(pool_id)
+                .and_then(|users| users.get(username))
+            {
+                found = Some((
+                    key.to_string(),
+                    account.account_id.clone(),
+                    account.region.clone(),
+                    crate::triggers::collect_user_attributes(user),
+                ));
+                break;
+            }
+        }
+        found?
+    };
+    let function_arn = crate::triggers::get_trigger_arn(
+        state,
+        pool_id,
+        crate::triggers::TriggerSource::TokenGenerationAuthentication,
+    )?;
+    // The event region/account come from the resolved account (not the request
+    // region), mirroring how the InitiateAuth flows build this event so the
+    // `userPoolId`/ARN in the trigger payload match the pool's own identity.
+    let event = crate::triggers::build_trigger_event(
+        crate::triggers::TriggerSource::TokenGenerationAuthentication,
+        pool_id,
+        Some(client_id),
+        username,
+        &user_attrs,
+        &event_region,
+        &account_id,
+    );
+    let started = std::time::Instant::now();
+    let invoked_at = Utc::now();
+    let raw_response = crate::triggers::invoke_trigger(ctx, &function_arn, &event).await;
+    let duration_ms = started.elapsed().as_millis() as u64;
+    auth::record_pre_token_gen_invocation(
+        state,
+        &account_id_key,
+        pool_id,
+        &event_region,
+        &account_id,
+        username,
+        &function_arn,
+        &event,
+        raw_response.as_ref(),
+        invoked_at,
+        duration_ms,
+    );
+    raw_response
+}
+
 pub async fn handle_oauth2_token(
     state: &SharedCognitoState,
     params: &BTreeMap<String, String>,
     basic_auth: Option<(&str, &str)>,
     region: &str,
+    delivery_ctx: Option<&CognitoDeliveryContext>,
 ) -> Result<OAuthTokenResponse, OAuthTokenError> {
     let grant_type = params
         .get("grant_type")
@@ -2550,11 +2610,13 @@ pub async fn handle_oauth2_token(
                 &allowed_flows,
                 oauth_flows_enabled,
                 region,
+                delivery_ctx,
             )
             .await
         }
         "refresh_token" => {
-            handle_refresh_token_grant(state, params, client_id, &pool_id, region).await
+            handle_refresh_token_grant(state, params, client_id, &pool_id, region, delivery_ctx)
+                .await
         }
         "client_credentials" => {
             handle_client_credentials_grant(
@@ -2574,6 +2636,7 @@ pub async fn handle_oauth2_token(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_authorization_code_grant(
     state: &SharedCognitoState,
     params: &BTreeMap<String, String>,
@@ -2582,6 +2645,7 @@ async fn handle_authorization_code_grant(
     allowed_flows: &[String],
     oauth_flows_enabled: bool,
     region: &str,
+    delivery_ctx: Option<&CognitoDeliveryContext>,
 ) -> Result<OAuthTokenResponse, OAuthTokenError> {
     // Cognito only accepts authorization_code on app clients that have
     // explicitly opted into Hosted-UI OAuth flows. When the client
@@ -2661,7 +2725,10 @@ async fn handle_authorization_code_grant(
         Some(consumed.scopes.join(" "))
     };
     let claims = collect_token_claims(state, pool_id, &consumed.username, client_id);
-    let tokens = generate_tokens_with_scope(
+    let overrides =
+        oauth_pre_token_overrides(state, delivery_ctx, pool_id, client_id, &consumed.username)
+            .await;
+    let tokens = generate_tokens_with_overrides(
         pool_id,
         client_id,
         &sub,
@@ -2670,6 +2737,7 @@ async fn handle_authorization_code_grant(
         signing_ref,
         scope_str.as_deref(),
         consumed.nonce.as_deref(),
+        overrides.as_ref(),
         &claims,
     );
 
@@ -2717,6 +2785,7 @@ async fn handle_refresh_token_grant(
     client_id: &str,
     pool_id: &str,
     region: &str,
+    delivery_ctx: Option<&CognitoDeliveryContext>,
 ) -> Result<OAuthTokenResponse, OAuthTokenError> {
     let refresh_token = params
         .get("refresh_token")
@@ -2758,13 +2827,18 @@ async fn handle_refresh_token_grant(
     let signing = ensure_pool_signing_key(state, pool_id).await;
     let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
     let claims = collect_token_claims(state, pool_id, &username, client_id);
-    let tokens = generate_tokens(
+    let overrides =
+        oauth_pre_token_overrides(state, delivery_ctx, pool_id, client_id, &username).await;
+    let tokens = generate_tokens_with_overrides(
         pool_id,
         client_id,
         &sub,
         &username,
         region,
         signing_ref,
+        None,
+        None,
+        overrides.as_ref(),
         &claims,
     );
     let rotated_refresh = {
@@ -3263,6 +3337,7 @@ pub async fn handle_oauth2_authorize(
     state: &SharedCognitoState,
     req: &OAuth2AuthorizeRequest,
     region: &str,
+    delivery_ctx: Option<&CognitoDeliveryContext>,
 ) -> Result<OAuth2AuthorizeOutcome, OAuth2AuthorizeError> {
     // Look up the client and validate redirect_uri *before* trusting
     // anything else. RFC 6749 §3.1.2.4: an invalid redirect_uri MUST
@@ -3455,7 +3530,10 @@ pub async fn handle_oauth2_authorize(
             let signing = ensure_pool_signing_key(state, &pool_id).await;
             let signing_ref = signing.as_ref().map(|(p, k)| (p.as_str(), k.as_str()));
             let claims = collect_token_claims(state, &pool_id, username, &req.client_id);
-            let tokens = generate_tokens_with_scope(
+            let overrides =
+                oauth_pre_token_overrides(state, delivery_ctx, &pool_id, &req.client_id, username)
+                    .await;
+            let tokens = generate_tokens_with_overrides(
                 &pool_id,
                 &req.client_id,
                 &sub,
@@ -3464,6 +3542,7 @@ pub async fn handle_oauth2_authorize(
                 signing_ref,
                 scope_str.as_deref(),
                 req.nonce.as_deref(),
+                overrides.as_ref(),
                 &claims,
             );
             // Persist the access_token so /oauth2/userInfo and

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -8266,6 +8266,252 @@ fn custom_auth_issue_tokens_applies_pretoken_overrides_on_current_thread_runtime
     assert_eq!(claims["tenant"], "acme");
 }
 
+/// Build a standalone delivery context wired to [`SwitchingTriggerLambda`] for
+/// driving the free `handle_oauth2_*` handlers (the service owns its ctx
+/// privately, so the hosted-UI grant tests construct their own).
+fn pretoken_ctx() -> triggers::CognitoDeliveryContext {
+    let bus = std::sync::Arc::new(
+        fakecloud_core::delivery::DeliveryBus::new()
+            .with_lambda(std::sync::Arc::new(SwitchingTriggerLambda)),
+    );
+    triggers::CognitoDeliveryContext::new(bus)
+}
+
+/// Hosted-UI OAuth `authorization_code` grant must route token generation
+/// through the PreTokenGeneration override path. The asserted claims come ONLY
+/// from the trigger — reverting `handle_authorization_code_grant` to plain
+/// (no-override) issuance drops both.
+#[test]
+fn oauth_authorization_code_grant_applies_pretoken_overrides_to_access_token() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "alice");
+    set_user_password(&svc, &pool_id, "alice", "P@ssw0rd!");
+    set_lambda_config(
+        &state,
+        &pool_id,
+        json!({"PreTokenGeneration": "arn:aws:lambda:us-east-1:123456789012:function:pretoken"}),
+    );
+
+    // Seed the single-use authorization code the grant will consume.
+    {
+        let mut w = state.write();
+        let acct = w.default_mut();
+        acct.authorization_codes.insert(
+            "code-abc".to_string(),
+            AuthorizationCodeData {
+                user_pool_id: pool_id.clone(),
+                client_id: client_id.clone(),
+                username: "alice".to_string(),
+                redirect_uri: "https://app/callback".to_string(),
+                scopes: vec![],
+                code_challenge: None,
+                code_challenge_method: None,
+                nonce: None,
+                issued_at: Utc::now(),
+            },
+        );
+    }
+
+    let ctx = pretoken_ctx();
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("grant_type".to_string(), "authorization_code".to_string());
+    params.insert("code".to_string(), "code-abc".to_string());
+    params.insert(
+        "redirect_uri".to_string(),
+        "https://app/callback".to_string(),
+    );
+    params.insert("client_id".to_string(), client_id.clone());
+
+    let resp = block_on(handle_oauth2_token(
+        &state,
+        &params,
+        None,
+        "us-east-1",
+        Some(&ctx),
+    ))
+    .unwrap();
+    let claims = decode_jwt_claims(&resp.access_token);
+
+    assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
+    assert_eq!(claims["tenant"], "acme");
+}
+
+/// Hosted-UI OAuth `refresh_token` grant must route token generation through the
+/// PreTokenGeneration override path. Reverting `handle_refresh_token_grant` to
+/// no-override issuance drops both asserted claims.
+#[test]
+fn oauth_refresh_token_grant_applies_pretoken_overrides_to_access_token() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "alice");
+    set_user_password(&svc, &pool_id, "alice", "P@ssw0rd!");
+    set_lambda_config(
+        &state,
+        &pool_id,
+        json!({"PreTokenGeneration": "arn:aws:lambda:us-east-1:123456789012:function:pretoken"}),
+    );
+
+    // Seed a valid refresh token bound to the user/client.
+    {
+        let mut w = state.write();
+        let acct = w.default_mut();
+        acct.refresh_tokens.insert(
+            "rt-xyz".to_string(),
+            crate::state::RefreshTokenData {
+                user_pool_id: pool_id.clone(),
+                username: "alice".to_string(),
+                client_id: client_id.clone(),
+                issued_at: Utc::now(),
+            },
+        );
+    }
+
+    let ctx = pretoken_ctx();
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("grant_type".to_string(), "refresh_token".to_string());
+    params.insert("refresh_token".to_string(), "rt-xyz".to_string());
+    params.insert("client_id".to_string(), client_id.clone());
+
+    let resp = block_on(handle_oauth2_token(
+        &state,
+        &params,
+        None,
+        "us-east-1",
+        Some(&ctx),
+    ))
+    .unwrap();
+    let claims = decode_jwt_claims(&resp.access_token);
+
+    assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
+    assert_eq!(claims["tenant"], "acme");
+}
+
+/// Hosted-UI OAuth implicit grant (`response_type=token`) must route token
+/// generation through the PreTokenGeneration override path. The access token is
+/// returned in the redirect URL fragment; reverting the `token` branch to
+/// no-override issuance drops both asserted claims.
+#[test]
+fn oauth_implicit_grant_applies_pretoken_overrides_to_access_token() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "alice");
+    set_user_password(&svc, &pool_id, "alice", "P@ssw0rd!");
+    set_lambda_config(
+        &state,
+        &pool_id,
+        json!({"PreTokenGeneration": "arn:aws:lambda:us-east-1:123456789012:function:pretoken"}),
+    );
+
+    let ctx = pretoken_ctx();
+    let req = OAuth2AuthorizeRequest {
+        response_type: "token".to_string(),
+        client_id: client_id.clone(),
+        redirect_uri: "https://app/callback".to_string(),
+        scope: None,
+        state: None,
+        code_challenge: None,
+        code_challenge_method: None,
+        nonce: None,
+        username: Some("alice".to_string()),
+        password: Some("P@ssw0rd!".to_string()),
+    };
+
+    let outcome = block_on(handle_oauth2_authorize(
+        &state,
+        &req,
+        "us-east-1",
+        Some(&ctx),
+    ))
+    .unwrap();
+    let url = match outcome {
+        OAuth2AuthorizeOutcome::Redirect(u) => u,
+        other => panic!("expected implicit-grant redirect, got {other:?}"),
+    };
+    // Implicit grant returns tokens in the URL fragment (RFC 6749 §4.2.2).
+    let fragment = url
+        .split_once('#')
+        .expect("redirect must carry a fragment")
+        .1;
+    let access = fragment
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("access_token="))
+        .expect("fragment must contain access_token");
+    // JWT chars are all URL-unreserved, so the token is verbatim in the fragment.
+    let claims = decode_jwt_claims(access);
+
+    assert_eq!(claims["cognito:groups"], json!(["pretoken-admins"]));
+    assert_eq!(claims["tenant"], "acme");
+}
+
+/// With NO PreTokenGeneration trigger configured, the OAuth grant path must mint
+/// tokens unchanged: `oauth_pre_token_overrides` returns `None` and
+/// `generate_tokens_with_overrides` injects nothing. Guards that the override
+/// wiring is inert when the trigger is absent (no phantom `tenant`/group claims).
+#[test]
+fn oauth_token_grant_without_trigger_is_unchanged() {
+    let (svc, state) = svc_with_pretoken_lambda();
+    let pool_id = create_pool(&svc);
+    let client_id = create_client(&svc, &pool_id);
+    admin_create_user_helper(&svc, &pool_id, "alice");
+    set_user_password(&svc, &pool_id, "alice", "P@ssw0rd!");
+    // Deliberately skip set_lambda_config: no PreTokenGeneration trigger.
+
+    {
+        let mut w = state.write();
+        let acct = w.default_mut();
+        acct.authorization_codes.insert(
+            "code-noop".to_string(),
+            AuthorizationCodeData {
+                user_pool_id: pool_id.clone(),
+                client_id: client_id.clone(),
+                username: "alice".to_string(),
+                redirect_uri: "https://app/callback".to_string(),
+                scopes: vec![],
+                code_challenge: None,
+                code_challenge_method: None,
+                nonce: None,
+                issued_at: Utc::now(),
+            },
+        );
+    }
+
+    let ctx = pretoken_ctx();
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("grant_type".to_string(), "authorization_code".to_string());
+    params.insert("code".to_string(), "code-noop".to_string());
+    params.insert(
+        "redirect_uri".to_string(),
+        "https://app/callback".to_string(),
+    );
+    params.insert("client_id".to_string(), client_id.clone());
+
+    let resp = block_on(handle_oauth2_token(
+        &state,
+        &params,
+        None,
+        "us-east-1",
+        Some(&ctx),
+    ))
+    .unwrap();
+    let claims = decode_jwt_claims(&resp.access_token);
+
+    // No trigger => no injected overrides. `alice` has no group membership.
+    assert!(
+        claims.get("tenant").is_none(),
+        "no PreTokenGeneration trigger must not inject a `tenant` claim, got {:?}",
+        claims.get("tenant")
+    );
+    assert!(
+        claims["cognito:groups"].is_null(),
+        "no PreTokenGeneration trigger must not inject `cognito:groups`, got {:?}",
+        claims["cognito:groups"]
+    );
+}
+
 #[test]
 fn get_signing_certificate_returns_real_x509_matching_pool_jwt_key() {
     use base64::Engine;

--- a/crates/fakecloud-server/src/main.rs
+++ b/crates/fakecloud-server/src/main.rs
@@ -2894,6 +2894,12 @@ async fn main() {
     // shared lock; snapshot files are written atomically.
     let cognito_oauth2_snapshot_store = cognito_snapshot_store.clone();
     let cognito_oauth2_snapshot_lock = Arc::new(tokio::sync::Mutex::new(()));
+    // The Hosted-UI OAuth2 routes issue tokens outside the service object, so
+    // hand them a clone of the delivery context to fire the PreTokenGeneration
+    // trigger on the authorization_code / refresh_token / implicit grants
+    // (issue #2448); without it those grants drop Lambda claim overrides.
+    let cognito_authorize_delivery_ctx = cognito_delivery_ctx.clone();
+    let cognito_token_delivery_ctx = cognito_delivery_ctx.clone();
     let mut cognito_service =
         CognitoService::new(cognito_state.clone()).with_delivery(cognito_delivery_ctx);
     if let Some(store) = cognito_snapshot_store {
@@ -9201,12 +9207,14 @@ async fn main() {
                 let cs = cognito_authorize_state;
                 let store = cognito_oauth2_snapshot_store.clone();
                 let lock = cognito_oauth2_snapshot_lock.clone();
+                let dctx = cognito_authorize_delivery_ctx;
                 move |axum::extract::Query(q): axum::extract::Query<
                     std::collections::BTreeMap<String, String>,
                 >| {
                     let cs = cs.clone();
                     let store = store.clone();
                     let lock = lock.clone();
+                    let dctx = dctx.clone();
                     async move {
                         let region = std::env::var("AWS_DEFAULT_REGION")
                             .or_else(|_| std::env::var("AWS_REGION"))
@@ -9262,7 +9270,14 @@ async fn main() {
                             username: q.get("username").cloned(),
                             password: q.get("password").cloned(),
                         };
-                        match fakecloud_cognito::handle_oauth2_authorize(&cs, &req, &region).await {
+                        match fakecloud_cognito::handle_oauth2_authorize(
+                            &cs,
+                            &req,
+                            &region,
+                            Some(&dctx),
+                        )
+                        .await
+                        {
                             Ok(fakecloud_cognito::OAuth2AuthorizeOutcome::Redirect(url)) => {
                                 // A successful authorize minted an authorization
                                 // code (or implicit-grant token) in state; write
@@ -9316,10 +9331,12 @@ async fn main() {
                 let cs = cognito_token_state;
                 let store = cognito_oauth2_snapshot_store.clone();
                 let lock = cognito_oauth2_snapshot_lock.clone();
+                let dctx = cognito_token_delivery_ctx;
                 move |headers: axum::http::HeaderMap, body: String| {
                     let cs = cs.clone();
                     let store = store.clone();
                     let lock = lock.clone();
+                    let dctx = dctx.clone();
                     async move {
                         let params: std::collections::BTreeMap<String, String> =
                             match serde_urlencoded::from_str::<Vec<(String, String)>>(&body) {
@@ -9337,7 +9354,11 @@ async fn main() {
                             .unwrap_or_else(|_| "us-east-1".to_string());
                         let basic_ref = basic.as_ref().map(|(i, s)| (i.as_str(), s.as_str()));
                         match fakecloud_cognito::handle_oauth2_token(
-                            &cs, &params, basic_ref, &region,
+                            &cs,
+                            &params,
+                            basic_ref,
+                            &region,
+                            Some(&dctx),
                         )
                         .await
                         {


### PR DESCRIPTION
## Summary

Closes #2448 — the follow-up split out of #2436.

The hosted-UI OAuth token endpoints issued access tokens **without firing the PreTokenGeneration Lambda trigger**, so `cognito:groups` and other claim overrides were silently dropped for apps signing in via the hosted UI / OAuth2 `/token` endpoint. Real AWS fires Pre Token Generation on these grants too.

Three grants were unwired (all in `crates/fakecloud-cognito/src/service/mod.rs`):
- `authorization_code` grant (`handle_authorization_code_grant`)
- OAuth `refresh_token` grant (`handle_refresh_token_grant`)
- implicit `response_type=token` grant (`handle_oauth2_authorize`)

Root cause: `handle_oauth2_token` / `handle_oauth2_authorize` are free `async fn`s taking only `state: &SharedCognitoState`, with no `CognitoDeliveryContext` to invoke the trigger.

## What changed

- Thread `delivery_ctx: Option<&CognitoDeliveryContext>` through the OAuth dispatch. `crates/fakecloud-server/src/main.rs` clones the cognito delivery context into the `/oauth2/token` and `/oauth2/authorize` route closures and passes `Some(&ctx)`.
- Add a shared `oauth_pre_token_overrides` helper that runs the same trigger-invocation block the InitiateAuth flows use (`get_trigger_arn` -> `build_trigger_event` -> `invoke_trigger` -> `record_pre_token_gen_invocation`) and returns the overrides `Value`. The read lock resolving the user is released before the trigger `await` (same lock discipline as #2436). Returns `None` (issuance unchanged) when there is no delivery context, no configured trigger, or the user can't be resolved.
- Feed the overrides into `generate_tokens_with_overrides` at all three mint sites.
- `client_credentials` stays unwired (no user, no PreTokenGeneration event — matches AWS).
- Collapse the now-unused `generate_tokens_with_scope` middle layer and gate the test-only `generate_tokens` wrapper on `#[cfg(test)]` (every production caller now goes through `generate_tokens_with_overrides`).

## Test plan

New flow-level regression tests in `crates/fakecloud-cognito/src/service/tests.rs`, each decoding the issued **access token** and asserting the trigger's `cognito:groups` (`["pretoken-admins"]`) and `tenant` (`acme`) overrides land — each fails if that grant's override wiring is reverted:
- `oauth_authorization_code_grant_applies_pretoken_overrides_to_access_token`
- `oauth_refresh_token_grant_applies_pretoken_overrides_to_access_token`
- `oauth_implicit_grant_applies_pretoken_overrides_to_access_token`
- `oauth_token_grant_without_trigger_is_unchanged` (guard: no trigger -> tokens issue unchanged, no phantom claims)

`cargo test -p fakecloud-cognito --lib` (387 passed), `cargo clippy -p fakecloud-cognito --all-targets -- -D warnings` clean, workspace binary builds, `cargo fmt --check` clean.

## Surface (non-code) — checked

- **SDKs / introspection**: no new/changed API surface or field; the trigger fires on existing endpoints and invocations surface via the existing `record_pre_token_gen_invocation` record. No SDK change.
- **Conformance baseline**: `/oauth2/*` endpoints are not Smithy operations; no baseline count/shape change.
- **Docs**: `website/content/cognito-emulator.md` already states PreTokenGeneration `claimsOverrideDetails` are merged into issued tokens; nothing enumerates flows or excludes hosted-UI, so no doc is made stale (the statement is now more complete). No update needed.
- **Repo description counts** (services/ops/variants): unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted-UI OAuth grants now invoke the Pre Token Generation trigger so access tokens include Lambda overrides (e.g., `cognito:groups`), matching AWS. Fixes missing claims for `authorization_code`, `refresh_token`, and implicit (`response_type=token`) flows.

- **Bug Fixes**
  - Threaded `CognitoDeliveryContext` through `/oauth2/token` and `/oauth2/authorize`, added `oauth_pre_token_overrides` to invoke and record the trigger.
  - Applied overrides when minting tokens via `generate_tokens_with_overrides` for the three grants.
  - Left `client_credentials` unchanged (no user, no trigger).
  - Added flow-level tests for all three grants and a no-trigger guard.

- **Refactors**
  - Removed `generate_tokens_with_scope`; the test-only `generate_tokens` is now behind `#[cfg(test)]`.

<sup>Written for commit 42057be8294a765ac917d8c9dd04c0a5651b414d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

