### PR TITLE
fix(elasticache): CopySnapshot finalizes to available instead of stuck creating

### DIFF
--- a/crates/fakecloud-elasticache/src/service/snapshots.rs
+++ b/crates/fakecloud-elasticache/src/service/snapshots.rs
@@ -555,7 +555,24 @@ impl ElastiCacheService {
             state.account_id,
             target
         );
-        snap.snapshot_status = "creating".to_string();
+        // A copy duplicates an already-complete snapshot, so it is available
+        // immediately — there is nothing to dump. (Previously it was left
+        // `creating` with no finalizer, so it was stuck forever: unusable as a
+        // restore source with its name permanently blocked.) Give the copy its
+        // own RDB file so deleting the source can't dangle it.
+        if let Some(src_rdb) = snap.rdb_path.clone() {
+            let dst_rdb = snapshot_rdb_path(self.data_dir.as_deref(), &state.account_id, &target);
+            match std::fs::copy(&src_rdb, &dst_rdb) {
+                Ok(_) => snap.rdb_path = Some(dst_rdb),
+                Err(err) => {
+                    // Fall back to a metadata-only copy rather than blocking the
+                    // row; the snapshot still becomes usable, just without data.
+                    tracing::warn!("CopySnapshot: failed to copy RDB {src_rdb}: {err}");
+                    snap.rdb_path = None;
+                }
+            }
+        }
+        snap.snapshot_status = "available".to_string();
         snap.snapshot_source = "manual".to_string();
         let xml = snapshot_xml(&snap);
         state.snapshots.insert(target, snap);
@@ -603,7 +620,9 @@ impl ElastiCacheService {
             state.account_id,
             target
         );
-        snap.status = "creating".to_string();
+        // A copy of an already-complete serverless snapshot is available
+        // immediately; it was previously stuck `creating` with no finalizer.
+        snap.status = "available".to_string();
         let xml = serverless_cache_snapshot_xml(&snap);
         state.serverless_cache_snapshots.insert(target, snap);
         Ok(AwsResponse::xml(

--- a/crates/fakecloud-elasticache/src/service_tests.rs
+++ b/crates/fakecloud-elasticache/src/service_tests.rs
@@ -2477,6 +2477,76 @@ async fn create_snapshot_without_runtime_is_available_immediately() {
 }
 
 #[tokio::test]
+async fn copy_snapshot_is_available_not_stuck_creating() {
+    let service = service_with_replication_group("copy-rg", 1);
+    service
+        .create_snapshot(&request(
+            "CreateSnapshot",
+            &[
+                ("SnapshotName", "src-snap"),
+                ("ReplicationGroupId", "copy-rg"),
+            ],
+        ))
+        .await
+        .unwrap();
+
+    let body = String::from_utf8(
+        service
+            .copy_snapshot(&request(
+                "CopySnapshot",
+                &[
+                    ("SourceSnapshotName", "src-snap"),
+                    ("TargetSnapshotName", "dst-snap"),
+                ],
+            ))
+            .unwrap()
+            .body
+            .expect_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    // Previously the copy was left `creating` with no finalizer -> stuck forever.
+    assert!(
+        body.contains("<SnapshotStatus>available</SnapshotStatus>"),
+        "copied snapshot must be available, not stuck creating: {body}"
+    );
+}
+
+#[tokio::test]
+async fn copy_serverless_cache_snapshot_is_available_not_stuck_creating() {
+    let service = service_with_serverless_cache("sl-cache");
+    // Seed a source serverless snapshot directly, then copy it.
+    service
+        .create_serverless_cache_snapshot(&request(
+            "CreateServerlessCacheSnapshot",
+            &[
+                ("ServerlessCacheSnapshotName", "sl-src"),
+                ("ServerlessCacheName", "sl-cache"),
+            ],
+        ))
+        .unwrap();
+    let body = String::from_utf8(
+        service
+            .copy_serverless_cache_snapshot(&request(
+                "CopyServerlessCacheSnapshot",
+                &[
+                    ("SourceServerlessCacheSnapshotName", "sl-src"),
+                    ("TargetServerlessCacheSnapshotName", "sl-dst"),
+                ],
+            ))
+            .unwrap()
+            .body
+            .expect_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    assert!(
+        body.contains("<Status>available</Status>"),
+        "copied serverless snapshot must be available: {body}"
+    );
+}
+
+#[tokio::test]
 async fn create_snapshot_via_cache_cluster_id() {
     let service = service_with_replication_group("cc-rg", 2);
     let req = request(


### PR DESCRIPTION
## Summary

`CopySnapshot` and `CopyServerlessCacheSnapshot` cloned an already-complete source snapshot, renamed it, then left `snapshot_status = "creating"` and spawned **no finalizer** — so the copy was stuck `creating` for the whole process lifetime (and across restarts, since the serverless path isn't walked by snapshot recovery). Unusable as a restore source, with its name permanently blocked; wrong even in metadata-only mode where a fresh snapshot is `available` immediately. 2026-08-22 bug hunt, finding 4.5 (Tier 4, HIGH).

A copy duplicates existing data — there is nothing to dump — so both now flip to `available` immediately. For `CopySnapshot`, the copy gets its **own** RDB file (`std::fs::copy` from the source, metadata-only fallback on error) so deleting the source can't dangle the copy's `rdb_path`.

No new API surface → no SDK/doc/count changes.

## Test plan
- `copy_snapshot_is_available_not_stuck_creating` — the copy reports `available`.
- `copy_serverless_cache_snapshot_is_available_not_stuck_creating`.
- `cargo clippy --all-targets` + `cargo fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copied ElastiCache snapshots now become available immediately. Previously `CopySnapshot` and `CopyServerlessCacheSnapshot` left copies stuck in creating with no finalizer, making them unusable as restore sources and leaving their names blocked across restarts.

- Set snapshot status to available on copy; no finalizer required because data already exists.
- For `CopySnapshot`, copy the source RDB to a new file for the target; on copy error, fall back to metadata-only and log a warning.
- Added tests that assert copied snapshots report available.
- No API changes; restores can use copied snapshots immediately.

<sup>Written for commit f401c2bf735b2b5de276d91def71bd6664d9263c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

