### PR TITLE
fix(conformance): recognize S3's published shared error responses

### DIFF
--- a/crates/fakecloud-conformance/src/probe/mod.rs
+++ b/crates/fakecloud-conformance/src/probe/mod.rs
@@ -795,6 +795,55 @@ mod tests {
     // -- error-shape-driven 4xx classification --
 
     #[test]
+    fn classify_s3_common_error_codes_pass_on_any_op() {
+        // S3's Smithy file enumerates almost no per-operation errors, but the
+        // published "Error Responses" reference documents these as responses
+        // any op can give. A handler returning one ran correctly, so the
+        // classifier must not read it as an undeclared error.
+        for (status, code) in [
+            (400, "MalformedXML"),
+            (400, "InvalidArgument"),
+            (404, "NoSuchBucketPolicy"),
+            (404, "NoSuchCORSConfiguration"),
+            (404, "NoSuchLifecycleConfiguration"),
+            (404, "NoSuchTagSet"),
+            (404, "NoSuchUpload"),
+        ] {
+            let body = format!("<Error><Code>{code}</Code><Message>m</Message></Error>");
+            let result = classify_response(
+                "v1",
+                status,
+                &body,
+                &Expectation::Success,
+                0,
+                Some(&["SomethingElse".to_string()]),
+                "s3",
+            );
+            assert_eq!(
+                result.status,
+                ProbeStatus::Pass,
+                "{code} should pass for s3"
+            );
+
+            // The same code from a service with no shared-error list stays
+            // undeclared — the allowlist is per service, not global.
+            let result = classify_response(
+                "v1",
+                status,
+                &body,
+                &Expectation::Success,
+                0,
+                Some(&["SomethingElse".to_string()]),
+                "dynamodb",
+            );
+            assert!(
+                matches!(result.status, ProbeStatus::UnexpectedResult(_)),
+                "{code} must not pass for a service without it in its list"
+            );
+        }
+    }
+
+    #[test]
     fn classify_404_with_no_aws_error_shape_fails() {
         // Mirrors #817: routing miss returns 404 with a body that has no
         // AWS error code. Must NOT pass — that's the gaming we're closing.

--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -156,6 +156,26 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
             "InvalidBucketName",
             "AccessDenied",
             "NotFound",
+            // The XML-body and argument-validation codes from the same
+            // reference. S3 takes XML request bodies, so a body that isn't
+            // well-formed XML (or doesn't match the published schema) is
+            // MalformedXML on any op that reads one — CompleteMultipartUpload,
+            // DeleteObjects, PutBucketCors and friends. InvalidArgument is
+            // S3's catch-all for a bad query/header argument, e.g. a
+            // continuation token that isn't valid base64 or a `max-buckets`
+            // outside 1..10000.
+            "MalformedXML",
+            "InvalidArgument",
+            // Sub-resource "not configured" codes. AWS returns each of these
+            // when the bucket exists but the named configuration was never
+            // set, which is the state most probe variants find a bucket in.
+            "NoSuchBucketPolicy",
+            "NoSuchCORSConfiguration",
+            "NoSuchLifecycleConfiguration",
+            "NoSuchTagSet",
+            // A multipart upload id that does not exist (or was already
+            // completed/aborted).
+            "NoSuchUpload",
         ],
         // EC2's Smithy model declares no per-operation `errors:` lists at all,
         // yet the EC2 Query API has a large, well-documented set of client


### PR DESCRIPTION
## Summary

S3's Smithy file enumerates almost no per-operation `errors:`, so the probe classifier read seven codes AWS documents as *shared* error responses as "undeclared error" and failed **168 variants across ten operations that had answered correctly**.

| Code | Variants | Why the handler is right |
|---|---|---|
| `MalformedXML` | 123 | S3 takes XML request bodies and the probe posts JSON. `CompleteMultipartUpload`, `DeleteObjects`, `PutBucketCors` reject it exactly as AWS does. |
| `InvalidArgument` | 33 | A continuation token that isn't valid base64, or `max-buckets` outside 1..10000 - both verified in `service/buckets.rs`. |
| `NoSuchUpload` | 4 | Unknown / already-completed multipart upload id. |
| `NoSuchCORSConfiguration`, `NoSuchLifecycleConfiguration`, `NoSuchBucketPolicy`, `NoSuchTagSet` | 2 each | Bucket exists, named sub-resource was never configured. |

Every entry is from the same published source as the five codes already in the list: <https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html>.

**No handler behavior changes** - this corrects the classifier, which was measuring S3 against an enumeration the AWS model does not provide. Consistent with how `ec2` and `eks` shared errors are already handled in the same function.

## Tests

`classify_s3_common_error_codes_pass_on_any_op` walks all seven codes and asserts each passes for `s3` while the *same* code from a service without a shared-error list still classifies as undeclared - the allowlist stays per service, not global. `cargo test -p fakecloud-conformance --lib` 91 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the conformance probe classifier to recognize S3's published shared error responses, which were falsely flagged as undeclared errors across 168 variants. Adds seven codes from S3's Error Responses reference to the S3 allowlist. No handler behavior changes; the new test also pins that the allowlist is per-service, not global.

<sup>Written for commit 2073360209b66f7014ba85d986138dff2b066e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

