### PR TITLE
fix(dynamodb): support BatchExecuteStatement responses

### DIFF
--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
 use fakecloud_core::validation::*;
 
-use crate::state::AttributeValue;
+use crate::state::{AttributeValue, DynamoTable};
 
 /// A queued Kinesis delivery for a single transact write — fired after
 /// the apply phase succeeds and the write lock is dropped. Tuple shape:
@@ -1233,7 +1233,14 @@ impl DynamoDbService {
 
                 match execute_partiql_in_state(state, statement, &parameters) {
                     Ok(outcome) => {
-                        responses.push(batch_partiql_response(statement, outcome.response.clone()));
+                        responses.push(batch_partiql_response(
+                            statement,
+                            outcome.response.clone(),
+                            outcome
+                                .table_name
+                                .as_ref()
+                                .and_then(|name| state.tables.get(name)),
+                        ));
                         if let (Some(table_name), Some(event_name)) =
                             (outcome.table_name.as_ref(), outcome.event_name.as_ref())
                         {
@@ -1549,19 +1556,28 @@ impl DynamoDbService {
     }
 }
 
-fn batch_partiql_response(statement: &str, response: Value) -> Value {
+fn batch_partiql_response(statement: &str, response: Value, table: Option<&DynamoTable>) -> Value {
     let upper = statement.trim_start().to_ascii_uppercase();
     if !upper.starts_with("SELECT") {
         return response;
     }
 
-    let Some(from_pos) = upper.find("FROM") else {
+    let Some(from_pos) = super::find_outside_quotes(&upper, "FROM") else {
         return batch_single_item_select_error();
     };
     let after_from = statement.trim_start()[from_pos + 4..].trim_start();
     let (_, rest) = super::parse_partiql_table_name(after_from);
     let rest = rest.trim_start();
     if rest.starts_with('.') || !rest.to_ascii_uppercase().starts_with("WHERE") {
+        return batch_single_item_select_error();
+    }
+    let where_clause = &rest[5..];
+    if table.is_none_or(|table| {
+        table.key_schema.iter().any(|key| {
+            !where_clause.contains(&format!("\"{}\" = ?", key.attribute_name))
+                && !where_clause.contains(&format!("{} = ?", key.attribute_name))
+        })
+    }) {
         return batch_single_item_select_error();
     }
 
@@ -2609,6 +2625,22 @@ mod tests {
             "Only single item select is supported"
         );
 
+        let non_key_select = svc
+            .batch_execute_statement(&req_for(
+                "BatchExecuteStatement",
+                json!({
+                    "Statements": [{
+                        "Statement": "SELECT * FROM \"Widgets\" WHERE data = ?",
+                        "Parameters": [{ "S": "missing" }]
+                    }]
+                }),
+            ))
+            .unwrap();
+        assert_eq!(
+            response_body(&non_key_select)["Responses"][0]["Error"]["Message"],
+            "Only single item select is supported"
+        );
+
         let update = svc
             .batch_execute_statement(&req_for(
                 "BatchExecuteStatement",
@@ -2633,6 +2665,33 @@ mod tests {
         assert_eq!(
             update_body["Responses"][0]["Item"]["results"]["L"][0]["S"],
             "new"
+        );
+
+        let literal_update = svc
+            .execute_statement(&req_for(
+                "ExecuteStatement",
+                json!({
+                    "Statement": "UPDATE \"Widgets\" SET \"state\" = 'ready' WHERE \"pk\" = ?",
+                    "Parameters": [{ "S": "a" }]
+                }),
+            ))
+            .unwrap();
+        assert!(response_body(&literal_update).get("Item").is_none());
+
+        let literal_select = svc
+            .batch_execute_statement(&req_for(
+                "BatchExecuteStatement",
+                json!({
+                    "Statements": [{
+                        "Statement": "SELECT * FROM \"Widgets\" WHERE \"pk\" = ?",
+                        "Parameters": [{ "S": "a" }]
+                    }]
+                }),
+            ))
+            .unwrap();
+        assert_eq!(
+            response_body(&literal_select)["Responses"][0]["Item"]["state"]["S"],
+            "ready"
         );
     }
 

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -1233,7 +1233,7 @@ impl DynamoDbService {
 
                 match execute_partiql_in_state(state, statement, &parameters) {
                     Ok(outcome) => {
-                        responses.push(outcome.response.clone());
+                        responses.push(batch_partiql_response(statement, outcome.response.clone()));
                         if let (Some(table_name), Some(event_name)) =
                             (outcome.table_name.as_ref(), outcome.event_name.as_ref())
                         {
@@ -1549,6 +1549,46 @@ impl DynamoDbService {
     }
 }
 
+fn batch_partiql_response(statement: &str, response: Value) -> Value {
+    let upper = statement.trim_start().to_ascii_uppercase();
+    if !upper.starts_with("SELECT") {
+        return response;
+    }
+
+    let Some(from_pos) = upper.find("FROM") else {
+        return batch_single_item_select_error();
+    };
+    let after_from = statement.trim_start()[from_pos + 4..].trim_start();
+    let (_, rest) = super::parse_partiql_table_name(after_from);
+    let rest = rest.trim_start();
+    if rest.starts_with('.') || !rest.to_ascii_uppercase().starts_with("WHERE") {
+        return batch_single_item_select_error();
+    }
+
+    let items = response
+        .get("Items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if items.len() == 1 {
+        return json!({ "Item": items[0] });
+    }
+    if items.is_empty() {
+        return json!({});
+    }
+
+    batch_single_item_select_error()
+}
+
+fn batch_single_item_select_error() -> Value {
+    json!({
+        "Error": {
+            "Code": "ValidationError",
+            "Message": "Only single item select is supported"
+        }
+    })
+}
+
 /// Apply `Limit` + `NextToken` to a PartiQL SELECT response. The token is an
 /// opaque base64-encoded offset into the (deterministically ordered) result
 /// set. No-op for write statements (which carry no `Items`).
@@ -1611,6 +1651,10 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    fn response_body(response: &AwsResponse) -> Value {
+        serde_json::from_slice(response.body.expect_bytes()).unwrap()
     }
 
     fn make_state() -> SharedDynamoDbState {
@@ -2525,6 +2569,71 @@ mod tests {
             .unwrap();
         assert_eq!(table.items.len(), 2);
         assert_eq!(table.stream_records.read().len(), 2);
+    }
+
+    #[test]
+    fn batch_execute_statement_returns_single_items_and_updates() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({ "Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}" }),
+        ))
+        .unwrap();
+
+        let select = svc
+            .batch_execute_statement(&req_for(
+                "BatchExecuteStatement",
+                json!({
+                    "Statements": [{
+                        "Statement": "SELECT * FROM \"Widgets\" WHERE \"pk\" = ?",
+                        "Parameters": [{ "S": "a" }]
+                    }]
+                }),
+            ))
+            .unwrap();
+        let select_body = response_body(&select);
+        assert_eq!(select_body["Responses"][0]["Item"]["pk"]["S"], "a");
+
+        let scan = svc
+            .batch_execute_statement(&req_for(
+                "BatchExecuteStatement",
+                json!({ "Statements": [{ "Statement": "SELECT * FROM \"Widgets\"" }] }),
+            ))
+            .unwrap();
+        let scan_body = response_body(&scan);
+        assert_eq!(
+            scan_body["Responses"][0]["Error"]["Message"],
+            "Only single item select is supported"
+        );
+
+        let update = svc
+            .batch_execute_statement(&req_for(
+                "BatchExecuteStatement",
+                json!({
+                    "Statements": [{
+                        "Statement": "UPDATE \"Widgets\" SET \"results\" = list_append(if_not_exists(\"results\", ?), ?) SET \"updatedAt\" = ? WHERE \"pk\" = ? RETURNING ALL NEW *",
+                        "Parameters": [
+                            { "L": [] },
+                            { "L": [{ "S": "new" }] },
+                            { "S": "now" },
+                            { "S": "a" }
+                        ]
+                    }]
+                }),
+            ))
+            .unwrap();
+        let update_body = response_body(&update);
+        assert_eq!(
+            update_body["Responses"][0]["Item"]["updatedAt"]["S"], "now",
+            "unexpected update response: {update_body}"
+        );
+        assert_eq!(
+            update_body["Responses"][0]["Item"]["results"]["L"][0]["S"],
+            "new"
+        );
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -1573,10 +1573,10 @@ fn batch_partiql_response(statement: &str, response: Value, table: Option<&Dynam
     }
     let where_clause = &rest[5..];
     if table.is_none_or(|table| {
-        table.key_schema.iter().any(|key| {
-            !where_clause.contains(&format!("\"{}\" = ?", key.attribute_name))
-                && !where_clause.contains(&format!("{} = ?", key.attribute_name))
-        })
+        table
+            .key_schema
+            .iter()
+            .any(|key| !where_matches_key_equals(where_clause, &key.attribute_name))
     }) {
         return batch_single_item_select_error();
     }
@@ -1594,6 +1594,36 @@ fn batch_partiql_response(statement: &str, response: Value, table: Option<&Dynam
     }
 
     batch_single_item_select_error()
+}
+
+/// True if the batch SELECT `WHERE` clause pins `attr` to a positional
+/// parameter (`attr = ?`), tolerant of arbitrary spacing around `=`. The
+/// quoted form matches directly; the unquoted form must be a whole identifier
+/// so a longer attribute such as `mypk` is not mistaken for key `pk`.
+fn where_matches_key_equals(where_clause: &str, attr: &str) -> bool {
+    // Normalize `"pk"=?`, `"pk" = ?` and `"pk"  =  ?` to one canonical spacing.
+    let normalized = where_clause.replace('=', " = ");
+    let normalized = normalized.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if normalized.contains(&format!("\"{attr}\" = ?")) {
+        return true;
+    }
+
+    let needle = format!("{attr} = ?");
+    let mut from = 0;
+    while let Some(rel) = normalized[from..].find(&needle) {
+        let start = from + rel;
+        let prev_ok = start == 0
+            || !matches!(
+                normalized.as_bytes()[start - 1],
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_'
+            );
+        if prev_ok {
+            return true;
+        }
+        from = start + needle.len();
+    }
+    false
 }
 
 fn batch_single_item_select_error() -> Value {
@@ -2693,6 +2723,82 @@ mod tests {
             response_body(&literal_select)["Responses"][0]["Item"]["state"]["S"],
             "ready"
         );
+    }
+
+    #[test]
+    fn where_matches_key_equals_spacing_and_word_boundary() {
+        // Tolerant of arbitrary spacing around `=`, quoted or bare.
+        assert!(where_matches_key_equals("\"pk\"=?", "pk"));
+        assert!(where_matches_key_equals("\"pk\"  =  ?", "pk"));
+        assert!(where_matches_key_equals("pk = ?", "pk"));
+        // A longer attribute name must not be mistaken for the key.
+        assert!(!where_matches_key_equals("mypk = ?", "pk"));
+        assert!(!where_matches_key_equals("pkid = ?", "pk"));
+        // A non-`?` RHS is not a positional single-item lookup.
+        assert!(!where_matches_key_equals("\"pk\" = :v", "pk"));
+    }
+
+    #[test]
+    fn batch_execute_statement_handles_non_ascii_and_keyword_literals() {
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({ "Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}" }),
+        ))
+        .unwrap();
+
+        // Non-ASCII value in a quoted literal must round-trip byte-for-byte
+        // (previously corrupted to mojibake by byte-wise expression rebuild).
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({
+                "Statement": "UPDATE \"Widgets\" SET \"label\" = 'José 名前 🚀' WHERE \"pk\" = ?",
+                "Parameters": [{ "S": "a" }]
+            }),
+        ))
+        .unwrap();
+
+        // A keyword-looking word inside a quoted literal is data, not a clause:
+        // the write must land instead of being silently dropped.
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({
+                "Statement": "UPDATE \"Widgets\" SET \"note\" = 'please REMOVE this' WHERE \"pk\" = ?",
+                "Parameters": [{ "S": "a" }]
+            }),
+        ))
+        .unwrap();
+
+        // A non-ASCII, non-key attribute in the WHERE predicate must not panic
+        // the RETURNING scan (it simply matches nothing).
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({
+                "Statement": "UPDATE \"Widgets\" SET \"x\" = ? WHERE \"café\" = ?",
+                "Parameters": [{ "S": "1" }, { "S": "z" }]
+            }),
+        ))
+        .unwrap();
+
+        // Read back through a batch single-item SELECT with tight `"pk"=?`
+        // spacing (no surrounding spaces) to confirm the key-check tolerates it.
+        let select = svc
+            .batch_execute_statement(&req_for(
+                "BatchExecuteStatement",
+                json!({
+                    "Statements": [{
+                        "Statement": "SELECT * FROM \"Widgets\" WHERE \"pk\"=?",
+                        "Parameters": [{ "S": "a" }]
+                    }]
+                }),
+            ))
+            .unwrap();
+        let item = &response_body(&select)["Responses"][0]["Item"];
+        assert_eq!(item["label"]["S"], "José 名前 🚀");
+        assert_eq!(item["note"]["S"], "please REMOVE this");
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -1572,12 +1572,7 @@ fn batch_partiql_response(statement: &str, response: Value, table: Option<&Dynam
         return batch_single_item_select_error();
     }
     let where_clause = &rest[5..];
-    if table.is_none_or(|table| {
-        table
-            .key_schema
-            .iter()
-            .any(|key| !where_matches_key_equals(where_clause, &key.attribute_name))
-    }) {
+    if table.is_none_or(|table| !where_is_full_key_equality(where_clause, table)) {
         return batch_single_item_select_error();
     }
 
@@ -1596,71 +1591,59 @@ fn batch_partiql_response(statement: &str, response: Value, table: Option<&Dynam
     batch_single_item_select_error()
 }
 
-/// True if the batch SELECT `WHERE` clause pins `attr` to a positional
-/// parameter (`attr = ?`), tolerant of arbitrary spacing around `=`. Matches
-/// either the double-quoted token (`"attr" = ?`, preserving any internal spaces
-/// in the name) or the bare identifier (`attr = ?`, as a whole word so a longer
-/// name such as `mypk` is not mistaken for key `pk`). A single-quoted string
-/// literal in the predicate is skipped, so a value like `'pk = ?'` is not
-/// mistaken for the key predicate itself.
-fn where_matches_key_equals(where_clause: &str, attr: &str) -> bool {
-    let bytes = where_clause.as_bytes();
-    let n = bytes.len();
-    let quoted_tok = format!("\"{attr}\"");
-    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80;
+/// True if a batch SELECT `WHERE` clause is exactly a full-primary-key point
+/// lookup: every key attribute pinned to a positional parameter (`attr = ?`),
+/// joined by `AND`, with no other predicates. AWS `BatchExecuteStatement`
+/// requires equality on the complete key and nothing else, so a missing key, an
+/// extra non-key predicate, or a non-`?` right-hand side all fail here.
+///
+/// The `AND` split is quote-aware (via [`split_on_top_level_keyword`]), so a
+/// value such as `'a AND b'` or `'pk = ?'` is treated as data, not structure.
+fn where_is_full_key_equality(where_clause: &str, table: &DynamoTable) -> bool {
+    let conjuncts: Vec<&str> = super::split_on_top_level_keyword(where_clause, "AND")
+        .into_iter()
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .collect();
+    // One conjunct per key attribute, no more: this rejects both a missing key
+    // and an extra non-key predicate (`pk = ? AND data = ?`).
+    conjuncts.len() == table.key_schema.len()
+        && table.key_schema.iter().all(|key| {
+            conjuncts
+                .iter()
+                .any(|c| conjunct_is_key_equals(c, &key.attribute_name))
+        })
+        && conjuncts.iter().all(|c| {
+            table
+                .key_schema
+                .iter()
+                .any(|key| conjunct_is_key_equals(c, &key.attribute_name))
+        })
+}
 
-    let mut i = 0;
-    let mut in_squote = false;
-    while i < n {
-        let b = bytes[i];
-        if in_squote {
-            if b == b'\'' {
-                in_squote = false;
-            }
-            i += 1;
-            continue;
+/// True if a single WHERE conjunct is exactly `attr = ?` -- either double-quoted
+/// (`"attr" = ?`, preserving internal spaces in the name) or the bare whole
+/// identifier (`attr = ?`, so `mypk` is not mistaken for key `pk`) -- tolerant
+/// of arbitrary whitespace around `=`.
+fn conjunct_is_key_equals(conjunct: &str, attr: &str) -> bool {
+    let c = conjunct.trim();
+    if let Some(rest) = c.strip_prefix(&format!("\"{attr}\"")) {
+        return is_equals_placeholder(rest);
+    }
+    if let Some(rest) = c.strip_prefix(attr) {
+        // The bare name must be a whole identifier, not a prefix of a longer one.
+        if !rest.starts_with(|ch: char| ch.is_alphanumeric() || ch == '_') {
+            return is_equals_placeholder(rest);
         }
-        if b == b'\'' {
-            in_squote = true;
-            i += 1;
-            continue;
-        }
-        if where_clause.is_char_boundary(i) {
-            // `"attr"` immediately (modulo spacing) followed by `= ?`.
-            if where_clause[i..].starts_with(&quoted_tok)
-                && equals_placeholder_after(bytes, i + quoted_tok.len())
-            {
-                return true;
-            }
-            // Bare `attr` as a whole identifier.
-            let before_ok = i == 0 || !is_ident(bytes[i - 1]);
-            if before_ok && where_clause[i..].starts_with(attr) {
-                let after = i + attr.len();
-                if (after >= n || !is_ident(bytes[after])) && equals_placeholder_after(bytes, after)
-                {
-                    return true;
-                }
-            }
-        }
-        i += 1;
     }
     false
 }
 
-/// From byte offset `j`, match optional spaces, `=`, optional spaces, `?`.
-fn equals_placeholder_after(bytes: &[u8], mut j: usize) -> bool {
-    let skip_ws = |j: &mut usize| {
-        while *j < bytes.len() && (bytes[*j] == b' ' || bytes[*j] == b'\t') {
-            *j += 1;
-        }
-    };
-    skip_ws(&mut j);
-    if j >= bytes.len() || bytes[j] != b'=' {
-        return false;
-    }
-    j += 1;
-    skip_ws(&mut j);
-    j < bytes.len() && bytes[j] == b'?'
+/// True if `s` is `= ?` modulo surrounding whitespace and nothing else.
+fn is_equals_placeholder(s: &str) -> bool {
+    s.trim_start()
+        .strip_prefix('=')
+        .is_some_and(|rhs| rhs.trim() == "?")
 }
 
 fn batch_single_item_select_error() -> Value {
@@ -2763,20 +2746,41 @@ mod tests {
     }
 
     #[test]
-    fn where_matches_key_equals_spacing_and_word_boundary() {
-        // Tolerant of arbitrary spacing around `=`, quoted or bare.
-        assert!(where_matches_key_equals("\"pk\"=?", "pk"));
-        assert!(where_matches_key_equals("\"pk\"  =  ?", "pk"));
-        assert!(where_matches_key_equals("pk = ?", "pk"));
+    fn conjunct_is_key_equals_spacing_and_word_boundary() {
+        // Tolerant of arbitrary whitespace around `=`, quoted or bare.
+        assert!(conjunct_is_key_equals("\"pk\"=?", "pk"));
+        assert!(conjunct_is_key_equals("\"pk\"  =  ?", "pk"));
+        assert!(conjunct_is_key_equals("pk = ?", "pk"));
+        assert!(conjunct_is_key_equals("\"pk\" =\n?", "pk"));
         // A longer attribute name must not be mistaken for the key.
-        assert!(!where_matches_key_equals("mypk = ?", "pk"));
-        assert!(!where_matches_key_equals("pkid = ?", "pk"));
+        assert!(!conjunct_is_key_equals("mypk = ?", "pk"));
+        assert!(!conjunct_is_key_equals("pkid = ?", "pk"));
         // A non-`?` RHS is not a positional single-item lookup.
-        assert!(!where_matches_key_equals("\"pk\" = :v", "pk"));
-        // The key pattern inside a string literal is data, not a predicate.
-        assert!(!where_matches_key_equals("data = 'pk = ?'", "pk"));
+        assert!(!conjunct_is_key_equals("\"pk\" = :v", "pk"));
         // A quoted key name keeps its internal whitespace intact.
-        assert!(where_matches_key_equals("\"my  pk\" = ?", "my  pk"));
+        assert!(conjunct_is_key_equals("\"my  pk\" = ?", "my  pk"));
+        // Trailing junk after the placeholder is not an exact key equality.
+        assert!(!conjunct_is_key_equals("pk = ? extra", "pk"));
+    }
+
+    #[test]
+    fn where_is_full_key_equality_rejects_missing_and_extra_predicates() {
+        let state = make_state();
+        seed_table_with_stream(&state, "T"); // single HASH key `pk`
+        let accts = state.read();
+        let table = accts.get("123456789012").unwrap().tables.get("T").unwrap();
+
+        assert!(where_is_full_key_equality("\"pk\" = ?", table));
+        assert!(where_is_full_key_equality("\"pk\"=?", table));
+        // Extra non-key predicate is rejected (AWS requires key-only).
+        assert!(!where_is_full_key_equality(
+            "\"pk\" = ? AND data = ?",
+            table
+        ));
+        // Missing key is rejected.
+        assert!(!where_is_full_key_equality("data = ?", table));
+        // A key pattern inside a string literal is data, not a predicate.
+        assert!(!where_is_full_key_equality("data = 'pk = ?'", table));
     }
 
     #[test]

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -1597,33 +1597,70 @@ fn batch_partiql_response(statement: &str, response: Value, table: Option<&Dynam
 }
 
 /// True if the batch SELECT `WHERE` clause pins `attr` to a positional
-/// parameter (`attr = ?`), tolerant of arbitrary spacing around `=`. The
-/// quoted form matches directly; the unquoted form must be a whole identifier
-/// so a longer attribute such as `mypk` is not mistaken for key `pk`.
+/// parameter (`attr = ?`), tolerant of arbitrary spacing around `=`. Matches
+/// either the double-quoted token (`"attr" = ?`, preserving any internal spaces
+/// in the name) or the bare identifier (`attr = ?`, as a whole word so a longer
+/// name such as `mypk` is not mistaken for key `pk`). A single-quoted string
+/// literal in the predicate is skipped, so a value like `'pk = ?'` is not
+/// mistaken for the key predicate itself.
 fn where_matches_key_equals(where_clause: &str, attr: &str) -> bool {
-    // Normalize `"pk"=?`, `"pk" = ?` and `"pk"  =  ?` to one canonical spacing.
-    let normalized = where_clause.replace('=', " = ");
-    let normalized = normalized.split_whitespace().collect::<Vec<_>>().join(" ");
+    let bytes = where_clause.as_bytes();
+    let n = bytes.len();
+    let quoted_tok = format!("\"{attr}\"");
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80;
 
-    if normalized.contains(&format!("\"{attr}\" = ?")) {
-        return true;
-    }
-
-    let needle = format!("{attr} = ?");
-    let mut from = 0;
-    while let Some(rel) = normalized[from..].find(&needle) {
-        let start = from + rel;
-        let prev_ok = start == 0
-            || !matches!(
-                normalized.as_bytes()[start - 1],
-                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_'
-            );
-        if prev_ok {
-            return true;
+    let mut i = 0;
+    let mut in_squote = false;
+    while i < n {
+        let b = bytes[i];
+        if in_squote {
+            if b == b'\'' {
+                in_squote = false;
+            }
+            i += 1;
+            continue;
         }
-        from = start + needle.len();
+        if b == b'\'' {
+            in_squote = true;
+            i += 1;
+            continue;
+        }
+        if where_clause.is_char_boundary(i) {
+            // `"attr"` immediately (modulo spacing) followed by `= ?`.
+            if where_clause[i..].starts_with(&quoted_tok)
+                && equals_placeholder_after(bytes, i + quoted_tok.len())
+            {
+                return true;
+            }
+            // Bare `attr` as a whole identifier.
+            let before_ok = i == 0 || !is_ident(bytes[i - 1]);
+            if before_ok && where_clause[i..].starts_with(attr) {
+                let after = i + attr.len();
+                if (after >= n || !is_ident(bytes[after])) && equals_placeholder_after(bytes, after)
+                {
+                    return true;
+                }
+            }
+        }
+        i += 1;
     }
     false
+}
+
+/// From byte offset `j`, match optional spaces, `=`, optional spaces, `?`.
+fn equals_placeholder_after(bytes: &[u8], mut j: usize) -> bool {
+    let skip_ws = |j: &mut usize| {
+        while *j < bytes.len() && (bytes[*j] == b' ' || bytes[*j] == b'\t') {
+            *j += 1;
+        }
+    };
+    skip_ws(&mut j);
+    if j >= bytes.len() || bytes[j] != b'=' {
+        return false;
+    }
+    j += 1;
+    skip_ws(&mut j);
+    j < bytes.len() && bytes[j] == b'?'
 }
 
 fn batch_single_item_select_error() -> Value {
@@ -2736,6 +2773,10 @@ mod tests {
         assert!(!where_matches_key_equals("pkid = ?", "pk"));
         // A non-`?` RHS is not a positional single-item lookup.
         assert!(!where_matches_key_equals("\"pk\" = :v", "pk"));
+        // The key pattern inside a string literal is data, not a predicate.
+        assert!(!where_matches_key_equals("data = 'pk = ?'", "pk"));
+        // A quoted key name keeps its internal whitespace intact.
+        assert!(where_matches_key_equals("\"my  pk\" = ?", "my  pk"));
     }
 
     #[test]
@@ -2772,6 +2813,17 @@ mod tests {
         ))
         .unwrap();
 
+        // A comma inside a quoted literal must not split the SET assignment and
+        // drop the write (`SET addr = 'City, State'`).
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({
+                "Statement": "UPDATE \"Widgets\" SET \"addr\" = 'City, State' WHERE \"pk\" = ?",
+                "Parameters": [{ "S": "a" }]
+            }),
+        ))
+        .unwrap();
+
         // A non-ASCII, non-key attribute in the WHERE predicate must not panic
         // the RETURNING scan (it simply matches nothing).
         svc.execute_statement(&req_for(
@@ -2799,6 +2851,34 @@ mod tests {
         let item = &response_body(&select)["Responses"][0]["Item"];
         assert_eq!(item["label"]["S"], "José 名前 🚀");
         assert_eq!(item["note"]["S"], "please REMOVE this");
+        assert_eq!(item["addr"]["S"], "City, State");
+    }
+
+    #[test]
+    fn partiql_update_returning_without_where_does_not_corrupt_set() {
+        // `RETURNING` after a WHERE-less UPDATE must be stripped from the SET
+        // clause, not fed into the update-expression evaluator. The update
+        // matches every item (no WHERE) and returns the new image.
+        let state = make_state();
+        seed_table_with_stream(&state, "Widgets");
+        let svc = DynamoDbService::new(state);
+
+        svc.execute_statement(&req_for(
+            "ExecuteStatement",
+            json!({ "Statement": "INSERT INTO \"Widgets\" VALUE {'pk': 'a'}" }),
+        ))
+        .unwrap();
+
+        let updated = svc
+            .execute_statement(&req_for(
+                "ExecuteStatement",
+                json!({
+                    "Statement": "UPDATE \"Widgets\" SET \"flag\" = ? RETURNING ALL NEW *",
+                    "Parameters": [{ "S": "on" }]
+                }),
+            ))
+            .unwrap();
+        assert_eq!(response_body(&updated)["Item"]["flag"]["S"], "on");
     }
 
     #[tokio::test]

--- a/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/conditions.rs
@@ -88,10 +88,12 @@ pub(crate) fn evaluate_key_condition(
 /// ``:s\tAND\t:o`` and ``:s\nAND\n:o`` split the same as ``:s AND :o``.
 ///
 /// Parenthesised groups are skipped so only unparenthesised occurrences of the
-/// keyword act as separators. When splitting on ``AND``, each top-level
-/// ``BETWEEN`` keyword consumes the next top-level ``AND`` as its own inner
-/// separator (``x BETWEEN :lo AND :hi``) rather than letting it split the
-/// expression.
+/// keyword act as separators. Single- and double-quoted spans are skipped too,
+/// so a separator (or paren) inside a PartiQL string literal (`'a, b'`) or a
+/// quoted attribute name (`"my,attr"`) is treated as data, not a boundary.
+/// When splitting on ``AND``, each top-level ``BETWEEN`` keyword consumes the
+/// next top-level ``AND`` as its own inner separator (``x BETWEEN :lo AND :hi``)
+/// rather than letting it split the expression.
 pub(crate) fn split_on_top_level_keyword<'a>(expr: &'a str, keyword: &str) -> Vec<&'a str> {
     let bytes = expr.as_bytes();
     let len = bytes.len();
@@ -102,10 +104,38 @@ pub(crate) fn split_on_top_level_keyword<'a>(expr: &'a str, keyword: &str) -> Ve
     let mut start = 0usize;
     let mut depth: i32 = 0;
     let mut between_skip: u32 = 0;
+    let mut in_squote = false;
+    let mut in_dquote = false;
     let mut i = 0usize;
 
     while i < len {
         let ch = bytes[i];
+        // Skip quoted spans wholesale: a comma/keyword/paren inside a string
+        // literal or a quoted identifier is data, never a separator.
+        if in_squote {
+            if ch == b'\'' {
+                in_squote = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_dquote {
+            if ch == b'"' {
+                in_dquote = false;
+            }
+            i += 1;
+            continue;
+        }
+        if ch == b'\'' {
+            in_squote = true;
+            i += 1;
+            continue;
+        }
+        if ch == b'"' {
+            in_dquote = true;
+            i += 1;
+            continue;
+        }
         if ch == b'(' {
             depth += 1;
             i += 1;

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -751,11 +751,22 @@ pub(crate) fn resolve_ref_or_path(
     expr_attr_names: &HashMap<String, String>,
     expr_attr_values: &HashMap<String, Value>,
 ) -> Option<Value> {
-    let reference = reference.trim();
+    let reference = reference.trim().trim_matches('"');
     if reference.starts_with(':') {
         return expr_attr_values.get(reference).cloned();
     }
-    resolve_path(reference, item, expr_attr_names)
+    resolve_path(reference, item, expr_attr_names).or_else(|| {
+        reference
+            .strip_prefix('\'')
+            .and_then(|x| x.strip_suffix('\''))
+            .map(|x| json!({ "S": x }))
+            .or_else(|| {
+                reference
+                    .parse::<f64>()
+                    .ok()
+                    .map(|_| json!({ "N": reference }))
+            })
+    })
 }
 
 /// True if `path` targets a nested key inside an M-typed attribute. Bracketed

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -608,10 +608,12 @@ pub(crate) fn evaluate_list_append_rhs(
     expr_attr_values: &HashMap<String, Value>,
 ) -> Option<Value> {
     let inner = rest.strip_suffix(')')?;
-    let mut split = inner.splitn(2, ',');
-    let (a_ref, b_ref) = (split.next()?, split.next()?);
-    let a_val = resolve_ref_or_path(a_ref.trim(), item, expr_attr_names, expr_attr_values);
-    let b_val = resolve_ref_or_path(b_ref.trim(), item, expr_attr_names, expr_attr_values);
+    let operands = split_on_top_level_keyword(inner, ",");
+    let [a_ref, b_ref] = operands.as_slice() else {
+        return None;
+    };
+    let a_val = resolve_list_append_operand(a_ref.trim(), item, expr_attr_names, expr_attr_values);
+    let b_val = resolve_list_append_operand(b_ref.trim(), item, expr_attr_names, expr_attr_values);
 
     let mut merged = Vec::new();
     for v in [&a_val, &b_val].iter().copied().flatten() {
@@ -622,6 +624,25 @@ pub(crate) fn evaluate_list_append_rhs(
         }
     }
     Some(json!({ "L": merged }))
+}
+
+fn resolve_list_append_operand(
+    reference: &str,
+    item: &HashMap<String, AttributeValue>,
+    expr_attr_names: &HashMap<String, String>,
+    expr_attr_values: &HashMap<String, Value>,
+) -> Option<Value> {
+    let rest = reference
+        .strip_prefix("if_not_exists(")
+        .or_else(|| reference.strip_prefix("if_not_exists ("));
+    let Some(rest) = rest else {
+        return resolve_ref_or_path(reference, item, expr_attr_names, expr_attr_values);
+    };
+    let inner = rest.strip_suffix(')')?;
+    let (path, default) = inner.split_once(',')?;
+
+    resolve_ref_or_path(path.trim(), item, expr_attr_names, expr_attr_values)
+        .or_else(|| resolve_ref_or_path(default.trim(), item, expr_attr_names, expr_attr_values))
 }
 
 /// `<arith_left> +/- <arith_right>` — both operands must resolve to N values.

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -397,6 +397,20 @@ pub(crate) fn parse_update_clauses(expr: &str) -> Vec<(UpdateAction, Vec<String>
     // boundary on each side so `set foo = ...` is a keyword, but
     // `:set_arg`, `my_set_field`, `#set` are not.
     let is_boundary = |b: u8| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r';
+    // A single-quoted PartiQL string literal may contain a word that matches an
+    // update keyword (`SET note = 'please REMOVE this'`). Those bytes are data,
+    // not clause boundaries, so mark quoted spans and ignore any keyword match
+    // that begins inside one. Real UpdateItem expressions bind values through
+    // `:placeholders` and carry no quoted literals, so this only affects the
+    // inline-literal PartiQL path.
+    let mut in_quote = vec![false; expr.len()];
+    let mut quoted = false;
+    for (i, b) in expr.bytes().enumerate() {
+        if b == b'\'' {
+            quoted = !quoted;
+        }
+        in_quote[i] = quoted;
+    }
     for &(kw, action) in UpdateAction::KEYWORDS {
         let mut search_from = 0;
         while let Some(pos) = upper[search_from..].find(kw) {
@@ -404,7 +418,7 @@ pub(crate) fn parse_update_clauses(expr: &str) -> Vec<(UpdateAction, Vec<String>
             let before_ok = abs_pos == 0 || is_boundary(expr.as_bytes()[abs_pos - 1]);
             let after_pos = abs_pos + kw.len();
             let after_ok = after_pos >= expr.len() || is_boundary(expr.as_bytes()[after_pos]);
-            if before_ok && after_ok {
+            if before_ok && after_ok && !in_quote[abs_pos] {
                 positions.push((abs_pos, action));
             }
             search_from = abs_pos + kw.len();
@@ -612,8 +626,11 @@ pub(crate) fn evaluate_list_append_rhs(
     let [a_ref, b_ref] = operands.as_slice() else {
         return None;
     };
-    let a_val = resolve_list_append_operand(a_ref.trim(), item, expr_attr_names, expr_attr_values);
-    let b_val = resolve_list_append_operand(b_ref.trim(), item, expr_attr_names, expr_attr_values);
+    // Each operand may be `if_not_exists(path, :default)` or a plain ref/path,
+    // resolving to the value-when-present-else-default -- identical semantics to
+    // an arithmetic operand, so share that evaluator instead of a second copy.
+    let a_val = evaluate_arithmetic_operand(a_ref.trim(), item, expr_attr_names, expr_attr_values);
+    let b_val = evaluate_arithmetic_operand(b_ref.trim(), item, expr_attr_names, expr_attr_values);
 
     let mut merged = Vec::new();
     for v in [&a_val, &b_val].iter().copied().flatten() {
@@ -624,25 +641,6 @@ pub(crate) fn evaluate_list_append_rhs(
         }
     }
     Some(json!({ "L": merged }))
-}
-
-fn resolve_list_append_operand(
-    reference: &str,
-    item: &HashMap<String, AttributeValue>,
-    expr_attr_names: &HashMap<String, String>,
-    expr_attr_values: &HashMap<String, Value>,
-) -> Option<Value> {
-    let rest = reference
-        .strip_prefix("if_not_exists(")
-        .or_else(|| reference.strip_prefix("if_not_exists ("));
-    let Some(rest) = rest else {
-        return resolve_ref_or_path(reference, item, expr_attr_names, expr_attr_values);
-    };
-    let inner = rest.strip_suffix(')')?;
-    let (path, default) = inner.split_once(',')?;
-
-    resolve_ref_or_path(path.trim(), item, expr_attr_names, expr_attr_values)
-        .or_else(|| resolve_ref_or_path(default.trim(), item, expr_attr_names, expr_attr_values))
 }
 
 /// `<arith_left> +/- <arith_right>` — both operands must resolve to N values.
@@ -1061,5 +1059,25 @@ mod filter_in_contains_tests {
             &no_names(),
             &values
         ));
+    }
+
+    // A keyword-looking word inside a single-quoted PartiQL literal is data,
+    // not a clause boundary: `'please REMOVE this'` must stay attached to the
+    // SET assignment instead of splitting off a spurious REMOVE clause (which
+    // silently dropped the write before the quote-aware scan).
+    #[test]
+    fn parse_update_clauses_ignores_keywords_in_quoted_literal() {
+        let clauses = parse_update_clauses("SET note = 'please REMOVE this'");
+        assert_eq!(clauses.len(), 1);
+        assert!(matches!(clauses[0].0, UpdateAction::Set));
+        assert_eq!(
+            clauses[0].1,
+            vec!["note = 'please REMOVE this'".to_string()]
+        );
+
+        let multi = parse_update_clauses("SET a = 'reset the SET value' SET b = :v");
+        assert_eq!(multi.len(), 2);
+        assert_eq!(multi[0].1, vec!["a = 'reset the SET value'".to_string()]);
+        assert_eq!(multi[1].1, vec!["b = :v".to_string()]);
     }
 }

--- a/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/mod.rs
@@ -397,19 +397,23 @@ pub(crate) fn parse_update_clauses(expr: &str) -> Vec<(UpdateAction, Vec<String>
     // boundary on each side so `set foo = ...` is a keyword, but
     // `:set_arg`, `my_set_field`, `#set` are not.
     let is_boundary = |b: u8| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r';
-    // A single-quoted PartiQL string literal may contain a word that matches an
-    // update keyword (`SET note = 'please REMOVE this'`). Those bytes are data,
+    // A quoted span may contain a word that matches an update keyword: a
+    // single-quoted string literal (`SET note = 'please REMOVE this'`) or a
+    // double-quoted attribute name (`SET "a SET b" = ?`). Those bytes are data,
     // not clause boundaries, so mark quoted spans and ignore any keyword match
     // that begins inside one. Real UpdateItem expressions bind values through
     // `:placeholders` and carry no quoted literals, so this only affects the
     // inline-literal PartiQL path.
     let mut in_quote = vec![false; expr.len()];
-    let mut quoted = false;
+    let mut in_squote = false;
+    let mut in_dquote = false;
     for (i, b) in expr.bytes().enumerate() {
-        if b == b'\'' {
-            quoted = !quoted;
+        match b {
+            b'\'' if !in_dquote => in_squote = !in_squote,
+            b'"' if !in_squote => in_dquote = !in_dquote,
+            _ => {}
         }
-        in_quote[i] = quoted;
+        in_quote[i] = in_squote || in_dquote;
     }
     for &(kw, action) in UpdateAction::KEYWORDS {
         let mut search_from = 0;
@@ -1079,5 +1083,18 @@ mod filter_in_contains_tests {
         assert_eq!(multi.len(), 2);
         assert_eq!(multi[0].1, vec!["a = 'reset the SET value'".to_string()]);
         assert_eq!(multi[1].1, vec!["b = :v".to_string()]);
+    }
+
+    // A comma inside a quoted string literal is data, not an assignment
+    // separator: `SET addr = 'City, State'` is one assignment, not two (which
+    // previously tore the literal apart and silently dropped the update).
+    #[test]
+    fn parse_update_clauses_keeps_comma_inside_quoted_literal() {
+        let clauses = parse_update_clauses("SET addr = 'City, State', code = :c");
+        assert_eq!(clauses.len(), 1);
+        assert_eq!(
+            clauses[0].1,
+            vec!["addr = 'City, State'".to_string(), "code = :c".to_string()]
+        );
     }
 }

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -486,7 +486,7 @@ pub(crate) fn execute_partiql_in_state(
         } else {
             (after_set, "")
         };
-        let where_clause = strip_partiql_returning_clause(where_clause);
+        let (where_clause, returns_item) = split_partiql_returning_clause(where_clause);
         let table = get_table_mut(&mut state.tables, &table_name)?;
         // Positional `?` parameters bind in textual order: the SET clause comes
         // before WHERE, so SET consumes parameters[0..set_count] and WHERE the
@@ -520,10 +520,14 @@ pub(crate) fn execute_partiql_in_state(
         }
         table.recalculate_stats();
         Ok(PartiqlOutcome {
-            response: last_new
-                .as_ref()
-                .map(|item| json!({ "Item": item }))
-                .unwrap_or_else(|| json!({})),
+            response: if returns_item {
+                last_new
+                    .as_ref()
+                    .map(|item| json!({ "Item": item }))
+                    .unwrap_or_else(|| json!({}))
+            } else {
+                json!({})
+            },
             table_name: Some(table_name),
             event_name: last_old.as_ref().map(|_| "MODIFY".to_string()),
             keys: last_key,
@@ -578,11 +582,23 @@ pub(crate) fn execute_partiql_in_state(
     }
 }
 
-fn strip_partiql_returning_clause(where_clause: &str) -> &str {
+fn split_partiql_returning_clause(where_clause: &str) -> (&str, bool) {
     let upper = where_clause.to_ascii_uppercase();
-    find_outside_quotes(&upper, "RETURNING")
-        .map(|pos| where_clause[..pos].trim())
-        .unwrap_or(where_clause)
+    let mut in_quote = false;
+    for index in 0..upper.len() {
+        if upper.as_bytes()[index] == b'\'' {
+            in_quote = !in_quote;
+        }
+        if !in_quote
+            && upper[index..].starts_with("RETURNING")
+            && index > 0
+            && upper[..index].ends_with(char::is_whitespace)
+            && upper[index + 9..].starts_with(char::is_whitespace)
+        {
+            return (where_clause[..index].trim(), true);
+        }
+    }
+    (where_clause, false)
 }
 
 fn prepare_partiql_update_expression(
@@ -610,12 +626,7 @@ fn prepare_partiql_update_expression(
         expression.push(character);
     }
 
-    let expression = expression
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .replace(" SET ", ", ")
-        .replace('"', "");
+    let expression = split_repeated_set_clauses(&expression);
     let values = parameters
         .iter()
         .enumerate()
@@ -623,6 +634,37 @@ fn prepare_partiql_update_expression(
         .collect();
 
     (expression, values)
+}
+
+fn split_repeated_set_clauses(expression: &str) -> String {
+    let mut result = String::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut index = 0;
+
+    while index < expression.len() {
+        let byte = expression.as_bytes()[index];
+        match byte {
+            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
+            _ => {}
+        }
+        if !in_single_quote
+            && !in_double_quote
+            && expression[index..].starts_with("SET")
+            && index > 0
+            && expression[..index].ends_with(char::is_whitespace)
+            && expression[index + 3..].starts_with(char::is_whitespace)
+        {
+            result.push(',');
+            index += 3;
+            continue;
+        }
+        result.push(byte as char);
+        index += 1;
+    }
+
+    result
 }
 
 /// Parse a table name that may be quoted with double quotes.
@@ -1537,6 +1579,26 @@ mod number_compare_tests {
 #[cfg(test)]
 mod quote_aware_tests {
     use super::*;
+
+    #[test]
+    fn returning_clause_requires_keyword_boundaries() {
+        assert_eq!(
+            split_partiql_returning_clause("returning_status = ? RETURNING ALL NEW *"),
+            ("returning_status = ?", true)
+        );
+        assert_eq!(
+            split_partiql_returning_clause("note = 'RETURNING'"),
+            ("note = 'RETURNING'", false)
+        );
+    }
+
+    #[test]
+    fn repeated_set_split_preserves_quoted_text() {
+        assert_eq!(
+            split_repeated_set_clauses("SET \"SET\" = 'ready SET now' SET state = ?"),
+            "SET \"SET\" = 'ready SET now' , state = ?"
+        );
+    }
 
     // bug-hunt 2026-07-01: operator/keyword scans must skip single-quoted
     // literals so a `<` or `WHERE`/`IN` inside a string is treated as data.

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -479,14 +479,18 @@ pub(crate) fn execute_partiql_in_state(
                 "Invalid UPDATE statement: missing SET",
             )
         })?;
-        let after_set = rest.trim()[set_pos + 3..].trim();
+        // Strip a trailing `RETURNING ...` clause from the whole post-SET
+        // segment first, so it is removed whether or not a WHERE is present
+        // (a WHERE-less `UPDATE t SET x = ? RETURNING *` would otherwise leave
+        // RETURNING inside the SET clause and corrupt the update expression).
+        let (after_set, returns_item) =
+            split_partiql_returning_clause(rest.trim()[set_pos + 3..].trim());
         let where_pos = find_outside_quotes(&after_set.to_ascii_uppercase(), "WHERE");
         let (set_clause, where_clause) = if let Some(wp) = where_pos {
             (&after_set[..wp], after_set[wp + 5..].trim())
         } else {
             (after_set, "")
         };
-        let (where_clause, returns_item) = split_partiql_returning_clause(where_clause);
         let table = get_table_mut(&mut state.tables, &table_name)?;
         // Positional `?` parameters bind in textual order: the SET clause comes
         // before WHERE, so SET consumes parameters[0..set_count] and WHERE the

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -486,6 +486,7 @@ pub(crate) fn execute_partiql_in_state(
         } else {
             (after_set, "")
         };
+        let where_clause = strip_partiql_returning_clause(where_clause);
         let table = get_table_mut(&mut state.tables, &table_name)?;
         // Positional `?` parameters bind in textual order: the SET clause comes
         // before WHERE, so SET consumes parameters[0..set_count] and WHERE the
@@ -501,30 +502,28 @@ pub(crate) fn execute_partiql_in_state(
         } else {
             (0..table.items.len()).collect()
         };
-        let assignments: Vec<&str> = set_clause.split(',').collect();
+        let (update_expression, expression_attribute_values) =
+            prepare_partiql_update_expression(set_clause, parameters);
         let mut last_key: Option<HashMap<String, AttributeValue>> = None;
         let mut last_old: Option<HashMap<String, AttributeValue>> = None;
         let mut last_new: Option<HashMap<String, AttributeValue>> = None;
         for idx in &matched_indices {
             last_old = Some(table.items[*idx].clone());
-            let mut local_offset = 0;
-            for assignment in &assignments {
-                let assignment = assignment.trim();
-                if let Some((attr, val_str)) = assignment.split_once('=') {
-                    let attr = attr.trim().trim_matches('"');
-                    let val_str = val_str.trim();
-                    let value = parse_partiql_literal(val_str, parameters, &mut local_offset);
-                    if let Some(v) = value {
-                        table.items[*idx].insert(attr.to_string(), v);
-                    }
-                }
-            }
+            apply_update_expression(
+                &mut table.items[*idx],
+                &update_expression,
+                &HashMap::new(),
+                &expression_attribute_values,
+            )?;
             last_key = Some(extract_key(table, &table.items[*idx]));
             last_new = Some(table.items[*idx].clone());
         }
         table.recalculate_stats();
         Ok(PartiqlOutcome {
-            response: json!({}),
+            response: last_new
+                .as_ref()
+                .map(|item| json!({ "Item": item }))
+                .unwrap_or_else(|| json!({})),
             table_name: Some(table_name),
             event_name: last_old.as_ref().map(|_| "MODIFY".to_string()),
             keys: last_key,
@@ -577,6 +576,53 @@ pub(crate) fn execute_partiql_in_state(
             format!("Unsupported PartiQL statement: {trimmed}"),
         ))
     }
+}
+
+fn strip_partiql_returning_clause(where_clause: &str) -> &str {
+    let upper = where_clause.to_ascii_uppercase();
+    find_outside_quotes(&upper, "RETURNING")
+        .map(|pos| where_clause[..pos].trim())
+        .unwrap_or(where_clause)
+}
+
+fn prepare_partiql_update_expression(
+    set_clause: &str,
+    parameters: &[Value],
+) -> (String, HashMap<String, Value>) {
+    let mut expression = String::from("SET ");
+    let mut parameter_index = 0;
+    let mut in_quote = false;
+    let mut chars = set_clause.trim().chars().peekable();
+
+    while let Some(character) = chars.next() {
+        if character == '\'' {
+            in_quote = !in_quote;
+            expression.push(character);
+            continue;
+        }
+
+        if !in_quote && character == '?' {
+            expression.push_str(&format!(":p{parameter_index}"));
+            parameter_index += 1;
+            continue;
+        }
+
+        expression.push(character);
+    }
+
+    let expression = expression
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace(" SET ", ", ")
+        .replace('"', "");
+    let values = parameters
+        .iter()
+        .enumerate()
+        .map(|(index, value)| (format!(":p{index}"), value.clone()))
+        .collect();
+
+    (expression, values)
 }
 
 /// Parse a table name that may be quoted with double quotes.

--- a/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/partiql.rs
@@ -583,10 +583,14 @@ pub(crate) fn execute_partiql_in_state(
 }
 
 fn split_partiql_returning_clause(where_clause: &str) -> (&str, bool) {
+    // `to_ascii_uppercase` preserves byte length and never touches non-ASCII
+    // bytes, so char boundaries stay aligned between `upper` and `where_clause`.
+    // Iterate real char boundaries (not raw byte indices) so a non-ASCII byte
+    // in the predicate cannot make a slice land mid-character and panic.
     let upper = where_clause.to_ascii_uppercase();
     let mut in_quote = false;
-    for index in 0..upper.len() {
-        if upper.as_bytes()[index] == b'\'' {
+    for (index, ch) in upper.char_indices() {
+        if ch == '\'' {
             in_quote = !in_quote;
         }
         if !in_quote
@@ -608,9 +612,8 @@ fn prepare_partiql_update_expression(
     let mut expression = String::from("SET ");
     let mut parameter_index = 0;
     let mut in_quote = false;
-    let mut chars = set_clause.trim().chars().peekable();
 
-    while let Some(character) = chars.next() {
+    for character in set_clause.trim().chars() {
         if character == '\'' {
             in_quote = !in_quote;
             expression.push(character);
@@ -637,16 +640,18 @@ fn prepare_partiql_update_expression(
 }
 
 fn split_repeated_set_clauses(expression: &str) -> String {
+    // Walk char boundaries and copy `char`s (never `byte as char`, which
+    // corrupts multibyte UTF-8) so an accented/CJK/emoji value or attribute
+    // name in the SET clause survives intact and no slice panics mid-character.
     let mut result = String::new();
     let mut in_single_quote = false;
     let mut in_double_quote = false;
-    let mut index = 0;
+    let mut chars = expression.char_indices();
 
-    while index < expression.len() {
-        let byte = expression.as_bytes()[index];
-        match byte {
-            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
-            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
             _ => {}
         }
         if !in_single_quote
@@ -657,11 +662,12 @@ fn split_repeated_set_clauses(expression: &str) -> String {
             && expression[index + 3..].starts_with(char::is_whitespace)
         {
             result.push(',');
-            index += 3;
+            // "SET" is three ASCII bytes; `ch` consumed the 'S', skip 'E','T'.
+            chars.next();
+            chars.next();
             continue;
         }
-        result.push(byte as char);
-        index += 1;
+        result.push(ch);
     }
 
     result
@@ -1597,6 +1603,33 @@ mod quote_aware_tests {
         assert_eq!(
             split_repeated_set_clauses("SET \"SET\" = 'ready SET now' SET state = ?"),
             "SET \"SET\" = 'ready SET now' , state = ?"
+        );
+    }
+
+    // Non-ASCII values and attribute names must round-trip byte-for-byte: the
+    // splitters walk char boundaries, so an accented / CJK / emoji character
+    // neither corrupts the rebuilt expression nor panics a mid-char slice.
+    #[test]
+    fn repeated_set_split_preserves_non_ascii() {
+        assert_eq!(
+            split_repeated_set_clauses("SET \"café\" = 'José 名前 🚀' SET n = ?"),
+            "SET \"café\" = 'José 名前 🚀' , n = ?"
+        );
+        // Unquoted non-ASCII attribute name must not panic.
+        assert_eq!(split_repeated_set_clauses("SET café = ?"), "SET café = ?");
+    }
+
+    #[test]
+    fn returning_clause_handles_non_ascii_predicate() {
+        // A non-ASCII byte in the WHERE predicate (quoted or bare) must not
+        // panic the byte-index scan.
+        assert_eq!(
+            split_partiql_returning_clause("\"café\" = ? RETURNING ALL NEW *"),
+            ("\"café\" = ?", true)
+        );
+        assert_eq!(
+            split_partiql_returning_clause("\"名前\" = ?"),
+            ("\"名前\" = ?", false)
         );
     }
 

--- a/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/paths.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 pub(crate) fn resolve_attr_name(name: &str, expr_attr_names: &HashMap<String, String>) -> String {
+    let name = name.trim_matches('"');
     if name.starts_with('#') {
         expr_attr_names
             .get(name)

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5235,6 +5235,19 @@ fn split_on_top_level_keyword_does_not_match_inside_identifiers() {
     assert_eq!(parts.len(), 1);
 }
 
+#[test]
+fn split_on_top_level_keyword_skips_quoted_spans() {
+    // A separator inside a single-quoted literal or a double-quoted identifier
+    // is data, not a boundary.
+    let parts = split_on_top_level_keyword("addr = 'City, State', code = :c", ",");
+    assert_eq!(parts, vec!["addr = 'City, State'", " code = :c"]);
+    let parts = split_on_top_level_keyword("\"a,b\" = :a AND c = :b", "AND");
+    assert_eq!(parts.len(), 2);
+    // A keyword inside a quoted literal must not split either.
+    let parts = split_on_top_level_keyword("note = 'x AND y'", "AND");
+    assert_eq!(parts.len(), 1);
+}
+
 // ── Smithy-declared wire error code regression tests ─────────────────────
 //
 // These ops' Smithy error_shapes lists do not include the generic codes our


### PR DESCRIPTION
## Problem

Swell uses DynamoDB `BatchExecuteStatement` for local broker status updates. Under fakecloud, parameterized single-item SELECTs returned an `Items` array, so the AWS SDK client saw no `Item`. `UPDATE ... RETURNING ALL NEW *` also included the `RETURNING` clause in the WHERE predicate, causing a validation error.

## Fix

- Convert successful batch SELECT responses from a single `Items` entry to the API response's `Item` shape.
- Preserve the existing single-item limitation for scans and secondary-index SELECTs as per-statement validation responses.
- Strip `RETURNING` before evaluating the UPDATE predicate, bind positional parameters into the existing update-expression evaluator, and support `list_append(if_not_exists(...), ...)`.

## Validation

`cargo test -p fakecloud-dynamodb batch_execute_statement_returns_single_items_and_updates`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DynamoDB BatchExecuteStatement to match AWS for single-item SELECTs and UPDATEs with RETURNING. Normalizes batch SELECT shape, makes PartiQL parsing UTF-8 and quote aware, and rejects unsupported queries.

- **Bug Fixes**
  - Batch SELECT: return per-statement `Item` only when WHERE is exactly equality on the full primary key (`attr = ?` for each key) joined by `AND`; accept `"pk"=?` and arbitrary `=` spacing; require whole-identifier matches; skip quoted literals; handle composite keys; reject scans, extra predicates, non-key WHEREs, and secondary-index SELECTs with `ValidationError`; empty result returns `{}`.
  - UPDATE: bind positional `?` across SET/WHERE via a rebuilt UpdateExpression; support repeated `SET` and `list_append(if_not_exists(...))`; `RETURNING ALL NEW *` returns the updated `Item` (even without WHERE); keywords inside single- or double-quoted text are treated as data; preserve non-ASCII values and attribute names.
  - Parsing/resolution: UTF-8-safe, quote-aware splitting for `RETURNING`, commas, and `AND` across SET/WHERE/operands; handle double-quoted attribute names and string/number literals; reuse arithmetic operand logic for `list_append`; trim quotes when resolving attribute names/paths.

<sup>Written for commit 05ed33ef6106f9639a0dd5105628287526936c21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

