### PR TITLE
fix(lambda): authorize localhost registry pulls

### DIFF
--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -318,6 +318,7 @@ fn in_container_mode(env_value: Option<String>) -> bool {
 /// drift again.
 pub fn registry_auth_hosts(server_port: u16) -> Vec<String> {
     [
+        "localhost",
         "127.0.0.1",
         "host.docker.internal",
         "host.containers.internal",
@@ -377,6 +378,7 @@ mod tests {
         // The podman sibling alias (host.containers.internal) must be authorized
         // or image-based Lambda/ECS pulls 401 under podman-in-a-container (0.B2).
         let hosts = registry_auth_hosts(4566);
+        assert!(hosts.contains(&"localhost:4566".to_string()));
         assert!(hosts.contains(&"127.0.0.1:4566".to_string()));
         assert!(hosts.contains(&"host.docker.internal:4566".to_string()));
         assert!(

--- a/crates/fakecloud-core/src/container_net.rs
+++ b/crates/fakecloud-core/src/container_net.rs
@@ -303,15 +303,16 @@ fn in_container_mode(env_value: Option<String>) -> bool {
         .unwrap_or(false)
 }
 
-/// Hostnames fakecloud's bundled ECR/OCI registry can be addressed by from a
-/// sibling container, each at `server_port`.
+/// Hostnames fakecloud's bundled ECR/OCI registry can be addressed from a
+/// sibling container or the host, each at `server_port`.
 ///
 /// A container-spawning service rewrites the image pull URI to the runtime's
 /// sibling host -- `host.docker.internal` under Docker, `host.containers.internal`
-/// under podman -- or leaves it `127.0.0.1` when fakecloud runs on the host. The
-/// registry enforces auth, and the Docker/Podman CLI only attaches the
-/// `Authorization` header for hosts present in `config.json`, so the isolated
-/// pull config must list *every* alias or the pull gets a 401. The map
+/// under podman -- or leaves it `localhost` / `127.0.0.1` when fakecloud runs on
+/// the host (`localhost:<port>` is the documented local ECR endpoint, e.g.
+/// `localhost:4566`). The registry enforces auth, and the Docker/Podman CLI only
+/// attaches the `Authorization` header for hosts present in `config.json`, so the
+/// isolated pull config must list *every* alias or the pull gets a 401. The map
 /// previously omitted the podman alias, so image-based Lambda/ECS pulls failed
 /// under podman-in-a-container (bug-audit 2026-06-20, 0.B2). Authorize all of
 /// them with the same credential; centralized here so the two builders can't


### PR DESCRIPTION
## Summary

Image-backed Lambda functions inherit a Docker config generated by fakecloud. Add `localhost:<port>` to the authorized registry aliases so images pushed to the documented local ECR endpoint (`localhost:4566`) can be pulled by Lambda containers.

## Testing

- `cargo fmt --check`
- `cargo test -p fakecloud-core registry_auth_hosts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize `localhost:<port>` in `registry_auth_hosts` so image-backed Lambda containers can pull from the documented local ECR endpoint (`localhost:4566`) without 401s. Updated the doc comment and tests to reflect the new alias.

<sup>Written for commit ea9033afe48bebd9416e82037643dd56e6f36db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

