### PR TITLE
fix(conformance): recognize five more EC2 .NotFound error codes

### DIFF
--- a/crates/fakecloud-conformance/src/probe/mod.rs
+++ b/crates/fakecloud-conformance/src/probe/mod.rs
@@ -844,6 +844,37 @@ mod tests {
     }
 
     #[test]
+    fn classify_ec2_notfound_codes_pass_on_any_op() {
+        // EC2's Smithy model declares no per-operation `errors:` at all, so
+        // every `.NotFound` a handler returns for a synthetic id has to come
+        // from the service-wide list or it reads as an undeclared error.
+        for code in [
+            "InvalidVpcEndpointServiceId.NotFound",
+            "InvalidVerifiedAccessEndpointId.NotFound",
+            "InvalidPublicIpv4PoolID.NotFound",
+            "InvalidVpcID.NotFound",
+            "InvalidSubnetID.NotFound",
+        ] {
+            let body =
+                format!("<Response><Errors><Error><Code>{code}</Code></Error></Errors></Response>");
+            let result = classify_response(
+                "v1",
+                400,
+                &body,
+                &Expectation::Success,
+                0,
+                Some(&["SomethingElse".to_string()]),
+                "ec2",
+            );
+            assert_eq!(
+                result.status,
+                ProbeStatus::Pass,
+                "{code} should pass for ec2"
+            );
+        }
+    }
+
+    #[test]
     fn classify_404_with_no_aws_error_shape_fails() {
         // Mirrors #817: routing miss returns 404 with a body that has no
         // AWS error code. Must NOT pass — that's the gaming we're closing.

--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -218,6 +218,17 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
             "InvalidCapacityReservationFleetId.NotFound",
             "InvalidTransitGatewayAttachmentID.NotFound",
             "InvalidVpcEndpointId.NotFound",
+            // Same `.NotFound` family, for resources whose handlers were
+            // hardened after the list above was written. Each is emitted by a
+            // real handler for a synthetic id: VPC endpoint services
+            // (`service/endpoint.rs`), Verified Access endpoints
+            // (`service/va.rs`), public IPv4 pools (`service/eip.rs`), and the
+            // VPC / subnet describes (`service/vpc.rs`, `service/subnet.rs`).
+            "InvalidVpcEndpointServiceId.NotFound",
+            "InvalidVerifiedAccessEndpointId.NotFound",
+            "InvalidPublicIpv4PoolID.NotFound",
+            "InvalidVpcID.NotFound",
+            "InvalidSubnetID.NotFound",
             "InvalidID",
         ],
         // EKS under-declares two client errors that the real API returns for


### PR DESCRIPTION
## Summary

EC2's Smithy model declares no per-operation `errors:` at all, so every code a handler returns must come from the service-wide shared list or the probe reads it as an undeclared error. Five `.NotFound` codes were missing, failing **141 variants across six operations that had answered correctly**.

| Code | Variants | Emitted by |
|---|---|---|
| `InvalidVpcEndpointServiceId.NotFound` | 85 | `service/endpoint.rs:585` |
| `InvalidVerifiedAccessEndpointId.NotFound` | 30 | `service/va.rs:724` |
| `InvalidPublicIpv4PoolID.NotFound` | 11 | `service/eip.rs:107` |
| `InvalidVpcID.NotFound` | 10 | `service/vpc.rs:253` |
| `InvalidSubnetID.NotFound` | 5 | `service/subnet.rs:314` |

All five follow the same `.NotFound`-per-resource-family convention as the codes already in the list, all are responses to a synthetic id, and each already has a unit test in `fakecloud-ec2` asserting that exact code. **No handler behavior changes.**

## Tests

`classify_ec2_notfound_codes_pass_on_any_op` asserts each code classifies as `Pass` for `ec2` even when the op declares an unrelated error. `cargo test -p fakecloud-conformance --lib` 91 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five missing EC2 `.NotFound` error codes to the conformance probe's service-wide list. Because EC2's Smithy model declares no per-operation errors, these codes were previously read as undeclared and failed 141 variants across six operations that had answered correctly.

- Adds `InvalidVpcEndpointServiceId.NotFound`, `InvalidVerifiedAccessEndpointId.NotFound`, `InvalidPublicIpv4PoolID.NotFound`, `InvalidVpcID.NotFound`, and `InvalidSubnetID.NotFound`.
- No handler behavior changes; each code is already asserted by a unit test in `fakecloud-ec2`.
- `classify_ec2_notfound_codes_pass_on_any_op` covers the new codes, and `cargo test -p fakecloud-conformance --lib` passes.

<sup>Written for commit 3af4d8b3ee0b8a64f9527f101713c5de86f20a64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

