### PR TITLE
fix(secretsmanager): ResourceNotFoundException returns HTTP 400, not 404

### DIFF
--- a/crates/fakecloud-secretsmanager/src/service.rs
+++ b/crates/fakecloud-secretsmanager/src/service.rs
@@ -436,7 +436,7 @@ impl SecretsManagerService {
             None => {
                 // No versions exist
                 return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
+                    StatusCode::BAD_REQUEST,
                     "ResourceNotFoundException",
                     format!(
                         "Secrets Manager can't find the specified secret value for staging label: {requested_stage}"
@@ -447,7 +447,7 @@ impl SecretsManagerService {
 
         let version = secret.versions.get(&version_id).ok_or_else(|| {
             AwsServiceError::aws_error(
-                StatusCode::NOT_FOUND,
+                StatusCode::BAD_REQUEST,
                 "ResourceNotFoundException",
                 format!(
                     "Secrets Manager can't find the specified secret value for VersionId: {version_id}"
@@ -460,7 +460,7 @@ impl SecretsManagerService {
             if let Some(stage) = body["VersionStage"].as_str() {
                 if !version.stages.contains(&stage.to_string()) {
                     return Err(AwsServiceError::aws_error(
-                        StatusCode::NOT_FOUND,
+                        StatusCode::BAD_REQUEST,
                         "ResourceNotFoundException",
                         "You provided a VersionStage that is not associated to the provided VersionId.",
                     ));
@@ -532,7 +532,7 @@ impl SecretsManagerService {
             Ok(s) => s,
             Err(_) => {
                 return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
+                    StatusCode::BAD_REQUEST,
                     "ResourceNotFoundException",
                     "Secrets Manager can't find the specified secret.",
                 ));
@@ -678,7 +678,7 @@ impl SecretsManagerService {
             Ok(s) => s,
             Err(_) => {
                 return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
+                    StatusCode::BAD_REQUEST,
                     "ResourceNotFoundException",
                     "Secrets Manager can't find the specified secret.",
                 ));
@@ -1923,7 +1923,7 @@ impl SecretsManagerService {
 
             if no_value_found && secret_values.is_empty() {
                 return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
+                    StatusCode::BAD_REQUEST,
                     "ResourceNotFoundException",
                     "Secrets Manager can't find the specified secret.",
                 ));
@@ -2198,7 +2198,7 @@ impl SecretsManagerService {
 /// The standard "secret can't be found" error, shared by the resolution helpers.
 fn secret_not_found() -> AwsServiceError {
     AwsServiceError::aws_error(
-        StatusCode::NOT_FOUND,
+        StatusCode::BAD_REQUEST,
         "ResourceNotFoundException",
         "Secrets Manager can't find the specified secret.",
     )

--- a/crates/fakecloud-secretsmanager/src/service_tests.rs
+++ b/crates/fakecloud-secretsmanager/src/service_tests.rs
@@ -1470,6 +1470,9 @@ async fn get_secret_value_not_found() {
     let req = make_request("GetSecretValue", r#"{"SecretId": "nope"}"#);
     let err = expect_err(svc.handle(req).await);
     assert!(err.to_string().contains("ResourceNotFoundException"));
+    // awsJson1_1: ResourceNotFoundException has no @httpError trait, so AWS
+    // returns HTTP 400, not 404. SDK retry classifiers key on this.
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

SecretsManager is **awsJson1_1** and `ResourceNotFoundException` carries no `@httpError` trait (`error: client`), so AWS returns **HTTP 400** — but every not-found path shipped **404**. SDK retry classifiers and status-keyed clients diverge from real AWS on any op against a missing/purged `SecretId`. 2026-08-22 bug hunt, finding 1.18.

Flipped the 7 not-found sites (`GetSecretValue`, `DescribeSecret`, `PutSecretValue`, the shared `secret_not_found()` helper, …) from `NOT_FOUND` to `BAD_REQUEST`; the `"ResourceNotFoundException"` code is unchanged. The JSON-body `ErrorCode` fields in `BatchGetSecretValue` responses are the per-secret error shape (not the HTTP status) and are left as-is.

Verified against `aws-models/secretsmanager.json` — no `httpError` trait on the exception.

No new API surface → no SDK/doc/count changes.

## Test plan
- `get_secret_value_not_found` now asserts HTTP 400 (was implicitly 404).
- `cargo clippy --all-targets` + `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return HTTP 400 for SecretsManager `ResourceNotFoundException` instead of 404. This matches AWS `awsJson1_1` behavior and aligns SDK retry and status-keyed clients with real responses.

- Changed seven not-found paths (`GetSecretValue`, `DescribeSecret`, `PutSecretValue`, and the shared `secret_not_found()` helper) from `NOT_FOUND` to `BAD_REQUEST`; kept the error code "ResourceNotFoundException".
- Left `BatchGetSecretValue` per-item `ErrorCode` fields unchanged; they are not HTTP status.
- Updated test `get_secret_value_not_found` to assert 400.
- No API changes; no migration required.

<sup>Written for commit 3dd06f998979afa1b17c6879737219273bd1ee7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

