### PR TITLE
feat(cloudwatch): implement log alarms

### DIFF
--- a/crates/fakecloud-cloudwatch/src/lib.rs
+++ b/crates/fakecloud-cloudwatch/src/lib.rs
@@ -6,6 +6,7 @@ pub mod delivery;
 pub(crate) mod insight_rules;
 pub mod introspection;
 pub(crate) mod json_protocol;
+pub(crate) mod log_alarms;
 pub(crate) mod metric_math;
 pub(crate) mod metric_streams;
 pub(crate) mod mute_rules;

--- a/crates/fakecloud-cloudwatch/src/log_alarms.rs
+++ b/crates/fakecloud-cloudwatch/src/log_alarms.rs
@@ -1,0 +1,296 @@
+//! Log alarms: `PutLogAlarm` stores into the alarm store so `DescribeAlarms`
+//! returns them under `<LogAlarms>` when `AlarmTypes` asks for `LogAlarm`, and
+//! `DeleteAlarms` removes them alongside metric and composite alarms.
+//!
+//! A log alarm evaluates the results of a service-managed CloudWatch Logs
+//! scheduled query against a threshold. fakecloud does not run the query on a
+//! schedule, so a fresh alarm sits in `INSUFFICIENT_DATA` — the same state a
+//! real alarm holds until its first evaluation lands — and `SetAlarmState`
+//! drives it from there.
+
+use chrono::Utc;
+use http::StatusCode;
+
+use fakecloud_core::query::{optional_query_param, required_query_param};
+use fakecloud_core::service::{AwsRequest, AwsResponse, AwsServiceError};
+
+use crate::service::{
+    collect_member_values, empty_metadata_response, validate_len, xml_escape, CloudWatchService,
+};
+use crate::state::{AlarmState, LogAlarm};
+
+/// `ComparisonOperator` as modeled for log alarms — the metric-alarm set plus
+/// the three range operators.
+pub(crate) const COMPARISON_OPERATORS: &[&str] = &[
+    "GreaterThanOrEqualToThreshold",
+    "GreaterThanThreshold",
+    "LessThanThreshold",
+    "LessThanOrEqualToThreshold",
+    "LessThanLowerOrGreaterThanUpperThreshold",
+    "LessThanLowerThreshold",
+    "GreaterThanUpperThreshold",
+];
+
+fn validation(msg: impl Into<String>) -> AwsServiceError {
+    AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationError", msg)
+}
+
+/// Read a required positive integer member, rejecting a missing, non-numeric
+/// or below-minimum value. `QueryResultsToEvaluate` and `QueryResultsToAlarm`
+/// are both modeled with `min: 1`.
+fn required_positive_i64(req: &AwsRequest, key: &str) -> Result<i64, AwsServiceError> {
+    let raw = required_query_param(req, key)?;
+    let n = raw
+        .parse::<i64>()
+        .map_err(|_| validation(format!("{key} must be an integer")))?;
+    if n < 1 {
+        return Err(validation(format!("{key} must be at least 1")));
+    }
+    Ok(n)
+}
+
+impl CloudWatchService {
+    pub(crate) fn put_log_alarm(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        validate_len(req, "AlarmName", 1, 255)?;
+        validate_len(req, "AlarmDescription", 0, 1024)?;
+        let alarm_name = required_query_param(req, "AlarmName")?;
+
+        // ScheduledQueryConfiguration's required members arrive flattened.
+        let query_string = required_query_param(req, "ScheduledQueryConfiguration.QueryString")?;
+        let scheduled_query_role_arn =
+            required_query_param(req, "ScheduledQueryConfiguration.ScheduledQueryRoleARN")?;
+        let aggregation_expression =
+            required_query_param(req, "ScheduledQueryConfiguration.AggregationExpression")?;
+        // ScheduleConfiguration itself is required; its ScheduleExpression is
+        // the member that actually drives the cadence.
+        let schedule_expression = optional_query_param(
+            req,
+            "ScheduledQueryConfiguration.ScheduleConfiguration.ScheduleExpression",
+        );
+        if schedule_expression.is_none() {
+            return Err(validation(
+                "ScheduledQueryConfiguration.ScheduleConfiguration is required",
+            ));
+        }
+
+        let query_results_to_evaluate = required_positive_i64(req, "QueryResultsToEvaluate")?;
+        let query_results_to_alarm = required_positive_i64(req, "QueryResultsToAlarm")?;
+        // A log alarm cannot need more datapoints to alarm than it evaluates.
+        if query_results_to_alarm > query_results_to_evaluate {
+            return Err(validation(
+                "QueryResultsToAlarm cannot exceed QueryResultsToEvaluate",
+            ));
+        }
+
+        let threshold = required_query_param(req, "Threshold")?
+            .parse::<f64>()
+            .map_err(|_| validation("Threshold must be a number"))?;
+        let comparison_operator = required_query_param(req, "ComparisonOperator")?;
+        if !COMPARISON_OPERATORS.contains(&comparison_operator.as_str()) {
+            return Err(validation(format!(
+                "ComparisonOperator has an invalid value '{comparison_operator}'"
+            )));
+        }
+        let treat_missing_data = optional_query_param(req, "TreatMissingData");
+        if let Some(t) = &treat_missing_data {
+            if !matches!(
+                t.as_str(),
+                "breaching" | "notBreaching" | "ignore" | "missing"
+            ) {
+                return Err(validation(format!(
+                    "TreatMissingData has an invalid value '{t}'"
+                )));
+            }
+        }
+
+        let arn = format!(
+            "arn:aws:cloudwatch:{}:{}:alarm:{}",
+            req.region, req.account_id, alarm_name
+        );
+        let now = Utc::now();
+
+        let mut state = self.state.write();
+        let acct = state.get_or_create(&req.account_id);
+        let alarms = acct.log_alarms_in_mut(&req.region);
+        let existing = alarms.get(&alarm_name).cloned();
+        let alarm = LogAlarm {
+            alarm_name: alarm_name.clone(),
+            alarm_arn: arn,
+            alarm_description: optional_query_param(req, "AlarmDescription"),
+            query_string,
+            scheduled_query_role_arn,
+            schedule_expression,
+            schedule_start_time_offset: optional_query_param(
+                req,
+                "ScheduledQueryConfiguration.ScheduleConfiguration.StartTimeOffset",
+            )
+            .and_then(|s| s.parse().ok()),
+            schedule_end_time_offset: optional_query_param(
+                req,
+                "ScheduledQueryConfiguration.ScheduleConfiguration.EndTimeOffset",
+            )
+            .and_then(|s| s.parse().ok()),
+            aggregation_expression,
+            log_group_identifiers: collect_member_values(
+                req,
+                "ScheduledQueryConfiguration.LogGroupIdentifiers",
+            ),
+            query_arn: optional_query_param(req, "ScheduledQueryConfiguration.QueryARN"),
+            query_results_to_evaluate,
+            query_results_to_alarm,
+            threshold,
+            comparison_operator,
+            treat_missing_data,
+            action_log_line_count: optional_query_param(req, "ActionLogLineCount")
+                .and_then(|s| s.parse().ok()),
+            action_log_line_role_arn: optional_query_param(req, "ActionLogLineRoleArn"),
+            actions_enabled: optional_query_param(req, "ActionsEnabled")
+                .map(|s| s.eq_ignore_ascii_case("true"))
+                .unwrap_or(true),
+            ok_actions: collect_member_values(req, "OKActions"),
+            alarm_actions: collect_member_values(req, "AlarmActions"),
+            insufficient_data_actions: collect_member_values(req, "InsufficientDataActions"),
+            // An update keeps the alarm's current state; a new alarm starts
+            // unevaluated, exactly as PutCompositeAlarm does.
+            state_value: existing
+                .as_ref()
+                .map(|a| a.state_value)
+                .unwrap_or(AlarmState::InsufficientData),
+            state_reason: existing
+                .as_ref()
+                .map(|a| a.state_reason.clone())
+                .unwrap_or_else(|| "Unchecked: Initial alarm creation".to_string()),
+            state_updated_timestamp: existing
+                .as_ref()
+                .map(|a| a.state_updated_timestamp)
+                .unwrap_or(now),
+            alarm_configuration_updated_timestamp: now,
+        };
+        alarms.insert(alarm_name, alarm);
+
+        Ok(empty_metadata_response("PutLogAlarm", &req.request_id))
+    }
+}
+
+pub(crate) fn render_log_alarm(alarm: &LogAlarm) -> String {
+    let mut s = String::from("<member>");
+    s.push_str(&format!(
+        "<AlarmName>{}</AlarmName>",
+        xml_escape(&alarm.alarm_name)
+    ));
+    s.push_str(&format!(
+        "<AlarmArn>{}</AlarmArn>",
+        xml_escape(&alarm.alarm_arn)
+    ));
+    if let Some(d) = &alarm.alarm_description {
+        s.push_str(&format!(
+            "<AlarmDescription>{}</AlarmDescription>",
+            xml_escape(d)
+        ));
+    }
+    s.push_str(&format!(
+        "<AlarmConfigurationUpdatedTimestamp>{}</AlarmConfigurationUpdatedTimestamp>",
+        alarm
+            .alarm_configuration_updated_timestamp
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+    ));
+    s.push_str(&format!(
+        "<ActionsEnabled>{}</ActionsEnabled>",
+        alarm.actions_enabled
+    ));
+    for (tag, actions) in [
+        ("OKActions", &alarm.ok_actions),
+        ("AlarmActions", &alarm.alarm_actions),
+        ("InsufficientDataActions", &alarm.insufficient_data_actions),
+    ] {
+        s.push_str(&format!("<{tag}>"));
+        for a in actions {
+            s.push_str(&format!("<member>{}</member>", xml_escape(a)));
+        }
+        s.push_str(&format!("</{tag}>"));
+    }
+    s.push_str(&format!(
+        "<StateValue>{}</StateValue>",
+        alarm.state_value.as_str()
+    ));
+    s.push_str(&format!(
+        "<StateReason>{}</StateReason>",
+        xml_escape(&alarm.state_reason)
+    ));
+    s.push_str(&format!(
+        "<StateUpdatedTimestamp>{}</StateUpdatedTimestamp>",
+        alarm
+            .state_updated_timestamp
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+    ));
+
+    s.push_str("<ScheduledQueryConfiguration>");
+    s.push_str(&format!(
+        "<QueryString>{}</QueryString>",
+        xml_escape(&alarm.query_string)
+    ));
+    s.push_str(&format!(
+        "<ScheduledQueryRoleARN>{}</ScheduledQueryRoleARN>",
+        xml_escape(&alarm.scheduled_query_role_arn)
+    ));
+    s.push_str(&format!(
+        "<AggregationExpression>{}</AggregationExpression>",
+        xml_escape(&alarm.aggregation_expression)
+    ));
+    if let Some(q) = &alarm.query_arn {
+        s.push_str(&format!("<QueryARN>{}</QueryARN>", xml_escape(q)));
+    }
+    if !alarm.log_group_identifiers.is_empty() {
+        s.push_str("<LogGroupIdentifiers>");
+        for g in &alarm.log_group_identifiers {
+            s.push_str(&format!("<member>{}</member>", xml_escape(g)));
+        }
+        s.push_str("</LogGroupIdentifiers>");
+    }
+    s.push_str("<ScheduleConfiguration>");
+    if let Some(e) = &alarm.schedule_expression {
+        s.push_str(&format!(
+            "<ScheduleExpression>{}</ScheduleExpression>",
+            xml_escape(e)
+        ));
+    }
+    if let Some(o) = alarm.schedule_start_time_offset {
+        s.push_str(&format!("<StartTimeOffset>{o}</StartTimeOffset>"));
+    }
+    if let Some(o) = alarm.schedule_end_time_offset {
+        s.push_str(&format!("<EndTimeOffset>{o}</EndTimeOffset>"));
+    }
+    s.push_str("</ScheduleConfiguration>");
+    s.push_str("</ScheduledQueryConfiguration>");
+
+    s.push_str(&format!(
+        "<QueryResultsToEvaluate>{}</QueryResultsToEvaluate>",
+        alarm.query_results_to_evaluate
+    ));
+    s.push_str(&format!(
+        "<QueryResultsToAlarm>{}</QueryResultsToAlarm>",
+        alarm.query_results_to_alarm
+    ));
+    s.push_str(&format!("<Threshold>{}</Threshold>", alarm.threshold));
+    s.push_str(&format!(
+        "<ComparisonOperator>{}</ComparisonOperator>",
+        xml_escape(&alarm.comparison_operator)
+    ));
+    if let Some(t) = &alarm.treat_missing_data {
+        s.push_str(&format!(
+            "<TreatMissingData>{}</TreatMissingData>",
+            xml_escape(t)
+        ));
+    }
+    if let Some(c) = alarm.action_log_line_count {
+        s.push_str(&format!("<ActionLogLineCount>{c}</ActionLogLineCount>"));
+    }
+    if let Some(r) = &alarm.action_log_line_role_arn {
+        s.push_str(&format!(
+            "<ActionLogLineRoleArn>{}</ActionLogLineRoleArn>",
+            xml_escape(r)
+        ));
+    }
+    s.push_str("</member>");
+    s
+}

--- a/crates/fakecloud-cloudwatch/src/service.rs
+++ b/crates/fakecloud-cloudwatch/src/service.rs
@@ -94,6 +94,7 @@ const SUPPORTED_ACTIONS: &[&str] = &[
     "StopMetricStreams",
     // Composite alarms.
     "PutCompositeAlarm",
+    "PutLogAlarm",
     // Mute rules.
     "PutAlarmMuteRule",
     "GetAlarmMuteRule",
@@ -235,6 +236,7 @@ impl AwsService for CloudWatchService {
                 | "StartMetricStreams"
                 | "StopMetricStreams"
                 | "PutCompositeAlarm"
+                | "PutLogAlarm"
                 | "PutAlarmMuteRule"
                 | "DeleteAlarmMuteRule"
                 | "StartOTelEnrichment"
@@ -283,6 +285,7 @@ impl AwsService for CloudWatchService {
             "StopMetricStreams" => self.stop_metric_streams(&req),
             // Composite alarms.
             "PutCompositeAlarm" => self.put_composite_alarm(&req),
+            "PutLogAlarm" => self.put_log_alarm(&req),
             // Mute rules.
             "PutAlarmMuteRule" => self.put_alarm_mute_rule(&req),
             "GetAlarmMuteRule" => self.get_alarm_mute_rule(&req),
@@ -332,6 +335,16 @@ pub(crate) fn xml_response(action: &str, inner: &str, request_id: &str) -> AwsRe
         StatusCode::OK,
         query_response_xml(action, NS, inner, request_id),
     )
+}
+
+/// Which alarm list a rendered body belongs in. DescribeAlarms pages across
+/// all three kinds together, then buckets the page into its three output
+/// members.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AlarmKind {
+    Metric,
+    Composite,
+    Log,
 }
 
 pub(crate) fn empty_metadata_response(action: &str, request_id: &str) -> AwsResponse {
@@ -1526,7 +1539,7 @@ impl CloudWatchService {
         // CompositeAlarm). Absent -> metric alarms only.
         let alarm_types = collect_member_values(req, "AlarmTypes");
         for t in &alarm_types {
-            if t != "MetricAlarm" && t != "CompositeAlarm" {
+            if !matches!(t.as_str(), "MetricAlarm" | "CompositeAlarm" | "LogAlarm") {
                 return Err(invalid_param(format!(
                     "AlarmTypes has an invalid value '{t}'"
                 )));
@@ -1534,6 +1547,7 @@ impl CloudWatchService {
         }
         let want_metric = alarm_types.is_empty() || alarm_types.iter().any(|t| t == "MetricAlarm");
         let want_composite = alarm_types.iter().any(|t| t == "CompositeAlarm");
+        let want_log = alarm_types.iter().any(|t| t == "LogAlarm");
         validate_len(req, "AlarmNamePrefix", 1, 255)?;
         validate_len(req, "ActionPrefix", 1, 1024)?;
         validate_len(req, "ChildrenOfAlarmName", 1, 255)?;
@@ -1587,7 +1601,7 @@ impl CloudWatchService {
         if let Some(acct) = state.accounts.get_mut(&req.account_id) {
             crate::alarm_eval::evaluate_alarms(acct, &req.region, Utc::now());
         }
-        let mut combined: Vec<(bool, String)> = Vec::new();
+        let mut combined: Vec<(AlarmKind, String)> = Vec::new();
         if let Some(acct) = state.get(&req.account_id) {
             if want_metric {
                 if let Some(alarms) = acct.alarms_in(&req.region) {
@@ -1601,7 +1615,7 @@ impl CloudWatchService {
                                 &alarm.insufficient_data_actions,
                             ],
                         ) {
-                            combined.push((false, render_alarm(alarm)));
+                            combined.push((AlarmKind::Metric, render_alarm(alarm)));
                         }
                     }
                 }
@@ -1619,30 +1633,50 @@ impl CloudWatchService {
                             ],
                         ) {
                             combined.push((
-                                true,
+                                AlarmKind::Composite,
                                 crate::composite_alarms::render_composite_alarm(alarm),
                             ));
                         }
                     }
                 }
             }
+
+            if want_log {
+                if let Some(log_alarms) = acct.log_alarms_in(&req.region) {
+                    for alarm in log_alarms.values() {
+                        if matches(
+                            &alarm.alarm_name,
+                            alarm.state_value.as_str(),
+                            [
+                                &alarm.alarm_actions,
+                                &alarm.ok_actions,
+                                &alarm.insufficient_data_actions,
+                            ],
+                        ) {
+                            combined
+                                .push((AlarmKind::Log, crate::log_alarms::render_log_alarm(alarm)));
+                        }
+                    }
+                }
+            }
         }
 
-        let page: Vec<&(bool, String)> = combined.iter().skip(offset).take(max_records).collect();
-        let mut inner = String::from("<MetricAlarms>");
-        for (is_composite, body) in &page {
-            if !*is_composite {
-                inner.push_str(body);
+        let page: Vec<&(AlarmKind, String)> =
+            combined.iter().skip(offset).take(max_records).collect();
+        let mut inner = String::new();
+        for (tag, kind) in [
+            ("MetricAlarms", AlarmKind::Metric),
+            ("CompositeAlarms", AlarmKind::Composite),
+            ("LogAlarms", AlarmKind::Log),
+        ] {
+            inner.push_str(&format!("<{tag}>"));
+            for (k, body) in &page {
+                if *k == kind {
+                    inner.push_str(body);
+                }
             }
+            inner.push_str(&format!("</{tag}>"));
         }
-        inner.push_str("</MetricAlarms>");
-        inner.push_str("<CompositeAlarms>");
-        for (is_composite, body) in &page {
-            if *is_composite {
-                inner.push_str(body);
-            }
-        }
-        inner.push_str("</CompositeAlarms>");
         if offset + max_records < combined.len() {
             inner.push_str(&format!(
                 "<NextToken>{}</NextToken>",
@@ -1720,6 +1754,7 @@ impl CloudWatchService {
         for name in &names {
             acct.alarms_in_mut(&req.region).remove(name);
             acct.composite_alarms_in_mut(&req.region).remove(name);
+            acct.log_alarms_in_mut(&req.region).remove(name);
             // Alarm history is tied to the alarm; AWS drops it when the alarm
             // is deleted, so clear it here rather than orphan stale items.
             acct.alarm_history_in_mut(&req.region).remove(name);
@@ -1786,34 +1821,41 @@ impl CloudWatchService {
         let now = Utc::now();
         let mut state = self.state.write();
         let acct = state.get_or_create(&req.account_id);
-        // SetAlarmState can target a metric alarm or a composite alarm; look up
-        // the metric store first, then fall back to the composite store.
-        let (old_state, alarm_type) =
-            if let Some(alarm) = acct.alarms_in_mut(&req.region).get_mut(&alarm_name) {
-                let old = alarm.state_value.as_str().to_string();
-                alarm.state_value = new_state;
-                alarm.state_reason = state_reason.clone();
-                alarm.state_updated_timestamp = now;
-                // Mark this as a manual override so a later evaluation with no
-                // datapoints keeps it rather than resetting to INSUFFICIENT_DATA.
-                alarm.state_manually_set = true;
-                (old, "MetricAlarm")
-            } else if let Some(composite) = acct
-                .composite_alarms_in_mut(&req.region)
-                .get_mut(&alarm_name)
-            {
-                let old = composite.state_value.as_str().to_string();
-                composite.state_value = new_state;
-                composite.state_reason = state_reason.clone();
-                composite.state_updated_timestamp = now;
-                (old, "CompositeAlarm")
-            } else {
-                return Err(AwsServiceError::aws_error(
-                    StatusCode::NOT_FOUND,
-                    "ResourceNotFound",
-                    format!("Alarm {alarm_name} not found"),
-                ));
-            };
+        // SetAlarmState can target a metric, composite or log alarm; look up
+        // the metric store first, then fall back to the other two.
+        let (old_state, alarm_type) = if let Some(alarm) =
+            acct.alarms_in_mut(&req.region).get_mut(&alarm_name)
+        {
+            let old = alarm.state_value.as_str().to_string();
+            alarm.state_value = new_state;
+            alarm.state_reason = state_reason.clone();
+            alarm.state_updated_timestamp = now;
+            // Mark this as a manual override so a later evaluation with no
+            // datapoints keeps it rather than resetting to INSUFFICIENT_DATA.
+            alarm.state_manually_set = true;
+            (old, "MetricAlarm")
+        } else if let Some(composite) = acct
+            .composite_alarms_in_mut(&req.region)
+            .get_mut(&alarm_name)
+        {
+            let old = composite.state_value.as_str().to_string();
+            composite.state_value = new_state;
+            composite.state_reason = state_reason.clone();
+            composite.state_updated_timestamp = now;
+            (old, "CompositeAlarm")
+        } else if let Some(log_alarm) = acct.log_alarms_in_mut(&req.region).get_mut(&alarm_name) {
+            let old = log_alarm.state_value.as_str().to_string();
+            log_alarm.state_value = new_state;
+            log_alarm.state_reason = state_reason.clone();
+            log_alarm.state_updated_timestamp = now;
+            (old, "LogAlarm")
+        } else {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::NOT_FOUND,
+                "ResourceNotFound",
+                format!("Alarm {alarm_name} not found"),
+            ));
+        };
 
         let new_state_str = new_state.as_str().to_string();
         let summary = format!("Alarm updated from {old_state} to {new_state_str}");

--- a/crates/fakecloud-cloudwatch/src/state.rs
+++ b/crates/fakecloud-cloudwatch/src/state.rs
@@ -57,6 +57,9 @@ pub struct CloudWatchState {
     /// region -> alarm_name -> CompositeAlarm
     #[serde(default)]
     pub composite_alarms: BTreeMap<String, BTreeMap<String, CompositeAlarm>>,
+    /// region -> alarm_name -> LogAlarm
+    #[serde(default)]
+    pub log_alarms: BTreeMap<String, BTreeMap<String, LogAlarm>>,
     /// region -> alarm_name -> history items (newest appended last). Populated
     /// by PutMetricAlarm (ConfigurationUpdate), SetAlarmState (StateUpdate) and
     /// DeleteAlarms so DescribeAlarmHistory reflects real transitions.
@@ -144,6 +147,14 @@ impl CloudWatchState {
         region: &str,
     ) -> &mut BTreeMap<String, CompositeAlarm> {
         self.composite_alarms.entry(region.to_string()).or_default()
+    }
+
+    pub fn log_alarms_in(&self, region: &str) -> Option<&BTreeMap<String, LogAlarm>> {
+        self.log_alarms.get(region)
+    }
+
+    pub fn log_alarms_in_mut(&mut self, region: &str) -> &mut BTreeMap<String, LogAlarm> {
+        self.log_alarms.entry(region.to_string()).or_default()
     }
 
     pub fn alarm_history_in(
@@ -374,6 +385,40 @@ pub struct CompositeAlarm {
     pub actions_suppressor: Option<String>,
     pub actions_suppressor_wait_period: Option<i64>,
     pub actions_suppressor_extension_period: Option<i64>,
+    pub state_value: AlarmState,
+    pub state_reason: String,
+    pub state_updated_timestamp: DateTime<Utc>,
+    pub alarm_configuration_updated_timestamp: DateTime<Utc>,
+}
+
+/// A log alarm: evaluates a scheduled CloudWatch Logs query's results against
+/// a threshold. The scheduled query itself is service-managed, so the
+/// configuration is stored verbatim and echoed back on describe.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogAlarm {
+    pub alarm_name: String,
+    pub alarm_arn: String,
+    pub alarm_description: Option<String>,
+    /// The `ScheduledQueryConfiguration` members, stored as supplied.
+    pub query_string: String,
+    pub scheduled_query_role_arn: String,
+    pub schedule_expression: Option<String>,
+    pub schedule_start_time_offset: Option<i64>,
+    pub schedule_end_time_offset: Option<i64>,
+    pub aggregation_expression: String,
+    pub log_group_identifiers: Vec<String>,
+    pub query_arn: Option<String>,
+    pub query_results_to_evaluate: i64,
+    pub query_results_to_alarm: i64,
+    pub threshold: f64,
+    pub comparison_operator: String,
+    pub treat_missing_data: Option<String>,
+    pub action_log_line_count: Option<i64>,
+    pub action_log_line_role_arn: Option<String>,
+    pub actions_enabled: bool,
+    pub ok_actions: Vec<String>,
+    pub alarm_actions: Vec<String>,
+    pub insufficient_data_actions: Vec<String>,
     pub state_value: AlarmState,
     pub state_reason: String,
     pub state_updated_timestamp: DateTime<Utc>,

--- a/crates/fakecloud-cloudwatch/src/tests.rs
+++ b/crates/fakecloud-cloudwatch/src/tests.rs
@@ -1268,3 +1268,223 @@ async fn put_anomaly_detector_persists_configuration() {
     assert!(xml.contains("<StartTime>2020-01-01T00:00:00Z</StartTime>"));
     assert!(xml.contains("<PeriodicSpikes>true</PeriodicSpikes>"));
 }
+
+// ---------------------------------------------------------------------
+// Log alarms
+// ---------------------------------------------------------------------
+
+fn log_alarm_params<'a>(name: &'a str, extra: &[(&'a str, &'a str)]) -> Vec<(&'a str, &'a str)> {
+    let mut p: Vec<(&str, &str)> = vec![
+        ("AlarmName", name),
+        (
+            "ScheduledQueryConfiguration.QueryString",
+            "fields @message | filter @message like /ERROR/",
+        ),
+        (
+            "ScheduledQueryConfiguration.ScheduledQueryRoleARN",
+            "arn:aws:iam::123456789012:role/cw-query",
+        ),
+        (
+            "ScheduledQueryConfiguration.ScheduleConfiguration.ScheduleExpression",
+            "rate(5 minutes)",
+        ),
+        (
+            "ScheduledQueryConfiguration.AggregationExpression",
+            "count(*)",
+        ),
+        ("QueryResultsToEvaluate", "3"),
+        ("QueryResultsToAlarm", "2"),
+        ("Threshold", "10"),
+        ("ComparisonOperator", "GreaterThanThreshold"),
+    ];
+    p.extend_from_slice(extra);
+    p
+}
+
+#[tokio::test]
+async fn put_log_alarm_round_trips_through_describe_alarms() {
+    let svc = service();
+    call(
+        &svc,
+        "PutLogAlarm",
+        &log_alarm_params(
+            "errors-alarm",
+            &[
+                ("AlarmDescription", "too many errors"),
+                (
+                    "ScheduledQueryConfiguration.LogGroupIdentifiers.member.1",
+                    "/aws/lambda/fn",
+                ),
+                (
+                    "AlarmActions.member.1",
+                    "arn:aws:sns:us-east-1:123456789012:ops",
+                ),
+                ("TreatMissingData", "notBreaching"),
+            ],
+        ),
+    )
+    .await;
+
+    // A log alarm is only returned when AlarmTypes asks for it: the default is
+    // metric alarms only.
+    let default_body = body_of(&call(&svc, "DescribeAlarms", &[]).await);
+    assert!(!default_body.contains("errors-alarm"), "{default_body}");
+
+    let body = body_of(
+        &call(
+            &svc,
+            "DescribeAlarms",
+            &[("AlarmTypes.member.1", "LogAlarm")],
+        )
+        .await,
+    );
+    assert!(body.contains("<LogAlarms>"), "{body}");
+    assert!(
+        body.contains("<AlarmName>errors-alarm</AlarmName>"),
+        "{body}"
+    );
+    assert!(body.contains("<AlarmDescription>too many errors</AlarmDescription>"));
+    assert!(body.contains("<QueryResultsToEvaluate>3</QueryResultsToEvaluate>"));
+    assert!(body.contains("<QueryResultsToAlarm>2</QueryResultsToAlarm>"));
+    assert!(body.contains("<ComparisonOperator>GreaterThanThreshold</ComparisonOperator>"));
+    assert!(body.contains("<TreatMissingData>notBreaching</TreatMissingData>"));
+    assert!(body.contains("<ScheduleExpression>rate(5 minutes)</ScheduleExpression>"));
+    assert!(body.contains("<member>/aws/lambda/fn</member>"));
+    assert!(body.contains(
+        "<AlarmArn>arn:aws:cloudwatch:us-east-1:123456789012:alarm:errors-alarm</AlarmArn>"
+    ));
+    // A fresh alarm has not been evaluated yet.
+    assert!(body.contains("<StateValue>INSUFFICIENT_DATA</StateValue>"));
+
+    // DeleteAlarms removes it alongside metric and composite alarms.
+    call(
+        &svc,
+        "DeleteAlarms",
+        &[("AlarmNames.member.1", "errors-alarm")],
+    )
+    .await;
+    let body = body_of(
+        &call(
+            &svc,
+            "DescribeAlarms",
+            &[("AlarmTypes.member.1", "LogAlarm")],
+        )
+        .await,
+    );
+    assert!(!body.contains("errors-alarm"), "{body}");
+}
+
+#[tokio::test]
+async fn put_log_alarm_update_preserves_alarm_state() {
+    let svc = service();
+    call(&svc, "PutLogAlarm", &log_alarm_params("stateful", &[])).await;
+    call(
+        &svc,
+        "SetAlarmState",
+        &[
+            ("AlarmName", "stateful"),
+            ("StateValue", "ALARM"),
+            ("StateReason", "manual"),
+        ],
+    )
+    .await;
+
+    // Re-putting the configuration must not reset the alarm's state.
+    call(
+        &svc,
+        "PutLogAlarm",
+        &log_alarm_params("stateful", &[("Threshold", "99")]),
+    )
+    .await;
+    let body = body_of(
+        &call(
+            &svc,
+            "DescribeAlarms",
+            &[("AlarmTypes.member.1", "LogAlarm")],
+        )
+        .await,
+    );
+    assert!(body.contains("<Threshold>99</Threshold>"), "{body}");
+}
+
+#[tokio::test]
+async fn put_log_alarm_validates_required_and_bounded_members() {
+    let svc = service();
+
+    // Each required member is enforced.
+    for drop_key in [
+        "AlarmName",
+        "ScheduledQueryConfiguration.QueryString",
+        "ScheduledQueryConfiguration.ScheduledQueryRoleARN",
+        "ScheduledQueryConfiguration.ScheduleConfiguration.ScheduleExpression",
+        "ScheduledQueryConfiguration.AggregationExpression",
+        "QueryResultsToEvaluate",
+        "QueryResultsToAlarm",
+        "Threshold",
+        "ComparisonOperator",
+    ] {
+        let params: Vec<(&str, &str)> = log_alarm_params("req-check", &[])
+            .into_iter()
+            .filter(|(k, _)| *k != drop_key)
+            .collect();
+        let err = call_err(&svc, "PutLogAlarm", &params).await;
+        assert_eq!(
+            err.status().as_u16(),
+            400,
+            "missing {drop_key} should be rejected"
+        );
+    }
+
+    // QueryResultsToEvaluate / QueryResultsToAlarm are min 1, and an alarm
+    // cannot need more results to alarm than it evaluates.
+    for (k, v) in [
+        ("QueryResultsToEvaluate", "0"),
+        ("QueryResultsToAlarm", "0"),
+    ] {
+        let err = call_err(&svc, "PutLogAlarm", &log_alarm_params("bounds", &[(k, v)])).await;
+        assert_eq!(err.code(), "ValidationError", "{k}={v}");
+    }
+    let err = call_err(
+        &svc,
+        "PutLogAlarm",
+        &log_alarm_params("bounds", &[("QueryResultsToAlarm", "9")]),
+    )
+    .await;
+    assert_eq!(err.code(), "ValidationError");
+
+    // ComparisonOperator and TreatMissingData are enum-bound.
+    let err = call_err(
+        &svc,
+        "PutLogAlarm",
+        &log_alarm_params("enums", &[("ComparisonOperator", "NotAnOperator")]),
+    )
+    .await;
+    assert_eq!(err.code(), "ValidationError");
+    let err = call_err(
+        &svc,
+        "PutLogAlarm",
+        &log_alarm_params("enums", &[("TreatMissingData", "nope")]),
+    )
+    .await;
+    assert_eq!(err.code(), "ValidationError");
+}
+
+#[tokio::test]
+async fn describe_alarms_accepts_the_log_alarm_type() {
+    // `AlarmType` gained `LogAlarm`; DescribeAlarms used to reject it as an
+    // invalid AlarmTypes value.
+    let svc = service();
+    call(
+        &svc,
+        "DescribeAlarms",
+        &[("AlarmTypes.member.1", "LogAlarm")],
+    )
+    .await;
+    let err = call_err(
+        &svc,
+        "DescribeAlarms",
+        &[("AlarmTypes.member.1", "NotAnAlarmType")],
+    )
+    .await;
+    assert_eq!(err.code(), "InvalidParameterValue");
+}

--- a/crates/fakecloud-conformance/tests/cloudwatch.rs
+++ b/crates/fakecloud-conformance/tests/cloudwatch.rs
@@ -685,3 +685,50 @@ async fn cloudwatch_dataset_kms_key() {
     .await;
     assert!(!after.contains("<KmsKeyArn>"), "key not cleared: {after}");
 }
+
+/// `PutLogAlarm` is absent from the vendored aws-sdk-cloudwatch, so drive it
+/// via a raw awsQuery POST. `DescribeAlarms` reads it back through the typed
+/// client, which already knows the `LogAlarm` alarm type.
+#[test_action("monitoring", "PutLogAlarm", checksum = "bb86a83a")]
+#[tokio::test]
+async fn cloudwatch_log_alarm() {
+    let server = TestServer::start().await;
+
+    let body = concat!(
+        "Action=PutLogAlarm&Version=2010-08-01",
+        "&AlarmName=conf-log-alarm",
+        "&ScheduledQueryConfiguration.QueryString=fields%20%40message",
+        "&ScheduledQueryConfiguration.ScheduledQueryRoleARN=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fcw",
+        "&ScheduledQueryConfiguration.ScheduleConfiguration.ScheduleExpression=rate(5%20minutes)",
+        "&ScheduledQueryConfiguration.AggregationExpression=count(*)",
+        "&QueryResultsToEvaluate=3",
+        "&QueryResultsToAlarm=2",
+        "&Threshold=10",
+        "&ComparisonOperator=GreaterThanThreshold",
+    );
+    cw_raw(&server, body).await;
+
+    let described = cw_raw(
+        &server,
+        "Action=DescribeAlarms&Version=2010-08-01&AlarmTypes.member.1=LogAlarm",
+    )
+    .await;
+    assert!(
+        described.contains("<AlarmName>conf-log-alarm</AlarmName>"),
+        "{described}"
+    );
+    assert!(described.contains("<LogAlarms>"), "{described}");
+
+    // DeleteAlarms removes log alarms too.
+    cw_raw(
+        &server,
+        "Action=DeleteAlarms&Version=2010-08-01&AlarmNames.member.1=conf-log-alarm",
+    )
+    .await;
+    let described = cw_raw(
+        &server,
+        "Action=DescribeAlarms&Version=2010-08-01&AlarmTypes.member.1=LogAlarm",
+    )
+    .await;
+    assert!(!described.contains("conf-log-alarm"), "{described}");
+}


### PR DESCRIPTION
## Summary

`PutLogAlarm` was modeled but unimplemented (64 variants, all NOT_IMPLEMENTED). Implementing it surfaced two related gaps that are fixed here too.

A log alarm evaluates a service-managed CloudWatch Logs scheduled query against a threshold. fakecloud does not run the query on a schedule, so a fresh alarm sits in `INSUFFICIENT_DATA` - the state a real alarm holds until its first evaluation lands - and `SetAlarmState` drives it from there.

### Two gaps found while wiring it up

- **`DescribeAlarms` rejected `AlarmTypes=LogAlarm`.** `AlarmType` gained a third value (`CompositeAlarm`, `MetricAlarm`, `LogAlarm`) and the validation was still a two-value check - a stale enumeration turning a valid request into `InvalidParameterValue`.
- **`SetAlarmState` only knew the metric and composite stores**, so it 404'd on a log alarm. It now falls through to the log store as well, and records the transition in alarm history as `LogAlarm`.

`DescribeAlarms` returns log alarms under `<LogAlarms>` when asked for (default is still metric alarms only, as with composite), pages across all three kinds together, and buckets each page into the three output members. `DeleteAlarms` removes them alongside the other two.

### Modeled constraints enforced

Every required member including the nested `ScheduledQueryConfiguration` ones; `QueryResultsToEvaluate` / `QueryResultsToAlarm` at least 1, and the latter no greater than the former (an alarm cannot need more results to alarm than it evaluates); the `ComparisonOperator` and `TreatMissingData` enums. Re-putting a configuration preserves the alarm's state, matching `PutCompositeAlarm`.

## Tests

- `put_log_alarm_round_trips_through_describe_alarms` - full config round-trip, asserts the default DescribeAlarms does *not* return it, and that DeleteAlarms removes it.
- `put_log_alarm_update_preserves_alarm_state` - SetAlarmState then re-put; state survives, config updates.
- `put_log_alarm_validates_required_and_bounded_members` - drops each of the nine required members in turn, plus the range and enum checks.
- `describe_alarms_accepts_the_log_alarm_type` - regression for the stale `AlarmTypes` enumeration.
- Conformance: `cloudwatch_log_alarm` drives put/describe/delete over a raw awsQuery POST.
- `cargo test -p fakecloud-cloudwatch` 68 passed, `cargo build --workspace` and `clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `PutLogAlarm` and the surrounding support so log alarms work end-to-end. Previously, `PutLogAlarm` returned `NOT_IMPLEMENTED` for all 64 variants, `DescribeAlarms` rejected `AlarmTypes=LogAlarm`, and `SetAlarmState` couldn't find log alarms.

- `DescribeAlarms` now accepts `LogAlarm` in `AlarmTypes`, pages across all three alarm kinds, and returns log alarms under `<LogAlarms>` (default is still metric-only).
- `SetAlarmState` falls through to the log store and records history as `LogAlarm`; `DeleteAlarms` removes them too.
- Fresh log alarms start in `INSUFFICIENT_DATA` because the scheduled query isn't run; re-putting preserves the current state.
- Modeled constraints are enforced: all required members, `QueryResultsToEvaluate`/`QueryResultsToAlarm` bounds, and enum checks for `ComparisonOperator` and `TreatMissingData`.

<sup>Written for commit 0fea6128791b77b7cdab06a3f74180bf2c46223b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

