### PR TITLE
fix(conformance): recognize the Query-protocol services' shared errors

### DIFF
--- a/crates/fakecloud-conformance/src/probe/mod.rs
+++ b/crates/fakecloud-conformance/src/probe/mod.rs
@@ -899,6 +899,56 @@ mod tests {
     }
 
     #[test]
+    fn classify_query_protocol_shared_errors_pass() {
+        // Each Query-protocol service has one generic client-error code its
+        // model mostly omits from per-operation `errors:` lists.
+        for (service, status, code) in [
+            ("monitoring", 400, "ValidationError"),
+            ("monitoring", 400, "InvalidParameterValue"),
+            ("iam", 400, "ValidationError"),
+            ("iam", 404, "NoSuchEntity"),
+            ("cloudformation", 400, "ValidationError"),
+            ("rds", 400, "InvalidParameterValue"),
+            ("elasticache", 400, "InvalidParameterValue"),
+            ("kms", 400, "ValidationException"),
+        ] {
+            let body = format!(
+                "<ErrorResponse><Error><Code>{code}</Code><Message>m</Message></Error></ErrorResponse>"
+            );
+            let result = classify_response(
+                "v1",
+                status,
+                &body,
+                &Expectation::Success,
+                0,
+                Some(&["SomethingElse".to_string()]),
+                service,
+            );
+            assert_eq!(
+                result.status,
+                ProbeStatus::Pass,
+                "{code} should pass for {service}"
+            );
+
+            // The lists stay per service: the same code from a service with
+            // no shared-error list at all is still an undeclared error.
+            let result = classify_response(
+                "v1",
+                status,
+                &body,
+                &Expectation::Success,
+                0,
+                Some(&["SomethingElse".to_string()]),
+                "service-with-no-shared-errors",
+            );
+            assert!(
+                matches!(result.status, ProbeStatus::UnexpectedResult(_)),
+                "{code} must not pass for a service without it"
+            );
+        }
+    }
+
+    #[test]
     fn classify_404_with_no_aws_error_shape_fails() {
         // Mirrors #817: routing miss returns 404 with a body that has no
         // AWS error code. Must NOT pass — that's the gaming we're closing.

--- a/crates/fakecloud-conformance/src/probe/response.rs
+++ b/crates/fakecloud-conformance/src/probe/response.rs
@@ -254,6 +254,30 @@ pub(super) fn service_common_errors(service_name: &str) -> &'static [&'static st
         // `fakecloud_core::validation` helpers emit for an out-of-range or
         // malformed member on any SSM op. Source: SSM API reference "Errors"
         // per operation.
+        // The Query-protocol services share a generic client-error code that
+        // their Smithy models mostly leave off per-operation `errors:` lists.
+        // Each entry below was traced to the handler that emits it, against a
+        // synthetic input real AWS rejects the same way:
+        //   - cloudwatch (`monitoring`): `PutCompositeAlarm` rejects a
+        //     malformed `AlarmRule` and an out-of-range `ActionsSuppressor`;
+        //     `DescribeAlarms` rejects a bad parameter value.
+        //   - iam: `ListVirtualMFADevices` rejects a non-numeric `Marker` and
+        //     an off-enum `AssignmentStatus`; `GetAccessKeyLastUsed` reports an
+        //     unknown key id with `NoSuchEntity`, IAM's universal
+        //     "no such resource" code.
+        //   - cloudformation: `DescribeStacks` / `CreateStackRefactor` reject
+        //     malformed input with CFN's standard `ValidationError`.
+        //   - rds / elasticache: both Query APIs report a bad parameter with
+        //     `InvalidParameterValue`.
+        //   - kms: `CreateKey` rejects an incompatible `KeySpec`/`KeyUsage`
+        //     pair (an ECC spec cannot do the default `ENCRYPT_DECRYPT`) with
+        //     `ValidationException`, KMS's modeled input-validation error.
+        "monitoring" => &["ValidationError", "InvalidParameterValue"],
+        "iam" => &["ValidationError", "NoSuchEntity"],
+        "cloudformation" => &["ValidationError"],
+        "rds" => &["InvalidParameterValue"],
+        "elasticache" => &["InvalidParameterValue"],
+        "kms" => &["ValidationException"],
         "ssm" => &["InvalidNextToken", "ValidationException"],
         "eks" => &["ResourceNotFoundException", "ResourceInUseException"],
         // STS returns AccessDenied (HTTP 403) whenever a role can't be assumed


### PR DESCRIPTION
## Summary

Six services report a generic client error their Smithy models mostly leave off per-operation `errors:` lists, so **213 variants failed on operations that had answered correctly**.

| Service | Codes | Variants |
|---|---|---|
| monitoring | `ValidationError`, `InvalidParameterValue` | 46 |
| iam | `NoSuchEntity`, `ValidationError` | 44 |
| elasticache | `InvalidParameterValue` | 35 |
| kms | `ValidationException` | 33 |
| rds | `InvalidParameterValue` | 30 |
| cloudformation | `ValidationError` | 25 |

## Each traced to the handler before allowlisting

- `PutCompositeAlarm` rejects the probe's malformed `AlarmRule` - the rule must parse as a boolean expression over ALARM/OK/INSUFFICIENT_DATA - and an out-of-range `ActionsSuppressor`.
- `ListVirtualMFADevices` rejects a non-numeric `Marker` and an off-enum `AssignmentStatus` (with AWS's exact constraint-message format).
- `GetAccessKeyLastUsed` reports an unknown key id with `NoSuchEntity`, IAM's universal missing-resource code.
- `CreateKey` rejects an ECC `KeySpec` under the default `ENCRYPT_DECRYPT` usage - ECC keys are SIGN_VERIFY only, and AWS refuses the same pair.
- The RDS and ElastiCache Query APIs both report a bad parameter with `InvalidParameterValue`.

**No handler behavior changes** - same per-service mechanism `s3`, `ec2`, `eks` and `ssm` already use.

## Tests

`classify_query_protocol_shared_errors_pass` walks all eight service/code pairs and asserts each passes for its own service while the same code from a service with no shared-error list still classifies as undeclared. `cargo test -p fakecloud-conformance --lib` 94 passed, `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the conformance probe recognize the generic client-error codes that six Query-protocol services report but leave off per-operation `errors:` lists. This fixes 213 variants that were failing on correct responses.

- Adds per-service shared error lists for `monitoring`, `iam`, `cloudformation`, `rds`, `elasticache`, and `kms`.
- Adds a test covering all eight service/code pairs and confirming the lists stay per-service.
- No handler behavior changes; the mechanism is the same one `s3`, `ec2`, `eks`, and `ssm` already use.

<sup>Written for commit 4e4ba07dad00885e002a64972921003f452aa4c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

