### PR TITLE
fix(kms): generate key material before taking the state lock

### DIFF
--- a/crates/fakecloud-kms/src/service.rs
+++ b/crates/fakecloud-kms/src/service.rs
@@ -128,6 +128,10 @@ static KMS_ACTIONS: &[&str] = &[
     "UpdateCustomKeyStore",
 ];
 
+/// The DER halves of a generated keypair: `(private_pkcs8, public_spki)`,
+/// both `None` for a symmetric or HMAC `KeySpec`.
+type KeyMaterial = (Option<Vec<u8>>, Option<Vec<u8>>);
+
 pub struct KmsService {
     state: SharedKmsState,
     snapshot_store: Option<Arc<dyn SnapshotStore>>,
@@ -136,18 +140,6 @@ pub struct KmsService {
 
 impl KmsService {
     pub fn new(state: SharedKmsState) -> Self {
-        // Warm the RSA keypair cache in the background. Generation is
-        // CPU-bound (~20s for RSA-4096) and reused across every CreateKey
-        // with that bit width; doing it here off a blocking thread keeps
-        // the first concurrent CreateKey from racing N tokio workers into
-        // a 30s read-timeout cliff (see `asym::generate_keypair`).
-        if tokio::runtime::Handle::try_current().is_ok() {
-            tokio::task::spawn_blocking(|| {
-                let _ = self::asym::generate_keypair("RSA_2048");
-                let _ = self::asym::generate_keypair("RSA_3072");
-                let _ = self::asym::generate_keypair("RSA_4096");
-            });
-        }
         Self {
             state,
             snapshot_store: None,
@@ -548,11 +540,62 @@ impl KmsService {
             })
     }
 
+    /// Generate `(private_pkcs8_der, public_spki_der)` for an asymmetric
+    /// `KeySpec`, or `(None, None)` for symmetric / HMAC specs.
+    ///
+    /// RSA generation is CPU-bound and would otherwise stall the tokio worker
+    /// that is driving the request, so on a multi-thread runtime it runs under
+    /// `block_in_place`, which hands the worker's other tasks off to a sibling
+    /// thread for the duration. `block_in_place` panics on a current-thread
+    /// runtime (and there is no runtime at all under `cargo test`), so those
+    /// cases call straight through.
+    fn generate_asymmetric_material(key_spec: &str) -> Result<KeyMaterial, AwsServiceError> {
+        fn generate(key_spec: &str) -> Result<KeyMaterial, AwsServiceError> {
+            if let Some((p, k)) = asym::generate_keypair(key_spec).map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMSInternalException",
+                    format!("failed to generate asymmetric key: {e}"),
+                )
+            })? {
+                return Ok((Some(p), Some(k)));
+            }
+            if let Some((p, k)) = asym_ecdsa::generate_keypair(key_spec).map_err(|e| {
+                AwsServiceError::aws_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "KMSInternalException",
+                    format!("failed to generate ecdsa key: {e}"),
+                )
+            })? {
+                return Ok((Some(p), Some(k)));
+            }
+            Ok((None, None))
+        }
+
+        let multi_thread = matches!(
+            tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread)
+        );
+        if multi_thread {
+            tokio::task::block_in_place(|| generate(key_spec))
+        } else {
+            generate(key_spec)
+        }
+    }
+
     fn create_key(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
         let input = CreateKeyInput::from_body(&req.json_body())?;
         // Reject incompatible KeySpec/KeyUsage combinations (e.g. an HMAC spec
         // with ENCRYPT_DECRYPT) before minting a key no operation can use.
         validate_key_spec_usage(&input.key_spec, &input.key_usage)?;
+
+        // Mint the key material *before* taking the state lock. RSA generation
+        // is CPU-bound (seconds, and far worse for RSA-4096 in a debug build);
+        // doing it under `state.write()` stalled every other KMS request —
+        // including symmetric CreateKey and Encrypt — behind one RSA key, and
+        // blocked the tokio worker on top of that. It depends only on
+        // `key_spec`, so it does not need the lock at all.
+        let (asym_priv, asym_pub) = Self::generate_asymmetric_material(&input.key_spec)?;
 
         let mut accounts = self.state.write();
         let state = accounts.get_or_create(&req.account_id);
@@ -584,28 +627,6 @@ impl KmsService {
         let key_policy = input
             .policy
             .unwrap_or_else(|| default_key_policy(&state.account_id));
-
-        let mut asym_priv: Option<Vec<u8>> = None;
-        let mut asym_pub: Option<Vec<u8>> = None;
-        if let Some((p, k)) = asym::generate_keypair(&input.key_spec).map_err(|e| {
-            AwsServiceError::aws_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "KMSInternalException",
-                format!("failed to generate asymmetric key: {e}"),
-            )
-        })? {
-            asym_priv = Some(p);
-            asym_pub = Some(k);
-        } else if let Some((p, k)) = asym_ecdsa::generate_keypair(&input.key_spec).map_err(|e| {
-            AwsServiceError::aws_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "KMSInternalException",
-                format!("failed to generate ecdsa key: {e}"),
-            )
-        })? {
-            asym_priv = Some(p);
-            asym_pub = Some(k);
-        }
 
         // Refuse asymmetric specs we cannot really generate keys for
         // rather than store a no-DER key that would later fall through

--- a/crates/fakecloud-kms/src/service_tests.rs
+++ b/crates/fakecloud-kms/src/service_tests.rs
@@ -3876,3 +3876,53 @@ fn encrypt_rejects_non_string_encryption_context_value() {
         "got {err:?}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rsa_key_generation_does_not_hold_the_state_lock() {
+    // Regression: `create_key` used to generate the RSA keypair *after*
+    // taking `state.write()`, so one RSA CreateKey stalled every other KMS
+    // request — symmetric CreateKey included — for the whole generation.
+    // Key material depends only on `KeySpec`, so it is now minted before the
+    // lock is taken.
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let svc = Arc::new(make_service());
+    let rsa_done = Arc::new(AtomicBool::new(false));
+
+    let rsa_svc = svc.clone();
+    let rsa_flag = rsa_done.clone();
+    let rsa = tokio::task::spawn(async move {
+        let req = make_request(
+            "CreateKey",
+            json!({ "KeySpec": "RSA_3072", "KeyUsage": "SIGN_VERIFY" }),
+        );
+        let resp = rsa_svc.create_key(&req).expect("rsa CreateKey ok");
+        rsa_flag.store(true, Ordering::SeqCst);
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string()
+    });
+
+    // Give the RSA task a moment to reach generation, then hammer the same
+    // service with symmetric work. Under the old code these blocked on the
+    // write lock until the RSA key was done.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let mut ids = Vec::new();
+    for _ in 0..20 {
+        let req = make_request("CreateKey", json!({}));
+        let resp = svc.create_key(&req).expect("symmetric CreateKey ok");
+        let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+        ids.push(body["KeyMetadata"]["KeyId"].as_str().unwrap().to_string());
+    }
+    assert!(
+        !rsa_done.load(Ordering::SeqCst),
+        "20 symmetric CreateKey calls should finish long before one RSA-3072 keygen"
+    );
+
+    let rsa_id = rsa.await.expect("rsa task joined");
+    assert_eq!(ids.len(), 20);
+    // Every key is distinct and the RSA one really carries generated material.
+    let req = make_request("GetPublicKey", json!({ "KeyId": rsa_id }));
+    let resp = svc.get_public_key(&req).expect("GetPublicKey ok");
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(!body["PublicKey"].as_str().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

`create_key` took `state.write()` and *then* generated the RSA keypair while holding it. Generation is CPU-bound - seconds for RSA-3072, ~25s for RSA-4096 in a debug build - so one asymmetric `CreateKey` stalled every other KMS request behind the global lock: symmetric `CreateKey`, `Encrypt`, `Decrypt`, `DescribeKey`, all of it.

Measured on a running server (debug build):

```
SYMMETRIC_DEFAULT  25ms  ->  5.1s   (while an RSA-4096 key was minting)
RSA_4096          25.3s
```

A full conformance probe run showed four `CreateKey` variants failing outright as `CRASH: error sending request` - the client's 30s timeout, not a panic.

## Fix

- Key material depends only on `KeySpec`, so it is minted **before** the lock is taken.
- On a multi-thread runtime the generation runs under `block_in_place`, so the CPU-bound work also stops blocking the tokio worker driving the request. `block_in_place` panics on a current-thread runtime and there is no runtime at all under `cargo test`, so both fall through to a direct call.
- Dropped the startup warm-up in `KmsService::new`. It generated three RSA keypairs to "warm the RSA keypair cache" - but that cache was removed when per-key uniqueness was fixed (every `CreateKey` mints fresh material now), so it burned a blocking thread on three keypairs that were immediately discarded.

## Tests

`rsa_key_generation_does_not_hold_the_state_lock` runs an RSA-3072 `CreateKey` on one task and 20 symmetric `CreateKey` calls on another, asserting the 20 all finish before the RSA one does. Under the old code they blocked on the write lock until the RSA key was ready. `cargo test -p fakecloud-kms` 224 passed, `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates asymmetric key material before taking the KMS state lock so one RSA `CreateKey` no longer stalls every other KMS request behind the global write lock.

- Moves RSA/ECDSA keypair generation ahead of `state.write()` and runs it under `block_in_place` on multi-thread runtimes to keep the tokio worker responsive.
- Removes the startup RSA keypair warm-up, which was discarded work since the keypair cache no longer exists.
- Adds a regression test asserting 20 symmetric `CreateKey` calls finish before a single RSA-3072 key generation completes.

<sup>Written for commit cfe160636610c21542355e6abfd36b0020bd769d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

