### PR TITLE
fix(memorydb,xray): seeded default ARNs follow the request region

### DIFF
--- a/crates/fakecloud-memorydb/src/service.rs
+++ b/crates/fakecloud-memorydb/src/service.rs
@@ -114,6 +114,13 @@ impl AwsService for MemoryDbService {
 
     async fn handle(&self, request: AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let mutates = is_mutating(request.action.as_str());
+        // Account state is shared across regions; re-point the AWS-provided
+        // defaults' ARNs at the region this request names before any handler
+        // reads them (bug-hunt 2026-08-22 §0.4).
+        self.state
+            .write()
+            .get_or_create(&request.account_id)
+            .retarget_default_arns(&request.region, &request.account_id);
         let result = dispatch(self, &request);
         if mutates && matches!(result.as_ref(), Ok(resp) if resp.status.is_success()) {
             self.save().await;
@@ -2031,6 +2038,71 @@ mod tests {
         assert_eq!(
             users["Users"][0]["ARN"],
             "arn:aws:memorydb:us-east-1:123456789012:user/default"
+        );
+    }
+
+    #[tokio::test]
+    async fn seeded_defaults_carry_the_request_region_not_the_configured_one() {
+        let s = service();
+        let mut r = req("DescribeUsers", json!({"UserName": "default"}));
+        r.region = "eu-west-1".to_string();
+        let resp = s.handle(r).await.unwrap();
+        let users: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            users["Users"][0]["ARN"],
+            "arn:aws:memorydb:eu-west-1:123456789012:user/default"
+        );
+
+        let mut r = req("DescribeACLs", json!({"ACLName": "open-access"}));
+        r.region = "eu-west-1".to_string();
+        let resp = s.handle(r).await.unwrap();
+        let acls: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            acls["ACLs"][0]["ARN"],
+            "arn:aws:memorydb:eu-west-1:123456789012:acl/open-access"
+        );
+
+        let mut r = req(
+            "DescribeParameterGroups",
+            json!({"ParameterGroupName": "default.memorydb-redis7"}),
+        );
+        r.region = "eu-west-1".to_string();
+        let resp = s.handle(r).await.unwrap();
+        let pgs: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            pgs["ParameterGroups"][0]["ARN"],
+            "arn:aws:memorydb:eu-west-1:123456789012:parametergroup/default.memorydb-redis7"
+        );
+
+        // Back in the configured region the ARNs read back that region again.
+        let resp = s
+            .handle(req("DescribeUsers", json!({"UserName": "default"})))
+            .await
+            .unwrap();
+        let users: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(
+            users["Users"][0]["ARN"],
+            "arn:aws:memorydb:us-east-1:123456789012:user/default"
+        );
+    }
+
+    #[tokio::test]
+    async fn retargeting_defaults_leaves_created_resources_alone() {
+        let s = service();
+        call(
+            &s,
+            "CreateUser",
+            json!({"UserName": "app", "AccessString": "on ~* +@all", "AuthenticationMode": {"Type": "password", "Passwords": ["averylongpassword123"]}}),
+        )
+        .unwrap();
+        let mut r = req("DescribeUsers", json!({"UserName": "app"}));
+        r.region = "eu-west-1".to_string();
+        let resp = s.handle(r).await.unwrap();
+        let users: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        // A user created in us-east-1 keeps its us-east-1 ARN.
+        assert_eq!(
+            users["Users"][0]["ARN"],
+            "arn:aws:memorydb:us-east-1:123456789012:user/app"
         );
     }
 

--- a/crates/fakecloud-memorydb/src/state.rs
+++ b/crates/fakecloud-memorydb/src/state.rs
@@ -185,6 +185,32 @@ pub struct MemoryDbState {
     pub tags: BTreeMap<String, TagMap>,
 }
 
+impl MemoryDbState {
+    /// Re-point the ARNs of the AWS-provided defaults (`default` user,
+    /// `open-access` ACL, `default.memorydb-*` parameter groups) at the region
+    /// the caller is asking about.
+    ///
+    /// Account state is shared across regions, so defaults seeded when the
+    /// account was first touched from `us-east-1` would otherwise keep
+    /// answering `DescribeUsers`/`DescribeACLs`/`DescribeParameterGroups` in
+    /// `eu-west-1` with `us-east-1` ARNs, which the Terraform provider reads
+    /// back as drift. These resources exist in every region, so re-point them
+    /// rather than freezing whichever region created the account.
+    pub fn retarget_default_arns(&mut self, region: &str, account_id: &str) {
+        if let Some(user) = self.users.get_mut("default") {
+            user.arn = format!("arn:aws:memorydb:{region}:{account_id}:user/default");
+        }
+        if let Some(acl) = self.acls.get_mut("open-access") {
+            acl.arn = format!("arn:aws:memorydb:{region}:{account_id}:acl/open-access");
+        }
+        for (name, pg) in self.parameter_groups.iter_mut() {
+            if name.starts_with("default.") {
+                pg.arn = format!("arn:aws:memorydb:{region}:{account_id}:parametergroup/{name}");
+            }
+        }
+    }
+}
+
 impl AccountState for MemoryDbState {
     fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
         // AWS seeds every account with a default ACL and default user.

--- a/crates/fakecloud-xray/src/service.rs
+++ b/crates/fakecloud-xray/src/service.rs
@@ -224,6 +224,13 @@ impl XrayService {
             account: req.account_id.clone(),
             region: req.region.clone(),
         };
+        // Account state is shared across regions; re-point the built-in
+        // `Default` sampling rule's ARN at the region this request names
+        // before any handler reads it (bug-hunt 2026-08-22 §0.5).
+        self.state
+            .write()
+            .get_or_create(&ctx.account)
+            .ensure_default_rule(&ctx.region, &ctx.account);
         match action {
             "PutTraceSegments" => self.put_trace_segments(&ctx, &body),
             "BatchGetTraces" => self.batch_get_traces(&ctx, &body),
@@ -1576,6 +1583,39 @@ mod tests {
             access_key_id: None,
             principal: None,
         }
+    }
+
+    #[tokio::test]
+    async fn default_sampling_rule_arn_follows_the_request_region() {
+        let s = svc();
+        let mut r = req("/GetSamplingRules");
+        r.region = "eu-west-1".to_string();
+        let out = s.handle(r).await.unwrap();
+        let body = body_json(&out);
+        let rule = body["SamplingRuleRecords"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["SamplingRule"]["RuleName"] == "Default")
+            .expect("built-in Default rule");
+        assert_eq!(
+            rule["SamplingRule"]["RuleARN"],
+            "arn:aws:xray:eu-west-1:000000000000:sampling-rule/Default"
+        );
+
+        // Reading from the configured region reports that region again.
+        let out = s.handle(req("/GetSamplingRules")).await.unwrap();
+        let body = body_json(&out);
+        let rule = body["SamplingRuleRecords"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["SamplingRule"]["RuleName"] == "Default")
+            .expect("built-in Default rule");
+        assert_eq!(
+            rule["SamplingRule"]["RuleARN"],
+            "arn:aws:xray:us-east-1:000000000000:sampling-rule/Default"
+        );
     }
 
     #[test]

--- a/crates/fakecloud-xray/src/state.rs
+++ b/crates/fakecloud-xray/src/state.rs
@@ -81,17 +81,29 @@ impl Default for XrayData {
 
 impl XrayData {
     /// Seed the built-in, undeletable `Default` sampling rule that every X-Ray
-    /// account carries (matched last, 1 req/s reservoir + 5% of the rest).
-    fn seed_default_rule(&mut self, region: &str, account: &str) {
-        if self.sampling_rules.contains_key(DEFAULT_SAMPLING_RULE) {
+    /// account carries (matched last, 1 req/s reservoir + 5% of the rest), and
+    /// keep its `RuleARN` pointed at the region the caller is asking about.
+    ///
+    /// Account state is shared across regions, so a rule seeded when the
+    /// account was first touched from `us-east-1` would otherwise keep
+    /// answering `GetSamplingRules` in `eu-west-1` with a `us-east-1` ARN.
+    /// The built-in rule exists in every region, so re-point it instead of
+    /// freezing whichever region happened to create the account.
+    pub(crate) fn ensure_default_rule(&mut self, region: &str, account: &str) {
+        let want = format!("arn:aws:xray:{region}:{account}:sampling-rule/{DEFAULT_SAMPLING_RULE}");
+        if let Some(existing) = self.sampling_rules.get_mut(DEFAULT_SAMPLING_RULE) {
+            if let Some(rule) = existing.get_mut("SamplingRule") {
+                if rule.get("RuleARN").and_then(|v| v.as_str()) != Some(want.as_str()) {
+                    rule["RuleARN"] = json!(want);
+                }
+            }
             return;
         }
-        let arn = format!("arn:aws:xray:{region}:{account}:sampling-rule/{DEFAULT_SAMPLING_RULE}");
         let now = now_epoch();
         let record = json!({
             "SamplingRule": {
                 "RuleName": DEFAULT_SAMPLING_RULE,
-                "RuleARN": arn,
+                "RuleARN": want,
                 "ResourceARN": "*",
                 "Priority": 10000,
                 "FixedRate": 0.05,
@@ -122,7 +134,7 @@ pub fn now_epoch() -> f64 {
 impl AccountState for XrayData {
     fn new_for_account(account_id: &str, region: &str, _endpoint: &str) -> Self {
         let mut data = Self::default();
-        data.seed_default_rule(region, account_id);
+        data.ensure_default_rule(region, account_id);
         data
     }
 }


### PR DESCRIPTION
## Summary

`MultiAccountState::get_or_create` builds a new account's state with the server's *configured* region, so every AWS-provided default seeded in `new_for_account` froze whichever region first touched the account. A caller working in `eu-west-1` then read back `us-east-1` ARNs for resources that exist in every region, which the Terraform provider reads as drift.

- **MemoryDB** re-points the `default` user, the `open-access` ACL, and the `default.memorydb-*` parameter groups at the request's region before dispatch.
- **X-Ray** does the same for the built-in `Default` sampling rule's `RuleARN`.

Resources the caller actually created keep the region they were created in - only the always-present defaults follow the request region.

## Why these two were left out of #2476

The #2476 sweep fixed per-handler ARN builds (ECR pull-through, EventBridge -> Logs delivery, apigatewayv2 `ReimportApi`, SSM default patch baseline). Findings 0.4 and 0.5 are a different mechanism - `new_for_account` seeding through `multi_account.rs` - so they were deferred to their own change.

## Tests

- `memorydb`: `seeded_defaults_carry_the_request_region_not_the_configured_one` covers user/ACL/parameter-group defaults in a non-default region and back again; `retargeting_defaults_leaves_created_resources_alone` pins that a created user keeps its creation-region ARN.
- `xray`: `default_sampling_rule_arn_follows_the_request_region`.
- `cargo test -p fakecloud-memorydb -p fakecloud-xray` green, `clippy --all-targets` clean.

Closes bug-hunt 2026-08-22 findings 0.4 and 0.5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MemoryDB and X-Ray seeded default ARNs so they follow the request region instead of the server's configured region, preventing Terraform drift when users read from non-default regions.

- Retargets the `default` user, `open-access` ACL, and `default.memorydb-*` parameter group ARNs to the request region before dispatch.
- Retargets the X-Ray built-in `Default` sampling rule's `RuleARN` the same way.
- Only always-present defaults are retargeted; user-created resources keep their creation region.

<sup>Written for commit 3980798aa0cdb949ec1cd88bf4972f7859bb7ab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

