### PR TITLE
fix(ec2): persist TransitGateway Options, CapacityReservation ebs/ephemeral, FlowLog format, render instance affinity

### DIFF
--- a/crates/fakecloud-ec2/src/service/capacity.rs
+++ b/crates/fakecloud-ec2/src/service/capacity.rs
@@ -37,7 +37,7 @@ const INSTANCE_PLATFORMS: &[&str] = &[
 fn cr_xml(r: &CapacityReservation, tags: &[Tag], owner: &str) -> String {
     format!(
         "{}{}{}{}{}{}{}<totalInstanceCount>{}</totalInstanceCount><availableInstanceCount>{}</availableInstanceCount>\
-         <ebsOptimized>false</ebsOptimized><ephemeralStorage>false</ephemeralStorage>{}{}{}{}{}{}",
+         <ebsOptimized>{}</ebsOptimized><ephemeralStorage>{}</ephemeralStorage>{}{}{}{}{}{}",
         ec2_elem("capacityReservationId", &r.id),
         ec2_elem("ownerId", owner),
         ec2_elem("capacityReservationArn", &format!("arn:aws:ec2:{}:{owner}:capacity-reservation/{}", region_of(r), r.id)),
@@ -47,6 +47,8 @@ fn cr_xml(r: &CapacityReservation, tags: &[Tag], owner: &str) -> String {
         ec2_elem("tenancy", &r.tenancy),
         r.total_instance_count,
         r.available_instance_count,
+        r.ebs_optimized,
+        r.ephemeral_storage,
         ec2_elem("state", &r.state),
         ec2_elem("endDateType", &r.end_date_type),
         ec2_elem("instanceMatchCriteria", &r.instance_match_criteria),
@@ -121,6 +123,14 @@ pub(crate) fn create_capacity_reservation(
         total_instance_count: count,
         available_instance_count: count,
         state: "active".to_string(),
+        ebs_optimized: req
+            .query_params
+            .get("EbsOptimized")
+            .is_some_and(|v| v == "true"),
+        ephemeral_storage: req
+            .query_params
+            .get("EphemeralStorage")
+            .is_some_and(|v| v == "true"),
         end_date_type: req
             .query_params
             .get("EndDateType")
@@ -439,6 +449,8 @@ fn synth_cr_xml(id: &str, owner: &str, count: i64) -> String {
         state: "active".to_string(),
         end_date_type: "unlimited".to_string(),
         instance_match_criteria: "open".to_string(),
+        ebs_optimized: false,
+        ephemeral_storage: false,
     };
     cr_xml(&r, &[], owner)
 }
@@ -625,6 +637,8 @@ pub(crate) fn purchase_capacity_block(
                     state: "active".to_string(),
                     end_date_type: "limited".to_string(),
                     instance_match_criteria: "targeted".to_string(),
+                    ebs_optimized: false,
+                    ephemeral_storage: false,
                 },
             );
     }
@@ -752,6 +766,39 @@ mod crfleet_tests {
 
     fn body(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn create_capacity_reservation_persists_ebs_optimized_and_ephemeral() {
+        // bug-audit 2026-07-29 (cycle 8) E2-3: CreateCapacityReservation dropped
+        // EbsOptimized/EphemeralStorage; cr_xml hardcoded both false.
+        let svc = Ec2Service::new();
+        body(
+            create_capacity_reservation(
+                &svc,
+                &req(
+                    "CreateCapacityReservation",
+                    &[
+                        ("InstanceType", "t3.micro"),
+                        ("InstancePlatform", "Linux/UNIX"),
+                        ("AvailabilityZone", "us-east-1a"),
+                        ("InstanceCount", "1"),
+                        ("EbsOptimized", "true"),
+                        ("EphemeralStorage", "true"),
+                    ],
+                ),
+            )
+            .unwrap(),
+        );
+        let desc = body(
+            describe_capacity_reservations(&svc, &req("DescribeCapacityReservations", &[]))
+                .unwrap(),
+        );
+        assert!(desc.contains("<ebsOptimized>true</ebsOptimized>"), "{desc}");
+        assert!(
+            desc.contains("<ephemeralStorage>true</ephemeralStorage>"),
+            "{desc}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/endpoint.rs
+++ b/crates/fakecloud-ec2/src/service/endpoint.rs
@@ -727,7 +727,7 @@ pub(crate) fn describe_vpc_endpoint_associations(
 
 fn flow_log_xml(f: &FlowLog, tags: &[Tag]) -> String {
     format!(
-        "{}{}{}{}<flowLogStatus>ACTIVE</flowLogStatus><deliverLogsStatus>SUCCESS</deliverLogsStatus>{}{}{}{}{}{}",
+        "{}{}{}{}<flowLogStatus>ACTIVE</flowLogStatus><deliverLogsStatus>SUCCESS</deliverLogsStatus>{}{}{}{}{}{}{}",
         ec2_elem("flowLogId", &f.id),
         ec2_elem("resourceId", &f.resource_id),
         ec2_elem("trafficType", &f.traffic_type),
@@ -736,6 +736,7 @@ fn flow_log_xml(f: &FlowLog, tags: &[Tag]) -> String {
         f.log_destination.as_ref().map(|d| ec2_elem("logDestination", d)).unwrap_or_default(),
         f.deliver_logs_permission_arn.as_ref().map(|a| ec2_elem("deliverLogsPermissionArn", a)).unwrap_or_default(),
         ec2_elem("maxAggregationInterval", &f.max_aggregation_interval.to_string()),
+        f.log_format.as_ref().map(|l| ec2_elem("logFormat", l)).unwrap_or_default(),
         ec2_elem("creationTime", FIXED_TIME),
         super::tags::tag_set_xml(tags),
     )
@@ -815,6 +816,7 @@ pub(crate) fn create_flow_logs(
                     log_destination: log_destination.clone(),
                     deliver_logs_permission_arn: deliver_logs_permission_arn.clone(),
                     max_aggregation_interval,
+                    log_format: req.query_params.get("LogFormat").cloned(),
                 },
             );
             ids.push(id);
@@ -1014,6 +1016,37 @@ mod tests {
 
     fn body_str(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn create_flow_logs_persists_log_format() {
+        // bug-audit 2026-07-29 (cycle 8) E2-8: CreateFlowLogs dropped LogFormat.
+        let svc = Ec2Service::new();
+        let fmt = "${version} ${account-id} ${interface-id}";
+        create_flow_logs(
+            &svc,
+            &req(
+                "CreateFlowLogs",
+                &[
+                    ("ResourceId.1", "vpc-1"),
+                    ("ResourceType", "VPC"),
+                    ("TrafficType", "ALL"),
+                    ("LogDestinationType", "cloud-watch-logs"),
+                    ("LogGroupName", "lg"),
+                    (
+                        "DeliverLogsPermissionArn",
+                        "arn:aws:iam::000000000000:role/r",
+                    ),
+                    ("LogFormat", fmt),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc = body_str(describe_flow_logs(&svc, &req("DescribeFlowLogs", &[])).unwrap());
+        assert!(
+            desc.contains("<logFormat>${version} ${account-id} ${interface-id}</logFormat>"),
+            "{desc}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -159,6 +159,14 @@ fn instance_xml(
         .as_ref()
         .map(|g| ec2_elem("groupName", g))
         .unwrap_or_default();
+    // `placement_affinity` was written by ModifyInstancePlacement/RunInstances
+    // but never rendered here (a dead write) -> the value never reflected on
+    // DescribeInstances. Emit it when set.
+    let affinity = i
+        .placement_affinity
+        .as_ref()
+        .map(|a| ec2_elem("affinity", a))
+        .unwrap_or_default();
     format!(
         "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
         ec2_elem("instanceId", &i.instance_id),
@@ -184,8 +192,8 @@ fn instance_xml(
             i.ebs_optimized, i.source_dest_check
         ),
         format_args!(
-            "<placement><availabilityZone>{}</availabilityZone>{}<tenancy>{}</tenancy></placement>",
-            i.az, placement_group, tenancy
+            "<placement><availabilityZone>{}</availabilityZone>{}{}<tenancy>{}</tenancy></placement>",
+            i.az, affinity, placement_group, tenancy
         ),
         format_args!(
             "<monitoring><state>{}</state></monitoring>",
@@ -2484,6 +2492,25 @@ mod modify_tests {
 
     fn body(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn modify_instance_placement_renders_affinity() {
+        // bug-audit 2026-07-29 (cycle 8) E2-7: placement_affinity was written but
+        // the DescribeInstances <placement> render omitted <affinity> (dead
+        // write) -> the value never reflected.
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-aff");
+        modify_instance_placement(
+            &svc,
+            &req(
+                "ModifyInstancePlacement",
+                &[("InstanceId", "i-aff"), ("Affinity", "host")],
+            ),
+        )
+        .unwrap();
+        let desc = body(describe_instances(&svc, &req("DescribeInstances", &[])).unwrap());
+        assert!(desc.contains("<affinity>host</affinity>"), "{desc}");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/tgw.rs
+++ b/crates/fakecloud-ec2/src/service/tgw.rs
@@ -6,7 +6,9 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 
 use crate::service::Ec2Service;
 use crate::service_helpers::{gen_id, indexed_list, require, validate_max_results};
-use crate::state::{Ec2State, Tag, TgwAttachment, TgwRoute, TgwRouteTable, TransitGateway};
+use crate::state::{
+    Ec2State, Tag, TgwAttachment, TgwRoute, TgwRouteTable, TransitGateway, TransitGatewayOptions,
+};
 
 const FIXED_TIME: &str = "2024-01-01T00:00:00.000Z";
 
@@ -17,12 +19,14 @@ fn mr(req: &AwsRequest) -> Result<(), AwsServiceError> {
 // ---- transit gateways ----
 
 fn tgw_xml(t: &TransitGateway, tags: &[Tag], owner: &str, region: &str) -> String {
+    let o = &t.options;
     format!(
-        "{}{}{}{}{}{}<options><amazonSideAsn>64512</amazonSideAsn>\
-         <autoAcceptSharedAttachments>disable</autoAcceptSharedAttachments>\
-         <defaultRouteTableAssociation>enable</defaultRouteTableAssociation>\
-         <defaultRouteTablePropagation>enable</defaultRouteTablePropagation>\
-         <dnsSupport>enable</dnsSupport><vpnEcmpSupport>enable</vpnEcmpSupport></options>{}",
+        "{}{}{}{}{}{}<options><amazonSideAsn>{}</amazonSideAsn>\
+         <autoAcceptSharedAttachments>{}</autoAcceptSharedAttachments>\
+         <defaultRouteTableAssociation>{}</defaultRouteTableAssociation>\
+         <defaultRouteTablePropagation>{}</defaultRouteTablePropagation>\
+         <dnsSupport>{}</dnsSupport><vpnEcmpSupport>{}</vpnEcmpSupport>\
+         <multicastSupport>{}</multicastSupport></options>{}",
         ec2_elem("transitGatewayId", &t.id),
         ec2_elem("state", &t.state),
         ec2_elem(
@@ -32,8 +36,46 @@ fn tgw_xml(t: &TransitGateway, tags: &[Tag], owner: &str, region: &str) -> Strin
         ec2_elem("ownerId", owner),
         ec2_elem("description", &t.description),
         ec2_elem("creationTime", FIXED_TIME),
+        o.amazon_side_asn,
+        o.auto_accept_shared_attachments,
+        o.default_route_table_association,
+        o.default_route_table_propagation,
+        o.dns_support,
+        o.vpn_ecmp_support,
+        o.multicast_support,
         super::tags::tag_set_xml(tags),
     )
+}
+
+/// Parse the flattened `Options.*` request params into stored options, keeping
+/// AWS's create-time defaults for any member the caller omits.
+fn parse_tgw_options(params: &std::collections::HashMap<String, String>) -> TransitGatewayOptions {
+    let mut o = TransitGatewayOptions::default();
+    if let Some(v) = params
+        .get("Options.AmazonSideAsn")
+        .and_then(|v| v.parse().ok())
+    {
+        o.amazon_side_asn = v;
+    }
+    if let Some(v) = params.get("Options.AutoAcceptSharedAttachments") {
+        o.auto_accept_shared_attachments = v.clone();
+    }
+    if let Some(v) = params.get("Options.DefaultRouteTableAssociation") {
+        o.default_route_table_association = v.clone();
+    }
+    if let Some(v) = params.get("Options.DefaultRouteTablePropagation") {
+        o.default_route_table_propagation = v.clone();
+    }
+    if let Some(v) = params.get("Options.DnsSupport") {
+        o.dns_support = v.clone();
+    }
+    if let Some(v) = params.get("Options.VpnEcmpSupport") {
+        o.vpn_ecmp_support = v.clone();
+    }
+    if let Some(v) = params.get("Options.MulticastSupport") {
+        o.multicast_support = v.clone();
+    }
+    o
 }
 
 pub(crate) fn create_transit_gateway(
@@ -49,6 +91,7 @@ pub(crate) fn create_transit_gateway(
             .cloned()
             .unwrap_or_default(),
         state: "available".to_string(),
+        options: parse_tgw_options(&req.query_params),
     };
     let owner = req.account_id.clone();
     let tags = {
@@ -89,6 +132,7 @@ pub(crate) fn delete_transit_gateway(
             id: id.clone(),
             description: String::new(),
             state: "available".to_string(),
+            options: TransitGatewayOptions::default(),
         });
     let tags = state.tags_for(&id).to_vec();
     state.tags.remove(&id);
@@ -147,6 +191,7 @@ pub(crate) fn modify_transit_gateway(
             id: id.clone(),
             description: String::new(),
             state: "available".to_string(),
+            options: TransitGatewayOptions::default(),
         });
     let tags = state.tags_for(&id).to_vec();
     Ok(Ec2Service::respond(
@@ -919,6 +964,63 @@ pub(crate) fn get_transit_gateway_prefix_list_references(
 }
 
 #[cfg(test)]
+mod options_tests {
+    use super::*;
+    use crate::test_support::ec2_request as req;
+
+    #[test]
+    fn create_transit_gateway_persists_options() {
+        // bug-audit 2026-07-29 (cycle 8) E2-1: CreateTransitGateway dropped the
+        // whole Options block; the describe render hardcoded ASN 64512 + all
+        // defaults, so a non-default value never round-tripped.
+        let svc = Ec2Service::new();
+        let resp = create_transit_gateway(
+            &svc,
+            &req(
+                "CreateTransitGateway",
+                &[
+                    ("Options.AmazonSideAsn", "64513"),
+                    ("Options.DnsSupport", "disable"),
+                    ("Options.DefaultRouteTableAssociation", "disable"),
+                    ("Options.MulticastSupport", "enable"),
+                ],
+            ),
+        )
+        .unwrap();
+        let b = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        let id = b
+            .split("<transitGatewayId>")
+            .nth(1)
+            .unwrap()
+            .split("</transitGatewayId>")
+            .next()
+            .unwrap()
+            .to_string();
+        let desc = String::from_utf8_lossy(
+            describe_transit_gateways(&svc, &req("DescribeTransitGateways", &[]))
+                .unwrap()
+                .body
+                .expect_bytes(),
+        )
+        .to_string();
+        assert!(desc.contains(&id));
+        assert!(
+            desc.contains("<amazonSideAsn>64513</amazonSideAsn>"),
+            "{desc}"
+        );
+        assert!(desc.contains("<dnsSupport>disable</dnsSupport>"), "{desc}");
+        assert!(
+            desc.contains("<defaultRouteTableAssociation>disable</defaultRouteTableAssociation>"),
+            "{desc}"
+        );
+        assert!(
+            desc.contains("<multicastSupport>enable</multicastSupport>"),
+            "{desc}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod modify_tests {
     use super::*;
 
@@ -990,6 +1092,7 @@ mod modify_tests {
             id: "tgw-abc123".into(),
             description: String::new(),
             state: "available".into(),
+            options: TransitGatewayOptions::default(),
         };
         let xml = tgw_xml(&t, &[], "000000000000", "eu-central-1");
         assert!(

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -744,6 +744,10 @@ pub struct FlowLog {
     /// defaults to 600 when unspecified.
     #[serde(default = "default_max_aggregation_interval")]
     pub max_aggregation_interval: i64,
+    /// Custom log line format. Accepted at CreateFlowLogs but previously
+    /// dropped; AWS always echoes `LogFormat` on DescribeFlowLogs.
+    #[serde(default)]
+    pub log_format: Option<String>,
 }
 
 fn default_max_aggregation_interval() -> i64 {
@@ -812,6 +816,13 @@ pub struct CapacityReservation {
     pub state: String,
     pub end_date_type: String,
     pub instance_match_criteria: String,
+    /// Accepted at CreateCapacityReservation but previously hardcoded false in
+    /// the describe render, so `aws_ec2_capacity_reservation` drifted on these
+    /// ForceNew flags.
+    #[serde(default)]
+    pub ebs_optimized: bool,
+    #[serde(default)]
+    pub ephemeral_storage: bool,
 }
 
 /// A Reserved Instance purchase.
@@ -870,6 +881,54 @@ pub struct TransitGateway {
     /// `pending` | `available` | `modifying` | `deleting` | `deleted`.
     #[serde(default = "tgw_default_state")]
     pub state: String,
+    /// The `Options` block. Previously hardcoded in the describe render, so a
+    /// non-default AmazonSideAsn / DnsSupport / route-table default read back
+    /// wrong and churned `aws_ec2_transit_gateway` (several are ForceNew).
+    #[serde(default)]
+    pub options: TransitGatewayOptions,
+}
+
+/// `AWS::EC2::TransitGateway` Options, with AWS's create-time defaults.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransitGatewayOptions {
+    #[serde(default = "tgw_default_asn")]
+    pub amazon_side_asn: i64,
+    #[serde(default = "tgw_disable")]
+    pub auto_accept_shared_attachments: String,
+    #[serde(default = "tgw_enable")]
+    pub default_route_table_association: String,
+    #[serde(default = "tgw_enable")]
+    pub default_route_table_propagation: String,
+    #[serde(default = "tgw_enable")]
+    pub dns_support: String,
+    #[serde(default = "tgw_enable")]
+    pub vpn_ecmp_support: String,
+    #[serde(default = "tgw_disable")]
+    pub multicast_support: String,
+}
+
+fn tgw_default_asn() -> i64 {
+    64512
+}
+fn tgw_enable() -> String {
+    "enable".to_string()
+}
+fn tgw_disable() -> String {
+    "disable".to_string()
+}
+
+impl Default for TransitGatewayOptions {
+    fn default() -> Self {
+        Self {
+            amazon_side_asn: tgw_default_asn(),
+            auto_accept_shared_attachments: tgw_disable(),
+            default_route_table_association: tgw_enable(),
+            default_route_table_propagation: tgw_enable(),
+            dns_support: tgw_enable(),
+            vpn_ecmp_support: tgw_enable(),
+            multicast_support: tgw_disable(),
+        }
+    }
 }
 
 fn tgw_default_state() -> String {


### PR DESCRIPTION
## Summary
Cycle-8 bug-hunt EC2 write-read-loss round 2 (part 1) — more accepted-then-dropped fields on the 767-op surface, all causing terraform drift (several ForceNew → non-converging plans).

- **E2-1 (HIGH)** `CreateTransitGateway` dropped the entire Options block; `tgw_xml` hardcoded ASN 64512 + all route-table/dns/ecmp defaults. Added a `TransitGatewayOptions` struct (AWS create-time defaults), parse `Options.*` on create, render the real values (+ multicastSupport).
- **E2-3 (HIGH)** `CreateCapacityReservation` dropped EbsOptimized/EphemeralStorage; `cr_xml` hardcoded both false. Added the fields + parse + render.
- **E2-8 (MED)** `CreateFlowLogs` dropped LogFormat; added the field + parse + render (AWS always echoes it).
- **E2-7 (MED)** `placement_affinity` was written but the DescribeInstances `<placement>` render omitted `<affinity>` (dead write) — now rendered when set.

New state fields are `#[serde(default)]` so existing snapshots load.

Deferred to part 2 (documented in the cycle-8 report): RequestSpotInstances options+launch-spec (E2-2), CreateVpnConnection/CreateVpnGateway (E2-4/5), GetLaunchTemplateData stub (E2-6).

## Test plan
- New: TGW options, CR ebs/ephemeral, FlowLog format, instance affinity render.
- `cargo nextest run -p fakecloud-ec2`: 211 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and render previously dropped EC2 fields to stop write/read loss and Terraform drift. Fixes Transit Gateway options, Capacity Reservation EBS/Ephemeral flags, Flow Log format, and instance placement affinity rendering.

- **Bug Fixes**
  - Transit Gateway: store and describe `Options` (AmazonSideAsn, route-table association/propagation, DNS, VPN ECMP, Multicast); parse `Options.*` on create.
  - Capacity Reservation: persist `EbsOptimized` and `EphemeralStorage`; describe reflects actual values.
  - Flow Logs: persist `LogFormat`; echoed in `DescribeFlowLogs`.
  - Instances: render `<affinity>` within `<placement>` when set.
  - Backward compatible: new state fields use `#[serde(default)]`; no API changes.

<sup>Written for commit 874937dd32ffb893a8f83b9c9da5acbe1e0164b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

