### PR TITLE
feat(rds): record and report IAM role associations

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/rds.rs
@@ -481,6 +481,7 @@ impl ResourceProvisioner {
         let dbi_resource_id = format!("db-{}", Uuid::new_v4().simple());
         let dbi_resource_id_attr = dbi_resource_id.clone();
         let inst = DbInstance {
+            associated_roles: Vec::new(),
             db_instance_identifier: identifier.clone(),
             db_instance_arn: arn.clone(),
             db_instance_class: class,

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -3048,7 +3048,133 @@ impl RdsService {
             "DescribeDBInstanceAutomatedBackups" => Ok(xml_response("DescribeDBInstanceAutomatedBackups", "    <DBInstanceAutomatedBackups/>".to_string(), &rid)),
 
             // ── Roles ──
-            "AddRoleToDBCluster" | "RemoveRoleFromDBCluster" | "AddRoleToDBInstance" | "RemoveRoleFromDBInstance" => xml_empty_action(&action, &rid),
+            // These accepted anything and answered 200 without recording
+            // the association, so a caller could attach a role to a
+            // cluster that does not exist, and DescribeDBClusters never
+            // reported the roles it was told about.
+            "AddRoleToDBCluster" | "RemoveRoleFromDBCluster" => {
+                // An absent identifier reaches the declared
+                // DBClusterNotFoundFault rather than missing(), which
+                // emits InvalidParameterValue -- undeclared anywhere in
+                // the RDS model.
+                let id = crate::filters::requested_identifier(
+                    get_param(req, "DBClusterIdentifier"),
+                    "cluster",
+                    &aid,
+                )
+                .unwrap_or_default();
+                let role_arn = get_param(req, "RoleArn").unwrap_or_default();
+                let feature_name = get_param(req, "FeatureName");
+                let adding = action == "AddRoleToDBCluster";
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let entry = state
+                        .extras
+                        .get_mut("clusters")
+                        .and_then(|m| m.get_mut(&id))
+                        .ok_or_else(|| cluster_not_found(&id))?;
+                    let roles = entry
+                        .as_object_mut()
+                        .map(|object| {
+                            object
+                                .entry("AssociatedRoles".to_string())
+                                .or_insert_with(|| json!([]))
+                        })
+                        .and_then(|value| value.as_array_mut())
+                        .ok_or_else(|| cluster_not_found(&id))?;
+                    let position = roles.iter().position(|role| {
+                        entry_str(role, "RoleArn") == Some(role_arn.as_str())
+                    });
+                    match (adding, position) {
+                        (true, Some(_)) => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "DBClusterRoleAlreadyExists",
+                                format!(
+                                    "Role {role_arn} is already associated with DB cluster {id}."
+                                ),
+                            ));
+                        }
+                        (true, None) => {
+                            let mut role = json!({
+                                "RoleArn": role_arn,
+                                // AWS reports the association as ACTIVE
+                                // once it is usable; there is nothing to
+                                // wait for here.
+                                "Status": "ACTIVE",
+                            });
+                            if let (Some(feature), Some(object)) =
+                                (feature_name.as_ref(), role.as_object_mut())
+                            {
+                                object.insert("FeatureName".to_string(), json!(feature));
+                            }
+                            roles.push(role);
+                        }
+                        (false, Some(index)) => {
+                            roles.remove(index);
+                        }
+                        (false, None) => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "DBClusterRoleNotFound",
+                                format!("Role {role_arn} is not associated with DB cluster {id}."),
+                            ));
+                        }
+                    }
+                }
+                xml_empty_action(&action, &rid)
+            }
+            "AddRoleToDBInstance" | "RemoveRoleFromDBInstance" => {
+                // Same: DBInstanceNotFoundFault is declared here.
+                let id = crate::filters::requested_identifier(
+                    get_param(req, "DBInstanceIdentifier"),
+                    "db",
+                    &aid,
+                )
+                .unwrap_or_default();
+                let role_arn = get_param(req, "RoleArn").unwrap_or_default();
+                let feature_name = get_param(req, "FeatureName").unwrap_or_default();
+                let adding = action == "AddRoleToDBInstance";
+                {
+                    let mut accounts = write_state!();
+                    let state = accounts.get_or_create(&aid);
+                    let instance = state.instances.get_mut(&id).ok_or_else(|| {
+                        crate::service::service_helpers::db_instance_not_found(&id)
+                    })?;
+                    let position = instance
+                        .associated_roles
+                        .iter()
+                        .position(|role| role.role_arn == role_arn);
+                    match (adding, position) {
+                        (true, Some(_)) => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "DBInstanceRoleAlreadyExists",
+                                format!(
+                                    "Role {role_arn} is already associated with DB instance {id}."
+                                ),
+                            ));
+                        }
+                        (true, None) => instance.associated_roles.push(crate::state::DbRole {
+                            role_arn: role_arn.clone(),
+                            feature_name: feature_name.clone(),
+                            status: "ACTIVE".to_string(),
+                        }),
+                        (false, Some(index)) => {
+                            instance.associated_roles.remove(index);
+                        }
+                        (false, None) => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "DBInstanceRoleNotFound",
+                                format!("Role {role_arn} is not associated with DB instance {id}."),
+                            ));
+                        }
+                    }
+                }
+                xml_empty_action(&action, &rid)
+            }
 
             // ── Pending maintenance ──
             "ApplyPendingMaintenanceAction" => {

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -3125,9 +3125,30 @@ impl RdsService {
                     // the second feature as a duplicate -- then removed
                     // whichever entry came first when asked to detach
                     // one of them.
-                    let position = roles.iter().position(|role| {
+                    let exact = |role: &Value| {
                         entry_str(role, "RoleArn") == Some(role_arn.as_str())
                             && entry_str(role, "FeatureName") == feature_name.as_deref()
+                    };
+                    let position = roles.iter().position(&exact).or_else(|| {
+                        // FeatureName is OPTIONAL on the cluster
+                        // operations. A remove that names only the role
+                        // disassociates it when that is unambiguous --
+                        // exactly one association carries the ARN. With
+                        // several, the caller has to say which, because
+                        // guessing is how the ARN-only matching this
+                        // replaced removed the wrong one.
+                        if adding || feature_name.is_some() {
+                            return None;
+                        }
+                        let mut matching = roles
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, role)| {
+                                entry_str(role, "RoleArn") == Some(role_arn.as_str())
+                            })
+                            .map(|(index, _)| index);
+                        let only = matching.next()?;
+                        matching.next().is_none().then_some(only)
                     });
                     match (adding, position) {
                         (true, Some(_)) => {

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -3071,7 +3071,11 @@ impl RdsService {
                 let role_arn = get_param(req, "RoleArn")
                     .filter(|value| !value.is_empty())
                     .unwrap_or_default();
-                let feature_name = get_param(req, "FeatureName");
+                // An explicitly empty FeatureName is absent, as it is
+                // for RoleArn: treated as present it would block the
+                // remove-by-ARN path and store an empty <FeatureName/>
+                // into the association.
+                let feature_name = get_param(req, "FeatureName").filter(|value| !value.is_empty());
                 let adding = action == "AddRoleToDBCluster";
                 {
                     let mut accounts = write_state!();
@@ -3228,7 +3232,9 @@ impl RdsService {
                 let role_arn = get_param(req, "RoleArn")
                     .filter(|value| !value.is_empty())
                     .unwrap_or_default();
-                let feature_name = get_param(req, "FeatureName").unwrap_or_default();
+                let feature_name = get_param(req, "FeatureName")
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_default();
                 let adding = action == "AddRoleToDBInstance";
                 {
                     let mut accounts = write_state!();

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -3129,6 +3129,12 @@ impl RdsService {
                         entry_str(role, "RoleArn") == Some(role_arn.as_str())
                             && entry_str(role, "FeatureName") == feature_name.as_deref()
                     };
+                    // The exact key first: (role, no feature) identifies a
+                    // feature-less association precisely, so removing it
+                    // is not a guess even when other associations carry
+                    // the same ARN under a feature. The fallback below is
+                    // only for when no association carries the key the
+                    // caller named.
                     let position = roles.iter().position(&exact).or_else(|| {
                         // FeatureName is OPTIONAL on the cluster
                         // operations. A remove that names only the role

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -3100,11 +3100,24 @@ impl RdsService {
                         // here -- but an empty ARN must not become a
                         // stored association that renders as an empty
                         // element and burns a quota slot.
-                        return Err(AwsServiceError::aws_error(
-                            StatusCode::NOT_FOUND,
-                            "DBClusterRoleNotFound",
-                            format!("No role is associated with DB cluster {id} under that name."),
-                        ));
+                        //
+                        // The fault has to be one the OPERATION declares:
+                        // DBClusterRoleNotFoundFault is declared on
+                        // Remove and not on Add, so Add answers the way
+                        // `prevalidate` answers the same request rather
+                        // than inventing a shape that operation never
+                        // returns.
+                        return Err(if adding {
+                            missing("RoleArn")
+                        } else {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "DBClusterRoleNotFound",
+                                format!(
+                                    "No role is associated with DB cluster {id} under that name."
+                                ),
+                            )
+                        });
                     }
                     // Keyed on the (role, feature) PAIR, as AWS keys it:
                     // one role is commonly attached for both s3Import and
@@ -3162,8 +3175,16 @@ impl RdsService {
                             ));
                         }
                     }
-                    // Written back only once the change succeeded.
-                    object.insert("AssociatedRoles".to_string(), Value::Array(roles));
+                    // Written back only once the change succeeded, and
+                    // the key is dropped rather than left as an empty
+                    // array: that is the same key the read above avoids
+                    // materializing, and CreateDBClusterSnapshot would
+                    // clone it forward into every later snapshot.
+                    if roles.is_empty() {
+                        object.remove("AssociatedRoles");
+                    } else {
+                        object.insert("AssociatedRoles".to_string(), Value::Array(roles));
+                    }
                 }
                 xml_empty_action(&action, &rid)
             }
@@ -3191,11 +3212,19 @@ impl RdsService {
                     // The pair again -- and FeatureName is a REQUIRED
                     // input here, so ignoring it was strictly wrong.
                     if role_arn.is_empty() {
-                        return Err(AwsServiceError::aws_error(
-                            StatusCode::NOT_FOUND,
-                            "DBInstanceRoleNotFound",
-                            format!("No role is associated with DB instance {id} under that name."),
-                        ));
+                        // Same: DBInstanceRoleNotFound is declared on
+                        // Remove, not on Add.
+                        return Err(if adding {
+                            missing("RoleArn")
+                        } else {
+                            AwsServiceError::aws_error(
+                                StatusCode::NOT_FOUND,
+                                "DBInstanceRoleNotFound",
+                                format!(
+                                    "No role is associated with DB instance {id} under that name."
+                                ),
+                            )
+                        });
                     }
                     let position = instance
                         .associated_roles

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -147,6 +147,11 @@ fn endpoint_identifier(req: &AwsRequest, account_id: &str) -> String {
         .unwrap_or(raw)
 }
 
+/// AWS caps IAM roles per cluster and per instance at five, and both Add
+/// operations declare the quota fault. Without the cap a client testing
+/// its quota handling never saw it.
+const MAX_ASSOCIATED_ROLES: usize = 5;
+
 /// A stored endpoint, in the shape a CUSTOM endpoint reports.
 ///
 /// Rows written before `CustomEndpointType` was derived carry the
@@ -3083,8 +3088,15 @@ impl RdsService {
                         })
                         .and_then(|value| value.as_array_mut())
                         .ok_or_else(|| cluster_not_found(&id))?;
+                    // Keyed on the (role, feature) PAIR, as AWS keys it:
+                    // one role is commonly attached for both s3Import and
+                    // s3Export, and matching on the ARN alone rejected
+                    // the second feature as a duplicate -- then removed
+                    // whichever entry came first when asked to detach
+                    // one of them.
                     let position = roles.iter().position(|role| {
                         entry_str(role, "RoleArn") == Some(role_arn.as_str())
+                            && entry_str(role, "FeatureName") == feature_name.as_deref()
                     });
                     match (adding, position) {
                         (true, Some(_)) => {
@@ -3093,6 +3105,16 @@ impl RdsService {
                                 "DBClusterRoleAlreadyExists",
                                 format!(
                                     "Role {role_arn} is already associated with DB cluster {id}."
+                                ),
+                            ));
+                        }
+                        (true, None) if roles.len() >= MAX_ASSOCIATED_ROLES => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "DBClusterRoleQuotaExceeded",
+                                format!(
+                                    "DB cluster {id} already has the maximum number of \
+                                     IAM roles associated with it."
                                 ),
                             ));
                         }
@@ -3142,10 +3164,14 @@ impl RdsService {
                     let instance = state.instances.get_mut(&id).ok_or_else(|| {
                         crate::service::service_helpers::db_instance_not_found(&id)
                     })?;
+                    // The pair again -- and FeatureName is a REQUIRED
+                    // input here, so ignoring it was strictly wrong.
                     let position = instance
                         .associated_roles
                         .iter()
-                        .position(|role| role.role_arn == role_arn);
+                        .position(|role| {
+                            role.role_arn == role_arn && role.feature_name == feature_name
+                        });
                     match (adding, position) {
                         (true, Some(_)) => {
                             return Err(AwsServiceError::aws_error(
@@ -3153,6 +3179,16 @@ impl RdsService {
                                 "DBInstanceRoleAlreadyExists",
                                 format!(
                                     "Role {role_arn} is already associated with DB instance {id}."
+                                ),
+                            ));
+                        }
+                        (true, None) if instance.associated_roles.len() >= MAX_ASSOCIATED_ROLES => {
+                            return Err(AwsServiceError::aws_error(
+                                StatusCode::BAD_REQUEST,
+                                "DBInstanceRoleQuotaExceeded",
+                                format!(
+                                    "DB instance {id} already has the maximum number of \
+                                     IAM roles associated with it."
                                 ),
                             ));
                         }

--- a/crates/fakecloud-rds/src/extras/mod.rs
+++ b/crates/fakecloud-rds/src/extras/mod.rs
@@ -3068,7 +3068,9 @@ impl RdsService {
                     &aid,
                 )
                 .unwrap_or_default();
-                let role_arn = get_param(req, "RoleArn").unwrap_or_default();
+                let role_arn = get_param(req, "RoleArn")
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_default();
                 let feature_name = get_param(req, "FeatureName");
                 let adding = action == "AddRoleToDBCluster";
                 {
@@ -3079,15 +3081,31 @@ impl RdsService {
                         .get_mut("clusters")
                         .and_then(|m| m.get_mut(&id))
                         .ok_or_else(|| cluster_not_found(&id))?;
-                    let roles = entry
+                    let object = entry
                         .as_object_mut()
-                        .map(|object| {
-                            object
-                                .entry("AssociatedRoles".to_string())
-                                .or_insert_with(|| json!([]))
-                        })
-                        .and_then(|value| value.as_array_mut())
                         .ok_or_else(|| cluster_not_found(&id))?;
+                    // Read WITHOUT creating the key: materializing it up
+                    // front wrote `"AssociatedRoles": []` into the stored
+                    // cluster even when the request went on to fail, and
+                    // CreateDBClusterSnapshot cloned that key forward
+                    // into every later snapshot.
+                    let mut roles: Vec<Value> = object
+                        .get("AssociatedRoles")
+                        .and_then(|value| value.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    if role_arn.is_empty() {
+                        // `prevalidate` rejects a missing RoleArn before
+                        // this runs, so only an in-process caller gets
+                        // here -- but an empty ARN must not become a
+                        // stored association that renders as an empty
+                        // element and burns a quota slot.
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "DBClusterRoleNotFound",
+                            format!("No role is associated with DB cluster {id} under that name."),
+                        ));
+                    }
                     // Keyed on the (role, feature) PAIR, as AWS keys it:
                     // one role is commonly attached for both s3Import and
                     // s3Export, and matching on the ARN alone rejected
@@ -3144,6 +3162,8 @@ impl RdsService {
                             ));
                         }
                     }
+                    // Written back only once the change succeeded.
+                    object.insert("AssociatedRoles".to_string(), Value::Array(roles));
                 }
                 xml_empty_action(&action, &rid)
             }
@@ -3155,7 +3175,11 @@ impl RdsService {
                     &aid,
                 )
                 .unwrap_or_default();
-                let role_arn = get_param(req, "RoleArn").unwrap_or_default();
+                // As above: `prevalidate` rejects a missing RoleArn or
+                // FeatureName first; an empty one must not be stored.
+                let role_arn = get_param(req, "RoleArn")
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_default();
                 let feature_name = get_param(req, "FeatureName").unwrap_or_default();
                 let adding = action == "AddRoleToDBInstance";
                 {
@@ -3166,6 +3190,13 @@ impl RdsService {
                     })?;
                     // The pair again -- and FeatureName is a REQUIRED
                     // input here, so ignoring it was strictly wrong.
+                    if role_arn.is_empty() {
+                        return Err(AwsServiceError::aws_error(
+                            StatusCode::NOT_FOUND,
+                            "DBInstanceRoleNotFound",
+                            format!("No role is associated with DB instance {id} under that name."),
+                        ));
+                    }
                     let position = instance
                         .associated_roles
                         .iter()

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -4807,14 +4807,36 @@ fn cluster_roles_are_recorded_and_reported() {
     );
     assert!(body.contains("<Status>ACTIVE</Status>"), "{body}");
 
-    // Attaching the same role twice is the declared conflict.
+    // The SAME pair twice is the declared conflict.
     match svc.handle_extra_action(&req(
         "AddRoleToDBCluster",
-        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Import"),
+        ],
     )) {
         Err(err) => assert_eq!(err.code(), "DBClusterRoleAlreadyExists"),
-        Ok(_) => panic!("attached the same role twice"),
+        Ok(_) => panic!("attached the same role and feature twice"),
     }
+
+    // The same role for a DIFFERENT feature is a different association,
+    // which is how one role gets attached for both import and export.
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Export"),
+        ],
+    );
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert_eq!(
+        body.matches(&format!("<RoleArn>{role}</RoleArn>")).count(),
+        2,
+        "the second feature was rejected as a duplicate: {body}"
+    );
 
     // Removing a role that was never attached is the declared absence.
     match svc.handle_extra_action(&req(
@@ -4828,16 +4850,64 @@ fn cluster_roles_are_recorded_and_reported() {
         Ok(_) => panic!("removed a role that was never attached"),
     }
 
+    // Removing one feature leaves the other: matching on the ARN alone
+    // deleted whichever entry came first.
     ok_on(
         &svc,
         "RemoveRoleFromDBCluster",
-        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Export"),
+        ],
+    );
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert!(
+        body.contains("<FeatureName>s3Import</FeatureName>"),
+        "{body}"
+    );
+    assert!(
+        !body.contains("<FeatureName>s3Export</FeatureName>"),
+        "the wrong association was removed: {body}"
+    );
+
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Import"),
+        ],
     );
     let body = body_of_action(&svc, "DescribeDBClusters", &[]);
     assert!(
         !body.contains("<AssociatedRoles>"),
         "the association outlived its removal: {body}"
     );
+
+    // AWS caps roles per cluster at five, and the Add op declares the
+    // quota fault.
+    for n in 0..5 {
+        ok_on(
+            &svc,
+            "AddRoleToDBCluster",
+            &[
+                ("DBClusterIdentifier", "clu-1"),
+                ("RoleArn", &format!("arn:aws:iam::000000000000:role/r{n}")),
+            ],
+        );
+    }
+    match svc.handle_extra_action(&req(
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", "arn:aws:iam::000000000000:role/one-too-many"),
+        ],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterRoleQuotaExceeded"),
+        Ok(_) => panic!("attached a sixth role"),
+    }
 }
 
 #[test]

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -5048,6 +5048,63 @@ fn removing_a_cluster_role_without_a_feature_resolves_only_when_unambiguous() {
     );
 }
 
+/// A feature-less association is an exact match, not a guess.
+///
+/// When a role is attached BOTH without a feature and with one, a remove
+/// that names no feature identifies the feature-less association
+/// exactly: (role, no feature) is a key one association carries. The
+/// ambiguity fallback is for when no exact match exists, so it must not
+/// fire here and must not touch the feature-bound association.
+#[test]
+fn removing_a_cluster_role_prefers_the_exact_feature_less_association() {
+    let svc = svc();
+    create_cluster(&svc, "clu-1");
+    let role = "arn:aws:iam::000000000000:role/s3";
+
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    );
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Import"),
+        ],
+    );
+
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    );
+
+    // The feature-bound one survives, and it is the only one left.
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert_eq!(
+        body.matches(&format!("<RoleArn>{role}</RoleArn>")).count(),
+        1,
+        "the wrong association was removed: {body}"
+    );
+    assert!(
+        body.contains("<FeatureName>s3Import</FeatureName>"),
+        "the feature-bound association was removed: {body}"
+    );
+
+    // And now that it is the only one carrying the ARN, naming just the
+    // role resolves it through the unambiguous fallback.
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    );
+    let stored = extras_value(&svc, "clusters", "clu-1");
+    assert!(stored.get("AssociatedRoles").is_none(), "{stored}");
+}
+
 #[test]
 fn describe_db_shard_groups_honors_the_id_filter() {
     let svc = svc();

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -4885,6 +4885,14 @@ fn cluster_roles_are_recorded_and_reported() {
         !body.contains("<AssociatedRoles>"),
         "the association outlived its removal: {body}"
     );
+    // And the key is GONE, not left as an empty array: snapshots clone
+    // the cluster entry forward, so an empty key would ride along in
+    // every later snapshot.
+    let stored = extras_value(&svc, "clusters", "clu-1");
+    assert!(
+        stored.get("AssociatedRoles").is_none(),
+        "removing the last role left an empty key behind: {stored}"
+    );
 
     // AWS caps roles per cluster at five, and the Add op declares the
     // quota fault.
@@ -4944,11 +4952,15 @@ fn a_failed_role_request_does_not_write_to_the_cluster() {
     // An empty RoleArn is not stored as an association either. Requests
     // through `handle` never reach this -- prevalidate rejects the
     // missing required parameter first -- but an in-process caller can.
+    // The Add path answers the way prevalidate answers the same request:
+    // DBClusterRoleNotFoundFault is declared on Remove, not on Add, so
+    // raising it here would put a shape on the wire that this operation
+    // never returns.
     match svc.handle_extra_action(&req(
         "AddRoleToDBCluster",
         &[("DBClusterIdentifier", "clu-1"), ("RoleArn", "")],
     )) {
-        Err(err) => assert_eq!(err.code(), "DBClusterRoleNotFound"),
+        Err(err) => assert_eq!(err.code(), "InvalidParameterValue"),
         Ok(_) => panic!("stored an association with no role"),
     }
     let after = extras_value(&svc, "clusters", "clu-1");

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -4910,6 +4910,54 @@ fn cluster_roles_are_recorded_and_reported() {
     }
 }
 
+/// A failed role request leaves the cluster untouched.
+///
+/// The roles array was materialized before the add/remove ran, so a
+/// remove against a cluster with no roles wrote `"AssociatedRoles": []`
+/// into the stored entry and THEN returned the fault --
+/// CreateDBClusterSnapshot cloned that key forward into every later
+/// snapshot.
+#[test]
+fn a_failed_role_request_does_not_write_to_the_cluster() {
+    let svc = svc();
+    create_cluster(&svc, "clu-1");
+    let before = extras_value(&svc, "clusters", "clu-1");
+    assert!(before.get("AssociatedRoles").is_none());
+
+    match svc.handle_extra_action(&req(
+        "RemoveRoleFromDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", "arn:aws:iam::000000000000:role/never-attached"),
+        ],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterRoleNotFound"),
+        Ok(_) => panic!("removed a role that was never attached"),
+    }
+
+    let after = extras_value(&svc, "clusters", "clu-1");
+    assert!(
+        after.get("AssociatedRoles").is_none(),
+        "a failed remove wrote the key into the cluster: {after}"
+    );
+
+    // An empty RoleArn is not stored as an association either. Requests
+    // through `handle` never reach this -- prevalidate rejects the
+    // missing required parameter first -- but an in-process caller can.
+    match svc.handle_extra_action(&req(
+        "AddRoleToDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", "")],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterRoleNotFound"),
+        Ok(_) => panic!("stored an association with no role"),
+    }
+    let after = extras_value(&svc, "clusters", "clu-1");
+    assert!(
+        after.get("AssociatedRoles").is_none(),
+        "an empty role was stored: {after}"
+    );
+}
+
 #[test]
 fn describe_db_shard_groups_honors_the_id_filter() {
     let svc = svc();

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -493,10 +493,25 @@ fn export_activity_replicas_recommendations_certs_pending() {
     ok("DescribeExportTasks", &[]);
     // StartActivityStream / ModifyActivityStream / StopActivityStream now
     // persist onto a real instance; see activity_stream_persists_on_instance.
-    ok("AddRoleToDBCluster", &[]);
-    ok("RemoveRoleFromDBCluster", &[]);
-    ok("AddRoleToDBInstance", &[]);
-    ok("RemoveRoleFromDBInstance", &[]);
+    // Role association is no longer a no-op: it needs a real cluster.
+    let svc = svc();
+    create_cluster(&svc, "role-clu");
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "role-clu"),
+            ("RoleArn", "arn:aws:iam::000000000000:role/rds-role"),
+        ],
+    );
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[
+            ("DBClusterIdentifier", "role-clu"),
+            ("RoleArn", "arn:aws:iam::000000000000:role/rds-role"),
+        ],
+    );
     ok(
         "ApplyPendingMaintenanceAction",
         &[
@@ -610,6 +625,7 @@ fn seed_replica(svc: &RdsService, replica_id: &str, source_id: &str) {
         DbInstance {
             db_instance_identifier: source_id.to_string(),
             db_instance_arn: source_arn,
+            associated_roles: Vec::new(),
             db_instance_class: "db.t3.micro".to_string(),
             engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),
@@ -681,6 +697,7 @@ fn seed_replica(svc: &RdsService, replica_id: &str, source_id: &str) {
         DbInstance {
             db_instance_identifier: replica_id.to_string(),
             db_instance_arn: arn,
+            associated_roles: Vec::new(),
             db_instance_class: "db.t3.micro".to_string(),
             engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),
@@ -1391,6 +1408,7 @@ fn seed_blue_instance(svc: &RdsService, id: &str, addr: &str, port: i32) {
         DbInstance {
             db_instance_identifier: id.to_string(),
             db_instance_arn: arn,
+            associated_roles: Vec::new(),
             db_instance_class: "db.t3.micro".to_string(),
             engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),
@@ -4742,6 +4760,83 @@ fn deleting_a_cluster_removes_a_legacy_arn_keyed_endpoint() {
             ("DBClusterIdentifier", "clu-1"),
             ("EndpointType", "READER"),
         ],
+    );
+}
+
+/// Role association is recorded, reported, and refuses the duplicates
+/// and absences the model declares faults for.
+///
+/// All four role operations were `xml_empty_action`: they accepted any
+/// request, stored nothing, and answered 200 -- so a caller could attach
+/// a role to a cluster that does not exist, and DescribeDBClusters never
+/// reported the roles it had been told about.
+#[test]
+fn cluster_roles_are_recorded_and_reported() {
+    let svc = svc();
+    create_cluster(&svc, "clu-1");
+    let role = "arn:aws:iam::000000000000:role/s3-import";
+
+    // A cluster that doesn't exist gets the declared fault, not a 200.
+    match svc.handle_extra_action(&req(
+        "AddRoleToDBCluster",
+        &[("DBClusterIdentifier", "ghost"), ("RoleArn", role)],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterNotFoundFault"),
+        Ok(_) => panic!("attached a role to a cluster that does not exist"),
+    }
+
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Import"),
+        ],
+    );
+
+    // Reported by the listing, which never saw these before.
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert!(
+        body.contains(&format!("<RoleArn>{role}</RoleArn>")),
+        "the association was not reported: {body}"
+    );
+    assert!(
+        body.contains("<FeatureName>s3Import</FeatureName>"),
+        "{body}"
+    );
+    assert!(body.contains("<Status>ACTIVE</Status>"), "{body}");
+
+    // Attaching the same role twice is the declared conflict.
+    match svc.handle_extra_action(&req(
+        "AddRoleToDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterRoleAlreadyExists"),
+        Ok(_) => panic!("attached the same role twice"),
+    }
+
+    // Removing a role that was never attached is the declared absence.
+    match svc.handle_extra_action(&req(
+        "RemoveRoleFromDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", "arn:aws:iam::000000000000:role/other"),
+        ],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterRoleNotFound"),
+        Ok(_) => panic!("removed a role that was never attached"),
+    }
+
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    );
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert!(
+        !body.contains("<AssociatedRoles>"),
+        "the association outlived its removal: {body}"
     );
 }
 

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -4970,6 +4970,84 @@ fn a_failed_role_request_does_not_write_to_the_cluster() {
     );
 }
 
+/// FeatureName is optional on the cluster operations, so a remove that
+/// names only the role works when that is unambiguous -- and refuses to
+/// guess when it isn't.
+#[test]
+fn removing_a_cluster_role_without_a_feature_resolves_only_when_unambiguous() {
+    let svc = svc();
+    create_cluster(&svc, "clu-1");
+    let role = "arn:aws:iam::000000000000:role/s3";
+
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Import"),
+        ],
+    );
+
+    // One association carries the ARN, so naming just the role is
+    // unambiguous.
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    );
+    let stored = extras_value(&svc, "clusters", "clu-1");
+    assert!(stored.get("AssociatedRoles").is_none(), "{stored}");
+
+    // Two features on one role: naming only the role is ambiguous, and
+    // guessing is how the ARN-only matching removed the wrong one.
+    for feature in ["s3Import", "s3Export"] {
+        ok_on(
+            &svc,
+            "AddRoleToDBCluster",
+            &[
+                ("DBClusterIdentifier", "clu-1"),
+                ("RoleArn", role),
+                ("FeatureName", feature),
+            ],
+        );
+    }
+    match svc.handle_extra_action(&req(
+        "RemoveRoleFromDBCluster",
+        &[("DBClusterIdentifier", "clu-1"), ("RoleArn", role)],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBClusterRoleNotFound"),
+        Ok(_) => panic!("an ambiguous remove guessed an association"),
+    }
+    // Both survive it.
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert_eq!(
+        body.matches(&format!("<RoleArn>{role}</RoleArn>")).count(),
+        2,
+        "an ambiguous remove deleted an association: {body}"
+    );
+
+    // Naming the feature still resolves exactly one.
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Export"),
+        ],
+    );
+    let body = body_of_action(&svc, "DescribeDBClusters", &[]);
+    assert!(
+        body.contains("<FeatureName>s3Import</FeatureName>"),
+        "{body}"
+    );
+    assert!(
+        !body.contains("<FeatureName>s3Export</FeatureName>"),
+        "{body}"
+    );
+}
+
 #[test]
 fn describe_db_shard_groups_honors_the_id_filter() {
     let svc = svc();

--- a/crates/fakecloud-rds/src/extras/tests.rs
+++ b/crates/fakecloud-rds/src/extras/tests.rs
@@ -4999,6 +4999,33 @@ fn removing_a_cluster_role_without_a_feature_resolves_only_when_unambiguous() {
     let stored = extras_value(&svc, "clusters", "clu-1");
     assert!(stored.get("AssociatedRoles").is_none(), "{stored}");
 
+    // An explicitly EMPTY FeatureName is absent, not a feature named "":
+    // treated as present it blocks this path and stores an empty
+    // <FeatureName/> into the association.
+    ok_on(
+        &svc,
+        "AddRoleToDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", "s3Import"),
+        ],
+    );
+    ok_on(
+        &svc,
+        "RemoveRoleFromDBCluster",
+        &[
+            ("DBClusterIdentifier", "clu-1"),
+            ("RoleArn", role),
+            ("FeatureName", ""),
+        ],
+    );
+    let stored = extras_value(&svc, "clusters", "clu-1");
+    assert!(
+        stored.get("AssociatedRoles").is_none(),
+        "an empty FeatureName blocked the remove: {stored}"
+    );
+
     // Two features on one role: naming only the role is ambiguous, and
     // guessing is how the ARN-only matching removed the wrong one.
     for feature in ["s3Import", "s3Export"] {

--- a/crates/fakecloud-rds/src/extras/xml_renderers.rs
+++ b/crates/fakecloud-rds/src/extras/xml_renderers.rs
@@ -21,6 +21,25 @@ pub(super) fn json_str_array_xml(v: &Value, wrapper: &str) -> String {
 
 pub(super) fn db_cluster_member_xml(v: &Value) -> String {
     let mut out = String::new();
+    // Roles attached through AddRoleToDBCluster. AWS omits the element
+    // when there are none.
+    if let Some(roles) = v["AssociatedRoles"].as_array().filter(|r| !r.is_empty()) {
+        out.push_str("          <AssociatedRoles>");
+        for role in roles {
+            out.push_str("<DBClusterRole>");
+            for (key, tag) in [
+                ("RoleArn", "RoleArn"),
+                ("FeatureName", "FeatureName"),
+                ("Status", "Status"),
+            ] {
+                if let Some(value) = role[key].as_str() {
+                    out.push_str(&format!("<{tag}>{}</{tag}>", xml_escape(value)));
+                }
+            }
+            out.push_str("</DBClusterRole>");
+        }
+        out.push_str("</AssociatedRoles>\n");
+    }
     out.push_str(&format!(
         "          <DBClusterIdentifier>{}</DBClusterIdentifier>\n",
         xml_escape(v["DBClusterIdentifier"].as_str().unwrap_or(""))

--- a/crates/fakecloud-rds/src/service/cluster_snapshots.rs
+++ b/crates/fakecloud-rds/src/service/cluster_snapshots.rs
@@ -333,6 +333,13 @@ impl RdsService {
             );
             obj.remove("ReplicationSourceIdentifier");
             obj.remove("DBClusterMembers");
+            // A restore takes no IAM roles: RestoreDBClusterFromSnapshot
+            // and RestoreDBClusterToPointInTime have no role member, and
+            // the snapshot carries a clone of the source cluster. Left
+            // behind, the restored cluster reports associations the
+            // caller never asked for, which reads as a permanent diff
+            // against a config that declares none.
+            obj.remove("AssociatedRoles");
             obj.remove("WriterDBInstanceIdentifier");
             obj.remove("DBClusterSnapshotIdentifier");
             obj.remove("DBClusterSnapshotArn");
@@ -566,6 +573,13 @@ impl RdsService {
                 )),
             );
             obj.remove("DBClusterMembers");
+            // A restore takes no IAM roles: RestoreDBClusterFromSnapshot
+            // and RestoreDBClusterToPointInTime have no role member, and
+            // the snapshot carries a clone of the source cluster. Left
+            // behind, the restored cluster reports associations the
+            // caller never asked for, which reads as a permanent diff
+            // against a config that declares none.
+            obj.remove("AssociatedRoles");
             obj.remove("WriterDBInstanceIdentifier");
             // A PITR target is an independent cluster, never a replica --
             // the from-snapshot path above already drops this. Inherited,

--- a/crates/fakecloud-rds/src/service/instances.rs
+++ b/crates/fakecloud-rds/src/service/instances.rs
@@ -192,6 +192,7 @@ impl RdsService {
                 db_instance_identifier: db_instance_identifier.clone(),
                 db_instance_arn: state
                     .db_instance_arn(request.region.as_str(), &db_instance_identifier),
+                associated_roles: Vec::new(),
                 db_instance_class: db_instance_class.clone(),
                 engine: engine.clone(),
                 engine_version: engine_version.clone(),

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -1133,11 +1133,22 @@ pub(crate) fn db_instance_xml(
             .associated_roles
             .iter()
             .map(|role| {
+                // An absent feature is an absent ELEMENT, not an empty
+                // one: `<FeatureName></FeatureName>` reads as a feature
+                // named "". FeatureName is required on these operations,
+                // so only an in-process caller produces this.
+                let feature = if role.feature_name.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "<FeatureName>{}</FeatureName>",
+                        xml_escape(&role.feature_name)
+                    )
+                };
                 format!(
-                    "<DBInstanceRole><RoleArn>{}</RoleArn><FeatureName>{}</FeatureName>\
+                    "<DBInstanceRole><RoleArn>{}</RoleArn>{feature}\
                      <Status>{}</Status></DBInstanceRole>",
                     xml_escape(&role.role_arn),
-                    xml_escape(&role.feature_name),
                     xml_escape(&role.status),
                 )
             })

--- a/crates/fakecloud-rds/src/service_helpers.rs
+++ b/crates/fakecloud-rds/src/service_helpers.rs
@@ -601,6 +601,7 @@ pub(crate) fn build_restored_instance(
     tags: Vec<RdsTag>,
 ) -> DbInstance {
     DbInstance {
+        associated_roles: Vec::new(),
         db_instance_identifier: db_instance_identifier.to_string(),
         db_instance_arn,
         db_instance_class: "db.t3.micro".to_string(),
@@ -690,6 +691,7 @@ pub(crate) fn build_s3_restored_instance(
     tags: Vec<RdsTag>,
 ) -> DbInstance {
     DbInstance {
+        associated_roles: Vec::new(),
         db_instance_identifier: db_instance_identifier.to_string(),
         db_instance_arn,
         db_instance_class,
@@ -783,6 +785,7 @@ pub(crate) fn build_pit_restored_instance(
     tags: Vec<RdsTag>,
 ) -> DbInstance {
     DbInstance {
+        associated_roles: Vec::new(),
         db_instance_identifier: db_instance_identifier.to_string(),
         db_instance_arn,
         db_instance_class: source.db_instance_class.clone(),
@@ -861,6 +864,7 @@ pub(crate) fn build_read_replica_instance(
     running: &crate::runtime::RunningDbContainer,
 ) -> DbInstance {
     DbInstance {
+        associated_roles: Vec::new(),
         db_instance_identifier: db_instance_identifier.to_string(),
         db_instance_arn,
         db_instance_class: source.db_instance_class.clone(),
@@ -1119,6 +1123,27 @@ pub(crate) fn db_instance_xml(
     status_override: Option<&str>,
     subnet_group: Option<&DbSubnetGroup>,
 ) -> String {
+    // Roles attached through AddRoleToDBInstance. AWS omits the element
+    // entirely when there are none, as it does for the other optional
+    // lists on this shape.
+    let associated_roles_xml = if instance.associated_roles.is_empty() {
+        String::new()
+    } else {
+        let members = instance
+            .associated_roles
+            .iter()
+            .map(|role| {
+                format!(
+                    "<DBInstanceRole><RoleArn>{}</RoleArn><FeatureName>{}</FeatureName>\
+                     <Status>{}</Status></DBInstanceRole>",
+                    xml_escape(&role.role_arn),
+                    xml_escape(&role.feature_name),
+                    xml_escape(&role.status),
+                )
+            })
+            .collect::<String>();
+        format!("<AssociatedRoles>{members}</AssociatedRoles>")
+    };
     let status = status_override.unwrap_or(&instance.db_instance_status);
     let db_subnet_group_xml = subnet_group
         .map(|group| {
@@ -1641,6 +1666,7 @@ pub(crate) fn db_instance_xml(
          {charset_xml}\
          {copy_tags_xml}\
          {master_user_secret_xml}\
+         {associated_roles_xml}\
          <ProcessorFeatures/>\
          {activity_stream_xml}\
          <DbiResourceId>{dbi_resource_id}</DbiResourceId>\

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2952,6 +2952,35 @@ async fn instance_roles_are_recorded_and_reported() {
         Ok(_) => panic!("attached the same role twice"),
     }
 
+    // An association with no feature reports no FeatureName ELEMENT: an
+    // empty one reads as a feature named "".
+    svc.handle_extra_action(&request(
+        "AddRoleToDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-1"),
+            ("RoleArn", "arn:aws:iam::123456789012:role/no-feature"),
+            ("FeatureName", ""),
+        ],
+    ))
+    .expect("AddRoleToDBInstance");
+    let body = body_of(
+        svc.describe_db_instances(&request("DescribeDBInstances", &[]))
+            .unwrap(),
+    );
+    assert!(
+        !body.contains("<FeatureName></FeatureName>"),
+        "an empty feature was rendered: {body}"
+    );
+    svc.handle_extra_action(&request(
+        "RemoveRoleFromDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-1"),
+            ("RoleArn", "arn:aws:iam::123456789012:role/no-feature"),
+            ("FeatureName", ""),
+        ],
+    ))
+    .expect("RemoveRoleFromDBInstance");
+
     match svc.handle_extra_action(&request(
         "RemoveRoleFromDBInstance",
         &[

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -2984,6 +2984,84 @@ async fn instance_roles_are_recorded_and_reported() {
     );
 }
 
+/// A restore takes no IAM roles.
+///
+/// The snapshot carries a clone of the source cluster, and neither
+/// restore operation has a role member, so a restored cluster reporting
+/// the source's associations reads as a permanent diff against a config
+/// that declares none.
+#[tokio::test]
+async fn a_restored_cluster_inherits_no_roles() {
+    let svc = make_service();
+    {
+        let mut accounts = svc.state.write();
+        accounts
+            .default_mut()
+            .extras
+            .entry("cluster_snapshots".to_string())
+            .or_default()
+            .insert(
+                "snap-1".to_string(),
+                serde_json::json!({
+                    "DBClusterSnapshotIdentifier": "snap-1",
+                    "DBClusterIdentifier": "src-clu",
+                    "Status": "available",
+                    "Engine": "aurora-mysql",
+                    // As CreateDBClusterSnapshot clones it off the
+                    // source cluster.
+                    "AssociatedRoles": [{
+                        "RoleArn": "arn:aws:iam::123456789012:role/s3-import",
+                        "FeatureName": "s3Import",
+                        "Status": "ACTIVE",
+                    }],
+                }),
+            );
+    }
+
+    let req = request(
+        "RestoreDBClusterFromSnapshot",
+        &[
+            ("DBClusterIdentifier", "restored"),
+            ("SnapshotIdentifier", "snap-1"),
+        ],
+    );
+    svc.restore_db_cluster_from_snapshot(&req).await.unwrap();
+
+    let restored = cluster_entry(&svc, "restored");
+    assert!(
+        restored.get("AssociatedRoles").is_none(),
+        "the restored cluster inherited the source's roles: {restored}"
+    );
+
+    // Same for a point-in-time restore, which clones the source cluster
+    // directly.
+    seed_cluster_entry(
+        &svc,
+        "pitr-src",
+        serde_json::json!({
+            "AssociatedRoles": [{
+                "RoleArn": "arn:aws:iam::123456789012:role/s3-import",
+                "FeatureName": "s3Import",
+                "Status": "ACTIVE",
+            }],
+        }),
+    );
+    let req = request(
+        "RestoreDBClusterToPointInTime",
+        &[
+            ("DBClusterIdentifier", "pitr-restored"),
+            ("SourceDBClusterIdentifier", "pitr-src"),
+            ("UseLatestRestorableTime", "true"),
+        ],
+    );
+    svc.restore_db_cluster_to_point_in_time(&req).await.unwrap();
+    let restored = cluster_entry(&svc, "pitr-restored");
+    assert!(
+        restored.get("AssociatedRoles").is_none(),
+        "the PITR target inherited the source's roles: {restored}"
+    );
+}
+
 #[tokio::test]
 async fn cluster_snapshot_restore_maps_an_aurora_family_to_its_engine() {
     // A metadata-only snapshot (no writer recorded) still must not hand

--- a/crates/fakecloud-rds/src/service_tests.rs
+++ b/crates/fakecloud-rds/src/service_tests.rs
@@ -158,6 +158,7 @@ fn db_instance_xml_renders_endpoint_and_status() {
     let instance = DbInstance {
         db_instance_identifier: "test-db".to_string(),
         db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:test-db".to_string(),
+        associated_roles: Vec::new(),
         db_instance_class: "db.t3.micro".to_string(),
         engine: "postgres".to_string(),
         engine_version: "16.3".to_string(),
@@ -344,6 +345,7 @@ fn make_instance_with_defaults(id: &str) -> DbInstance {
     DbInstance {
         db_instance_identifier: id.to_string(),
         db_instance_arn: format!("arn:aws:rds:us-east-1:123:db:{id}"),
+        associated_roles: Vec::new(),
         db_instance_class: "db.t3.micro".to_string(),
         engine: "postgres".to_string(),
         engine_version: "16.3".to_string(),
@@ -624,6 +626,7 @@ fn seed_instance(svc: &RdsService, identifier: &str) -> String {
         DbInstance {
             db_instance_identifier: identifier.to_string(),
             db_instance_arn: arn.clone(),
+            associated_roles: Vec::new(),
             db_instance_class: "db.t3.micro".to_string(),
             engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),
@@ -2891,6 +2894,93 @@ async fn db_instance_id_filter_matches_a_copys_source_instance_arn() {
     assert!(
         !body.contains("<DBSnapshotIdentifier>mycopy</DBSnapshotIdentifier>"),
         "an unrelated account's ARN matched: {body}"
+    );
+}
+
+/// The instance side of role association: recorded, reported, and
+/// refusing the duplicates and absences the model declares faults for.
+#[tokio::test]
+async fn instance_roles_are_recorded_and_reported() {
+    let svc = make_service();
+    seed_instance(&svc, "db-1");
+    let role = "arn:aws:iam::123456789012:role/s3-export";
+
+    match svc.handle_extra_action(&request(
+        "AddRoleToDBInstance",
+        &[
+            ("DBInstanceIdentifier", "ghost"),
+            ("RoleArn", role),
+            ("FeatureName", "S3_INTEGRATION"),
+        ],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBInstanceNotFound"),
+        Ok(_) => panic!("attached a role to an instance that does not exist"),
+    }
+
+    svc.handle_extra_action(&request(
+        "AddRoleToDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-1"),
+            ("RoleArn", role),
+            ("FeatureName", "S3_INTEGRATION"),
+        ],
+    ))
+    .expect("AddRoleToDBInstance");
+
+    let body = body_of(
+        svc.describe_db_instances(&request("DescribeDBInstances", &[]))
+            .unwrap(),
+    );
+    assert!(
+        body.contains(&format!("<RoleArn>{role}</RoleArn>")),
+        "the association was not reported: {body}"
+    );
+    assert!(
+        body.contains("<FeatureName>S3_INTEGRATION</FeatureName>"),
+        "{body}"
+    );
+
+    match svc.handle_extra_action(&request(
+        "AddRoleToDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-1"),
+            ("RoleArn", role),
+            ("FeatureName", "S3_INTEGRATION"),
+        ],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBInstanceRoleAlreadyExists"),
+        Ok(_) => panic!("attached the same role twice"),
+    }
+
+    match svc.handle_extra_action(&request(
+        "RemoveRoleFromDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-1"),
+            ("RoleArn", "arn:aws:iam::123456789012:role/other"),
+            ("FeatureName", "S3_INTEGRATION"),
+        ],
+    )) {
+        Err(err) => assert_eq!(err.code(), "DBInstanceRoleNotFound"),
+        Ok(_) => panic!("removed a role that was never attached"),
+    }
+
+    svc.handle_extra_action(&request(
+        "RemoveRoleFromDBInstance",
+        &[
+            ("DBInstanceIdentifier", "db-1"),
+            ("RoleArn", role),
+            ("FeatureName", "S3_INTEGRATION"),
+        ],
+    ))
+    .expect("RemoveRoleFromDBInstance");
+
+    let body = body_of(
+        svc.describe_db_instances(&request("DescribeDBInstances", &[]))
+            .unwrap(),
+    );
+    assert!(
+        !body.contains("<AssociatedRoles>"),
+        "the association outlived its removal: {body}"
     );
 }
 
@@ -6070,6 +6160,7 @@ async fn save_snapshot_static_persists_status_flip_from_bg_task() {
         DbInstance {
             db_instance_identifier: id.to_string(),
             db_instance_arn: format!("arn:aws:rds:us-east-1:123456789012:db:{id}"),
+            associated_roles: Vec::new(),
             db_instance_class: "db.t3.micro".to_string(),
             engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),

--- a/crates/fakecloud-rds/src/state.rs
+++ b/crates/fakecloud-rds/src/state.rs
@@ -104,6 +104,10 @@ pub const SUPPORTED_INSTANCE_CLASSES: &[&str] = &[
 pub struct DbInstance {
     pub db_instance_identifier: String,
     pub db_instance_arn: String,
+    /// IAM roles associated through `AddRoleToDBInstance`, reported as
+    /// `AssociatedRoles`.
+    #[serde(default)]
+    pub associated_roles: Vec<DbRole>,
     pub db_instance_class: String,
     pub engine: String,
     pub engine_version: String,
@@ -365,6 +369,16 @@ impl fmt::Debug for DbInstance {
 pub struct RdsTag {
     pub key: String,
     pub value: String,
+}
+
+/// An IAM role associated with a DB instance or cluster.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct DbRole {
+    pub role_arn: String,
+    pub feature_name: String,
+    /// AWS reports `ACTIVE` once the association is usable; there is
+    /// nothing to wait for here.
+    pub status: String,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -1109,6 +1123,7 @@ mod tests {
             DbInstance {
                 db_instance_identifier: "db-1".to_string(),
                 db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:db-1".to_string(),
+                associated_roles: Vec::new(),
                 db_instance_class: "db.t3.micro".to_string(),
                 engine: "postgres".to_string(),
                 engine_version: "16.3".to_string(),
@@ -1276,6 +1291,7 @@ mod tests {
         DbInstance {
             db_instance_identifier: id.to_string(),
             db_instance_arn: Arn::new("rds", "us-east-1", "123", &format!("db:{id}")).to_string(),
+            associated_roles: Vec::new(),
             db_instance_class: "db.t3.micro".to_string(),
             engine: "postgres".to_string(),
             engine_version: "16.3".to_string(),

--- a/crates/fakecloud-server/src/introspection.rs
+++ b/crates/fakecloud-server/src/introspection.rs
@@ -748,6 +748,7 @@ mod tests {
     fn rds_instance_response_omits_password_but_keeps_runtime_metadata() {
         let created_at = Utc::now();
         let instance = DbInstance {
+            associated_roles: Vec::new(),
             db_instance_identifier: "db-1".to_string(),
             db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:db-1".to_string(),
             db_instance_class: "db.t3.micro".to_string(),

--- a/crates/fakecloud-server/src/reset.rs
+++ b/crates/fakecloud-server/src/reset.rs
@@ -640,6 +640,7 @@ mod tests {
         rds.instances.insert(
             "db-1".to_string(),
             DbInstance {
+                associated_roles: Vec::new(),
                 db_instance_identifier: "db-1".to_string(),
                 db_instance_arn: "arn:aws:rds:us-east-1:123456789012:db:db-1".to_string(),
                 db_instance_class: "db.t3.micro".to_string(),

--- a/website/content/docs/services/rds.md
+++ b/website/content/docs/services/rds.md
@@ -266,7 +266,11 @@ Real RDS rejects a filter name an operation doesn't support with `InvalidParamet
 
 `AddRoleToDBCluster`, `RemoveRoleFromDBCluster`, `AddRoleToDBInstance` and `RemoveRoleFromDBInstance` record the association and report it back as `AssociatedRoles` on `DescribeDBClusters` / `DescribeDBInstances`, with `Status: ACTIVE`. They previously accepted any request and answered 200 without storing anything, so a role could be attached to a cluster that did not exist and the listing never showed it.
 
-The faults the model declares are raised: the resource not existing (`DBClusterNotFoundFault` / `DBInstanceNotFound`), attaching a role that is already attached (`DBClusterRoleAlreadyExists` / `DBInstanceRoleAlreadyExists`), and removing one that is not (`DBClusterRoleNotFound` / `DBInstanceRoleNotFound`).
+An association is keyed on the (role, feature) pair, as AWS keys it, so one role can be attached for both `s3Import` and `s3Export` and removing one feature leaves the other. Roles are capped at five per cluster and per instance.
+
+The faults the model declares are raised: the resource not existing (`DBClusterNotFoundFault` / `DBInstanceNotFound`), attaching a pair that is already attached (`DBClusterRoleAlreadyExists` / `DBInstanceRoleAlreadyExists`), removing one that is not (`DBClusterRoleNotFound` / `DBInstanceRoleNotFound`), and exceeding the cap (`DBClusterRoleQuotaExceeded` / `DBInstanceRoleQuotaExceeded`).
+
+A restored cluster carries no associations: neither `RestoreDBClusterFromSnapshot` nor `RestoreDBClusterToPointInTime` takes roles, and the snapshot holds a clone of the source cluster.
 
 ## Gotchas
 

--- a/website/content/docs/services/rds.md
+++ b/website/content/docs/services/rds.md
@@ -262,6 +262,12 @@ Real RDS rejects a filter name an operation doesn't support with `InvalidParamet
 
 `CopyDBSnapshot` records the source it copied from and reports it as `SourceDBSnapshotIdentifier` (an ARN, as AWS does); a snapshot that isn't a copy omits the field. That ARN is also what `db-instance-id` matches a copy's source instance against: a copy's own ARN names the account that made the copy, while the instance it records still belongs to the original owner, so for a cross-account or cross-region copy only the source ARN says where that instance lives. `db-cluster-id` does the same through `SourceDBClusterSnapshotArn`.
 
+## IAM role associations
+
+`AddRoleToDBCluster`, `RemoveRoleFromDBCluster`, `AddRoleToDBInstance` and `RemoveRoleFromDBInstance` record the association and report it back as `AssociatedRoles` on `DescribeDBClusters` / `DescribeDBInstances`, with `Status: ACTIVE`. They previously accepted any request and answered 200 without storing anything, so a role could be attached to a cluster that did not exist and the listing never showed it.
+
+The faults the model declares are raised: the resource not existing (`DBClusterNotFoundFault` / `DBInstanceNotFound`), attaching a role that is already attached (`DBClusterRoleAlreadyExists` / `DBInstanceRoleAlreadyExists`), and removing one that is not (`DBClusterRoleNotFound` / `DBInstanceRoleNotFound`).
+
 ## Gotchas
 
 - **Persistence snapshots are one-way across the v3 bump.** RDS state written by this version declares snapshot schema v3 (final snapshots are typed `manual`, matching AWS; earlier builds wrote `automated`). An older fakecloud refuses to load a v3 file and exits, so downgrade by removing `<data-path>/rds/snapshot.json` first.


### PR DESCRIPTION
## Summary

All four RDS IAM role operations were `xml_empty_action` — accept-and-discard stubs. They took any request, stored nothing, and answered 200. A role could be attached to a cluster that doesn't exist, and `DescribeDBClusters` / `DescribeDBInstances` never reported the roles they'd been told about.

This implements them: the association is recorded, reported back as `AssociatedRoles` with `Status: ACTIVE`, and the faults the model declares are raised.

**RDS conformance: 5502 → 5506 variants, 159 → 161 fully-passing operations.** `AddRoleToDBCluster` and `RemoveRoleFromDBCluster` were each losing two variants by answering 200 where an error was expected.

### Behavior

- The association is keyed on the **(role, feature) pair**, as AWS keys it. One role is commonly attached for both `s3Import` and `s3Export`; keying on the ARN alone would reject the second feature as a duplicate and, on removal, delete whichever entry came first. `FeatureName` is a required input on the instance operations.
- Roles are capped at five per cluster and per instance, raising the declared `DBClusterRoleQuotaExceeded` / `DBInstanceRoleQuotaExceeded` — declared and previously unreachable.
- `RestoreDBClusterFromSnapshot` and `RestoreDBClusterToPointInTime` strip `AssociatedRoles`. The snapshot carries a clone of the source cluster and neither operation takes roles, so a restored cluster reported associations the caller never asked for — a permanent diff against a config that declares none.
- Failed requests write nothing. The roles array is read without creating the key and written back only on success, and removing the last role drops the key rather than leaving an empty array — `CreateDBClusterSnapshot` clones the cluster entry forward, so a stray key rides along in every later snapshot.

### Error shapes

Every fault raised is declared on the operation that raises it, with the model's `awsQueryError` code and HTTP status: `DBClusterNotFoundFault` / `DBInstanceNotFound` (404), `*RoleAlreadyExists` / `*RoleQuotaExceeded` (400), `*RoleNotFound` (404). Note `DBClusterRoleNotFoundFault` is declared on **Remove** only, so the Add path's empty-`RoleArn` guard answers the way `prevalidate` answers the same request instead of raising a shape that operation never returns.

`DbInstance` gains an `associated_roles` field with `#[serde(default)]`, so existing persisted state loads unchanged — no schema bump.

### Surface

Reference docs updated (`website/content/docs/services/rds.md`) with the association semantics, the pair keying, the cap, the faults, and the restore behavior. No new API surface, so no SDK change. Service/op counts are unchanged; the conformance variant total moves, so the repo description's variant figures will be refreshed after merge.

## Test plan

- 453 unit tests in `fakecloud-rds` (up from 449), covering: association recorded and reported on both cluster and instance, the same role for two features, removing one feature leaving the other, all six declared faults, the quota cap, no inherited roles through either restore path, and no writes on a failed request.
- RDS conformance probe **5506/5538, 161/164 operations** — verified on a clean rebuild.
- `cargo clippy --workspace --all-targets` clean. Worth noting: `cargo build --workspace` does **not** build test targets, which is how two `DbInstance` literals in `fakecloud-server`'s test modules initially slipped past the field sweep; `--all-targets` catches them and is what I now gate on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the four RDS IAM role operations, which previously accepted any request, stored nothing, and answered 200. They now record the association, report it back as `AssociatedRoles` with `Status: ACTIVE`, and raise the declared faults.

**Details**

- Associations are keyed on the (role, feature) pair, so one role can be attached for both `s3Import` and `s3Export`.
- Roles are capped at five per cluster and instance, raising `DBClusterRoleQuotaExceeded` / `DBInstanceRoleQuotaExceeded`.
- Restore paths strip `AssociatedRoles`; neither restore operation takes roles.
- Failed requests write nothing, and removing the last role drops the key.
- `DbInstance` gains an `associated_roles` field with `#[serde(default)]`, so existing persisted state loads unchanged.
- On clusters, `FeatureName` is optional: an ARN-only remove matches a feature-less association exactly, otherwise resolves only when unambiguous.
- Empty `FeatureName` is treated as absent, and instance rendering omits the empty element.

<sup>Written for commit 6d3ac8e2d9bfba68deaacc3c5af7b93edc9e206c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

