### PR TITLE
fix: harden request-path panic/overflow DoS vectors

### DIFF
--- a/crates/fakecloud-batch/src/service.rs
+++ b/crates/fakecloud-batch/src/service.rs
@@ -1148,7 +1148,7 @@ impl BatchService {
             .collect();
         let mut resp = serde_json::Map::new();
         resp.insert("jobSummaryList".into(), Value::Array(items));
-        let next = start + max_results;
+        let next = start.saturating_add(max_results);
         if next < total {
             resp.insert("nextToken".into(), json!(next.to_string()));
         }

--- a/crates/fakecloud-cloudwatch/src/alarm_eval.rs
+++ b/crates/fakecloud-cloudwatch/src/alarm_eval.rs
@@ -388,7 +388,11 @@ fn eval_node(node: &RuleNode, states: &HashMap<String, AlarmState>) -> bool {
 /// malformed rule so `PutCompositeAlarm` can reject it.
 pub(crate) fn parse_alarm_rule(rule: &str) -> Result<RuleNode, String> {
     let chars: Vec<char> = rule.chars().collect();
-    let mut p = RuleParser { chars, pos: 0 };
+    let mut p = RuleParser {
+        chars,
+        pos: 0,
+        depth: 0,
+    };
     p.skip_ws();
     if p.pos >= p.chars.len() {
         return Err("empty alarm rule".to_string());
@@ -404,9 +408,16 @@ pub(crate) fn parse_alarm_rule(rule: &str) -> Result<RuleNode, String> {
     Ok(node)
 }
 
+/// Maximum nesting depth for an `AlarmRule`. Guards against a stack overflow
+/// on a pathologically nested rule (e.g. thousands of `(` or `NOT`); the
+/// length cap alone (~10240 chars) still permits ~5000 nesting levels. Mirrors
+/// the `metric_math` parser's depth guard.
+const MAX_RULE_DEPTH: usize = 256;
+
 struct RuleParser {
     chars: Vec<char>,
     pos: usize,
+    depth: usize,
 }
 
 impl RuleParser {
@@ -471,7 +482,12 @@ impl RuleParser {
     fn parse_unary(&mut self) -> Result<RuleNode, String> {
         if self.peek_keyword().as_deref() == Some("NOT") {
             self.consume_keyword("NOT");
+            self.depth += 1;
+            if self.depth > MAX_RULE_DEPTH {
+                return Err("alarm rule nested too deeply".to_string());
+            }
             let inner = self.parse_unary()?;
+            self.depth -= 1;
             return Ok(RuleNode::Not(Box::new(inner)));
         }
         self.parse_primary()
@@ -482,7 +498,12 @@ impl RuleParser {
         match self.peek() {
             Some('(') => {
                 self.pos += 1;
+                self.depth += 1;
+                if self.depth > MAX_RULE_DEPTH {
+                    return Err("alarm rule nested too deeply".to_string());
+                }
                 let node = self.parse_or()?;
+                self.depth -= 1;
                 self.skip_ws();
                 if self.peek() != Some(')') {
                     return Err("expected ')' in alarm rule".to_string());
@@ -634,6 +655,19 @@ mod tests {
         assert!(parse_alarm_rule("ALARM(a) AND").is_err());
         assert!(parse_alarm_rule("BOGUS(a)").is_err());
         assert!(parse_alarm_rule("ALARM(a) garbage").is_err());
+    }
+
+    #[test]
+    fn deeply_nested_rule_errors_without_stack_overflow() {
+        // Thousands of nested parens / NOTs would blow the stack via unbounded
+        // recursive descent; the depth guard rejects them with an error.
+        let parens = format!("{}TRUE{}", "(".repeat(5000), ")".repeat(5000));
+        assert!(parse_alarm_rule(&parens).is_err());
+        let nots = format!("{}TRUE", "NOT ".repeat(5000));
+        assert!(parse_alarm_rule(&nots).is_err());
+        // A modestly nested rule still parses.
+        assert!(parse_alarm_rule("((TRUE))").is_ok());
+        assert!(parse_alarm_rule("NOT NOT FALSE").is_ok());
     }
 
     #[test]

--- a/crates/fakecloud-eventbridge/src/scheduler.rs
+++ b/crates/fakecloud-eventbridge/src/scheduler.rs
@@ -147,7 +147,12 @@ fn parse_rate(inner: &str) -> Option<Schedule> {
     if singular != (value == 1) {
         return None;
     }
-    Some(Schedule::Rate(Duration::from_secs(value * secs_per)))
+    // A huge value (e.g. `rate(100000000000000000 days)`) overflows `value *
+    // secs_per`; saturate so it clamps instead of panicking (debug) / wrapping
+    // to a garbage rate (release).
+    Some(Schedule::Rate(Duration::from_secs(
+        value.saturating_mul(secs_per),
+    )))
 }
 
 fn parse_cron(inner: &str) -> Option<Schedule> {
@@ -603,6 +608,14 @@ mod tests {
         // AWS requires a positive value; `rate(0 ...)` is invalid.
         assert!(parse_schedule("rate(0 seconds)").is_none());
         assert!(parse_schedule("rate(0 minutes)").is_none());
+    }
+
+    #[test]
+    fn parse_rate_huge_value_saturates_without_panic() {
+        // `value * secs_per` would overflow u64; saturating_mul clamps instead
+        // of panicking (debug) or wrapping to a garbage rate (release).
+        let s = parse_schedule("rate(100000000000000000 days)");
+        assert!(matches!(s, Some(Schedule::Rate(_))));
     }
 
     #[test]

--- a/crates/fakecloud-iam/src/iam_service/policies.rs
+++ b/crates/fakecloud-iam/src/iam_service/policies.rs
@@ -606,7 +606,10 @@ impl IamService {
         // Validate version ID format: must match v[1-9][0-9]*(\.[A-Za-z0-9-]*)?
         let valid_format = version_id.starts_with('v')
             && version_id.len() > 1
-            && version_id[1..2]
+            // Slice from byte 1 (always a boundary — 'v' is one byte) and take
+            // the first char; slicing `[1..2]` panics when that char is
+            // multibyte (e.g. VersionId "v日").
+            && version_id[1..]
                 .chars()
                 .next()
                 .is_some_and(|c| c.is_ascii_digit() && c != '0')

--- a/crates/fakecloud-iam/src/iam_service/tests.rs
+++ b/crates/fakecloud-iam/src/iam_service/tests.rs
@@ -840,6 +840,32 @@ fn create_and_get_policy_version() {
 }
 
 #[test]
+fn set_default_policy_version_multibyte_version_id_does_not_panic() {
+    // Regression: `version_id[1..2]` panicked on a multibyte char after 'v'
+    // (byte 2 not a char boundary) before the format-reject branch ran. The
+    // handler must return an InvalidInput error instead of a slice panic.
+    let svc = make_service();
+    let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;
+    let req = make_request(
+        "CreatePolicy",
+        vec![("PolicyName", "mb-pol"), ("PolicyDocument", policy_doc)],
+    );
+    let resp = svc.create_policy(&req).unwrap();
+    let body = String::from_utf8_lossy(resp.body.expect_bytes());
+    let policy_arn = extract_xml_tag(&body, "Arn");
+
+    let req = make_request(
+        "SetDefaultPolicyVersion",
+        vec![("PolicyArn", policy_arn), ("VersionId", "v日")],
+    );
+    let err = svc
+        .set_default_policy_version(&req)
+        .err()
+        .expect("multibyte VersionId must be rejected, not panic");
+    assert_eq!(err.code(), "InvalidInput");
+}
+
+#[test]
 fn list_policy_versions() {
     let svc = make_service();
     let policy_doc = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}"#;

--- a/crates/fakecloud-timestream/src/query.rs
+++ b/crates/fakecloud-timestream/src/query.rs
@@ -197,7 +197,9 @@ pub fn parse_query(sql: &str) -> Result<Plan, QueryError> {
         let per = unit_nanos(unit).ok_or_else(|| {
             QueryError::Validation(format!("Unsupported ago() time unit '{unit}'."))
         })?;
-        Some((op, now_nanos() - n * per))
+        // A ~36-digit magnitude overflows i128 on `n * per`; saturate so a
+        // pathological ago() bound clamps instead of panicking.
+        Some((op, now_nanos().saturating_sub(n.saturating_mul(per))))
     } else {
         None
     };

--- a/crates/fakecloud-timestream/src/service.rs
+++ b/crates/fakecloud-timestream/src/service.rs
@@ -1403,7 +1403,7 @@ fn paginate(items: &[Value], start: usize, max: usize) -> (Vec<Value>, Option<St
     if start >= items.len() {
         return (Vec::new(), None);
     }
-    let end = (start + max).min(items.len());
+    let end = start.saturating_add(max).min(items.len());
     let page = items[start..end].to_vec();
     let next = if end < items.len() {
         Some(end.to_string())


### PR DESCRIPTION
## Summary

Five reachable crash vectors from the 2026-08-22 bug hunt (Tier 2). The first two panic in **all build profiles** (dropped connection / server crash); the rest panic in debug/dev builds and wrap to garbage in release.

- **IAM `SetDefaultPolicyVersion`** (`policies.rs`) — `version_id[1..2]` byte-slice panicked on a multibyte char after `v` (e.g. `VersionId "v日"`, byte 2 not a char boundary) *before* the format-reject branch ran. Now slices from byte 1 (always a boundary) and takes the first char.
- **CloudWatch `PutCompositeAlarm`** (`alarm_eval.rs`) — the recursive-descent `AlarmRule` parser had no depth limit; the length cap alone permits ~5000 nesting levels, so `(((…(TRUE)…)))` or `NOT NOT …` could stack-overflow the whole server. Added `MAX_RULE_DEPTH = 256` at the paren-group and `NOT` recursion points (mirrors the existing `metric_math` guard).
- **Integer-overflow guards** — Timestream pagination (`service.rs`) + `ago()` duration (`query.rs`), Batch `ListJobs` pagination (`service.rs`), EventBridge `parse_rate` (`scheduler.rs`): `start + max` / `n * per` / `value * secs_per` overflowed. Now `saturating_add` / `saturating_mul` / `saturating_sub`.

(The CFN `PasswordLength` capacity-overflow, finding 2.2b, is deferred to a follow-up — it shares `resource_provisioner/mod.rs` with in-flight PR #2472 and would conflict; picked up once that lands.)

No new API surface → no SDK/doc/count changes.

## Test plan
- `set_default_policy_version_multibyte_version_id_does_not_panic` — returns `InvalidInput`, no panic.
- `deeply_nested_rule_errors_without_stack_overflow` — 5000-deep parens / NOTs error cleanly; modest nesting still parses.
- `parse_rate_huge_value_saturates_without_panic`.
- `cargo clippy --all-targets` + `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens request parsing to prevent panics and integer overflows that could drop connections or crash the server. Previously, multibyte VersionIds, deeply nested alarm rules, and large pagination/scheduling values could panic (debug) or wrap to garbage (release); now these paths reject invalid input or clamp safely.

- IAM (`fakecloud-iam`): `SetDefaultPolicyVersion` no longer slices `version_id[1..2]`. Old: multibyte VersionId after 'v' panicked. New: returns InvalidInput; no API changes.
- CloudWatch (`fakecloud-cloudwatch`): adds `MAX_RULE_DEPTH = 256` for `AlarmRule` at `(` and `NOT`. Old: unbounded recursion could stack overflow. New: rules nested beyond 256 are rejected with "alarm rule nested too deeply".
- Pagination and schedule math (`fakecloud-batch`, `fakecloud-timestream`, `fakecloud-eventbridge`): replace `start + max`, `n * per`, and `value * secs_per` with `saturating_*`. Old: arithmetic overflowed. New: values clamp instead of panicking or wrapping.
- Tests: adds regression tests for multibyte VersionId, deeply nested rules, and huge rate() values.

<sup>Written for commit 122f76dcda416fda2ab2b26b9c396f233ba865fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

