### PR TITLE
fix(s3): accept every modeled StorageClass and SSEAlgorithm value

### DIFF
--- a/crates/fakecloud-s3/src/service/config/encryption.rs
+++ b/crates/fakecloud-s3/src/service/config/encryption.rs
@@ -22,8 +22,14 @@ impl S3Service {
         // a reachable, unauthenticated-input DoS (bug-audit 2026-06-13 2.1/2.2).
         if let Some(algo) = extract_xml_value(&body_str, "SSEAlgorithm") {
             // SSEAlgorithm is a closed enum; AWS returns MalformedXML for
-            // anything outside it.
-            if algo != "AES256" && algo != "aws:kms" && algo != "aws:kms:dsse" {
+            // anything outside it. The full set is the Smithy
+            // `ServerSideEncryption` enum in `aws-models/s3.json` — which
+            // includes the managed-service algorithms `aws:fsx` and
+            // `aws:backup` alongside the three customer-facing ones.
+            if !matches!(
+                algo.as_str(),
+                "AES256" | "aws:kms" | "aws:kms:dsse" | "aws:fsx" | "aws:backup"
+            ) {
                 return Err(malformed_encryption("SSEAlgorithm", &algo));
             }
         }

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -2397,6 +2397,9 @@ pub(crate) fn extract_user_metadata(
     meta
 }
 
+/// Every value of the Smithy `StorageClass` enum. Keep this in step with
+/// `aws-models/s3.json` — a class AWS models but this list omits is rejected
+/// with `InvalidStorageClass` on a request AWS accepts.
 pub(crate) fn is_valid_storage_class(class: &str) -> bool {
     matches!(
         class,
@@ -2411,6 +2414,10 @@ pub(crate) fn is_valid_storage_class(class: &str) -> bool {
             | "OUTPOSTS"
             | "SNOW"
             | "EXPRESS_ONEZONE"
+            | "FSX_OPENZFS"
+            | "FSX_ONTAP"
+            | "AWS_BACKUP_WARM"
+            | "AWS_BACKUP_LOW_COST_WARM"
     )
 }
 

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -5287,3 +5287,81 @@ fn list_object_versions_keeps_low_sorting_common_prefix_on_first_page() {
     // The page is capped at max-keys: "cc" spills to the next page.
     assert!(!body.contains("<Key>cc</Key>"), "body: {body}");
 }
+
+#[tokio::test]
+async fn put_object_accepts_every_modeled_storage_class() {
+    // The `StorageClass` allowlist drifted behind `aws-models/s3.json`: the
+    // FSx and AWS Backup classes are modeled values AWS accepts, and a stale
+    // list turned them into `InvalidStorageClass` on a valid request.
+    let svc = make_service();
+    seed_bucket(&svc, "classes");
+    for class in [
+        "STANDARD",
+        "REDUCED_REDUNDANCY",
+        "STANDARD_IA",
+        "ONEZONE_IA",
+        "INTELLIGENT_TIERING",
+        "GLACIER",
+        "DEEP_ARCHIVE",
+        "GLACIER_IR",
+        "OUTPOSTS",
+        "SNOW",
+        "EXPRESS_ONEZONE",
+        "FSX_OPENZFS",
+        "FSX_ONTAP",
+        "AWS_BACKUP_WARM",
+        "AWS_BACKUP_LOW_COST_WARM",
+    ] {
+        let key = format!("k-{class}");
+        let path = format!("/classes/{key}");
+        let mut req = make_request(Method::PUT, &path, &[], b"x");
+        req.headers
+            .insert("x-amz-storage-class", class.parse().unwrap());
+        svc.put_object("123456789012", &req, "classes", &key)
+            .await
+            .unwrap_or_else(|e| panic!("storage class {class} rejected: {e:?}"));
+
+        let req = make_request(Method::HEAD, &path, &[], b"");
+        let resp = svc
+            .head_object("123456789012", &req, "classes", &key)
+            .unwrap();
+        // STANDARD is the default and AWS omits the header for it.
+        if class != "STANDARD" {
+            assert_eq!(resp.headers.get("x-amz-storage-class").unwrap(), class);
+        }
+    }
+
+    // A value outside the enum is still rejected.
+    let mut req = make_request(Method::PUT, "/classes/bad", &[], b"x");
+    req.headers
+        .insert("x-amz-storage-class", "NOT_A_CLASS".parse().unwrap());
+    assert!(svc
+        .put_object("123456789012", &req, "classes", "bad")
+        .await
+        .is_err());
+}
+
+#[test]
+fn put_bucket_encryption_accepts_every_modeled_sse_algorithm() {
+    // `ServerSideEncryption` models five values; the validator only knew the
+    // three customer-facing ones, so `aws:fsx` / `aws:backup` came back as
+    // MalformedXML on a request AWS accepts.
+    let svc = make_service();
+    seed_bucket(&svc, "sse");
+    for algo in ["AES256", "aws:fsx", "aws:backup"] {
+        let body = format!(
+            "<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>{algo}</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>"
+        );
+        let req = make_request(Method::PUT, "/sse", &[("encryption", "")], body.as_bytes());
+        svc.put_bucket_encryption("123456789012", &req, "sse")
+            .unwrap_or_else(|e| panic!("SSEAlgorithm {algo} rejected: {e:?}"));
+    }
+
+    // Anything outside the enum is still MalformedXML.
+    let body = b"<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>aws:nope</SSEAlgorithm></ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>";
+    let req = make_request(Method::PUT, "/sse", &[("encryption", "")], body);
+    assert_aws_err(
+        svc.put_bucket_encryption("123456789012", &req, "sse"),
+        "MalformedXML",
+    );
+}


### PR DESCRIPTION
## Summary

Two hand-maintained allowlists in `fakecloud-s3` drifted behind `aws-models/s3.json`, so requests AWS accepts came back as client errors.

- `is_valid_storage_class` (`service/mod.rs`) was missing `FSX_OPENZFS`, `FSX_ONTAP`, `AWS_BACKUP_WARM`, `AWS_BACKUP_LOW_COST_WARM`. PutObject (`objects/write.rs:259`) and CopyObject (`objects/write.rs:766`) with any of those in `x-amz-storage-class` returned `InvalidStorageClass`.
- `PutBucketEncryption` (`service/config/encryption.rs`) rejected any `SSEAlgorithm` outside `{AES256, aws:kms, aws:kms:dsse}` with MalformedXML. The `ServerSideEncryption` enum models five values - the managed-service algorithms `aws:fsx` and `aws:backup` were also being refused.

## Why this stayed green

The conformance gate ratchets on `passed` per service, never on the `passed/total` ratio, so a model refresh that grows `total_variants` and adds failing `enum_exhaust` variants cannot trip it. Both of these arrived through model refreshes.

## Tests

- `put_object_accepts_every_modeled_storage_class` walks all 15 modeled classes end-to-end (put + head round-trip) and still rejects a non-enum value.
- `put_bucket_encryption_accepts_every_modeled_sse_algorithm` covers `AES256` / `aws:fsx` / `aws:backup` and still returns MalformedXML for a non-enum value.
- `cargo test -p fakecloud-s3` 403 passed, `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates two hand-maintained allowlists in `fakecloud-s3` that drifted behind `aws-models/s3.json`, so requests AWS accepts no longer come back as client errors.

- `is_valid_storage_class` now accepts the FSx and AWS Backup storage classes; previously PutObject and CopyObject returned `InvalidStorageClass` for them.
- `PutBucketEncryption` now accepts the managed-service SSE algorithms `aws:fsx` and `aws:backup`; previously it returned `MalformedXML` for them.
- Adds tests that walk every modeled `StorageClass` and SSE algorithm value, so future model drift fails instead of silently narrowing the accepted surface. Non-enum values are still rejected.

<sup>Written for commit 4df0eabec7f35f44b1c2168da779ccc79d8f58ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

