### PR TITLE
feat(s3): implement object annotations

### DIFF
--- a/crates/fakecloud-conformance/src/probe/rest_request.rs
+++ b/crates/fakecloud-conformance/src/probe/rest_request.rs
@@ -601,6 +601,35 @@ pub(super) fn rest_request_config(
                 None,
             ),
             "CopyObject" => (reqwest::Method::PUT, format!("/{}/{}", BUCKET, KEY), None),
+            // Object annotations. `AnnotationName` is an `@httpQuery` member,
+            // so `append_http_query_from_model` supplies it from the variant —
+            // which is also what separates GetObjectAnnotation (name present)
+            // from ListObjectAnnotations (name absent) on the shared URI.
+            "PutObjectAnnotation" => (
+                reqwest::Method::PUT,
+                format!("/{}/{}", BUCKET, KEY),
+                Some("annotation".to_string()),
+            ),
+            "GetObjectAnnotation" => (
+                reqwest::Method::GET,
+                format!("/{}/{}", BUCKET, KEY),
+                Some("annotation".to_string()),
+            ),
+            "DeleteObjectAnnotation" => (
+                reqwest::Method::DELETE,
+                format!("/{}/{}", BUCKET, KEY),
+                Some("annotation".to_string()),
+            ),
+            "ListObjectAnnotations" => (
+                reqwest::Method::GET,
+                format!("/{}/{}", BUCKET, KEY),
+                Some("annotation".to_string()),
+            ),
+            "UpdateBucketMetadataAnnotationTableConfiguration" => (
+                reqwest::Method::PUT,
+                format!("/{}", BUCKET),
+                Some("metadataAnnotationTable".to_string()),
+            ),
             "GetObjectTagging" => (
                 reqwest::Method::GET,
                 format!("/{}/{}", BUCKET, KEY),

--- a/crates/fakecloud-conformance/tests/s3.rs
+++ b/crates/fakecloud-conformance/tests/s3.rs
@@ -2109,3 +2109,91 @@ async fn s3_create_session() {
         .await
         .unwrap();
 }
+
+/// Object annotations: named payloads attached to an object version, listed
+/// and paged independently of the object. The vendored `aws-sdk-s3` predates
+/// these operations, so drive them over raw HTTP.
+#[test_action("s3", "PutObjectAnnotation", checksum = "eb87b59f")]
+#[test_action("s3", "GetObjectAnnotation", checksum = "6305fa7d")]
+#[test_action("s3", "ListObjectAnnotations", checksum = "b5824aab")]
+#[test_action("s3", "DeleteObjectAnnotation", checksum = "983883fb")]
+#[test_action(
+    "s3",
+    "UpdateBucketMetadataAnnotationTableConfiguration",
+    checksum = "83f11cf2"
+)]
+#[tokio::test]
+async fn s3_object_annotations_round_trip() {
+    let server = TestServer::start().await;
+    let s3 = server.s3_client().await;
+    s3.create_bucket().bucket("annot-bkt").send().await.unwrap();
+    s3.put_object()
+        .bucket("annot-bkt")
+        .key("doc.txt")
+        .body(aws_sdk_s3::primitives::ByteStream::from_static(b"body"))
+        .send()
+        .await
+        .unwrap();
+
+    let http = reqwest::Client::new();
+    let base = format!("{}/annot-bkt/doc.txt?annotation", server.endpoint());
+
+    let resp = http
+        .put(format!("{base}&AnnotationName=review"))
+        .header("Authorization", S3_AUTH)
+        .body("looks good")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "put: {}", resp.status());
+
+    let resp = http
+        .get(format!("{base}&AnnotationName=review"))
+        .header("Authorization", S3_AUTH)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "get: {}", resp.status());
+    assert_eq!(resp.text().await.unwrap(), "looks good");
+
+    let resp = http
+        .get(&base)
+        .header("Authorization", S3_AUTH)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "list: {}", resp.status());
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("<AnnotationName>review</AnnotationName>"),
+        "{body}"
+    );
+
+    let resp = http
+        .delete(format!("{base}&AnnotationName=review"))
+        .header("Authorization", S3_AUTH)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 204, "delete");
+
+    // The object itself is untouched by any of that.
+    let obj = s3
+        .get_object()
+        .bucket("annot-bkt")
+        .key("doc.txt")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        obj.body.collect().await.unwrap().into_bytes().as_ref(),
+        b"body"
+    );
+
+    raw_put(
+        &server,
+        "/annot-bkt?metadataAnnotationTable",
+        "<AnnotationTableConfigurationUpdates><Annotations><Annotation>review</Annotation></Annotations></AnnotationTableConfigurationUpdates>",
+    )
+    .await;
+}

--- a/crates/fakecloud-firehose/src/service.rs
+++ b/crates/fakecloud-firehose/src/service.rs
@@ -1148,6 +1148,7 @@ impl FirehoseService {
             lock_mode: None,
             lock_retain_until: None,
             lock_legal_hold: None,
+            annotations: BTreeMap::new(),
         };
         // Write through to the durable S3 store so delivered records survive a
         // restart. S3 has no state snapshot: on boot it is rebuilt from this

--- a/crates/fakecloud-persistence/src/lib.rs
+++ b/crates/fakecloud-persistence/src/lib.rs
@@ -8,9 +8,9 @@ pub mod version;
 
 pub use config::{PersistenceConfig, StorageMode};
 pub use s3::{
-    AclGrantSnapshot, AclSnapshot, BodyRef, BodySource, BucketMeta, BucketSnapshot,
-    BucketSubresource, InventorySnapshot, LoadedMpu, LoadedObject, LoadedPart, MemoryS3Store,
-    MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError, StoreResult,
-    TagsSnapshot, UploadPartMeta,
+    AclGrantSnapshot, AclSnapshot, AnnotationSnapshot, BodyRef, BodySource, BucketMeta,
+    BucketSnapshot, BucketSubresource, InventorySnapshot, LoadedMpu, LoadedObject, LoadedPart,
+    MemoryS3Store, MpuInit, ObjectMeta, S3State as S3StateSnapshot, S3Store, StoreError,
+    StoreResult, TagsSnapshot, UploadPartMeta,
 };
 pub use snapshot::{DiskSnapshotStore, MemorySnapshotStore, SnapshotHook, SnapshotStore};

--- a/crates/fakecloud-persistence/src/s3.rs
+++ b/crates/fakecloud-persistence/src/s3.rs
@@ -161,6 +161,10 @@ pub struct ObjectMeta {
     pub lock_retain_until: Option<DateTime<Utc>>,
     #[serde(default)]
     pub lock_legal_hold: Option<String>,
+    /// Named annotations attached to this object version. Base64 is avoided —
+    /// the payload rides as raw bytes so a restart restores it verbatim.
+    #[serde(default)]
+    pub annotations: Vec<AnnotationSnapshot>,
     #[serde(default)]
     pub content_encoding: Option<String>,
     #[serde(default)]
@@ -173,6 +177,22 @@ pub struct ObjectMeta {
     pub expires: Option<String>,
     #[serde(default)]
     pub website_redirect_location: Option<String>,
+}
+
+/// One `PutObjectAnnotation` payload, persisted alongside its object so
+/// annotations survive a restart like the object body does.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct AnnotationSnapshot {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub payload: Vec<u8>,
+    #[serde(default)]
+    pub etag: String,
+    #[serde(default = "default_time")]
+    pub last_modified: DateTime<Utc>,
+    #[serde(default)]
+    pub checksum_algorithm: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/fakecloud-s3/src/persistence.rs
+++ b/crates/fakecloud-s3/src/persistence.rs
@@ -1,11 +1,14 @@
 use std::collections::BTreeMap;
 
 use fakecloud_persistence::{
-    AclGrantSnapshot, AclSnapshot, BucketMeta, BucketSnapshot, InventorySnapshot, LoadedMpu,
-    LoadedObject, LoadedPart, MpuInit, ObjectMeta, S3StateSnapshot, TagsSnapshot, UploadPartMeta,
+    AclGrantSnapshot, AclSnapshot, AnnotationSnapshot, BucketMeta, BucketSnapshot,
+    InventorySnapshot, LoadedMpu, LoadedObject, LoadedPart, MpuInit, ObjectMeta, S3StateSnapshot,
+    TagsSnapshot, UploadPartMeta,
 };
 
-use crate::state::{AclGrant, MultipartUpload, S3Bucket, S3Object, S3State, UploadPart};
+use crate::state::{
+    AclGrant, MultipartUpload, ObjectAnnotation, S3Bucket, S3Object, S3State, UploadPart,
+};
 
 impl From<&AclGrant> for AclGrantSnapshot {
     fn from(g: &AclGrant) -> Self {
@@ -60,6 +63,17 @@ pub fn object_meta_snapshot(o: &S3Object) -> ObjectMeta {
         lock_mode: o.lock_mode.clone(),
         lock_retain_until: o.lock_retain_until,
         lock_legal_hold: o.lock_legal_hold.clone(),
+        annotations: o
+            .annotations
+            .values()
+            .map(|a| AnnotationSnapshot {
+                name: a.name.clone(),
+                payload: a.payload.clone(),
+                etag: a.etag.clone(),
+                last_modified: a.last_modified,
+                checksum_algorithm: a.checksum_algorithm.clone(),
+            })
+            .collect(),
         content_encoding: o.content_encoding.clone(),
         cache_control: o.cache_control.clone(),
         content_disposition: o.content_disposition.clone(),
@@ -146,6 +160,22 @@ pub fn s3_object_from_loaded(lo: LoadedObject) -> S3Object {
         lock_mode: meta.lock_mode,
         lock_retain_until: meta.lock_retain_until,
         lock_legal_hold: meta.lock_legal_hold,
+        annotations: meta
+            .annotations
+            .into_iter()
+            .map(|a| {
+                (
+                    a.name.clone(),
+                    ObjectAnnotation {
+                        name: a.name,
+                        payload: a.payload,
+                        etag: a.etag,
+                        last_modified: a.last_modified,
+                        checksum_algorithm: a.checksum_algorithm,
+                    },
+                )
+            })
+            .collect(),
     }
 }
 
@@ -257,6 +287,7 @@ pub fn s3_bucket_from_snapshot(
         abac_config: None,
         metadata_configuration: None,
         metadata_table_configuration: None,
+        annotation_table_config: None,
     };
     for (key, lo) in objects {
         b.objects.insert(key, s3_object_from_loaded(lo));

--- a/crates/fakecloud-s3/src/service/annotations.rs
+++ b/crates/fakecloud-s3/src/service/annotations.rs
@@ -1,0 +1,448 @@
+//! Object annotations: named payloads attached to an object version.
+//!
+//! `PutObjectAnnotation` / `GetObjectAnnotation` / `DeleteObjectAnnotation` /
+//! `ListObjectAnnotations` address a side-car keyed by `AnnotationName` on a
+//! single object version. The object's own body, ETag and metadata are never
+//! touched — annotations live beside it and are listed, paged and filtered
+//! independently.
+
+use base64::Engine;
+use http::{HeaderMap, StatusCode};
+use md5::{Digest, Md5};
+
+use bytes::Bytes;
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::state::ObjectAnnotation;
+
+use super::{no_such_bucket, no_such_key, s3_xml, xml_escape, S3Service};
+
+/// AWS caps an object at 50 annotations.
+const MAX_ANNOTATIONS_PER_OBJECT: usize = 50;
+/// `AnnotationName` is capped at 255 characters.
+const MAX_ANNOTATION_NAME_LEN: usize = 255;
+
+fn invalid_annotation_name(reason: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "InvalidAnnotationName", reason)
+}
+
+fn no_such_annotation(name: &str) -> AwsServiceError {
+    AwsServiceError::aws_error(
+        StatusCode::NOT_FOUND,
+        "NoSuchAnnotation",
+        format!("The specified annotation does not exist: {name}"),
+    )
+}
+
+/// `AnnotationName` is required on Put/Get/Delete, must be non-empty, must fit
+/// the documented length, and — like an object key — cannot contain a control
+/// character, which could not survive the response headers it is echoed in.
+fn require_annotation_name(req: &AwsRequest) -> Result<String, AwsServiceError> {
+    let name = req
+        .query_params
+        .get("AnnotationName")
+        .cloned()
+        .unwrap_or_default();
+    if name.is_empty() {
+        return Err(invalid_annotation_name("AnnotationName is required"));
+    }
+    if name.chars().count() > MAX_ANNOTATION_NAME_LEN {
+        return Err(AwsServiceError::aws_error(
+            StatusCode::BAD_REQUEST,
+            "AnnotationNameTooLong",
+            format!("AnnotationName exceeds {MAX_ANNOTATION_NAME_LEN} characters"),
+        ));
+    }
+    if name.chars().any(|c| c.is_control()) {
+        return Err(invalid_annotation_name(
+            "AnnotationName must not contain control characters",
+        ));
+    }
+    Ok(name)
+}
+
+fn annotation_etag(payload: &[u8]) -> String {
+    format!("\"{:x}\"", Md5::digest(payload))
+}
+
+impl S3Service {
+    pub(super) fn put_object_annotation(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        bucket: &str,
+        key: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = require_annotation_name(req)?;
+        let version_id = req.query_params.get("versionId").cloned();
+        let payload = req.body.to_vec();
+        let checksum_algorithm = req
+            .headers
+            .get("x-amz-sdk-checksum-algorithm")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let obj = resolve_object_mut(b, key, version_id.as_ref())?;
+
+        // The cap counts distinct names; overwriting an existing annotation is
+        // always allowed.
+        if !obj.annotations.contains_key(&name)
+            && obj.annotations.len() >= MAX_ANNOTATIONS_PER_OBJECT
+        {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "AnnotationLimitExceeded",
+                format!(
+                    "An object cannot carry more than {MAX_ANNOTATIONS_PER_OBJECT} annotations"
+                ),
+            ));
+        }
+
+        let etag = annotation_etag(&payload);
+        let object_version_id = obj.version_id.clone();
+        obj.annotations.insert(
+            name.clone(),
+            ObjectAnnotation {
+                name: name.clone(),
+                payload,
+                etag: etag.clone(),
+                last_modified: chrono::Utc::now(),
+                checksum_algorithm,
+            },
+        );
+
+        let mut headers = HeaderMap::new();
+        if let Ok(v) = etag.parse() {
+            headers.insert("ETag", v);
+        }
+        if let Some(vid) = object_version_id.as_deref().and_then(|v| v.parse().ok()) {
+            headers.insert("x-amz-version-id", vid);
+        }
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <PutObjectAnnotationResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Key>{}</Key><AnnotationName>{}</AnnotationName></PutObjectAnnotationResult>",
+            xml_escape(key),
+            xml_escape(&name),
+        );
+        let mut resp = s3_xml(StatusCode::OK, body);
+        resp.headers.extend(headers);
+        Ok(resp)
+    }
+
+    pub(super) fn get_object_annotation(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        bucket: &str,
+        key: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = require_annotation_name(req)?;
+        let version_id = req.query_params.get("versionId").cloned();
+
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let obj = super::resolve_object(b, key, version_id.as_ref())?;
+        let annotation = obj
+            .annotations
+            .get(&name)
+            .ok_or_else(|| no_such_annotation(&name))?;
+
+        let mut headers = HeaderMap::new();
+        if let Ok(v) = annotation.etag.parse() {
+            headers.insert("ETag", v);
+        }
+        if let Ok(v) = annotation.payload.len().to_string().parse() {
+            headers.insert("Content-Length", v);
+        }
+        if let Ok(v) = annotation
+            .last_modified
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string()
+            .parse()
+        {
+            headers.insert("Last-Modified", v);
+        }
+        if let Some(vid) = obj.version_id.as_deref().and_then(|v| v.parse().ok()) {
+            headers.insert("x-amz-version-id", vid);
+        }
+        // `ChecksumMode: ENABLED` asks for the stored checksum back.
+        if req
+            .headers
+            .get("x-amz-checksum-mode")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|m| m.eq_ignore_ascii_case("ENABLED"))
+        {
+            if let Some(algo) = annotation.checksum_algorithm.as_deref() {
+                let digest = base64::engine::general_purpose::STANDARD
+                    .encode(Md5::digest(&annotation.payload));
+                if let (Ok(header), Ok(value)) = (
+                    format!("x-amz-checksum-{}", algo.to_lowercase()).parse::<http::HeaderName>(),
+                    digest.parse(),
+                ) {
+                    headers.insert(header, value);
+                }
+            }
+        }
+
+        Ok(AwsResponse {
+            status: StatusCode::OK,
+            content_type: "application/octet-stream".to_string(),
+            headers,
+            body: fakecloud_core::service::ResponseBody::Bytes(Bytes::from(
+                annotation.payload.clone(),
+            )),
+        })
+    }
+
+    pub(super) fn delete_object_annotation(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        bucket: &str,
+        key: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let name = require_annotation_name(req)?;
+        let version_id = req.query_params.get("versionId").cloned();
+
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let obj = resolve_object_mut(b, key, version_id.as_ref())?;
+        // AWS deletes idempotently: removing an annotation that is not there
+        // is still a 204, the same way DeleteObject is.
+        obj.annotations.remove(&name);
+        let object_version_id = obj.version_id.clone();
+
+        let mut headers = HeaderMap::new();
+        if let Some(vid) = object_version_id.as_deref().and_then(|v| v.parse().ok()) {
+            headers.insert("x-amz-version-id", vid);
+        }
+        Ok(AwsResponse {
+            status: StatusCode::NO_CONTENT,
+            content_type: "application/xml".to_string(),
+            headers,
+            body: fakecloud_core::service::ResponseBody::Bytes(Bytes::new()),
+        })
+    }
+
+    pub(super) fn list_object_annotations(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        bucket: &str,
+        key: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let version_id = req.query_params.get("versionId").cloned();
+        let prefix = req
+            .query_params
+            .get("annotation-prefix")
+            .or_else(|| req.query_params.get("AnnotationPrefix"))
+            .cloned()
+            .unwrap_or_default();
+        if prefix.chars().any(|c| c.is_control()) {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidPrefix",
+                "AnnotationPrefix must not contain control characters",
+            ));
+        }
+        let max_results = match req
+            .query_params
+            .get("max-annotation-results")
+            .or_else(|| req.query_params.get("MaxAnnotationResults"))
+        {
+            Some(v) => match v.parse::<i64>() {
+                Ok(n) if (1..=1000).contains(&n) => n as usize,
+                _ => {
+                    return Err(AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidArgument",
+                        "MaxAnnotationResults must be between 1 and 1000",
+                    ))
+                }
+            },
+            None => 1000,
+        };
+        let continuation_token = req
+            .query_params
+            .get("continuation-token")
+            .or_else(|| req.query_params.get("ContinuationToken"))
+            .cloned();
+
+        let accts = self.state.read();
+        let __empty = crate::state::S3State::new(account_id, "us-east-1");
+        let state = accts.get(account_id).unwrap_or(&__empty);
+        let b = state
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        let obj = super::resolve_object(b, key, version_id.as_ref())?;
+
+        // Names sort naturally (BTreeMap), so a continuation token is just the
+        // last name returned — the next page starts after it.
+        let after = match continuation_token.as_deref() {
+            None => None,
+            Some(tok) => Some(
+                String::from_utf8(
+                    base64::engine::general_purpose::STANDARD
+                        .decode(tok)
+                        .map_err(|_| {
+                            AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "InvalidArgument",
+                                "The continuation token provided is incorrect",
+                            )
+                        })?,
+                )
+                .map_err(|_| {
+                    AwsServiceError::aws_error(
+                        StatusCode::BAD_REQUEST,
+                        "InvalidArgument",
+                        "The continuation token provided is incorrect",
+                    )
+                })?,
+            ),
+        };
+
+        let matching: Vec<&ObjectAnnotation> = obj
+            .annotations
+            .values()
+            .filter(|a| a.name.starts_with(&prefix))
+            .filter(|a| after.as_deref().is_none_or(|t| a.name.as_str() > t))
+            .collect();
+        let page: Vec<&ObjectAnnotation> = matching.iter().copied().take(max_results).collect();
+        let next_token = if matching.len() > page.len() {
+            page.last()
+                .map(|a| base64::engine::general_purpose::STANDARD.encode(a.name.as_bytes()))
+        } else {
+            None
+        };
+
+        let mut entries = String::new();
+        for a in &page {
+            entries.push_str(&format!(
+                "<AnnotationEntry><AnnotationName>{}</AnnotationName>\
+                 <LastModified>{}</LastModified><ETag>{}</ETag><Size>{}</Size>",
+                xml_escape(&a.name),
+                a.last_modified.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+                xml_escape(&a.etag),
+                a.payload.len(),
+            ));
+            if let Some(algo) = &a.checksum_algorithm {
+                entries.push_str(&format!(
+                    "<ChecksumAlgorithm>{}</ChecksumAlgorithm>",
+                    xml_escape(algo)
+                ));
+            }
+            entries.push_str("</AnnotationEntry>");
+        }
+
+        let mut body = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <ListObjectAnnotationsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+             <Bucket>{}</Bucket><Key>{}</Key><AnnotationPrefix>{}</AnnotationPrefix>\
+             <MaxAnnotationResults>{}</MaxAnnotationResults><AnnotationCount>{}</AnnotationCount>",
+            xml_escape(bucket),
+            xml_escape(key),
+            xml_escape(&prefix),
+            max_results,
+            page.len(),
+        );
+        if let Some(tok) = &continuation_token {
+            body.push_str(&format!(
+                "<ContinuationToken>{}</ContinuationToken>",
+                xml_escape(tok)
+            ));
+        }
+        if let Some(tok) = &next_token {
+            body.push_str(&format!(
+                "<NextContinuationToken>{}</NextContinuationToken>",
+                xml_escape(tok)
+            ));
+        }
+        body.push_str(&entries);
+        body.push_str("</ListObjectAnnotationsResult>");
+
+        let mut resp = s3_xml(StatusCode::OK, body);
+        if let Some(vid) = obj.version_id.as_deref().and_then(|v| v.parse().ok()) {
+            resp.headers.insert("x-amz-version-id", vid);
+        }
+        Ok(resp)
+    }
+
+    /// `UpdateBucketMetadataAnnotationTableConfiguration` records which
+    /// annotations a bucket surfaces in its metadata table. fakecloud stores
+    /// the configuration verbatim so it round-trips.
+    pub(super) fn update_bucket_metadata_annotation_table_configuration(
+        &self,
+        account_id: &str,
+        req: &AwsRequest,
+        bucket: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let body = String::from_utf8_lossy(&req.body).into_owned();
+        if body.trim().is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "MalformedXML",
+                "AnnotationTableConfiguration is required",
+            ));
+        }
+        let mut accts = self.state.write();
+        let state = accts.get_or_create(account_id);
+        let b = state
+            .buckets
+            .get_mut(bucket)
+            .ok_or_else(|| no_such_bucket(bucket))?;
+        b.annotation_table_config = Some(body);
+        Ok(AwsResponse {
+            status: StatusCode::OK,
+            content_type: "application/xml".to_string(),
+            headers: HeaderMap::new(),
+            body: fakecloud_core::service::ResponseBody::Bytes(Bytes::new()),
+        })
+    }
+}
+
+/// Mutable twin of [`super::resolve_object`]: the annotation write paths need
+/// the owning object version, not a copy of it.
+fn resolve_object_mut<'a>(
+    b: &'a mut crate::state::S3Bucket,
+    key: &str,
+    version_id: Option<&String>,
+) -> Result<&'a mut crate::state::S3Object, AwsServiceError> {
+    match version_id {
+        None => b.objects.get_mut(key).ok_or_else(|| no_such_key(key)),
+        Some(vid) => {
+            let wants_null = vid == "null";
+            let matches = |o: &crate::state::S3Object| {
+                if wants_null {
+                    o.version_id.is_none() || o.version_id.as_deref() == Some("null")
+                } else {
+                    o.version_id.as_deref() == Some(vid.as_str())
+                }
+            };
+            if b.objects.get(key).is_some_and(&matches) {
+                return b.objects.get_mut(key).ok_or_else(|| no_such_key(key));
+            }
+            b.object_versions
+                .get_mut(key)
+                .and_then(|versions| versions.iter_mut().find(|o| matches(o)))
+                .ok_or_else(|| no_such_key(key))
+        }
+    }
+}

--- a/crates/fakecloud-s3/src/service/mod.rs
+++ b/crates/fakecloud-s3/src/service/mod.rs
@@ -20,6 +20,7 @@ use crate::state::{AclGrant, S3Bucket, S3Object, SharedS3State};
 
 mod access_points;
 mod acl;
+mod annotations;
 mod buckets;
 pub(crate) mod config;
 mod lock;
@@ -230,6 +231,7 @@ impl AwsService for S3Service {
                 .unwrap_or(false);
         let q = &req.query_params;
         let is_put_object = is_put_to_key
+            && !q.contains_key("annotation")
             && !q.contains_key("tagging")
             && !q.contains_key("acl")
             && !q.contains_key("retention")
@@ -515,6 +517,7 @@ impl AwsService for S3Service {
         // error; mirroring that prevents bucket-required ops from being
         // accidentally answered by ListBuckets / WriteGetObjectResponse.
         let bucket_subresources: &[&str] = &[
+            "metadataAnnotationTable",
             "tagging",
             "acl",
             "versioning",
@@ -586,7 +589,9 @@ impl AwsService for S3Service {
 
             // Bucket-level operations (no key)
             (&Method::PUT, Some(b), None) => {
-                if req.query_params.contains_key("tagging") {
+                if req.query_params.contains_key("metadataAnnotationTable") {
+                    self.update_bucket_metadata_annotation_table_configuration(account_id, &req, b)
+                } else if req.query_params.contains_key("tagging") {
                     self.put_bucket_tagging(account_id, &req, b)
                 } else if req.query_params.contains_key("acl") {
                     self.put_bucket_acl(account_id, &req, b)
@@ -780,7 +785,9 @@ impl AwsService for S3Service {
 
             // Object-level operations
             (&Method::PUT, Some(b), Some(k)) => {
-                if req.query_params.contains_key("tagging") {
+                if req.query_params.contains_key("annotation") {
+                    self.put_object_annotation(account_id, &req, b, k)
+                } else if req.query_params.contains_key("tagging") {
                     self.put_object_tagging(account_id, &req, b, k)
                 } else if req.query_params.contains_key("acl") {
                     self.put_object_acl(account_id, &req, b, k)
@@ -799,7 +806,15 @@ impl AwsService for S3Service {
                 }
             }
             (&Method::GET, Some(b), Some(k)) => {
-                if req.query_params.contains_key("tagging") {
+                if req.query_params.contains_key("annotation") {
+                    // Both `?annotation` reads share a URI; `AnnotationName`
+                    // selects one annotation, its absence lists them.
+                    if req.query_params.contains_key("AnnotationName") {
+                        self.get_object_annotation(account_id, &req, b, k)
+                    } else {
+                        self.list_object_annotations(account_id, &req, b, k)
+                    }
+                } else if req.query_params.contains_key("tagging") {
                     self.get_object_tagging(account_id, &req, b, k)
                 } else if req.query_params.contains_key("acl") {
                     self.get_object_acl(account_id, &req, b, k)
@@ -848,7 +863,9 @@ impl AwsService for S3Service {
                 }
             }
             (&Method::DELETE, Some(b), Some(k)) => {
-                if req.query_params.contains_key("tagging") {
+                if req.query_params.contains_key("annotation") {
+                    self.delete_object_annotation(account_id, &req, b, k)
+                } else if req.query_params.contains_key("tagging") {
                     self.delete_object_tagging(account_id, b, k)
                 } else {
                     self.delete_object(account_id, &req, b, k)
@@ -987,6 +1004,12 @@ impl AwsService for S3Service {
             "ListObjectVersions",
             "GetObjectAttributes",
             "RestoreObject",
+            // Object annotations
+            "PutObjectAnnotation",
+            "GetObjectAnnotation",
+            "DeleteObjectAnnotation",
+            "ListObjectAnnotations",
+            "UpdateBucketMetadataAnnotationTableConfiguration",
             // Object properties
             "PutObjectTagging",
             "GetObjectTagging",
@@ -1366,6 +1389,17 @@ fn s3_detect_action(
     // since a request can carry multiple; we pick the most specific.
     // Object-level sub-resources come first (key present).
     if has_key {
+        if has("annotation") {
+            return Some(match method {
+                // One URI serves both reads; `AnnotationName` picks a single
+                // annotation, its absence lists them.
+                "GET" if has("AnnotationName") => "GetObjectAnnotation",
+                "GET" => "ListObjectAnnotations",
+                "PUT" => "PutObjectAnnotation",
+                "DELETE" => "DeleteObjectAnnotation",
+                _ => return None,
+            });
+        }
         if has("tagging") {
             return Some(match method {
                 "GET" => "GetObjectTagging",
@@ -1431,6 +1465,9 @@ fn s3_detect_action(
 
     // Bucket-level sub-resources (key absent).
     if !has_key {
+        if has("metadataAnnotationTable") && method == "PUT" {
+            return Some("UpdateBucketMetadataAnnotationTableConfiguration");
+        }
         if has("tagging") {
             return Some(match method {
                 "GET" => "GetBucketTagging",

--- a/crates/fakecloud-s3/src/service/tests.rs
+++ b/crates/fakecloud-s3/src/service/tests.rs
@@ -5365,3 +5365,247 @@ fn put_bucket_encryption_accepts_every_modeled_sse_algorithm() {
         "MalformedXML",
     );
 }
+
+// ---------------------------------------------------------------------
+// Object annotations
+// ---------------------------------------------------------------------
+
+fn put_annotation(
+    svc: &S3Service,
+    bucket: &str,
+    key: &str,
+    name: &str,
+    payload: &[u8],
+) -> Result<AwsResponse, AwsServiceError> {
+    let req = make_request(
+        Method::PUT,
+        &format!("/{bucket}/{key}"),
+        &[("annotation", ""), ("AnnotationName", name)],
+        payload,
+    );
+    svc.put_object_annotation("123456789012", &req, bucket, key)
+}
+
+#[test]
+fn object_annotations_round_trip_independently_of_the_object() {
+    let svc = make_service();
+    seed_bucket(&svc, "annot");
+    seed_object(&svc, "annot", "doc.txt", b"the object body");
+
+    put_annotation(&svc, "annot", "doc.txt", "review", b"looks good").unwrap();
+    put_annotation(&svc, "annot", "doc.txt", "summary", b"a summary").unwrap();
+
+    // Get returns the payload verbatim, with its own ETag and length.
+    let req = make_request(
+        Method::GET,
+        "/annot/doc.txt",
+        &[("annotation", ""), ("AnnotationName", "review")],
+        b"",
+    );
+    let resp = svc
+        .get_object_annotation("123456789012", &req, "annot", "doc.txt")
+        .unwrap();
+    assert_eq!(resp.body.expect_bytes(), b"looks good");
+    assert_eq!(resp.headers.get("Content-Length").unwrap(), "10");
+    assert!(resp.headers.get("ETag").is_some());
+
+    // The object itself is untouched.
+    let req = make_request(Method::GET, "/annot/doc.txt", &[], b"");
+    let resp = svc
+        .get_object("123456789012", &req, "annot", "doc.txt")
+        .unwrap();
+    assert_eq!(resp.body.expect_bytes(), b"the object body");
+
+    // Overwriting replaces the payload rather than adding a second entry.
+    put_annotation(&svc, "annot", "doc.txt", "review", b"revised").unwrap();
+    let req = make_request(
+        Method::GET,
+        "/annot/doc.txt",
+        &[("annotation", ""), ("AnnotationName", "review")],
+        b"",
+    );
+    let resp = svc
+        .get_object_annotation("123456789012", &req, "annot", "doc.txt")
+        .unwrap();
+    assert_eq!(resp.body.expect_bytes(), b"revised");
+
+    // Delete is idempotent, and a deleted annotation then 404s.
+    for _ in 0..2 {
+        let req = make_request(
+            Method::DELETE,
+            "/annot/doc.txt",
+            &[("annotation", ""), ("AnnotationName", "review")],
+            b"",
+        );
+        let resp = svc
+            .delete_object_annotation("123456789012", &req, "annot", "doc.txt")
+            .unwrap();
+        assert_eq!(resp.status, StatusCode::NO_CONTENT);
+    }
+    let req = make_request(
+        Method::GET,
+        "/annot/doc.txt",
+        &[("annotation", ""), ("AnnotationName", "review")],
+        b"",
+    );
+    assert_aws_err(
+        svc.get_object_annotation("123456789012", &req, "annot", "doc.txt"),
+        "NoSuchAnnotation",
+    );
+}
+
+#[test]
+fn list_object_annotations_filters_by_prefix_and_pages() {
+    let svc = make_service();
+    seed_bucket(&svc, "annot");
+    seed_object(&svc, "annot", "k", b"body");
+    for name in ["a-one", "a-two", "a-three", "b-one"] {
+        put_annotation(&svc, "annot", "k", name, name.as_bytes()).unwrap();
+    }
+
+    let list = |query: &[(&str, &str)]| -> String {
+        let mut q = vec![("annotation", "")];
+        q.extend_from_slice(query);
+        let req = make_request(Method::GET, "/annot/k", &q, b"");
+        let resp = svc
+            .list_object_annotations("123456789012", &req, "annot", "k")
+            .unwrap();
+        String::from_utf8(resp.body.expect_bytes().to_vec()).unwrap()
+    };
+
+    let all = list(&[]);
+    assert!(
+        all.contains("<AnnotationCount>4</AnnotationCount>"),
+        "{all}"
+    );
+    assert!(all.contains("<AnnotationName>b-one</AnnotationName>"));
+    // Size is the payload length, not the object's.
+    assert!(all.contains("<Size>5</Size>"), "{all}");
+
+    let prefixed = list(&[("AnnotationPrefix", "a-")]);
+    assert!(prefixed.contains("<AnnotationCount>3</AnnotationCount>"));
+    assert!(!prefixed.contains("b-one"));
+
+    // A short page reports a continuation token; following it returns the rest
+    // without repeating an entry.
+    let page1 = list(&[("MaxAnnotationResults", "2")]);
+    assert!(
+        page1.contains("<AnnotationCount>2</AnnotationCount>"),
+        "{page1}"
+    );
+    let token = page1
+        .split("<NextContinuationToken>")
+        .nth(1)
+        .and_then(|s| s.split("</NextContinuationToken>").next())
+        .expect("continuation token")
+        .to_string();
+    let page2 = list(&[("MaxAnnotationResults", "2"), ("ContinuationToken", &token)]);
+    assert!(
+        page2.contains("<AnnotationCount>2</AnnotationCount>"),
+        "{page2}"
+    );
+    // Names sort, so page 1 is a-one/a-three and page 2 is a-two/b-one.
+    assert!(
+        !page2.contains("<AnnotationName>a-one</AnnotationName>"),
+        "{page2}"
+    );
+    assert!(
+        page2.contains("<AnnotationName>b-one</AnnotationName>"),
+        "{page2}"
+    );
+}
+
+#[test]
+fn object_annotations_validate_names_and_missing_resources() {
+    let svc = make_service();
+    seed_bucket(&svc, "annot");
+    seed_object(&svc, "annot", "k", b"body");
+
+    // AnnotationName is required, length-bounded, and control-char free.
+    let req = make_request(Method::PUT, "/annot/k", &[("annotation", "")], b"x");
+    assert_aws_err(
+        svc.put_object_annotation("123456789012", &req, "annot", "k"),
+        "InvalidAnnotationName",
+    );
+    let long = "n".repeat(256);
+    assert_aws_err(
+        put_annotation(&svc, "annot", "k", &long, b"x"),
+        "AnnotationNameTooLong",
+    );
+    assert_aws_err(
+        put_annotation(&svc, "annot", "k", "bad\nname", b"x"),
+        "InvalidAnnotationName",
+    );
+
+    // Missing bucket / key report the object-level codes.
+    assert_aws_err(
+        put_annotation(&svc, "ghost", "k", "n", b"x"),
+        "NoSuchBucket",
+    );
+    assert_aws_err(
+        put_annotation(&svc, "annot", "missing", "n", b"x"),
+        "NoSuchKey",
+    );
+
+    // The 50-annotation ceiling is enforced, and overwriting stays allowed.
+    for i in 0..50 {
+        put_annotation(&svc, "annot", "k", &format!("a{i:02}"), b"x").unwrap();
+    }
+    assert_aws_err(
+        put_annotation(&svc, "annot", "k", "one-too-many", b"x"),
+        "AnnotationLimitExceeded",
+    );
+    put_annotation(&svc, "annot", "k", "a00", b"replaced").unwrap();
+}
+
+#[test]
+fn update_bucket_metadata_annotation_table_configuration_round_trips() {
+    let svc = make_service();
+    seed_bucket(&svc, "annot");
+    let body = b"<AnnotationTableConfigurationUpdates><Annotations><Annotation>review</Annotation></Annotations></AnnotationTableConfigurationUpdates>";
+    let req = make_request(
+        Method::PUT,
+        "/annot",
+        &[("metadataAnnotationTable", "")],
+        body,
+    );
+    let resp = svc
+        .update_bucket_metadata_annotation_table_configuration("123456789012", &req, "annot")
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+    {
+        let state = svc.state.read();
+        let stored = state
+            .get("123456789012")
+            .unwrap()
+            .buckets
+            .get("annot")
+            .unwrap()
+            .annotation_table_config
+            .as_deref()
+            .expect("configuration stored");
+        assert!(stored.contains("review"));
+    }
+
+    // An empty payload is MalformedXML, and an unknown bucket is NoSuchBucket.
+    let req = make_request(
+        Method::PUT,
+        "/annot",
+        &[("metadataAnnotationTable", "")],
+        b"",
+    );
+    assert_aws_err(
+        svc.update_bucket_metadata_annotation_table_configuration("123456789012", &req, "annot"),
+        "MalformedXML",
+    );
+    let req = make_request(
+        Method::PUT,
+        "/ghost",
+        &[("metadataAnnotationTable", "")],
+        body,
+    );
+    assert_aws_err(
+        svc.update_bucket_metadata_annotation_table_configuration("123456789012", &req, "ghost"),
+        "NoSuchBucket",
+    );
+}

--- a/crates/fakecloud-s3/src/state.rs
+++ b/crates/fakecloud-s3/src/state.rs
@@ -63,6 +63,22 @@ pub struct S3Object {
     pub lock_retain_until: Option<DateTime<Utc>>,
     /// Legal hold status (ON or OFF).
     pub lock_legal_hold: Option<String>,
+    /// Named annotations attached to this object version, keyed by
+    /// `AnnotationName`. Each is an independent payload with its own ETag and
+    /// last-modified stamp; the object's own body and ETag are untouched.
+    pub annotations: BTreeMap<String, ObjectAnnotation>,
+}
+
+/// A named payload attached to an object version by `PutObjectAnnotation`.
+#[derive(Debug, Clone, Default)]
+pub struct ObjectAnnotation {
+    pub name: String,
+    pub payload: Vec<u8>,
+    pub etag: String,
+    pub last_modified: DateTime<Utc>,
+    /// The `x-amz-sdk-checksum-algorithm` the writer declared, echoed back on
+    /// list and get.
+    pub checksum_algorithm: Option<String>,
 }
 
 /// A part uploaded via the multipart upload API.
@@ -130,6 +146,9 @@ pub struct S3Bucket {
     pub notification_config: Option<String>,
     pub logging_config: Option<String>,
     pub website_config: Option<String>,
+    /// Raw `AnnotationTableConfiguration` XML from
+    /// `UpdateBucketMetadataAnnotationTableConfiguration`.
+    pub annotation_table_config: Option<String>,
     pub accelerate_status: Option<String>,
     pub public_access_block: Option<String>,
     pub object_lock_config: Option<String>,
@@ -183,6 +202,7 @@ impl S3Bucket {
             notification_config: None,
             logging_config: None,
             website_config: None,
+            annotation_table_config: None,
             accelerate_status: None,
             public_access_block: None,
             object_lock_config: None,


### PR DESCRIPTION
## Summary

Five modeled-but-unimplemented S3 operations (201 conformance variants, all previously NOT_IMPLEMENTED): `PutObjectAnnotation`, `GetObjectAnnotation`, `DeleteObjectAnnotation`, `ListObjectAnnotations`, `UpdateBucketMetadataAnnotationTableConfiguration`.

An annotation is a **named payload attached to one object version**, stored beside the object rather than in it - writing, replacing or deleting one never touches the object's body, ETag or metadata. Each carries its own ETag, size and last-modified stamp.

### Routing

The two `?annotation` reads share a URI, so `AnnotationName` selects between them: present -> `GetObjectAnnotation`, absent -> `ListObjectAnnotations`. That split is mirrored in three places so they cannot drift:
- the request router,
- the IAM action resolver - each op resolves to its own action instead of falling through to `GetObject`, so a policy denying `s3:PutObjectAnnotation` is actually enforced,
- the conformance probe's route table (`s3` is in `SERVICES_WITH_HARDCODED_REST`, so a missing entry would have probed the wrong URI).

### Persistence

Annotations ride the S3 store's object metadata as a `#[serde(default)]` list, so old snapshots load unchanged and a restart restores payloads verbatim rather than dropping them.

### Modeled limits enforced

| Rule | Error |
|---|---|
| 50 annotations per object (overwrite always allowed) | `AnnotationLimitExceeded` |
| `AnnotationName` <= 255 chars | `AnnotationNameTooLong` |
| No control characters in name | `InvalidAnnotationName` |
| No control characters in prefix | `InvalidPrefix` |
| Unknown annotation name | `NoSuchAnnotation` |
| `MaxAnnotationResults` outside 1..1000, bad continuation token | `InvalidArgument` |

Delete is idempotent, as `DeleteObject` is.

## Tests

- `object_annotations_round_trip_independently_of_the_object` - put/get/overwrite/delete, and asserts the object body is unchanged throughout.
- `list_object_annotations_filters_by_prefix_and_pages` - prefix filter, `AnnotationCount`, per-annotation `Size`, and a two-page walk that asserts no entry repeats across pages.
- `object_annotations_validate_names_and_missing_resources` - name validation, `NoSuchBucket`/`NoSuchKey`, and the 50-annotation ceiling.
- `update_bucket_metadata_annotation_table_configuration_round_trips` - stores and reads back, plus `MalformedXML` and `NoSuchBucket`.
- Conformance: `s3_object_annotations_round_trip` drives all five over raw HTTP.
- `cargo test` green (s3 407, persistence 70), `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the five modeled S3 annotation operations that previously probed as `NOT_IMPLEMENTED`: `PutObjectAnnotation`, `GetObjectAnnotation`, `DeleteObjectAnnotation`, `ListObjectAnnotations`, and `UpdateBucketMetadataAnnotationTableConfiguration`. An annotation is a named payload attached to one object version, stored beside the object so writes never touch its body, ETag, or metadata.

**Routing**
- The two `?annotation` reads share a URI; `AnnotationName` present means `GetObjectAnnotation`, absent means `ListObjectAnnotations`.
- The same split is mirrored in the request router, IAM action resolver, and conformance probe's route table, so annotation-specific policies are enforced.
- Conformance tests drive all five over raw HTTP because the vendored SDK predates these operations.

**Persistence and limits**
- Annotations ride the object's metadata as a `#[serde(default)]` list, so old snapshots load unchanged and restarts restore payloads verbatim.
- Enforces the modeled limits: 50 per object, 255-char names, no control characters, `NoSuchAnnotation` for unknown names, and `InvalidArgument` for bad paging parameters.
- Delete is idempotent, like `DeleteObject`.

<sup>Written for commit 261f2f2b2834360c521f1b5f1c040fe9245f1ab2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

