### PR TITLE
fix(cloudformation): clamp GenerateSecretString PasswordLength

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/mod.rs
@@ -3448,10 +3448,14 @@ impl ResourceProvisioner {
 /// JSON template (this is the standard "DB credential" pattern).
 /// Without those two, the bare generated password is returned.
 fn generate_secret_string_payload(gen: &serde_json::Value) -> Result<String, String> {
+    // AWS bounds PasswordLength to 1..=4096 (default 32). Clamp into range so a
+    // negative value (`-1 as usize` == usize::MAX -> `with_capacity` abort) or a
+    // huge one (OOM in the fill loop) can't crash the server.
     let length = gen
         .get("PasswordLength")
         .and_then(|v| v.as_i64())
-        .unwrap_or(32) as usize;
+        .unwrap_or(32)
+        .clamp(1, 4096) as usize;
     let exclude_lowercase = gen
         .get("ExcludeLowercase")
         .and_then(|v| v.as_bool())
@@ -8148,6 +8152,34 @@ mod tests {
         ] {
             assert!(!policy_retains_physical(v), "{v:?} should delete");
         }
+    }
+
+    #[test]
+    fn generate_secret_string_clamps_password_length() {
+        // -1 previously became usize::MAX and aborted with a capacity overflow.
+        let neg = generate_secret_string_payload(&serde_json::json!({
+            "PasswordLength": -1
+        }))
+        .expect("negative length must not panic");
+        assert_eq!(neg.chars().count(), 1, "clamped up to the min of 1");
+
+        // A huge value would OOM the fill loop; clamp to the AWS max of 4096.
+        let huge = generate_secret_string_payload(&serde_json::json!({
+            "PasswordLength": 1_000_000_000
+        }))
+        .expect("huge length must not OOM");
+        assert_eq!(
+            huge.chars().count(),
+            4096,
+            "clamped down to the max of 4096"
+        );
+
+        // A normal value is honored.
+        let ok = generate_secret_string_payload(&serde_json::json!({
+            "PasswordLength": 24
+        }))
+        .unwrap();
+        assert_eq!(ok.chars().count(), 24);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A CFN `AWS::SecretsManager::Secret` whose `GenerateSecretString.PasswordLength` is `-1` turned into `usize::MAX` via `as usize`, so `String::with_capacity` aborted with a capacity overflow; a large positive value OOMed the fill loop. Either crashes the server on `CreateStack` / `UpdateStack`. From the 2026-08-22 bug hunt, finding 2.2b (Tier 2 DoS).

Clamp `PasswordLength` into AWS's documented `1..=4096` range (default 32).

Split from the panic-hardening PR (#2474) because it shares `resource_provisioner/mod.rs` with the DeletionPolicy PR (#2472, now merged).

No new API surface → no SDK/doc/count changes.

## Test plan
- `generate_secret_string_clamps_password_length` — `-1` clamps to 1 (no abort), `1_000_000_000` clamps to 4096 (no OOM), `24` is honored.
- `cargo clippy --all-targets` + `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamps `GenerateSecretString.PasswordLength` for `AWS::SecretsManager::Secret` to 1..=4096 to prevent crashes. Previously, negative values became `usize::MAX` and aborted allocation; very large values OOMed the fill loop during `CreateStack`/`UpdateStack`.

- Matches AWS bounds; honors in-range values and defaults to 32 when absent.
- Adds a unit test covering negative, huge, and normal lengths.
- No API or SDK changes; no migration required.

<sup>Written for commit bc7710ecb1606ee93fb8e498b232f4418cfb6c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

