### PR TITLE
fix(ec2): persist VpnConnection StaticRoutesOnly and VpnGateway AmazonSideAsn/AvailabilityZone

### DIFF
--- a/crates/fakecloud-ec2/src/service/vpn.rs
+++ b/crates/fakecloud-ec2/src/service/vpn.rs
@@ -111,10 +111,15 @@ fn vgw_xml(g: &VpnGateway, tags: &[Tag]) -> String {
         .map(|v| format!("{}<state>attached</state>", ec2_elem("vpcId", v)))
         .collect();
     format!(
-        "{}<state>{}</state>{}<amazonSideAsn>64512</amazonSideAsn>{}{}",
+        "{}<state>{}</state>{}<amazonSideAsn>{}</amazonSideAsn>{}{}{}",
         ec2_elem("vpnGatewayId", &g.id),
         g.state,
         ec2_elem("type", "ipsec.1"),
+        g.amazon_side_asn,
+        g.availability_zone
+            .as_ref()
+            .map(|z| ec2_elem("availabilityZone", z))
+            .unwrap_or_default(),
         ec2_list("attachments", &atts),
         super::tags::tag_set_xml(tags),
     )
@@ -131,6 +136,12 @@ pub(crate) fn create_vpn_gateway(
         id: id.clone(),
         state: "available".to_string(),
         attachments: Vec::new(),
+        amazon_side_asn: req
+            .query_params
+            .get("AmazonSideAsn")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(64512),
+        availability_zone: req.query_params.get("AvailabilityZone").cloned(),
     };
     let tags = {
         let mut accounts = svc.state.write();
@@ -256,7 +267,7 @@ fn vpn_conn_xml(c: &VpnConnection, tags: &[Tag]) -> String {
         .collect();
     format!(
         "{}<state>{}</state>{}{}{}<customerGatewayConfiguration>&lt;vpn_connection/&gt;</customerGatewayConfiguration>\
-         <options><staticRoutesOnly>false</staticRoutesOnly></options>{}{}{}",
+         <options><staticRoutesOnly>{}</staticRoutesOnly></options>{}{}{}",
         ec2_elem("vpnConnectionId", &c.id),
         c.state,
         ec2_elem("type", "ipsec.1"),
@@ -266,6 +277,7 @@ fn vpn_conn_xml(c: &VpnConnection, tags: &[Tag]) -> String {
             c.vpn_gateway_id.as_ref().map(|g| ec2_elem("vpnGatewayId", g)).unwrap_or_default(),
             c.transit_gateway_id.as_ref().map(|g| ec2_elem("transitGatewayId", g)).unwrap_or_default(),
         ),
+        c.static_routes_only,
         ec2_list("routes", &routes),
         ec2_list("vgwTelemetry", &[]),
         super::tags::tag_set_xml(tags),
@@ -289,6 +301,10 @@ pub(crate) fn create_vpn_connection(
         customer_gateway_id: cgw,
         vpn_gateway_id: req.query_params.get("VpnGatewayId").cloned(),
         transit_gateway_id: req.query_params.get("TransitGatewayId").cloned(),
+        static_routes_only: req
+            .query_params
+            .get("Options.StaticRoutesOnly")
+            .is_some_and(|v| v == "true"),
         routes: Vec::new(),
     };
     let tags = {
@@ -360,6 +376,7 @@ fn vpn_conn_lookup(svc: &Ec2Service, req: &AwsRequest, id: &str) -> (VpnConnecti
             customer_gateway_id: "cgw-0".to_string(),
             vpn_gateway_id: None,
             transit_gateway_id: None,
+            static_routes_only: false,
             routes: Vec::new(),
         });
     let tags = accounts
@@ -664,6 +681,61 @@ mod modify_vpn_tests {
 
     fn body(resp: AwsResponse) -> String {
         String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn create_vpn_connection_persists_static_routes_only() {
+        // bug-audit 2026-07-29 (cycle 8) E2-4: Options.StaticRoutesOnly was
+        // dropped; the describe render hardcoded false.
+        let svc = Ec2Service::new();
+        create_vpn_connection(
+            &svc,
+            &ec2_request(
+                "CreateVpnConnection",
+                &[
+                    ("CustomerGatewayId", "cgw-1"),
+                    ("Type", "ipsec.1"),
+                    ("Options.StaticRoutesOnly", "true"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc = body(
+            describe_vpn_connections(&svc, &ec2_request("DescribeVpnConnections", &[])).unwrap(),
+        );
+        assert!(
+            desc.contains("<staticRoutesOnly>true</staticRoutesOnly>"),
+            "{desc}"
+        );
+    }
+
+    #[test]
+    fn create_vpn_gateway_persists_asn_and_az() {
+        // bug-audit 2026-07-29 (cycle 8) E2-5: AmazonSideAsn/AvailabilityZone
+        // were dropped; the render hardcoded ASN 64512 and emitted no AZ.
+        let svc = Ec2Service::new();
+        create_vpn_gateway(
+            &svc,
+            &ec2_request(
+                "CreateVpnGateway",
+                &[
+                    ("Type", "ipsec.1"),
+                    ("AmazonSideAsn", "65001"),
+                    ("AvailabilityZone", "us-east-1b"),
+                ],
+            ),
+        )
+        .unwrap();
+        let desc =
+            body(describe_vpn_gateways(&svc, &ec2_request("DescribeVpnGateways", &[])).unwrap());
+        assert!(
+            desc.contains("<amazonSideAsn>65001</amazonSideAsn>"),
+            "{desc}"
+        );
+        assert!(
+            desc.contains("<availabilityZone>us-east-1b</availabilityZone>"),
+            "{desc}"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/state.rs
+++ b/crates/fakecloud-ec2/src/state.rs
@@ -992,6 +992,16 @@ pub struct VpnGateway {
     pub state: String,
     #[serde(default)]
     pub attachments: Vec<String>,
+    /// `AmazonSideAsn` / `AvailabilityZone`, previously hardcoded (asn 64512, no
+    /// AZ) in the describe render -> `aws_vpn_gateway` (ForceNew) drifted.
+    #[serde(default = "vgw_default_asn")]
+    pub amazon_side_asn: i64,
+    #[serde(default)]
+    pub availability_zone: Option<String>,
+}
+
+fn vgw_default_asn() -> i64 {
+    64512
 }
 
 /// A Site-to-Site VPN connection.
@@ -1003,6 +1013,10 @@ pub struct VpnConnection {
     pub vpn_gateway_id: Option<String>,
     #[serde(default)]
     pub transit_gateway_id: Option<String>,
+    /// `Options.StaticRoutesOnly`; previously hardcoded false in the describe
+    /// render, so `aws_vpn_connection` (ForceNew) drifted on a non-default.
+    #[serde(default)]
+    pub static_routes_only: bool,
     #[serde(default)]
     pub routes: Vec<String>,
 }


### PR DESCRIPTION
## Summary
Cycle-8 bug-hunt EC2 write-read-loss round 2 (part 2):

- **E2-4** — `CreateVpnConnection` dropped `Options.StaticRoutesOnly`; `vpn_conn_xml` hardcoded `<staticRoutesOnly>false</staticRoutesOnly>`. Added the field + parse + render. `aws_vpn_connection` (ForceNew) with `static_routes_only = true` now converges.
- **E2-5** — `CreateVpnGateway` dropped `AmazonSideAsn` (hardcoded 64512 in the render) and `AvailabilityZone` (never emitted). Added both fields + parse + render (AZ only when set). `aws_vpn_gateway` (ForceNew) round-trips a custom ASN/AZ.

New state fields are `#[serde(default)]` so existing snapshots load.

Remaining EC2 round-2 (documented in the cycle-8 report): RequestSpotInstances options+launch spec (E2-2, HIGH) and GetLaunchTemplateData derive-from-instance (E2-6).

## Test plan
- New: VpnConnection static-routes-only + VpnGateway asn/az round-trip.
- `cargo nextest run -p fakecloud-ec2`: 213 passed.
- clippy `--all-targets -D warnings` + fmt clean.
- No new API surface → no SDK/doc change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EC2 VPN write-read drift by persisting `StaticRoutesOnly` on VPN connections and `AmazonSideAsn`/`AvailabilityZone` on VPN gateways. Describe responses now reflect requested values, avoiding Terraform drift on non-defaults.

- **Bug Fixes**
  - `CreateVpnConnection`: parse and store `Options.StaticRoutesOnly`; render in `DescribeVpnConnections`.
  - `CreateVpnGateway`: parse and store `AmazonSideAsn` and `AvailabilityZone`; render in `DescribeVpnGateways` (AZ only when set).
  - Added state fields with serde defaults to keep existing snapshots loading.
  - New round-trip tests for both resources; no API surface changes.

<sup>Written for commit e4daccdd8d4e247bad916228ced6e0d8f208f5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

