### PR TITLE
fix: scope returned ARNs/endpoints to the request region, not frozen config

### DIFF
--- a/crates/fakecloud-apigatewayv2/src/extras.rs
+++ b/crates/fakecloud-apigatewayv2/src/extras.rs
@@ -1280,7 +1280,10 @@ impl ApiGatewayV2Service {
                 let spec_raw = req_str(&body, "Body")?.to_string();
                 let spec = parse_openapi_spec(&spec_raw)?;
                 let (rebuilt, routes, integrations) =
-                    build_api_from_spec(&spec, api.clone(), &region);
+                    // Use the request region (as ImportApi does), not the
+                    // frozen account region, so a ReimportApi from a different
+                    // region rebuilds a correctly-scoped api_endpoint host.
+                    build_api_from_spec(&spec, api.clone(), &req.region);
                 let mut accounts = self.state.write();
                 let state = accounts.get_or_create(aid);
                 let existing = state

--- a/crates/fakecloud-ecr/src/oci.rs
+++ b/crates/fakecloud-ecr/src/oci.rs
@@ -492,7 +492,8 @@ async fn blob_head(
     }
     // Cache miss: try pull-through, which (on success) also caches.
     if let Some(outcome) =
-        crate::pull_through::proxy_blob(service, &request.account_id, name, digest).await
+        crate::pull_through::proxy_blob(service, &request.account_id, &request.region, name, digest)
+            .await
     {
         let proxied = outcome?;
         let mut resp = crate::pull_through::blob_response(&proxied, digest);
@@ -562,7 +563,8 @@ async fn blob_get(
         return Ok(resp);
     }
     if let Some(outcome) =
-        crate::pull_through::proxy_blob(service, &request.account_id, name, digest).await
+        crate::pull_through::proxy_blob(service, &request.account_id, &request.region, name, digest)
+            .await
     {
         let proxied = outcome?;
         // Pull-through cached the blob; mirror the local-hit code path
@@ -1049,6 +1051,7 @@ async fn manifest_head(
     if let Some(outcome) = crate::pull_through::proxy_manifest(
         service,
         &request.account_id,
+        &request.region,
         name,
         reference,
         request.principal.as_ref().map(|p| p.arn.as_str()),
@@ -1118,6 +1121,7 @@ async fn manifest_get(
     if let Some(outcome) = crate::pull_through::proxy_manifest(
         service,
         &request.account_id,
+        &request.region,
         name,
         reference,
         request.principal.as_ref().map(|p| p.arn.as_str()),

--- a/crates/fakecloud-ecr/src/pull_through.rs
+++ b/crates/fakecloud-ecr/src/pull_through.rs
@@ -181,9 +181,11 @@ async fn exchange_bearer_token(
 
 /// Proxy a manifest GET. On success, persist the manifest + auto-create
 /// the local `Repository` so subsequent requests hit local.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn proxy_manifest(
     service: &EcrService,
     account_id: &str,
+    region: &str,
     repo_name: &str,
     reference: &str,
     caller_arn: Option<&str>,
@@ -230,6 +232,7 @@ pub(crate) async fn proxy_manifest(
     cache_manifest(
         service,
         account_id,
+        region,
         repo_name,
         reference,
         &bytes,
@@ -250,6 +253,7 @@ pub(crate) async fn proxy_manifest(
 pub(crate) async fn proxy_blob(
     service: &EcrService,
     account_id: &str,
+    region: &str,
     repo_name: &str,
     digest: &str,
 ) -> Option<Result<ProxiedBlob, AwsServiceError>> {
@@ -285,7 +289,15 @@ pub(crate) async fn proxy_blob(
         Ok(b) => b.to_vec(),
         Err(e) => return Some(Err(proxy_error(repo_name, &e.to_string()))),
     };
-    cache_blob(service, account_id, repo_name, digest, &bytes, &media_type);
+    cache_blob(
+        service,
+        account_id,
+        region,
+        repo_name,
+        digest,
+        &bytes,
+        &media_type,
+    );
     Some(Ok(ProxiedBlob { bytes, media_type }))
 }
 
@@ -293,6 +305,7 @@ pub(crate) async fn proxy_blob(
 fn cache_manifest(
     service: &EcrService,
     account_id: &str,
+    region: &str,
     repo_name: &str,
     reference: &str,
     bytes: &[u8],
@@ -304,7 +317,10 @@ fn cache_manifest(
     let mut accounts = service.state_handle().write();
     let state = accounts.get_or_create(account_id);
     let account_id = state.account_id.clone();
-    let region = state.region.clone();
+    // Scope the auto-created repository ARN to the request region, not the
+    // frozen account region, so a pull-through from a non-default region
+    // yields a correctly-scoped repositoryArn.
+    let region = region.to_string();
     // Honour pull-time exclusions: an excluded principal that triggers
     // a proxy-cache should not bump the in-use counter on the freshly
     // cached image. HEAD requests also opt out via `count_as_pull=false`
@@ -364,6 +380,7 @@ fn cache_manifest(
 fn cache_blob(
     service: &EcrService,
     account_id: &str,
+    region: &str,
     repo_name: &str,
     digest: &str,
     bytes: &[u8],
@@ -372,7 +389,8 @@ fn cache_blob(
     let mut accounts = service.state_handle().write();
     let state = accounts.get_or_create(account_id);
     let account_id = state.account_id.clone();
-    let region = state.region.clone();
+    // Scope the auto-created repository ARN to the request region.
+    let region = region.to_string();
     let repo = state
         .repositories
         .entry(repo_name.to_string())

--- a/crates/fakecloud-eventbridge/src/helpers.rs
+++ b/crates/fakecloud-eventbridge/src/helpers.rs
@@ -1116,12 +1116,25 @@ pub(crate) fn deliver_to_logs(
         log_group_arn
     };
 
+    // Deliver into the account and region the target log-group ARN names, not
+    // the default account/frozen region — otherwise a cross-account/region
+    // target silently lands in the default account with a wrong-region ARN.
+    // ARN shape: arn:aws:logs:REGION:ACCOUNT:log-group:NAME[:*].
+    let arn_parts: Vec<&str> = log_group_arn.split(':').collect();
+    let target_region = arn_parts.get(3).filter(|s| !s.is_empty()).copied();
+    let target_account = arn_parts.get(4).filter(|s| !s.is_empty()).copied();
+
     let stream_name = "events".to_string();
     let ts_millis = timestamp.timestamp_millis();
 
     let mut accounts = logs_state.write();
-    let state = accounts.default_mut();
-    let region = state.region.clone();
+    let state = match target_account {
+        Some(acct) => accounts.get_or_create(acct),
+        None => accounts.default_mut(),
+    };
+    let region = target_region
+        .map(str::to_string)
+        .unwrap_or_else(|| state.region.clone());
     let account_id = state.account_id.clone();
 
     // Auto-create log group and stream if they don't exist
@@ -1561,5 +1574,29 @@ mod logs_persist_tests {
         let accounts = logs_state.read();
         let logs = accounts.get("123456789012").unwrap();
         assert!(logs.log_groups.contains_key("/eb/nohook"));
+    }
+
+    #[test]
+    fn deliver_to_logs_honors_target_arn_account_and_region() {
+        // A target log-group ARN in a non-default account/region must deliver
+        // into THAT account with a correctly-scoped group ARN, not collapse
+        // into the default account with a wrong-region ARN.
+        let logs_state = empty_logs_state();
+        let arn = "arn:aws:logs:eu-central-1:999999999999:log-group:/eb/xacct:*";
+        deliver_to_logs(&logs_state, arn, "payload", chrono::Utc::now());
+
+        let accounts = logs_state.read();
+        let logs = accounts
+            .get("999999999999")
+            .expect("group must land in the target account, not the default");
+        let group = logs
+            .log_groups
+            .get("/eb/xacct")
+            .expect("group created in target account");
+        assert!(
+            group.arn.contains(":eu-central-1:999999999999:"),
+            "group ARN must carry the target region+account: {}",
+            group.arn
+        );
     }
 }

--- a/crates/fakecloud-ssm/src/service/patches.rs
+++ b/crates/fakecloud-ssm/src/service/patches.rs
@@ -879,9 +879,10 @@ impl SsmService {
             })));
         }
 
-        // Otherwise look up from defaults
-        let baseline_id =
-            default_patch_baseline(&state.region, operating_system).unwrap_or_default();
+        // Otherwise look up from defaults. Resolve against the request region,
+        // not the frozen account region, so GetDefaultPatchBaseline from a
+        // different region returns that region's baseline id.
+        let baseline_id = default_patch_baseline(&req.region, operating_system).unwrap_or_default();
         Ok(AwsResponse::ok_json(json!({
             "BaselineId": baseline_id,
             "OperatingSystem": operating_system,


### PR DESCRIPTION
## Summary

Residuals from the #2356 / `41f8cfa7` region-scope sweep — four handlers built a returned ARN/endpoint/id from the **frozen startup region** (`state.region`) instead of the request scope, so a client in a non-default region got a wrong-region value it then stored and reused (breaking the *next* call / IAM region conditions / Terraform round-trip). 2026-08-22 bug hunt, Tier 0 findings 0.1-0.3 + 0.6.

- **ECR pull-through** (`pull_through.rs`) — the auto-created cache repository ARN used `state.region`. Thread the request region through `proxy_manifest`/`proxy_blob` → `cache_manifest`/`cache_blob`.
- **EventBridge → CloudWatch Logs** (`helpers.rs`) — `deliver_to_logs` wrote into the **default account** with a `state.region` ARN, ignoring the region/account in the target log-group ARN. Parse both from the ARN and deliver into that account/region.
- **apigatewayv2 `ReimportApi`** (`extras.rs`) — rebuilt `api_endpoint` from the frozen account region; use `req.region` (as `ImportApi` already does).
- **SSM `GetDefaultPatchBaseline`** (`patches.rs`) — resolved the region-keyed baseline from `state.region`; use `req.region` (matches the existing `register` path).

(0.4/0.5 — MemoryDB/XRay `new_for_account` default-resource seeding — are a separate batch; they share the `multi_account.rs` first-touch seeding mechanism.)

No new API surface → no SDK/doc/count changes.

## Test plan
- `deliver_to_logs_honors_target_arn_account_and_region` — a cross-account/region target lands in the target account with a target-region group ARN; existing `deliver_to_logs_*` tests still pass.
- `cargo clippy --all-targets` + `cargo fmt` clean across all four crates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes returned ARNs, endpoints, and default IDs to the request region and target account. Previously these paths used the startup region and default account, so clients in non‑default regions received wrong‑region values they cached and reused.

- `fakecloud-ecr`: ECR pull‑through now threads the request region into `proxy_manifest`/`proxy_blob` and caches with a repositoryArn scoped to that region (fixes IAM region conditions and Terraform round‑trips).
- `fakecloud-eventbridge`: `deliver_to_logs` delivers to the account and region encoded in the target log‑group ARN, auto‑creating the group/stream there instead of the default account/state.region.
- `fakecloud-apigatewayv2`: `ReimportApi` rebuilds `api_endpoint` using `req.region` (consistent with `ImportApi`), not the frozen account region.
- `fakecloud-ssm`: `GetDefaultPatchBaseline` resolves the baseline against `req.region`, not `state.region`.

- No API shape changes; rollout is safe.

<sup>Written for commit 0f203a7e88d17ade7216735677c785e2e45e0fec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

