### PR TITLE
ci(security): ignore drifted transitive-dep RustSec advisories

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,6 +92,34 @@ jobs:
       # controlled documents. The fix requires jumping to quick-xml >=0.41, a
       # breaking API change across every XML service; tracked as a dedicated
       # upgrade rather than blocking every PR on a low-exposure DoS advisory.
+      #
+      # The advisories below are unmaintained / unsound / yanked warnings on
+      # transitive dependencies that handle no attacker-controlled input in
+      # fakecloud. They surfaced as the RustSec DB drifted and now redden every
+      # PR and main until an upstream fix lands; ignored with the same policy as
+      # the entries above.
+      #
+      # RUSTSEC-2024-0384 (paste), RUSTSEC-2024-0436 (proc-macro-error2) and
+      # RUSTSEC-2025-0012 (derivative) are unmaintained proc-macro / derive
+      # helpers used only at build time; they never touch runtime input.
+      #
+      # RUSTSEC-2024-0388 (instant) and RUSTSEC-2026-0235 (backoff) are
+      # unmaintained crates reached transitively through the async / kube retry
+      # stack (same reachability as RUSTSEC-2026-0185 above): timers and delay
+      # math over no untrusted input.
+      #
+      # RUSTSEC-2026-0173 (rustls-pemfile unmaintained) parses only the
+      # emulator's own trusted PEM material, never attacker-supplied files.
+      #
+      # RUSTSEC-2025-0134 (anyhow Error::downcast_mut unsoundness) and
+      # RUSTSEC-2026-0190 (event-listener !Send StackSlot unsoundness) reach us
+      # transitively; fakecloud does not exercise the unsound APIs (we never call
+      # anyhow's downcast_mut, nor cross a thread boundary with a !Send listener
+      # tag) and neither advisory has a fixed release on our pinned versions yet.
+      #
+      # RUSTSEC-2026-0221 (spin 0.9.8 yanked) is a yanked transitive spinlock
+      # dependency; nothing in fakecloud's tree can move off it until upstream
+      # crates republish.
       - run: |
           cargo audit \
             --ignore RUSTSEC-2026-0098 \
@@ -102,4 +130,13 @@ jobs:
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2026-0185 \
             --ignore RUSTSEC-2026-0194 \
-            --ignore RUSTSEC-2026-0195
+            --ignore RUSTSEC-2026-0195 \
+            --ignore RUSTSEC-2024-0384 \
+            --ignore RUSTSEC-2024-0388 \
+            --ignore RUSTSEC-2024-0436 \
+            --ignore RUSTSEC-2025-0012 \
+            --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2026-0173 \
+            --ignore RUSTSEC-2026-0190 \
+            --ignore RUSTSEC-2026-0221 \
+            --ignore RUSTSEC-2026-0235


### PR DESCRIPTION
## Problem

The RustSec advisory DB drifted and now flags nine additional advisories for transitive dependencies that are not in the audit ignore list. This reddens the `audit` job on **every** open PR and on main:

| Advisory | Crate | Class |
|---|---|---|
| RUSTSEC-2024-0384 | paste | unmaintained |
| RUSTSEC-2024-0388 | instant | unmaintained |
| RUSTSEC-2024-0436 | proc-macro-error2 | unmaintained |
| RUSTSEC-2025-0012 | derivative | unmaintained |
| RUSTSEC-2025-0134 | anyhow | unsound |
| RUSTSEC-2026-0173 | rustls-pemfile | unmaintained |
| RUSTSEC-2026-0190 | event-listener | unsound |
| RUSTSEC-2026-0221 | spin | yanked |
| RUSTSEC-2026-0235 | backoff | unmaintained |

## Fix

Add all nine to the `cargo audit --ignore` list with per-batch rationale, consistent with the existing allowlist policy. Every one is a build-time-only proc-macro/derive helper, or a transitive runtime dependency that fakecloud never feeds attacker-controlled input, or a yanked-version advisory with no upgrade path on our pinned tree. None has an actionable fixed release for our dependency graph today.

Unblocks all open PRs whose `audit` job is currently red purely from this drift.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore nine new RustSec advisories for transitive dependencies in CI to unbreak the `cargo audit` job and unblock PRs. Adds documented ignores until upstream fixes are available.

- **Bug Fixes**
  - Added ignore entries for unmaintained/unsound/yanked transitives (e.g., `paste`, `instant`, `proc-macro-error2`, `derivative`, `anyhow`, `rustls-pemfile`, `event-listener`, `spin`, `backoff`).
  - Notes why each is safe to ignore: build-time only, no attacker-controlled input, or no fixed releases on our pinned versions yet.

<sup>Written for commit 4c6315464b5c94b99028a790ba377d629485191c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

