### PR TITLE
fix(cognito,opensearch): return responses in the shapes the models define

### DIFF
--- a/crates/fakecloud-cognito/src/service/mod.rs
+++ b/crates/fakecloud-cognito/src/service/mod.rs
@@ -1439,11 +1439,11 @@ fn user_pool_to_json(pool: &UserPool) -> Value {
         }).collect::<Vec<Value>>(),
     });
 
-    // AWS always returns the pool's Endpoint (without scheme); Terraform reads
-    // it to wire the OIDC issuer / JWKS URL. The region is embedded in the pool
-    // id (`<region>_<random>`). Previously omitted (bug-audit 2026-06-20, 1.4).
-    let region = pool.id.split('_').next().unwrap_or("us-east-1");
-    obj["Endpoint"] = json!(format!("cognito-idp.{region}.amazonaws.com/{}", pool.id));
+    // No `Endpoint` member here: `UserPoolType` models `Domain` and
+    // `CustomDomain` only. A 2026-06-20 audit added `Endpoint` believing
+    // Terraform read it for the OIDC issuer / JWKS URL, but the provider
+    // derives that itself from the region and pool id — it never reads the
+    // field — and emitting it failed every `CreateUserPool` shape check.
 
     if let Some(ref v) = pool.email_verification_message {
         obj["EmailVerificationMessage"] = json!(v);

--- a/crates/fakecloud-cognito/src/service/tests.rs
+++ b/crates/fakecloud-cognito/src/service/tests.rs
@@ -4151,12 +4151,13 @@ fn describe_user_pool() {
     let b = resp_json(&resp);
     assert_eq!(b["UserPool"]["Id"], pool_id);
     assert_eq!(b["UserPool"]["Name"], "test-pool");
-    // Endpoint must be present for Terraform's OIDC issuer/JWKS wiring (1.4).
-    let endpoint = b["UserPool"]["Endpoint"]
-        .as_str()
-        .expect("Endpoint present");
-    assert!(endpoint.starts_with("cognito-idp."), "{endpoint}");
-    assert!(endpoint.ends_with(&pool_id), "{endpoint}");
+    // `UserPoolType` has no `Endpoint` member — it models `Domain` and
+    // `CustomDomain` only, and Terraform derives the OIDC issuer / JWKS URL
+    // from the region and pool id rather than reading it off the response.
+    assert!(
+        b["UserPool"].get("Endpoint").is_none(),
+        "UserPoolType models no Endpoint member"
+    );
 }
 
 #[test]

--- a/crates/fakecloud-opensearch/src/service.rs
+++ b/crates/fakecloud-opensearch/src/service.rs
@@ -2018,6 +2018,14 @@ impl OpenSearchService {
         if !options.get("workspace").is_some_and(Value::is_object) {
             return Err(validation("migrationOptions.workspace is required."));
         }
+        // `ClientToken` is bounded 1..64; it was read past without a check, so
+        // an empty or oversized token still returned 200.
+        if let Some(token) = b.get("clientToken").and_then(Value::as_str) {
+            let len = token.chars().count();
+            if !(1..=64).contains(&len) {
+                return Err(validation("clientToken must be 1..64 characters."));
+            }
+        }
         let mut accounts = self.state.write();
         let st = accounts.get_or_create(&req.account_id);
         let migration_id = short_id();
@@ -3363,18 +3371,47 @@ fn has_domain_name(v: &Value) -> bool {
     }
 }
 
+/// Render a stored connection endpoint in the shape the calling API models.
+///
+/// The two APIs disagree: `es` models `SourceDomainInfo` /
+/// `DestinationDomainInfo` as a flat `DomainInformation`
+/// (`OwnerId`/`DomainName`/`Region`), while `opensearch` models
+/// `LocalDomainInfo` / `RemoteDomainInfo` as a `DomainInformationContainer`
+/// that wraps the same members under `AWSDomainInformation`. Connections were
+/// stored exactly as the creating request spelled them and echoed back
+/// verbatim, so a connection created through one API described through the
+/// other came back in the wrong shape.
+fn render_domain_info(api: Api, v: &Value) -> Value {
+    // Accept either spelling on the way in.
+    let inner = v
+        .get("AWSDomainInformation")
+        .filter(|x| x.is_object())
+        .unwrap_or(v);
+    let mut flat = serde_json::Map::new();
+    for key in ["OwnerId", "DomainName", "Region"] {
+        if let Some(x) = inner.get(key) {
+            flat.insert(key.to_string(), x.clone());
+        }
+    }
+    let flat = Value::Object(flat);
+    match api {
+        Api::Es => flat,
+        Api::OpenSearch => json!({ "AWSDomainInformation": flat }),
+    }
+}
+
 fn connection_create_json(api: Api, c: &Connection) -> Value {
     match api {
         Api::Es => json!({
-            "SourceDomainInfo": c.source,
-            "DestinationDomainInfo": c.destination,
+            "SourceDomainInfo": render_domain_info(api, &c.source),
+            "DestinationDomainInfo": render_domain_info(api, &c.destination),
             "ConnectionAlias": c.alias,
             "ConnectionStatus": {"StatusCode": c.status_code, "Message": c.status_message},
             "CrossClusterSearchConnectionId": c.id,
         }),
         Api::OpenSearch => json!({
-            "LocalDomainInfo": c.source,
-            "RemoteDomainInfo": c.destination,
+            "LocalDomainInfo": render_domain_info(api, &c.source),
+            "RemoteDomainInfo": render_domain_info(api, &c.destination),
             "ConnectionAlias": c.alias,
             "ConnectionMode": c.mode,
             "ConnectionProperties": c.properties,
@@ -3387,15 +3424,15 @@ fn connection_create_json(api: Api, c: &Connection) -> Value {
 fn outbound_connection_json(api: Api, c: &Connection) -> Value {
     match api {
         Api::Es => json!({
-            "SourceDomainInfo": c.source,
-            "DestinationDomainInfo": c.destination,
+            "SourceDomainInfo": render_domain_info(api, &c.source),
+            "DestinationDomainInfo": render_domain_info(api, &c.destination),
             "ConnectionAlias": c.alias,
             "ConnectionStatus": {"StatusCode": c.status_code, "Message": c.status_message},
             "CrossClusterSearchConnectionId": c.id,
         }),
         Api::OpenSearch => json!({
-            "LocalDomainInfo": c.source,
-            "RemoteDomainInfo": c.destination,
+            "LocalDomainInfo": render_domain_info(api, &c.source),
+            "RemoteDomainInfo": render_domain_info(api, &c.destination),
             "ConnectionAlias": c.alias,
             "ConnectionMode": c.mode,
             "ConnectionProperties": c.properties,
@@ -3408,14 +3445,14 @@ fn outbound_connection_json(api: Api, c: &Connection) -> Value {
 fn inbound_connection_json(api: Api, c: &Connection) -> Value {
     match api {
         Api::Es => json!({
-            "SourceDomainInfo": c.source,
-            "DestinationDomainInfo": c.destination,
+            "SourceDomainInfo": render_domain_info(api, &c.source),
+            "DestinationDomainInfo": render_domain_info(api, &c.destination),
             "ConnectionStatus": {"StatusCode": c.status_code, "Message": c.status_message},
             "CrossClusterSearchConnectionId": c.id,
         }),
         Api::OpenSearch => json!({
-            "LocalDomainInfo": c.source,
-            "RemoteDomainInfo": c.destination,
+            "LocalDomainInfo": render_domain_info(api, &c.source),
+            "RemoteDomainInfo": render_domain_info(api, &c.destination),
             "ConnectionMode": c.mode,
             "ConnectionStatus": {"StatusCode": c.status_code, "Message": c.status_message},
             "ConnectionId": c.id,
@@ -3820,5 +3857,65 @@ mod is_mutating_tests {
         for action in ["ListScheduledActions", "ListDataSourceAttachments"] {
             assert!(!is_mutating(action), "{action} must not be mutating");
         }
+    }
+}
+
+#[cfg(test)]
+mod domain_info_tests {
+    use super::*;
+
+    /// The two APIs model a connection endpoint differently: `es` uses a flat
+    /// `DomainInformation`, `opensearch` wraps the same members in a
+    /// `DomainInformationContainer` under `AWSDomainInformation`. A connection
+    /// used to be echoed back in whatever shape created it, so one created
+    /// through `es` and described through `opensearch` (or the reverse) came
+    /// back malformed.
+    #[test]
+    fn domain_info_renders_in_the_calling_apis_shape() {
+        let flat = json!({
+            "OwnerId": "123456789012",
+            "DomainName": "logs",
+            "Region": "us-east-1",
+        });
+        let wrapped = json!({ "AWSDomainInformation": flat });
+
+        // Either stored spelling renders flat for `es` ...
+        for stored in [&flat, &wrapped] {
+            assert_eq!(
+                render_domain_info(Api::Es, stored),
+                flat,
+                "es from {stored}"
+            );
+        }
+        // ... and wrapped for `opensearch`.
+        for stored in [&flat, &wrapped] {
+            assert_eq!(
+                render_domain_info(Api::OpenSearch, stored),
+                wrapped,
+                "opensearch from {stored}"
+            );
+        }
+    }
+
+    #[test]
+    fn domain_info_drops_members_the_shape_does_not_model() {
+        // `DomainInformation` models exactly OwnerId / DomainName / Region;
+        // anything else a caller sends must not survive into the response.
+        let noisy = json!({
+            "OwnerId": "123456789012",
+            "DomainName": "logs",
+            "Region": "us-east-1",
+            "Bogus": "x",
+        });
+        let rendered = render_domain_info(Api::Es, &noisy);
+        assert!(rendered.get("Bogus").is_none());
+        assert_eq!(rendered.get("DomainName").unwrap(), "logs");
+
+        // A partial endpoint keeps only what it carried.
+        let partial = json!({ "DomainName": "logs" });
+        assert_eq!(
+            render_domain_info(Api::OpenSearch, &partial),
+            json!({ "AWSDomainInformation": { "DomainName": "logs" } })
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three response members diverged from their Smithy shapes, failing **135 conformance variants** on operations that were otherwise working.

### cognito-idp - `UserPoolType.Endpoint` (81 variants)

`CreateUserPool` / `DescribeUserPool` emitted an `Endpoint` field. `UserPoolType` models `Domain` and `CustomDomain` and **no** `Endpoint`.

A 2026-06-20 audit added it (`bug-audit 1.4`) believing Terraform read it for the OIDC issuer / JWKS URL. The provider derives that URL itself from the region and pool id - it never reads the field. The unit test that pinned its presence now pins its absence, and the repo's `cognitoidp` tfacc shard runs real `TestAccCognitoIDP*_basic` against `aws_cognito_user_pool`, so CI settles the original claim empirically. If that shard goes red, the field comes back.

### opensearch - connection endpoint shape (52 variants)

The two APIs disagree:

| API | Member | Shape |
|---|---|---|
| `es` | `SourceDomainInfo` / `DestinationDomainInfo` | `DomainInformation` - flat `OwnerId`/`DomainName`/`Region` |
| `opensearch` | `LocalDomainInfo` / `RemoteDomainInfo` | `DomainInformationContainer` - wraps those under `AWSDomainInformation` |

Connections were stored exactly as the creating request spelled them and echoed back verbatim, so one created through `es` and described through `opensearch` came back flat where the container was modeled. Both endpoints now render per calling API, accept either spelling on the way in, and drop members neither shape models.

### opensearch - `StartMigration.clientToken` (2 variants)

Read without a check, so an empty or oversized token still returned 200. It is bounded 1..64.

## Tests

`domain_info_renders_in_the_calling_apis_shape` covers both stored spellings against both APIs; `domain_info_drops_members_the_shape_does_not_model` pins the member filtering. `describe_user_pool` now asserts `Endpoint` is absent. `cargo test` green (cognito 387, opensearch 55), `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns responses in the shapes the Smithy models define, fixing 135 conformance variants on Cognito and OpenSearch operations that were otherwise working.

**Bug Fixes**
- `UserPoolType` no longer emits `Endpoint`; the model only has `Domain` and `CustomDomain`, and Terraform derives the OIDC issuer/JWKS URL itself.
- Cross-cluster connections were echoed back in whatever shape created them; they now render per calling API — flat for `es`, `AWSDomainInformation`-wrapped for `opensearch` — accept either spelling on input, and drop members neither shape models.
- `StartMigration` now rejects `clientToken` outside the modeled 1–64 character bound instead of returning 200.

<sup>Written for commit 2c7d120c294590a510620736e021043229f37544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

