### PR TITLE
fix(docker): clear Trivy gate on two go1.26.5 stdlib HIGHs in bundled docker CLI

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,15 +1,21 @@
-# CVE-2026-39822 — Go stdlib os.Root symlink-following vulnerability (HIGH),
-# fixed upstream in go1.26.5 / 1.27.0-rc.2.
-#
-# Present ONLY in the bundled static Docker CLI (/usr/local/bin/docker, from the
-# docker-cli build stage), which is compiled with go1.26.4. As of 2026-07-12 no
-# Docker static release ships a go>=1.26.5 toolchain (latest 29.6.1 is still on
-# go1.26.4), so the CLI version cannot yet be bumped past it.
+# Go stdlib HIGH vulnerabilities present ONLY in the bundled static Docker CLI
+# (/usr/local/bin/docker, from the docker-cli build stage), which as of
+# DOCKER_CLI_VERSION 29.7.2 is compiled with go1.26.5. Both are fixed upstream
+# only in go1.26.6 / 1.27.0-rc.3, and no Docker static release ships a
+# go>=1.26.6 toolchain yet (latest 29.7.2 is still on go1.26.5), so the CLI
+# version cannot be bumped past it.
 #
 # Not exploitable in fakecloud's usage: fakecloud shells out to the docker CLI
-# purely for container lifecycle (run/exec/cp/rm) and never invokes the os.Root
-# symlink-traversal code path. Our own binary is Rust.
+# purely for container lifecycle (run/exec/cp/rm). It never processes untrusted
+# Punycode/IDNA hostnames (CVE-2026-39821) or parses untrusted DNS wire messages
+# (CVE-2026-46600) through the CLI. Our own binary is Rust.
 #
-# REMOVE this entry once a Docker static release built with go>=1.26.5 exists and
-# DOCKER_CLI_VERSION in the Dockerfile is bumped to it.
-CVE-2026-39822
+# REMOVE these entries once a Docker static release built with go>=1.26.6 exists
+# and DOCKER_CLI_VERSION in the Dockerfile is bumped to it.
+#
+# CVE-2026-39821 — golang.org/x/net/idna: privilege escalation via incorrect
+#   Punycode label processing.
+# CVE-2026-46600 — golang.org/x/net/dns/dnsmessage: denial of service via
+#   invalid DNS record parsing.
+CVE-2026-39821
+CVE-2026-46600

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ ARG TARGETARCH
 # Pin a docker CLI built with a current Go toolchain — the static build
 # bakes the Go stdlib into the binary, so a stale toolchain trips the
 # image's Trivy CRITICAL/HIGH gate (27.5.1 shipped go1.22.11, flagged by
-# CVE-2025-68121). 29.5.3 ships go1.26.3, which clears the gate.
-ARG DOCKER_CLI_VERSION=29.5.3
+# CVE-2025-68121). 29.7.2 ships go1.26.5, which clears CVE-2026-39822; the
+# two remaining stdlib HIGHs (CVE-2026-39821, CVE-2026-46600) are fixed only
+# in go1.26.6, which no Docker static release ships yet — see .trivyignore.
+ARG DOCKER_CLI_VERSION=29.7.2
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && case "$TARGETARCH" in \


### PR DESCRIPTION
The Docker image's Trivy `CRITICAL,HIGH` scan (docker.yml `scan` job) has failed on every `main` and tag build since 2026-08-05, including the v0.44.10 release build. The image itself still publishes (the scan runs after the push), but the gate is red.

## Cause
Two newly-disclosed Go stdlib HIGHs are baked into the bundled static Docker CLI (built with go1.26.4):
- **CVE-2026-39821** — `golang.org/x/net/idna` privilege escalation via incorrect Punycode label processing.
- **CVE-2026-46600** — `golang.org/x/net/dns/dnsmessage` DoS via invalid DNS record parsing.

Both are fixed only in **go1.26.6** / 1.27.0-rc.3.

## Fix
- Bump `DOCKER_CLI_VERSION` 29.5.3 -> **29.7.2** (ships go1.26.5). This clears the previously-ignored **CVE-2026-39822** (fixed in go1.26.5), honoring that entry's own "REMOVE once a go>=1.26.5 static release exists" note, so it's dropped from `.trivyignore`.
- The two remaining HIGHs need go1.26.6, which **no Docker static release ships yet** (latest 29.7.2 is go1.26.5), so they're added to `.trivyignore` with justification and a removal condition.

## Not exploitable
fakecloud shells out to the docker CLI purely for container lifecycle (run/exec/cp/rm). It never feeds the CLI untrusted IDNA hostnames or DNS wire messages. Our own binary is Rust.

docker.yml runs only on `main`/tag pushes (not PRs), so the scan re-validates on merge to main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing Trivy CRITICAL/HIGH gate by bumping the bundled Docker CLI to 29.7.2 and temporarily ignoring two Go stdlib HIGHs that require go1.26.6, which no static CLI release provides yet. Previously, all main/tag builds failed the scan since 2026-08-05; now the gate passes while we wait for a `go>=1.26.6` Docker CLI.

**Review**
- Dockerfile: set DOCKER_CLI_VERSION to 29.7.2 (ships go1.26.5), which clears previously ignored CVE-2026-39822.
- `.trivyignore`: remove CVE-2026-39822; add CVE-2026-39821 (`golang.org/x/net/idna`) and CVE-2026-46600 (`golang.org/x/net/dns/dnsmessage`) with a removal condition once a static CLI built with `go>=1.26.6` is available and we bump to it.
- Not exploitable in our usage: we shell out to the CLI only for container lifecycle (run/exec/cp/rm), never process untrusted IDNA hostnames or DNS wire messages; our binary is Rust.
- Side effect: image includes Docker CLI 29.7.2; no app behavior change.

<sup>Written for commit 5fdca0e18518ea4d5e231bd5568bc6f596647554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

