### PR TITLE
fix(athena): honor workgroup ResultConfiguration.OutputLocation + enforcement

### DIFF
--- a/crates/fakecloud-athena/src/service/mod.rs
+++ b/crates/fakecloud-athena/src/service/mod.rs
@@ -1407,6 +1407,51 @@ mod tests {
     }
 
     #[test]
+    fn start_query_execution_uses_workgroup_output_location() {
+        // bug-audit 2026-07-29 (cycle 8) DP-1: StartQueryExecution resolved
+        // OutputLocation only from the request; a workgroup-configured location
+        // (the common pattern, esp. with EnforceWorkGroupConfiguration) was
+        // ignored, so GetQueryExecution echoed no location and no S3 result was
+        // written. It must fall back to (and enforce) the workgroup config.
+        let svc = AthenaService::new(SharedAthenaState::default());
+        svc.create_work_group(&req(
+            "CreateWorkGroup",
+            json!({
+                "Name": "wg",
+                "Configuration": {
+                    "ResultConfiguration": {"OutputLocation": "s3://wg-results/prefix/"},
+                    "EnforceWorkGroupConfiguration": true
+                }
+            }),
+        ))
+        .unwrap();
+
+        let started = parse_json(
+            &svc.start_query_execution(&req(
+                "StartQueryExecution",
+                json!({ "QueryString": "SELECT 1", "WorkGroup": "wg" }),
+            ))
+            .unwrap(),
+        );
+        let qid = started["QueryExecutionId"].as_str().unwrap().to_string();
+
+        let got = parse_json(
+            &svc.get_query_execution(&req(
+                "GetQueryExecution",
+                json!({ "QueryExecutionId": qid }),
+            ))
+            .unwrap(),
+        );
+        let loc = got["QueryExecution"]["ResultConfiguration"]["OutputLocation"]
+            .as_str()
+            .unwrap_or("");
+        assert!(
+            loc.contains("wg-results"),
+            "should resolve the workgroup output location, got: {got}"
+        );
+    }
+
+    #[test]
     fn start_query_execution_with_named_query_id() {
         let svc = AthenaService::new(SharedAthenaState::default());
         let create_resp = svc

--- a/crates/fakecloud-athena/src/service/queries.rs
+++ b/crates/fakecloud-athena/src/service/queries.rs
@@ -66,15 +66,38 @@ impl AthenaService {
         // EngineVersion from the workgroup it runs in (the workgroup's
         // Configuration/EngineVersion, set at Create/UpdateWorkGroup) rather than
         // hardcoding AUTO/v3.
-        let engine_version = {
+        let (engine_version, wg_output_location, enforce_wg) = {
             let mut state = self.state.write();
             let account = account_mut(&mut state, &req.account_id);
             match account.work_groups.get(&work_group) {
-                Some(wg) => resolve_engine_version(wg),
+                Some(wg) => {
+                    let cfg = wg.configuration.as_ref();
+                    let wg_out = cfg
+                        .and_then(|c| c.pointer("/ResultConfiguration/OutputLocation"))
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                    let enforce = cfg
+                        .and_then(|c| c.get("EnforceWorkGroupConfiguration"))
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    (resolve_engine_version(wg), wg_out, enforce)
+                }
                 None => {
                     return Err(invalid_request(format!("Workgroup {work_group} not found")));
                 }
             }
+        };
+
+        // Effective result location: the workgroup's own ResultConfiguration.
+        // OutputLocation is consulted when the request omits one, and OVERRIDES
+        // the request when EnforceWorkGroupConfiguration is set -- matching real
+        // Athena, where the common pattern is to configure OutputLocation once on
+        // the workgroup and omit it per query. Without this the result S3 object
+        // was never written and GetQueryExecution echoed an empty location.
+        let output_location = if enforce_wg {
+            wg_output_location.clone().or(output_location)
+        } else {
+            output_location.or_else(|| wg_output_location.clone())
         };
 
         let id = synth_uuid();
@@ -121,16 +144,18 @@ impl AthenaService {
             }
         };
 
-        // Re-merge the executed output_location back into ResultConfiguration
-        // so GetQueryExecution echoes the resolved s3:// key back to the
-        // caller (real Athena does this).
+        // Echo the resolved OutputLocation back in ResultConfiguration so
+        // GetQueryExecution reports where results go (real Athena always does,
+        // whether or not a file was materialized). Prefer the executor's exact
+        // s3:// key; otherwise fall back to the effective location resolved from
+        // the request / workgroup config above.
         let mut effective_result_config = result_configuration.clone();
-        if let Some(ref out) = output {
+        if let Some(out) = output.clone().or_else(|| output_location.clone()) {
             let cfg = effective_result_config
                 .get_or_insert_with(|| json!({}))
                 .as_object_mut();
             if let Some(obj) = cfg {
-                obj.insert("OutputLocation".to_string(), Value::String(out.clone()));
+                obj.insert("OutputLocation".to_string(), Value::String(out));
             }
         }
 


### PR DESCRIPTION
## Summary
Cycle-8 bug-hunt **DP-1**. `StartQueryExecution` resolved OutputLocation only from the request body `ResultConfiguration`; the workgroup's own configured `ResultConfiguration.OutputLocation` was never consulted and `EnforceWorkGroupConfiguration` was never applied. So the standard Athena pattern — configure OutputLocation once on the workgroup, omit it per query (often with enforcement on) — produced no S3 result object and GetQueryExecution echoed an empty location.

## Fix
Resolve the effective location from the workgroup config — used when the request omits one, and overriding the request when `EnforceWorkGroupConfiguration` is set — and echo it back in `ResultConfiguration` on GetQueryExecution whether or not a result file was materialized (matching real Athena).

## Test plan
- New: enforced workgroup output location + omitted request ResultConfiguration → GetQueryExecution reports the workgroup location.
- `cargo nextest run -p fakecloud-athena`: 34 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No API surface change → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DP-1: Athena now honors the workgroup `ResultConfiguration.OutputLocation` and `EnforceWorkGroupConfiguration` when starting queries, and returns the effective location in GetQueryExecution. Ensures results go to the expected S3 prefix and the location is always reported.

- **Bug Fixes**
  - Applies workgroup enforcement to override per-request OutputLocation when `EnforceWorkGroupConfiguration` is true.
  - Always echoes the effective OutputLocation in GetQueryExecution, even if no result file is written.
  - Adds a regression test for enforced workgroup output; no API or SDK changes.

<sup>Written for commit 1c4f58327b53be284119b340e1e0d2e8fe660d4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

