### PR TITLE
fix(ec2,iam): XML-escape user data in per-attribute describe responses

### DIFF
--- a/crates/fakecloud-ec2/src/service/eni.rs
+++ b/crates/fakecloud-ec2/src/service/eni.rs
@@ -452,7 +452,7 @@ pub(crate) fn describe_network_interface_attribute(
     let attr_xml = match attribute.as_str() {
         "description" => format!(
             "<description><value>{}</value></description>",
-            eni.map(|e| e.description.as_str()).unwrap_or("")
+            fakecloud_aws::xml::xml_escape(eni.map(|e| e.description.as_str()).unwrap_or(""))
         ),
         "groupSet" => {
             let groups: Vec<String> = eni
@@ -881,6 +881,26 @@ mod tests {
         assert!(describe_attr(&svc, "description")
             .contains("<description><value>new-desc</value></description>"));
         assert!(describe_attr(&svc, "groupSet").contains("<groupId>sg-a</groupId>"));
+    }
+
+    #[test]
+    fn describe_network_interface_attribute_escapes_description_xml() {
+        let svc = Ec2Service::new();
+        seed_eni(&svc);
+        modify_network_interface_attribute(
+            &svc,
+            &req(&[
+                ("NetworkInterfaceId", "eni-1"),
+                ("Description.Value", "web & db <tier>"),
+            ]),
+        )
+        .unwrap();
+        let xml = describe_attr(&svc, "description");
+        assert!(
+            xml.contains("web &amp; db &lt;tier&gt;"),
+            "description must be XML-escaped: {xml}"
+        );
+        assert!(!xml.contains("db <tier>"), "raw < must not appear: {xml}");
     }
 
     #[test]

--- a/crates/fakecloud-ec2/src/service/instance.rs
+++ b/crates/fakecloud-ec2/src/service/instance.rs
@@ -1762,7 +1762,10 @@ pub(crate) fn describe_instance_attribute(
             inst.instance_initiated_shutdown_behavior
         ),
         "userData" => match &inst.user_data {
-            Some(d) => format!("<userData><value>{d}</value></userData>"),
+            Some(d) => format!(
+                "<userData><value>{}</value></userData>",
+                fakecloud_aws::xml::xml_escape(d)
+            ),
             None => "<userData/>".to_string(),
         },
         "groupSet" => {
@@ -2547,6 +2550,31 @@ mod modify_tests {
         let empty = super::parse_launch_opts(&std::collections::HashMap::new());
         assert!(empty.cpu_options.is_none());
         assert!(empty.placement_tenancy.is_none());
+    }
+
+    #[test]
+    fn describe_instance_attribute_escapes_user_data_xml() {
+        let svc = Ec2Service::new();
+        seed_instance(&svc, "i-esc");
+        {
+            let mut accounts = svc.state.write();
+            let state = accounts.get_or_create("000000000000");
+            state.instances.get_mut("i-esc").unwrap().user_data = Some("echo a && b <c>".into());
+        }
+        let resp = describe_instance_attribute(
+            &svc,
+            &req(
+                "DescribeInstanceAttribute",
+                &[("InstanceId", "i-esc"), ("Attribute", "userData")],
+            ),
+        )
+        .unwrap();
+        let xml = String::from_utf8_lossy(resp.body.expect_bytes()).to_string();
+        assert!(
+            xml.contains("echo a &amp;&amp; b &lt;c&gt;"),
+            "userData must be XML-escaped: {xml}"
+        );
+        assert!(!xml.contains("b <c>"), "raw < must not appear: {xml}");
     }
 
     fn seed_instance(svc: &Ec2Service, id: &str) {

--- a/crates/fakecloud-iam/src/iam_service/helpers.rs
+++ b/crates/fakecloud-iam/src/iam_service/helpers.rs
@@ -839,7 +839,7 @@ pub(crate) fn paginate_policy_names(
     };
     let members = page
         .iter()
-        .map(|n| format!("      <member>{n}</member>"))
+        .map(|n| format!("      <member>{}</member>", xml_escape(n)))
         .collect::<Vec<_>>()
         .join("\n");
     (members, is_truncated, next_marker)

--- a/crates/fakecloud-iam/src/xml_responses.rs
+++ b/crates/fakecloud-iam/src/xml_responses.rs
@@ -546,7 +546,7 @@ pub fn get_policy_response(policy: &IamPolicy, request_id: &str) -> String {
 pub fn list_role_policies_response(policy_names: &[String], request_id: &str) -> String {
     let members: String = policy_names
         .iter()
-        .map(|name| format!("      <member>{name}</member>"))
+        .map(|name| format!("      <member>{}</member>", xml_escape(name)))
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -1036,6 +1036,19 @@ mod tests {
     fn url_encode_policy_escapes_special_chars() {
         let encoded = url_encode_policy("a b");
         assert!(encoded.contains("%20") || encoded.contains("+"));
+    }
+
+    #[test]
+    fn list_role_policies_response_escapes_policy_names() {
+        // Real AWS restricts PolicyName to [\w+=,.@-]+, but fakecloud is
+        // lenient on input, so an inline policy named with XML metacharacters
+        // must still produce a well-formed response rather than corrupt XML.
+        let xml = list_role_policies_response(&["a<b&c".to_string()], "req-1");
+        assert!(
+            xml.contains("<member>a&lt;b&amp;c</member>"),
+            "policy name must be XML-escaped: {xml}"
+        );
+        assert!(!xml.contains("a<b&c"), "raw metacharacters must not leak");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three per-attribute XML response builders emitted user-controlled values **raw**, bypassing the `xml_escape` the bulk `Describe*` paths already apply. A value containing `&`, `<`, `>`, or `"` produced not-well-formed XML that breaks the SDK's XML parser. From the 2026-08-22 bug hunt, findings 6.1-6.3 (Tier 6, HIGH).

- **EC2 `DescribeInstanceAttribute` userData** (`instance.rs`) — a cloud-init script with `&&` / `[ $x -lt 5 ]` corrupted the response.
- **EC2 `DescribeNetworkInterfaceAttribute` description** (`eni.rs`) — an ENI description like `"web & db tier"`.
- **IAM `List{Role,User,Group}Policies` inline policy names** (`helpers.rs`, `xml_responses.rs`) — AWS restricts `PolicyName` to `[\w+=,.@-]+`, but fakecloud is lenient on input, so a lenient client that stored `a<b&c` broke the list response.

All three route the value through `fakecloud_aws::xml::xml_escape`, matching the bulk `Describe*` paths (which already escape via `ec2_elem` / the tag helpers).

No new API surface → no SDK/doc/count changes.

## Test plan
- `describe_instance_attribute_escapes_user_data_xml` — `echo a && b <c>` renders escaped.
- `describe_network_interface_attribute_escapes_description_xml` — `web & db <tier>` renders escaped.
- `list_role_policies_response_escapes_policy_names` — `a<b&c` renders `a&lt;b&amp;c`.
- `cargo clippy --all-targets` + `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
XML-escape user-controlled fields in per-attribute EC2 and IAM XML responses to keep them well-formed and avoid SDK parser errors. Previously these fields were emitted raw; now they are routed through `fakecloud_aws::xml::xml_escape`.

- EC2: escape `DescribeInstanceAttribute` userData (`instance.rs`) and `DescribeNetworkInterfaceAttribute` description (`eni.rs`).
- IAM: escape inline policy names in `List{Role,User,Group}Policies` (`xml_responses.rs`, `helpers.rs`).
- Add regression tests that assert escaped output and no raw metacharacters.
- No API or schema changes; behavior now matches bulk Describe paths; no migration required.

<sup>Written for commit 8cc7c0402c8483bec5b0b2b2d49c0cc52ee62510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

