### PR TITLE
feat(backup): implement backup access points

### DIFF
--- a/crates/fakecloud-backup/src/handlers.rs
+++ b/crates/fakecloud-backup/src/handlers.rs
@@ -2908,3 +2908,201 @@ fn rts_for_list(s: &RestoreTestingSelectionRecord, plan_name: &str) -> Value {
         "ValidationWindowHours": s.selection.get("ValidationWindowHours"),
     })
 }
+
+// ===================== Backup access points =====================
+
+/// Project an [`AccessPointRecord`] into the members `DescribeBackupAccessPoint`
+/// and the three list operations share.
+fn access_point_json(ap: &AccessPointRecord) -> Value {
+    let mut out = json!({
+        "AccessPointArn": ap.arn,
+        "Name": ap.name,
+        "RecoveryPointArn": ap.recovery_point_arn,
+        "BackupVaultName": ap.backup_vault_name,
+        "BackupVaultArn": ap.backup_vault_arn,
+        "ResourceArn": ap.resource_arn,
+        "ResourceType": ap.resource_type,
+        "CreationTime": ts(ap.creation_time),
+        "Status": ap.status,
+    });
+    if !ap.metadata.is_empty() {
+        out["AccessPointMetadata"] = json!(ap.metadata);
+    }
+    if let Some(m) = &ap.status_message {
+        out["StatusMessage"] = json!(m);
+    }
+    out
+}
+
+fn parse_string_map(v: Option<&Value>) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    if let Some(Value::Object(m)) = v {
+        for (k, val) in m {
+            if let Some(s) = val.as_str() {
+                out.insert(k.clone(), s.to_string());
+            }
+        }
+    }
+    out
+}
+
+impl BackupService {
+    fn create_backup_access_point(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = req_body(req);
+        let name = str_field(&body, "Name")
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| missing_param("Name is required"))?;
+        // `AccessPointName` is bounded 3..50 and lower-case alphanumeric with
+        // interior hyphens.
+        let len = name.chars().count();
+        if !(3..=50).contains(&len) {
+            return Err(invalid_param("Name must be 3..50 characters"));
+        }
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            || name.starts_with('-')
+            || name.ends_with('-')
+        {
+            return Err(invalid_param(
+                "Name must be lower-case alphanumeric with interior hyphens",
+            ));
+        }
+        let recovery_point_arn = str_field(&body, "RecoveryPointArn")
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| missing_param("RecoveryPointArn is required"))?;
+
+        let region = req.region.clone();
+        let account_id = req.account_id.clone();
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+
+        // The access point hangs off a real recovery point, so resolve it —
+        // and the vault and resource it belongs to — rather than inventing one.
+        let (vault_name, point) = st
+            .vaults
+            .iter()
+            .find_map(|(vname, v)| {
+                v.recovery_points
+                    .get(&recovery_point_arn)
+                    .map(|p| (vname.clone(), p.clone()))
+            })
+            .ok_or_else(|| {
+                not_found(format!(
+                    "Recovery point not found: {recovery_point_arn}"
+                ))
+            })?;
+
+        let arn = access_point_arn(&region, &account_id, &name);
+        if st.access_points.contains_key(&arn) {
+            return Err(already_exists(format!(
+                "Backup access point already exists: {name}"
+            )));
+        }
+
+        let record = AccessPointRecord {
+            arn: arn.clone(),
+            name,
+            recovery_point_arn,
+            backup_vault_arn: vault_arn(&region, &account_id, &vault_name),
+            backup_vault_name: vault_name,
+            resource_arn: point
+                .get("ResourceArn")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            resource_type: point
+                .get("ResourceType")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            creation_time: Utc::now(),
+            // Creation is synchronous here, so the access point is usable as
+            // soon as the call returns.
+            status: "AVAILABLE".to_string(),
+            status_message: None,
+            metadata: parse_string_map(body.get("AccessPointMetadata")),
+            policy: str_field(&body, "AccessPointPolicy"),
+            tags: parse_string_map(body.get("Tags")),
+        };
+        let status = record.status.clone();
+        st.access_points.insert(arn.clone(), record);
+
+        let mut resp = ok(json!({ "AccessPointArn": arn, "Status": status }));
+        resp.status = StatusCode::CREATED;
+        Ok(resp)
+    }
+
+    fn describe_backup_access_point(
+        &self,
+        req: &AwsRequest,
+        arn: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let ap = accounts
+            .get(&req.account_id)
+            .and_then(|s| s.access_points.get(arn))
+            .ok_or_else(|| not_found(format!("Backup access point not found: {arn}")))?;
+        Ok(ok(access_point_json(ap)))
+    }
+
+    fn delete_backup_access_point(
+        &self,
+        req: &AwsRequest,
+        arn: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let mut accounts = self.state.write();
+        let st = accounts.get_or_create(&req.account_id);
+        st.access_points
+            .remove(arn)
+            .ok_or_else(|| not_found(format!("Backup access point not found: {arn}")))?;
+        Ok(empty(204))
+    }
+
+    fn list_backup_access_points(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let items: Vec<Value> = accounts
+            .get(&req.account_id)
+            .map(|s| s.access_points.values().map(access_point_json).collect())
+            .unwrap_or_default();
+        page_response(items, "BackupAccessPoints", req, &[])
+    }
+
+    fn list_backup_access_points_by_recovery_point(
+        &self,
+        req: &AwsRequest,
+        recovery_point_arn: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let items: Vec<Value> = accounts
+            .get(&req.account_id)
+            .map(|s| {
+                s.access_points
+                    .values()
+                    .filter(|ap| ap.recovery_point_arn == recovery_point_arn)
+                    .map(access_point_json)
+                    .collect()
+            })
+            .unwrap_or_default();
+        page_response(items, "BackupAccessPoints", req, &[])
+    }
+
+    fn list_backup_access_points_by_resource(
+        &self,
+        req: &AwsRequest,
+        resource_arn: &str,
+    ) -> Result<AwsResponse, AwsServiceError> {
+        let accounts = self.state.read();
+        let items: Vec<Value> = accounts
+            .get(&req.account_id)
+            .map(|s| {
+                s.access_points
+                    .values()
+                    .filter(|ap| ap.resource_arn == resource_arn)
+                    .map(access_point_json)
+                    .collect()
+            })
+            .unwrap_or_default();
+        page_response(items, "BackupAccessPoints", req, &[])
+    }
+}

--- a/crates/fakecloud-backup/src/service.rs
+++ b/crates/fakecloud-backup/src/service.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use http::{Method, StatusCode};
 use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -25,10 +26,10 @@ use fakecloud_core::service::{AwsRequest, AwsResponse, AwsService, AwsServiceErr
 use fakecloud_persistence::SnapshotStore;
 
 use crate::state::{
-    framework_arn, legal_hold_arn, plan_arn, recovery_point_arn, report_plan_arn,
-    restore_testing_plan_arn, tiering_configuration_arn, vault_arn, PlanRecord, PlanVersion,
-    RestoreTestingPlanRecord, RestoreTestingSelectionRecord, SelectionRecord, SharedBackupState,
-    TagMap, VaultRecord,
+    access_point_arn, framework_arn, legal_hold_arn, plan_arn, recovery_point_arn, report_plan_arn,
+    restore_testing_plan_arn, tiering_configuration_arn, vault_arn, AccessPointRecord, PlanRecord,
+    PlanVersion, RestoreTestingPlanRecord, RestoreTestingSelectionRecord, SelectionRecord,
+    SharedBackupState, TagMap, VaultRecord,
 };
 
 /// The resource types AWS Backup can protect (a representative catalogue,
@@ -53,6 +54,12 @@ const SUPPORTED_RESOURCE_TYPES: &[&str] = &[
 ];
 
 pub const BACKUP_ACTIONS: &[&str] = &[
+    "CreateBackupAccessPoint",
+    "DeleteBackupAccessPoint",
+    "DescribeBackupAccessPoint",
+    "ListBackupAccessPoints",
+    "ListBackupAccessPointsByRecoveryPoint",
+    "ListBackupAccessPointsByResource",
     "AssociateBackupVaultMpaApprovalTeam",
     "CancelLegalHold",
     "CreateBackupPlan",
@@ -234,6 +241,22 @@ impl BackupService {
             ($a:expr, $($x:expr),*) => { Some(($a, vec![$($x),*])) };
         }
         match (m, segs.as_slice()) {
+            // ---- backup access points ----
+            (&Method::PUT, ["backup-access-point", "create"]) => one("CreateBackupAccessPoint"),
+            (&Method::GET, ["backup-access-point"]) => one("ListBackupAccessPoints"),
+            (&Method::DELETE, ["backup-access-point", "delete", arn]) => {
+                l!("DeleteBackupAccessPoint", d(arn))
+            }
+            (&Method::POST, ["backup-access-point", "recovery-point", arn]) => {
+                l!("ListBackupAccessPointsByRecoveryPoint", d(arn))
+            }
+            (&Method::POST, ["backup-access-point", "resource", arn]) => {
+                l!("ListBackupAccessPointsByResource", d(arn))
+            }
+            (&Method::GET, ["backup-access-point", arn]) => {
+                l!("DescribeBackupAccessPoint", d(arn))
+            }
+
             // ---- backup plans ----
             (&Method::PUT, ["backup", "plans"]) => one("CreateBackupPlan"),
             (&Method::GET, ["backup", "plans"]) => one("ListBackupPlans"),
@@ -466,6 +489,8 @@ impl BackupService {
 }
 
 const MUTATING: &[&str] = &[
+    "CreateBackupAccessPoint",
+    "DeleteBackupAccessPoint",
     "CreateBackupPlan",
     "CreateBackupSelection",
     "CreateBackupVault",
@@ -563,6 +588,16 @@ impl BackupService {
     ) -> Result<AwsResponse, AwsServiceError> {
         validate_query_constraints(action, req)?;
         match action {
+            "CreateBackupAccessPoint" => self.create_backup_access_point(req),
+            "DescribeBackupAccessPoint" => self.describe_backup_access_point(req, &l[0]),
+            "DeleteBackupAccessPoint" => self.delete_backup_access_point(req, &l[0]),
+            "ListBackupAccessPoints" => self.list_backup_access_points(req),
+            "ListBackupAccessPointsByRecoveryPoint" => {
+                self.list_backup_access_points_by_recovery_point(req, &l[0])
+            }
+            "ListBackupAccessPointsByResource" => {
+                self.list_backup_access_points_by_resource(req, &l[0])
+            }
             "CreateBackupPlan" => self.create_backup_plan(req),
             "GetBackupPlan" => self.get_backup_plan(req, &l[0]),
             "UpdateBackupPlan" => self.update_backup_plan(req, &l[0]),

--- a/crates/fakecloud-backup/src/state.rs
+++ b/crates/fakecloud-backup/src/state.rs
@@ -85,6 +85,30 @@ pub struct VaultRecord {
     pub recovery_points: BTreeMap<String, Value>,
 }
 
+/// A backup access point: a named handle onto one recovery point, through
+/// which the backed-up data can be reached without touching the vault itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccessPointRecord {
+    pub arn: String,
+    pub name: String,
+    pub recovery_point_arn: String,
+    pub backup_vault_name: String,
+    pub backup_vault_arn: String,
+    pub resource_arn: String,
+    pub resource_type: String,
+    pub creation_time: DateTime<Utc>,
+    /// `AccessPointStatus` (AVAILABLE | CREATING | DELETING | ...).
+    pub status: String,
+    #[serde(default)]
+    pub status_message: Option<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
+    #[serde(default)]
+    pub policy: Option<String>,
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+}
+
 /// A restore-testing plan with its selections.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RestoreTestingPlanRecord {
@@ -141,6 +165,9 @@ pub struct BackupState {
     /// resourceArn -> list of recoveryPointArn (in creation order).
     #[serde(default)]
     pub resource_recovery_points: BTreeMap<String, Vec<String>>,
+    /// Backup access points keyed by `AccessPointArn`.
+    #[serde(default)]
+    pub access_points: BTreeMap<String, AccessPointRecord>,
     #[serde(default)]
     pub global_settings: BTreeMap<String, String>,
     /// Per-resource-type opt-in preference (defaults applied on read).
@@ -185,6 +212,11 @@ pub fn recovery_point_arn(region: &str, account_id: &str, id: &str) -> String {
 
 pub fn framework_arn(region: &str, account_id: &str, name: &str, id: &str) -> String {
     format!("arn:aws:backup:{region}:{account_id}:framework:{name}-{id}")
+}
+/// `AccessPointArn` — the model's pattern is
+/// `arn:aws...:backup:<region>:<account>:accesspoint/<name>`.
+pub fn access_point_arn(region: &str, account_id: &str, name: &str) -> String {
+    format!("arn:aws:backup:{region}:{account_id}:accesspoint/{name}")
 }
 
 pub fn report_plan_arn(region: &str, account_id: &str, name: &str, id: &str) -> String {

--- a/crates/fakecloud-backup/tests/service_tests.rs
+++ b/crates/fakecloud-backup/tests/service_tests.rs
@@ -989,3 +989,246 @@ async fn vault_lock_accepts_valid_changeable_days() {
     .await;
     assert_eq!(body_of(&resp)["Locked"], false);
 }
+
+// ---------------------------------------------------------------------------
+// Backup access points
+// ---------------------------------------------------------------------------
+
+/// Run a backup job so there is a real recovery point to hang an access point
+/// off; returns `(recovery_point_arn, resource_arn)`.
+async fn make_recovery_point(svc: &BackupService, vault: &str, resource_arn: &str) -> String {
+    make_vault(svc, vault).await;
+    let started = body_of(
+        &call(
+            svc,
+            req(
+                Method::PUT,
+                "/backup-jobs",
+                json!({
+                    "BackupVaultName": vault,
+                    "ResourceArn": resource_arn,
+                    "IamRoleArn": "arn:aws:iam::000000000000:role/backup",
+                }),
+            ),
+        )
+        .await,
+    );
+    started["RecoveryPointArn"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn access_point_create_describe_list_delete_roundtrip() {
+    let svc = service();
+    let resource = "arn:aws:ec2:us-east-1:000000000000:volume/vol-ap1";
+    let rp = make_recovery_point(&svc, "apvault", resource).await;
+
+    let created = body_of(
+        &call(
+            &svc,
+            req(
+                Method::PUT,
+                "/backup-access-point/create",
+                json!({
+                    "Name": "my-access-point",
+                    "RecoveryPointArn": rp,
+                    "AccessPointMetadata": { "team": "core" },
+                }),
+            ),
+        )
+        .await,
+    );
+    let ap_arn = created["AccessPointArn"].as_str().unwrap().to_string();
+    assert!(ap_arn.contains(":accesspoint/my-access-point"), "{ap_arn}");
+    assert_eq!(created["Status"], "AVAILABLE");
+
+    // Describe resolves the vault and resource from the recovery point rather
+    // than echoing the request.
+    let enc = percent(&ap_arn);
+    let d = body_of(
+        &call(
+            &svc,
+            req(
+                Method::GET,
+                &format!("/backup-access-point/{enc}"),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(d["Name"], "my-access-point");
+    assert_eq!(d["RecoveryPointArn"], rp.as_str());
+    assert_eq!(d["BackupVaultName"], "apvault");
+    assert_eq!(d["ResourceArn"], resource);
+    assert_eq!(d["AccessPointMetadata"]["team"], "core");
+    assert!(d["BackupVaultArn"]
+        .as_str()
+        .unwrap()
+        .contains(":backup-vault:apvault"));
+
+    // All three list forms find it.
+    let all = body_of(&call(&svc, req(Method::GET, "/backup-access-point", json!({}))).await);
+    assert_eq!(all["BackupAccessPoints"].as_array().unwrap().len(), 1);
+
+    let by_rp = body_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("/backup-access-point/recovery-point/{}", percent(&rp)),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(
+        by_rp["BackupAccessPoints"][0]["AccessPointArn"],
+        ap_arn.as_str()
+    );
+
+    let by_res = body_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!("/backup-access-point/resource/{}", percent(resource)),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert_eq!(by_res["BackupAccessPoints"][0]["Name"], "my-access-point");
+
+    // A different recovery point / resource matches nothing.
+    let other = body_of(
+        &call(
+            &svc,
+            req(
+                Method::POST,
+                &format!(
+                    "/backup-access-point/resource/{}",
+                    percent("arn:aws:ec2:us-east-1:000000000000:volume/vol-other")
+                ),
+                json!({}),
+            ),
+        )
+        .await,
+    );
+    assert!(other["BackupAccessPoints"].as_array().unwrap().is_empty());
+
+    // Delete removes it; describing it afterwards is ResourceNotFoundException.
+    let resp = call(
+        &svc,
+        req(
+            Method::DELETE,
+            &format!("/backup-access-point/delete/{enc}"),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status.as_u16(), 204);
+    let (_, code) = call_err(
+        &svc,
+        req(
+            Method::GET,
+            &format!("/backup-access-point/{enc}"),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(code, "ResourceNotFoundException");
+}
+
+#[tokio::test]
+async fn access_point_validates_name_and_recovery_point() {
+    let svc = service();
+    let rp = make_recovery_point(
+        &svc,
+        "valvault",
+        "arn:aws:ec2:us-east-1:000000000000:volume/vol-val",
+    )
+    .await;
+
+    // Name and RecoveryPointArn are both required.
+    let (_, code) = call_err(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-access-point/create",
+            json!({ "RecoveryPointArn": rp }),
+        ),
+    )
+    .await;
+    assert_eq!(code, "MissingParameterValueException");
+    let (_, code) = call_err(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-access-point/create",
+            json!({ "Name": "no-recovery-point" }),
+        ),
+    )
+    .await;
+    assert_eq!(code, "MissingParameterValueException");
+
+    // AccessPointName is 3..50, lower-case alphanumeric with interior hyphens.
+    for bad in ["ab", &"n".repeat(51), "Has-Upper", "-leading", "trailing-"] {
+        let (_, code) = call_err(
+            &svc,
+            req(
+                Method::PUT,
+                "/backup-access-point/create",
+                json!({ "Name": bad, "RecoveryPointArn": rp }),
+            ),
+        )
+        .await;
+        assert_eq!(code, "InvalidParameterValueException", "name {bad:?}");
+    }
+
+    // The recovery point has to exist — an access point never dangles.
+    let (_, code) = call_err(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-access-point/create",
+            json!({
+                "Name": "ghost-point",
+                "RecoveryPointArn": "arn:aws:backup:us-east-1:000000000000:recovery-point:nope",
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(code, "ResourceNotFoundException");
+
+    // A duplicate name conflicts.
+    call(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-access-point/create",
+            json!({ "Name": "dupe-point", "RecoveryPointArn": rp }),
+        ),
+    )
+    .await;
+    let (_, code) = call_err(
+        &svc,
+        req(
+            Method::PUT,
+            "/backup-access-point/create",
+            json!({ "Name": "dupe-point", "RecoveryPointArn": rp }),
+        ),
+    )
+    .await;
+    assert_eq!(code, "AlreadyExistsException");
+
+    // Deleting an unknown access point is ResourceNotFoundException.
+    let (_, code) = call_err(
+        &svc,
+        req(
+            Method::DELETE,
+            "/backup-access-point/delete/arn%3Aaws%3Abackup%3Aus-east-1%3A000000000000%3Aaccesspoint%2Fnope",
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(code, "ResourceNotFoundException");
+}

--- a/crates/fakecloud-conformance/tests/backup.rs
+++ b/crates/fakecloud-conformance/tests/backup.rs
@@ -107,6 +107,16 @@ use helpers::TestServer;
 #[test_action("backup", "TagResource", checksum = "f68dba96")]
 #[test_action("backup", "UntagResource", checksum = "cabb6a5c")]
 #[test_action("backup", "UpdateBackupPlan", checksum = "5910684c")]
+#[test_action("backup", "CreateBackupAccessPoint", checksum = "a0911d5d")]
+#[test_action("backup", "DeleteBackupAccessPoint", checksum = "ee5c22e6")]
+#[test_action("backup", "DescribeBackupAccessPoint", checksum = "f71ef580")]
+#[test_action("backup", "ListBackupAccessPoints", checksum = "b08abff3")]
+#[test_action(
+    "backup",
+    "ListBackupAccessPointsByRecoveryPoint",
+    checksum = "ca9202d4"
+)]
+#[test_action("backup", "ListBackupAccessPointsByResource", checksum = "03e85655")]
 #[test_action("backup", "UpdateFramework", checksum = "be5d9414")]
 #[test_action("backup", "UpdateGlobalSettings", checksum = "1ea40909")]
 #[test_action("backup", "UpdateRecoveryPointIndexSettings", checksum = "52d80975")]


### PR DESCRIPTION
## Summary

Six modeled-but-unimplemented AWS Backup operations (187 conformance variants, all previously NOT_IMPLEMENTED).

An access point is a **named handle onto one recovery point**. `CreateBackupAccessPoint` resolves that recovery point in the account's vaults and derives `BackupVaultName`, `BackupVaultArn`, `ResourceArn` and `ResourceType` from it rather than echoing the request - so an access point can never dangle, and the two by-parent list forms filter on genuinely derived values instead of returning the same set three times.

## Modeled constraints enforced

| Rule | Error |
|---|---|
| `Name` 3..50, lower-case alphanumeric, interior hyphens only | `InvalidParameterValueException` |
| `Name` / `RecoveryPointArn` required | `MissingParameterValueException` |
| Unknown recovery point | `ResourceNotFoundException` |
| Duplicate name | `AlreadyExistsException` |
| Unknown access point on describe/delete | `ResourceNotFoundException` |

Create answers 201 and Delete answers 204, per the model's `code`.

Access points persist with the rest of the Backup state under `#[serde(default)]`, so existing snapshots load unchanged.

## Tests

- `access_point_create_describe_list_delete_roundtrip` - runs a real backup job to get a genuine recovery point, then asserts Describe resolves the vault/resource from it, all three list forms find the access point, a *different* resource matches nothing, and delete makes it 404.
- `access_point_validates_name_and_recovery_point` - required members, all five name-constraint violations, a nonexistent recovery point, a duplicate name, and deleting an unknown ARN.
- `cargo test -p fakecloud-backup` 35 passed, `cargo build --workspace` and `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the six modeled AWS Backup access point operations, which previously returned NOT_IMPLEMENTED. An access point is a named handle onto one recovery point; Create resolves the recovery point in the account's vaults and derives `BackupVaultName`, `BackupVaultArn`, `ResourceArn`, and `ResourceType` from it, so an access point can never dangle.

- Enforces the modeled constraints: `Name` and `RecoveryPointArn` are required, `Name` must be 3–50 lower-case alphanumeric characters with interior hyphens only, unknown recovery points/access points return `ResourceNotFoundException`, and duplicate names return `AlreadyExistsException`.
- Create answers 201 and Delete answers 204, per the model.
- Access points persist with the rest of the Backup state under `#[serde(default)]`, so existing snapshots load unchanged.
- Roundtrip and validation tests cover create/describe/list/delete plus all name and recovery point failure cases.

<sup>Written for commit a53f8ed20141f8406800f834dec809e79750748d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

