### PR TITLE
fix(ssoadmin,logs,ec2): honor modeled members that were silently dropped

### DIFF
--- a/crates/fakecloud-ec2/src/service/fleet.rs
+++ b/crates/fakecloud-ec2/src/service/fleet.rs
@@ -896,6 +896,13 @@ pub(crate) fn get_spot_placement_scores(
         &["vcpu", "memory-mib", "units"],
     )?;
     validate_max_results(&req.query_params, 10, 1000)?;
+    // `IncludeLocalZones` widens the scored set to Local Zones. fakecloud
+    // models only the three standard availability zones per region (see
+    // `DescribeAvailabilityZones`, which reports `zoneType`
+    // `availability-zone` for all of them), so there is no Local Zone capacity
+    // to score and the result set is the same either way — but the flag is
+    // still a boolean and a non-boolean value is rejected as AWS would.
+    validate_enum(&req.query_params, "IncludeLocalZones", &["true", "false"])?;
     let region = if req.region.is_empty() {
         "us-east-1"
     } else {
@@ -1419,5 +1426,52 @@ mod capacity_tests {
             desc.contains("<targetCapacity>7</targetCapacity>"),
             "{desc}"
         );
+    }
+}
+
+#[cfg(test)]
+mod spot_placement_score_tests {
+    use super::*;
+    use crate::test_support::{ec2_request as req, err_of};
+
+    fn body(resp: AwsResponse) -> String {
+        String::from_utf8_lossy(resp.body.expect_bytes()).to_string()
+    }
+
+    #[test]
+    fn include_local_zones_is_boolean_and_does_not_change_the_scored_set() {
+        let svc = Ec2Service::new();
+        let base = body(
+            get_spot_placement_scores(
+                &svc,
+                &req("GetSpotPlacementScores", &[("TargetCapacity", "5")]),
+            )
+            .unwrap(),
+        );
+
+        // fakecloud models no Local Zones, so the scored set is identical.
+        for flag in ["true", "false"] {
+            let scored = body(
+                get_spot_placement_scores(
+                    &svc,
+                    &req(
+                        "GetSpotPlacementScores",
+                        &[("TargetCapacity", "5"), ("IncludeLocalZones", flag)],
+                    ),
+                )
+                .unwrap(),
+            );
+            assert_eq!(scored, base, "IncludeLocalZones={flag}");
+        }
+
+        // A non-boolean value is still rejected rather than silently ignored.
+        let err = err_of(get_spot_placement_scores(
+            &svc,
+            &req(
+                "GetSpotPlacementScores",
+                &[("TargetCapacity", "5"), ("IncludeLocalZones", "yes")],
+            ),
+        ));
+        assert_eq!(err.code(), "InvalidParameterValue");
     }
 }

--- a/crates/fakecloud-logs/src/service/policies.rs
+++ b/crates/fakecloud-logs/src/service/policies.rs
@@ -690,6 +690,35 @@ impl LogsService {
                 "logGroupIdentifiers is required",
             )
         })?;
+        // `indexCategories` filters the result set. Every index fakecloud
+        // reports comes from a customer-created index policy, so they are all
+        // `CUSTOM`; asking for only the other categories returns nothing.
+        let categories = match body["indexCategories"].as_array() {
+            Some(list) => {
+                if list.len() > 4 {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidParameterException",
+                        "indexCategories may contain at most 4 values",
+                    ));
+                }
+                let mut wanted = Vec::with_capacity(list.len());
+                for v in list {
+                    let c = v.as_str().unwrap_or_default();
+                    if !matches!(c, "DEFAULT" | "CUSTOM" | "AUTO" | "INACTIVE") {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::BAD_REQUEST,
+                            "InvalidParameterException",
+                            format!("indexCategories contains an unsupported value: {c}"),
+                        ));
+                    }
+                    wanted.push(c.to_string());
+                }
+                Some(wanted)
+            }
+            None => None,
+        };
+        let want_custom = categories.is_none_or(|c| c.iter().any(|c| c == "CUSTOM"));
 
         let accounts = self.state.read();
         let empty = crate::state::LogsState::new(&req.account_id, &req.region);
@@ -697,6 +726,9 @@ impl LogsService {
         let mut field_indexes = Vec::new();
 
         for id_val in log_group_ids {
+            if !want_custom {
+                break;
+            }
             let id = id_val.as_str().unwrap_or("");
             let group_name = if id.starts_with("arn:") {
                 extract_log_group_from_arn(id).unwrap_or_default()
@@ -717,6 +749,8 @@ impl LogsService {
                                 "lastScanTime": p.last_updated_time,
                                 "firstEventTime": p.last_updated_time,
                                 "lastEventTime": p.last_updated_time,
+                                "type": "FIELD_INDEX",
+                                "indexCategory": "CUSTOM",
                             }));
                         }
                     }
@@ -1314,6 +1348,71 @@ mod tests {
         let resp = svc.describe_field_indexes(&req).unwrap();
         let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
         assert!(body["fieldIndexes"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn describe_field_indexes_reports_and_filters_by_index_category() {
+        let svc = make_service();
+        create_group(&svc, "g");
+        let req = make_request(
+            "PutIndexPolicy",
+            json!({
+                "logGroupIdentifier": "g",
+                "policyDocument": "{\"Fields\":[\"userId\"]}"
+            }),
+        );
+        svc.put_index_policy(&req).unwrap();
+
+        // Every index fakecloud reports comes from a customer index policy.
+        let req = make_request(
+            "DescribeFieldIndexes",
+            json!({"logGroupIdentifiers": ["g"]}),
+        );
+        let resp = svc.describe_field_indexes(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["fieldIndexes"][0]["indexCategory"], "CUSTOM");
+        assert_eq!(body["fieldIndexes"][0]["type"], "FIELD_INDEX");
+
+        // Asking for CUSTOM keeps it; asking only for other categories drops it.
+        let req = make_request(
+            "DescribeFieldIndexes",
+            json!({"logGroupIdentifiers": ["g"], "indexCategories": ["CUSTOM"]}),
+        );
+        let resp = svc.describe_field_indexes(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["fieldIndexes"].as_array().unwrap().len(), 1);
+
+        let req = make_request(
+            "DescribeFieldIndexes",
+            json!({"logGroupIdentifiers": ["g"], "indexCategories": ["DEFAULT", "AUTO"]}),
+        );
+        let resp = svc.describe_field_indexes(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert!(body["fieldIndexes"].as_array().unwrap().is_empty());
+
+        // Index policies still list normally — the filter is field-index only.
+        let req = make_request(
+            "DescribeIndexPolicies",
+            json!({"logGroupIdentifiers": ["g"]}),
+        );
+        let resp = svc.describe_index_policies(&req).unwrap();
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        assert_eq!(body["indexPolicies"].as_array().unwrap().len(), 1);
+
+        // Values outside the enum, and an over-long list, are rejected.
+        let req = make_request(
+            "DescribeFieldIndexes",
+            json!({"logGroupIdentifiers": ["g"], "indexCategories": ["NOPE"]}),
+        );
+        assert!(svc.describe_field_indexes(&req).is_err());
+        let req = make_request(
+            "DescribeFieldIndexes",
+            json!({
+                "logGroupIdentifiers": ["g"],
+                "indexCategories": ["DEFAULT", "CUSTOM", "AUTO", "INACTIVE", "CUSTOM"]
+            }),
+        );
+        assert!(svc.describe_field_indexes(&req).is_err());
     }
 
     #[test]

--- a/crates/fakecloud-ssoadmin/src/service.rs
+++ b/crates/fakecloud-ssoadmin/src/service.rs
@@ -522,6 +522,21 @@ fn build_instance_describe(inst: &StoredInstance) -> Value {
     m.insert("CreatedDate".into(), json!(inst.created_date));
     m.insert("Status".into(), json!(inst.status));
     opt_str(&mut m, "Name", &inst.name);
+    m.insert(
+        "PermissionSetsEnabled".into(),
+        json!(inst.permission_sets_enabled),
+    );
+    // Every instance is encrypted; absent an explicit `UpdateInstance` the key
+    // is the AWS-owned one, which carries no ARN.
+    let key_type = inst
+        .encryption_key_type
+        .clone()
+        .unwrap_or_else(|| "AWS_OWNED_KMS_KEY".to_string());
+    let mut enc = serde_json::Map::new();
+    enc.insert("KeyType".into(), json!(key_type));
+    opt_str(&mut enc, "KmsKeyArn", &inst.encryption_kms_key_arn);
+    enc.insert("EncryptionStatus".into(), json!("ENABLED"));
+    m.insert("EncryptionConfigurationDetails".into(), Value::Object(enc));
     Value::Object(m)
 }
 
@@ -670,6 +685,9 @@ impl SsoAdminService {
             primary_region: Some(req.region.clone()),
             attr_config: None,
             attr_config_status: None,
+            permission_sets_enabled: false,
+            encryption_key_type: None,
+            encryption_kms_key_arn: None,
         };
         {
             let mut guard = self.state.write();
@@ -707,6 +725,9 @@ impl SsoAdminService {
             primary_region: Some(req.region.clone()),
             attr_config: None,
             attr_config_status: None,
+            permission_sets_enabled: false,
+            encryption_key_type: None,
+            encryption_kms_key_arn: None,
         };
         ok(build_instance_describe(&synth))
     }
@@ -723,6 +744,50 @@ impl SsoAdminService {
             .ok_or_else(|| not_found("Instance not found."))?;
         if let Some(name) = b.get("Name").and_then(Value::as_str) {
             inst.name = Some(name.to_string());
+        }
+        if let Some(enabled) = b.get("PermissionSetsEnabled") {
+            // Documented on the member: the only accepted value is `true`, and
+            // it can't be combined with an encryption change in one call.
+            if b.get("EncryptionConfiguration").is_some() {
+                return Err(validation(
+                    "EncryptionConfiguration and PermissionSetsEnabled cannot be set in the same request.",
+                ));
+            }
+            match enabled.as_bool() {
+                Some(true) => inst.permission_sets_enabled = true,
+                _ => {
+                    return Err(validation(
+                        "PermissionSetsEnabled only accepts the value true.",
+                    ))
+                }
+            }
+        }
+        if let Some(cfg) = b.get("EncryptionConfiguration") {
+            let key_type = cfg
+                .get("KeyType")
+                .and_then(Value::as_str)
+                .ok_or_else(|| validation("EncryptionConfiguration.KeyType must be specified."))?;
+            let kms_key_arn = cfg.get("KmsKeyArn").and_then(Value::as_str);
+            match key_type {
+                "AWS_OWNED_KMS_KEY" => {
+                    inst.encryption_key_type = Some(key_type.to_string());
+                    inst.encryption_kms_key_arn = None;
+                }
+                "CUSTOMER_MANAGED_KEY" => {
+                    let arn = kms_key_arn.filter(|a| !a.is_empty()).ok_or_else(|| {
+                        validation(
+                            "EncryptionConfiguration.KmsKeyArn must be specified for a CUSTOMER_MANAGED_KEY.",
+                        )
+                    })?;
+                    inst.encryption_key_type = Some(key_type.to_string());
+                    inst.encryption_kms_key_arn = Some(arn.to_string());
+                }
+                other => {
+                    return Err(validation(&format!(
+                        "EncryptionConfiguration.KeyType must be one of AWS_OWNED_KMS_KEY, CUSTOMER_MANAGED_KEY; got {other}."
+                    )))
+                }
+            }
         }
         ok(json!({}))
     }
@@ -2145,6 +2210,9 @@ impl SsoAdminService {
                 primary_region: Some(req.region.clone()),
                 attr_config: None,
                 attr_config_status: None,
+                permission_sets_enabled: false,
+                encryption_key_type: None,
+                encryption_kms_key_arn: None,
             });
         if !inst.regions.iter().any(|r| r.region_name == region_name) {
             let is_primary = inst.regions.is_empty();

--- a/crates/fakecloud-ssoadmin/src/service/tests.rs
+++ b/crates/fakecloud-ssoadmin/src/service/tests.rs
@@ -611,3 +611,139 @@ fn list_account_assignments_for_principal_filters_by_principal_type() {
     assert_eq!(rows[0]["PrincipalType"], json!("USER"));
     assert_eq!(rows[0]["AccountId"], json!("111122223333"));
 }
+
+#[test]
+fn update_instance_enables_permission_sets_and_describe_reports_it() {
+    let s = svc();
+    let arn = new_instance(&s);
+
+    // A fresh instance has permission sets off and rides the AWS-owned key.
+    let desc = call(&s, "DescribeInstance", json!({ "InstanceArn": arn }));
+    assert_eq!(desc["PermissionSetsEnabled"], json!(false));
+    assert_eq!(
+        desc["EncryptionConfigurationDetails"]["KeyType"],
+        json!("AWS_OWNED_KMS_KEY")
+    );
+    assert_eq!(
+        desc["EncryptionConfigurationDetails"]["EncryptionStatus"],
+        json!("ENABLED")
+    );
+    assert!(desc["EncryptionConfigurationDetails"]
+        .get("KmsKeyArn")
+        .is_none());
+
+    call(
+        &s,
+        "UpdateInstance",
+        json!({ "InstanceArn": arn, "PermissionSetsEnabled": true }),
+    );
+    let desc = call(&s, "DescribeInstance", json!({ "InstanceArn": arn }));
+    assert_eq!(desc["PermissionSetsEnabled"], json!(true));
+
+    // Only `true` is accepted, and permission sets cannot be turned back off.
+    let e = err(
+        &s,
+        "UpdateInstance",
+        json!({ "InstanceArn": arn, "PermissionSetsEnabled": false }),
+    );
+    assert_eq!(e.code(), "ValidationException");
+    let desc = call(&s, "DescribeInstance", json!({ "InstanceArn": arn }));
+    assert_eq!(desc["PermissionSetsEnabled"], json!(true));
+}
+
+#[test]
+fn update_instance_switches_to_a_customer_managed_key() {
+    let s = svc();
+    let arn = new_instance(&s);
+    let key = "arn:aws:kms:us-east-1:000000000000:key/12345678-1234-1234-1234-123456789012";
+
+    call(
+        &s,
+        "UpdateInstance",
+        json!({
+            "InstanceArn": arn,
+            "EncryptionConfiguration": { "KeyType": "CUSTOMER_MANAGED_KEY", "KmsKeyArn": key },
+        }),
+    );
+    let desc = call(&s, "DescribeInstance", json!({ "InstanceArn": arn }));
+    assert_eq!(
+        desc["EncryptionConfigurationDetails"]["KeyType"],
+        json!("CUSTOMER_MANAGED_KEY")
+    );
+    assert_eq!(
+        desc["EncryptionConfigurationDetails"]["KmsKeyArn"],
+        json!(key)
+    );
+
+    // Back to the AWS-owned key drops the ARN.
+    call(
+        &s,
+        "UpdateInstance",
+        json!({
+            "InstanceArn": arn,
+            "EncryptionConfiguration": { "KeyType": "AWS_OWNED_KMS_KEY" },
+        }),
+    );
+    let desc = call(&s, "DescribeInstance", json!({ "InstanceArn": arn }));
+    assert_eq!(
+        desc["EncryptionConfigurationDetails"]["KeyType"],
+        json!("AWS_OWNED_KMS_KEY")
+    );
+    assert!(desc["EncryptionConfigurationDetails"]
+        .get("KmsKeyArn")
+        .is_none());
+}
+
+#[test]
+fn update_instance_rejects_invalid_encryption_and_combined_requests() {
+    let s = svc();
+    let arn = new_instance(&s);
+
+    // A customer-managed key needs an ARN.
+    let e = err(
+        &s,
+        "UpdateInstance",
+        json!({
+            "InstanceArn": arn,
+            "EncryptionConfiguration": { "KeyType": "CUSTOMER_MANAGED_KEY" },
+        }),
+    );
+    assert_eq!(e.code(), "ValidationException");
+
+    // KeyType is required and enum-bound.
+    let e = err(
+        &s,
+        "UpdateInstance",
+        json!({ "InstanceArn": arn, "EncryptionConfiguration": { "KmsKeyArn": "x" } }),
+    );
+    assert_eq!(e.code(), "ValidationException");
+    let e = err(
+        &s,
+        "UpdateInstance",
+        json!({
+            "InstanceArn": arn,
+            "EncryptionConfiguration": { "KeyType": "SOMETHING_ELSE" },
+        }),
+    );
+    assert_eq!(e.code(), "ValidationException");
+
+    // The two settings cannot travel in one request.
+    let e = err(
+        &s,
+        "UpdateInstance",
+        json!({
+            "InstanceArn": arn,
+            "PermissionSetsEnabled": true,
+            "EncryptionConfiguration": { "KeyType": "AWS_OWNED_KMS_KEY" },
+        }),
+    );
+    assert_eq!(e.code(), "ValidationException");
+
+    // Neither setting was applied.
+    let desc = call(&s, "DescribeInstance", json!({ "InstanceArn": arn }));
+    assert_eq!(desc["PermissionSetsEnabled"], json!(false));
+    assert_eq!(
+        desc["EncryptionConfigurationDetails"]["KeyType"],
+        json!("AWS_OWNED_KMS_KEY")
+    );
+}

--- a/crates/fakecloud-ssoadmin/src/state.rs
+++ b/crates/fakecloud-ssoadmin/src/state.rs
@@ -52,6 +52,16 @@ pub struct StoredInstance {
     pub attr_config: Option<Value>,
     #[serde(default)]
     pub attr_config_status: Option<String>,
+    /// `PermissionSetsEnabled` — opt-in and one-way: `UpdateInstance` only
+    /// accepts `true`, and permission sets cannot be disabled again.
+    #[serde(default)]
+    pub permission_sets_enabled: bool,
+    /// `EncryptionConfigurationDetails.KeyType`. Every instance starts on the
+    /// AWS-owned key; `UpdateInstance` can move it to a customer-managed one.
+    #[serde(default)]
+    pub encryption_key_type: Option<String>,
+    #[serde(default)]
+    pub encryption_kms_key_arn: Option<String>,
 }
 
 /// A managed policy attached to a permission set.
@@ -253,6 +263,9 @@ pub fn ensure_default_instance(state: &SharedSsoAdminState, account_id: &str, re
             primary_region: Some(region.to_string()),
             attr_config: None,
             attr_config_status: None,
+            permission_sets_enabled: false,
+            encryption_key_type: None,
+            encryption_kms_key_arn: None,
         },
     );
 }


### PR DESCRIPTION
## Summary

Three request members the Smithy models define were parsed off the wire and discarded, so a client got a 200 for a setting that never took effect. One bug class, three disjoint crates.

### ssoadmin - `UpdateInstance` / `DescribeInstance`

`update_instance` read only `Name`. `PermissionSetsEnabled` and `EncryptionConfiguration` were accepted and dropped, and `DescribeInstance` never emitted the matching `PermissionSetsEnabled` / `EncryptionConfigurationDetails` - a write-read loss.

Now:
- `PermissionSetsEnabled` applies, with the member's documented rules: `true` is the only accepted value, and permission sets cannot be disabled once enabled.
- `EncryptionConfiguration` applies, with `KeyType` required and enum-bound; `CUSTOMER_MANAGED_KEY` requires a `KmsKeyArn`, `AWS_OWNED_KMS_KEY` drops it.
- The two cannot travel in one request, per the member documentation.
- A fresh instance reports permission sets off and the AWS-owned key, `EncryptionStatus: ENABLED`.

### logs - `DescribeFieldIndexes`

`indexCategories` was ignored, so a client asking for one category got every index for the log group - and no `indexCategory` on the results to filter client-side either. Each `FieldIndex` now carries `indexCategory` (`CUSTOM`; every index fakecloud reports comes from a customer index policy) and `type`, the filter is applied, and the enum plus the 0..4 length bound are validated.

### ec2 - `GetSpotPlacementScores`

`IncludeLocalZones` was accepted unvalidated. fakecloud models no Local Zones - `DescribeAvailabilityZones` reports `zoneType` `availability-zone` for all three zones - so the scored set is correctly identical either way; this adds the boolean validation rather than inventing Local Zone capacity that does not exist.

## Tests

- ssoadmin: `update_instance_enables_permission_sets_and_describe_reports_it`, `update_instance_switches_to_a_customer_managed_key`, `update_instance_rejects_invalid_encryption_and_combined_requests`
- logs: `describe_field_indexes_reports_and_filters_by_index_category` (also pins that `DescribeIndexPolicies` is unaffected)
- ec2: `include_local_zones_is_boolean_and_does_not_change_the_scored_set`
- `cargo test` green across all three crates, `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three request members that Smithy models define but fakecloud parsed off the wire and discarded, so clients got a successful response for a setting that never took effect.

**Bug Fixes**
- `ssoadmin` `UpdateInstance` now applies `PermissionSetsEnabled` and `EncryptionConfiguration` instead of dropping them, and `DescribeInstance` reports both; a fresh instance starts with permission sets off and the AWS-owned key.
- `logs` `DescribeFieldIndexes` now filters by `indexCategories`, and each result carries `indexCategory` (`CUSTOM`) and `type`.
- `ec2` `GetSpotPlacementScores` now validates `IncludeLocalZones` as a boolean; fakecloud models no Local Zones, so the scored set is unchanged.

<sup>Written for commit fc445894f5610185e5695d151917a7a75ac718fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

