### PR TITLE
feat(dynamodb): implement vector indexes and SearchVectors

### DIFF
--- a/crates/fakecloud-cloudformation/src/resource_provisioner/dynamodb.rs
+++ b/crates/fakecloud-cloudformation/src/resource_provisioner/dynamodb.rs
@@ -229,6 +229,7 @@ impl ResourceProvisioner {
                 .and_then(|v| v.as_str())
                 .unwrap_or("STANDARD")
                 .to_string(),
+            vector_indexes: Vec::new(),
         };
 
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-conformance/tests/dynamodb.rs
+++ b/crates/fakecloud-conformance/tests/dynamodb.rs
@@ -1650,3 +1650,85 @@ async fn dynamodb_get_item_nonexistent_table_returns_error() {
         .await;
     assert!(result.is_err(), "GetItem on nonexistent table should fail");
 }
+
+/// Vector indexes and similarity search. The vendored `aws-sdk-dynamodb`
+/// predates `SearchVectors` and the `VectorIndexes` members, so drive them
+/// over a raw awsJson1.0 POST.
+#[test_action("dynamodb", "SearchVectors", checksum = "6cbe2a90")]
+#[tokio::test]
+async fn dynamodb_vector_search() {
+    let server = TestServer::start().await;
+    let auth = "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/dynamodb/aws4_request, SignedHeaders=host, Signature=0";
+    let http = reqwest::Client::new();
+    let call = |target: &str, body: String| {
+        let url = server.endpoint().to_string();
+        let target = format!("DynamoDB_20120810.{target}");
+        let http = http.clone();
+        async move {
+            let resp = http
+                .post(&url)
+                .header("Authorization", auth)
+                .header("X-Amz-Target", target)
+                .header("Content-Type", "application/x-amz-json-1.0")
+                .body(body)
+                .send()
+                .await
+                .unwrap();
+            assert!(resp.status().is_success(), "status {}", resp.status());
+            resp.json::<serde_json::Value>().await.unwrap()
+        }
+    };
+
+    let created = call(
+        "CreateTable",
+        serde_json::json!({
+            "TableName": "conf-vectors",
+            "KeySchema": [{ "AttributeName": "pk", "KeyType": "HASH" }],
+            "AttributeDefinitions": [{ "AttributeName": "pk", "AttributeType": "S" }],
+            "BillingMode": "PAY_PER_REQUEST",
+            "VectorIndexes": [{
+                "IndexName": "emb",
+                "VectorAttribute": { "AttributeName": "embedding" },
+                "Dimensions": 2,
+                "DistanceFunction": "COSINE",
+                "Projection": { "ProjectionType": "ALL" },
+            }],
+        })
+        .to_string(),
+    )
+    .await;
+    assert_eq!(
+        created["TableDescription"]["VectorIndexes"][0]["IndexName"],
+        "emb"
+    );
+
+    for (pk, x, y) in [("near", "1", "0"), ("far", "-1", "0")] {
+        call(
+            "PutItem",
+            serde_json::json!({
+                "TableName": "conf-vectors",
+                "Item": {
+                    "pk": { "S": pk },
+                    "embedding": { "L": [{ "N": x }, { "N": y }] },
+                },
+            })
+            .to_string(),
+        )
+        .await;
+    }
+
+    let searched = call(
+        "SearchVectors",
+        serde_json::json!({
+            "TableName": "conf-vectors",
+            "IndexName": "emb",
+            "SearchVector": [{ "N": "1" }, { "N": "0" }],
+            "TopK": 1,
+        })
+        .to_string(),
+    )
+    .await;
+    let results = searched["SearchResults"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["Item"]["pk"]["S"], "near");
+}

--- a/crates/fakecloud-dynamodb/src/export_import.rs
+++ b/crates/fakecloud-dynamodb/src/export_import.rs
@@ -308,6 +308,7 @@ fn build_table(
         deletion_protection_enabled: false,
         on_demand_throughput: None,
         table_class: "STANDARD".to_string(),
+        vector_indexes: Vec::new(),
     };
     table.recalculate_stats(); // fills item_count / size_bytes
     Ok(table)

--- a/crates/fakecloud-dynamodb/src/service/batch.rs
+++ b/crates/fakecloud-dynamodb/src/service/batch.rs
@@ -1772,6 +1772,7 @@ mod tests {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         };
         s.tables.insert(name.to_string(), table);
     }

--- a/crates/fakecloud-dynamodb/src/service/helpers/schemas.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/schemas.rs
@@ -245,6 +245,81 @@ pub(crate) fn parse_expression_attribute_values(body: &Value) -> HashMap<String,
     values
 }
 
+/// `VectorDistanceFunction` values.
+pub const VECTOR_DISTANCE_FUNCTIONS: &[&str] = &["COSINE", "DOT_PRODUCT", "EUCLIDEAN"];
+
+/// Parse a `VectorIndexes` list (CreateTable) or a `Create` action body
+/// (UpdateTable) into stored indexes. `table_arn` seeds each `IndexArn`.
+pub fn parse_vector_indexes(
+    val: &Value,
+    table_arn: &str,
+) -> Result<Vec<VectorIndex>, AwsServiceError> {
+    let Some(arr) = val.as_array() else {
+        return Ok(Vec::new());
+    };
+    arr.iter()
+        .map(|v| parse_vector_index(v, table_arn))
+        .collect()
+}
+
+pub fn parse_vector_index(v: &Value, table_arn: &str) -> Result<VectorIndex, AwsServiceError> {
+    let invalid = |msg: String| {
+        AwsServiceError::aws_error(StatusCode::BAD_REQUEST, "ValidationException", msg)
+    };
+    let index_name = v["IndexName"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| invalid("VectorIndex.IndexName is required".to_string()))?
+        .to_string();
+    let vector_attribute = v["VectorAttribute"]["AttributeName"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            invalid("VectorIndex.VectorAttribute.AttributeName is required".to_string())
+        })?
+        .to_string();
+    let dimensions = v["Dimensions"]
+        .as_i64()
+        .filter(|d| *d > 0)
+        .ok_or_else(|| invalid("VectorIndex.Dimensions must be a positive integer".to_string()))?;
+    let distance_function = v["DistanceFunction"]
+        .as_str()
+        .unwrap_or("COSINE")
+        .to_string();
+    if !VECTOR_DISTANCE_FUNCTIONS.contains(&distance_function.as_str()) {
+        return Err(invalid(format!(
+            "VectorIndex.DistanceFunction has an invalid value '{distance_function}'"
+        )));
+    }
+    let search_schema = v["SearchSchema"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| {
+                    Some((
+                        e["AttributeName"].as_str()?.to_string(),
+                        e["SearchSchemaElementType"]
+                            .as_str()
+                            .unwrap_or("FILTERABLE")
+                            .to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(VectorIndex {
+        index_arn: format!("{table_arn}/vector-index/{index_name}"),
+        index_name,
+        vector_attribute,
+        dimensions,
+        distance_function,
+        search_schema,
+        projection: parse_projection(&v["Projection"]),
+        // Creation is synchronous here, so the index is queryable immediately.
+        status: "ACTIVE".to_string(),
+    })
+}
+
 #[cfg(test)]
 mod schema_validation_tests {
     use super::*;

--- a/crates/fakecloud-dynamodb/src/service/helpers/table_descriptions.rs
+++ b/crates/fakecloud-dynamodb/src/service/helpers/table_descriptions.rs
@@ -210,5 +210,44 @@ pub(crate) fn build_table_description(table: &DynamoTable) -> Value {
     // falls back to STANDARD when absent.
     desc["TableClassSummary"] = json!({ "TableClass": table.table_class });
 
+    // Vector indexes are only present once the table declares one, matching
+    // the way AWS omits an empty index list rather than returning `[]`.
+    if !table.vector_indexes.is_empty() {
+        desc["VectorIndexes"] = Value::Array(
+            table
+                .vector_indexes
+                .iter()
+                .map(build_vector_index_description)
+                .collect(),
+        );
+    }
+
     desc
+}
+
+/// Project a stored [`VectorIndex`] into a `VectorIndexDescription`.
+pub(crate) fn build_vector_index_description(idx: &VectorIndex) -> Value {
+    json!({
+        "IndexName": idx.index_name,
+        "IndexArn": idx.index_arn,
+        "IndexStatus": idx.status,
+        "Backfilling": false,
+        "ItemCount": 0,
+        "IndexSizeBytes": 0,
+        "Dimensions": idx.dimensions,
+        "DistanceFunction": idx.distance_function,
+        "VectorAttribute": { "AttributeName": idx.vector_attribute },
+        "SearchSchema": idx
+            .search_schema
+            .iter()
+            .map(|(name, kind)| json!({
+                "AttributeName": name,
+                "SearchSchemaElementType": kind,
+            }))
+            .collect::<Vec<Value>>(),
+        "Projection": {
+            "ProjectionType": idx.projection.projection_type,
+            "NonKeyAttributes": idx.projection.non_key_attributes,
+        },
+    })
 }

--- a/crates/fakecloud-dynamodb/src/service/items.rs
+++ b/crates/fakecloud-dynamodb/src/service/items.rs
@@ -829,6 +829,7 @@ mod tests {
                     deletion_protection_enabled: false,
                     on_demand_throughput: None,
                     table_class: "STANDARD".into(),
+                    vector_indexes: Vec::new(),
                 },
             );
         }

--- a/crates/fakecloud-dynamodb/src/service/mod.rs
+++ b/crates/fakecloud-dynamodb/src/service/mod.rs
@@ -6,6 +6,7 @@ mod items;
 mod queries;
 mod streams;
 mod tables;
+mod vectors;
 
 use std::collections::HashMap;
 use std::io;
@@ -465,6 +466,7 @@ impl AwsService for DynamoDbService {
             "DeleteItem" => self.delete_item(&req),
             "UpdateItem" => self.update_item(&req),
             "Query" => self.query(&req),
+            "SearchVectors" => self.search_vectors(&req),
             "Scan" => self.scan(&req),
             "BatchGetItem" => self.batch_get_item(&req),
             "BatchWriteItem" => self.batch_write_item(&req),
@@ -548,6 +550,7 @@ impl AwsService for DynamoDbService {
             "UpdateItem",
             "Query",
             "Scan",
+            "SearchVectors",
             "BatchGetItem",
             "BatchWriteItem",
             "TagResource",

--- a/crates/fakecloud-dynamodb/src/service/queries.rs
+++ b/crates/fakecloud-dynamodb/src/service/queries.rs
@@ -974,6 +974,7 @@ mod tests {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         };
         s.tables.insert(name.to_string(), table);
     }

--- a/crates/fakecloud-dynamodb/src/service/tables.rs
+++ b/crates/fakecloud-dynamodb/src/service/tables.rs
@@ -14,7 +14,7 @@ use crate::state::{
     ProvisionedThroughput,
 };
 
-use super::parse_projection;
+use super::{parse_projection, parse_vector_index, parse_vector_indexes};
 
 use super::{
     build_table_description, build_table_description_json, find_table_by_arn,
@@ -248,6 +248,7 @@ impl DynamoDbService {
             deletion_protection_enabled,
             on_demand_throughput: on_demand_throughput.clone(),
             table_class,
+            vector_indexes: parse_vector_indexes(&body["VectorIndexes"], &arn)?,
         };
 
         // Build the response from the inserted table so CreateTable returns
@@ -450,6 +451,25 @@ impl DynamoDbService {
         // Handle GlobalSecondaryIndexUpdates: a list of {Create, Update, Delete}
         // operations. Real AWS supports all three; fakecloud now mirrors the
         // semantics so Terraform's `aws_dynamodb_table` GSI lifecycle works.
+        // Vector index updates: Create adds (or replaces) an index, Delete
+        // removes one. Same Create/Delete shape as the GSI updates below.
+        if let Some(updates) = body.get("VectorIndexUpdates").and_then(|v| v.as_array()) {
+            let table_arn = table.arn.clone();
+            for op in updates {
+                if let Some(create) = op.get("Create") {
+                    let index = parse_vector_index(create, &table_arn)?;
+                    table
+                        .vector_indexes
+                        .retain(|i| i.index_name != index.index_name);
+                    table.vector_indexes.push(index);
+                }
+                if let Some(delete) = op.get("Delete") {
+                    if let Some(name) = delete.get("IndexName").and_then(|v| v.as_str()) {
+                        table.vector_indexes.retain(|i| i.index_name != name);
+                    }
+                }
+            }
+        }
         if let Some(updates) = body
             .get("GlobalSecondaryIndexUpdates")
             .and_then(|v| v.as_array())
@@ -1145,6 +1165,7 @@ impl DynamoDbService {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         };
         table.recalculate_stats();
 
@@ -1250,6 +1271,7 @@ impl DynamoDbService {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         };
         table.recalculate_stats();
 
@@ -1776,6 +1798,7 @@ impl DynamoDbService {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         };
         table.recalculate_stats();
         state.tables.insert(table_name.to_string(), table);

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5715,8 +5715,18 @@ fn set_arithmetic_on_missing_operand_errors() {
 // Vector indexes and SearchVectors
 // ---------------------------------------------------------------------
 
+/// An item attribute holding a vector: a DynamoDB `L` of `N`.
 fn vec_attr(values: &[f64]) -> Value {
     json!({ "L": values.iter().map(|v| json!({ "N": v.to_string() })).collect::<Vec<Value>>() })
+}
+
+/// A request `SearchVector`: `SearchVectorList` is a bare list of
+/// `AttributeValue`, not an `L`-wrapped attribute.
+fn search_vec(values: &[f64]) -> Value {
+    json!(values
+        .iter()
+        .map(|v| json!({ "N": v.to_string() }))
+        .collect::<Vec<Value>>())
 }
 
 fn create_vector_table(svc: &DynamoDbService, distance_function: &str) {
@@ -5866,7 +5876,7 @@ fn search_vectors_ranks_by_cosine_similarity() {
         json!({
             "TableName": "vec-table",
             "IndexName": "embedding-index",
-            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "SearchVector": search_vec(&[1.0, 0.0]),
             "TopK": 2,
         }),
     );
@@ -5891,7 +5901,7 @@ fn search_vectors_ranks_euclidean_nearest_first() {
         json!({
             "TableName": "vec-table",
             "IndexName": "embedding-index",
-            "SearchVector": vec_attr(&[0.0, 0.0]),
+            "SearchVector": search_vec(&[0.0, 0.0]),
             "TopK": 5,
         }),
     );
@@ -5920,7 +5930,7 @@ fn search_vectors_skips_items_without_a_usable_vector() {
         json!({
             "TableName": "vec-table",
             "IndexName": "embedding-index",
-            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "SearchVector": search_vec(&[1.0, 0.0]),
             "TopK": 10,
         }),
     );
@@ -5940,7 +5950,7 @@ fn search_vectors_honors_projection_and_consumed_capacity() {
         json!({
             "TableName": "vec-table",
             "IndexName": "embedding-index",
-            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "SearchVector": search_vec(&[1.0, 0.0]),
             "TopK": 1,
             "ProjectionExpression": "pk",
             "ReturnConsumedCapacity": "TOTAL",
@@ -5970,7 +5980,7 @@ fn search_vectors_validates_index_and_vector() {
         json!({
             "TableName": "vec-table",
             "IndexName": "no-such-index",
-            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "SearchVector": search_vec(&[1.0, 0.0]),
             "TopK": 1,
         }),
     )));
@@ -5982,7 +5992,7 @@ fn search_vectors_validates_index_and_vector() {
         json!({
             "TableName": "vec-table",
             "IndexName": "embedding-index",
-            "SearchVector": vec_attr(&[1.0, 0.0, 0.0]),
+            "SearchVector": search_vec(&[1.0, 0.0, 0.0]),
             "TopK": 1,
         }),
     )));
@@ -5993,7 +6003,7 @@ fn search_vectors_validates_index_and_vector() {
         let mut body = json!({
             "TableName": "vec-table",
             "IndexName": "embedding-index",
-            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "SearchVector": search_vec(&[1.0, 0.0]),
         });
         if !top_k.is_null() {
             body["TopK"] = top_k;

--- a/crates/fakecloud-dynamodb/src/service/tests.rs
+++ b/crates/fakecloud-dynamodb/src/service/tests.rs
@@ -5710,3 +5710,319 @@ fn set_arithmetic_on_missing_operand_errors() {
     let ok = evaluate_arithmetic_rhs("a", ":v", true, &item, &names, &values);
     assert!(ok.is_ok());
 }
+
+// ---------------------------------------------------------------------
+// Vector indexes and SearchVectors
+// ---------------------------------------------------------------------
+
+fn vec_attr(values: &[f64]) -> Value {
+    json!({ "L": values.iter().map(|v| json!({ "N": v.to_string() })).collect::<Vec<Value>>() })
+}
+
+fn create_vector_table(svc: &DynamoDbService, distance_function: &str) {
+    let req = make_request(
+        "CreateTable",
+        json!({
+            "TableName": "vec-table",
+            "KeySchema": [{ "AttributeName": "pk", "KeyType": "HASH" }],
+            "AttributeDefinitions": [{ "AttributeName": "pk", "AttributeType": "S" }],
+            "BillingMode": "PAY_PER_REQUEST",
+            "VectorIndexes": [{
+                "IndexName": "embedding-index",
+                "VectorAttribute": { "AttributeName": "embedding" },
+                "Dimensions": 2,
+                "DistanceFunction": distance_function,
+                "SearchSchema": [{ "AttributeName": "pk", "SearchSchemaElementType": "FILTERABLE" }],
+                "Projection": { "ProjectionType": "ALL" },
+            }],
+        }),
+    );
+    svc.create_table(&req).unwrap();
+}
+
+fn put_vector_item(svc: &DynamoDbService, pk: &str, embedding: &[f64]) {
+    let req = make_request(
+        "PutItem",
+        json!({
+            "TableName": "vec-table",
+            "Item": { "pk": { "S": pk }, "embedding": vec_attr(embedding) },
+        }),
+    );
+    svc.put_item(&req).unwrap();
+}
+
+/// `AwsResponse` isn't `Debug`, so `unwrap_err` can't be used directly.
+fn err_of(r: Result<AwsResponse, AwsServiceError>) -> AwsServiceError {
+    match r {
+        Ok(_) => panic!("expected an error"),
+        Err(e) => e,
+    }
+}
+
+fn search(svc: &DynamoDbService, body: Value) -> Value {
+    let resp = svc
+        .search_vectors(&make_request("SearchVectors", body))
+        .unwrap();
+    serde_json::from_slice(resp.body.expect_bytes()).unwrap()
+}
+
+#[test]
+fn create_table_stores_vector_indexes_and_describe_returns_them() {
+    let svc = make_service();
+    create_vector_table(&svc, "COSINE");
+
+    let resp = svc
+        .describe_table(&make_request(
+            "DescribeTable",
+            json!({ "TableName": "vec-table" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    let idx = &body["Table"]["VectorIndexes"][0];
+    assert_eq!(idx["IndexName"], "embedding-index");
+    assert_eq!(idx["Dimensions"], 2);
+    assert_eq!(idx["DistanceFunction"], "COSINE");
+    assert_eq!(idx["VectorAttribute"]["AttributeName"], "embedding");
+    assert_eq!(idx["IndexStatus"], "ACTIVE");
+    assert_eq!(idx["SearchSchema"][0]["AttributeName"], "pk");
+    assert!(idx["IndexArn"]
+        .as_str()
+        .unwrap()
+        .ends_with("/vector-index/embedding-index"));
+
+    // A table with no vector index omits the member rather than sending [].
+    create_test_table(&svc);
+    let resp = svc
+        .describe_table(&make_request(
+            "DescribeTable",
+            json!({ "TableName": "test-table" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(body["Table"].get("VectorIndexes").is_none());
+}
+
+#[test]
+fn update_table_creates_and_deletes_vector_indexes() {
+    let svc = make_service();
+    create_test_table(&svc);
+
+    svc.update_table(&make_request(
+        "UpdateTable",
+        json!({
+            "TableName": "test-table",
+            "VectorIndexUpdates": [{ "Create": {
+                "IndexName": "added",
+                "VectorAttribute": { "AttributeName": "vec" },
+                "Dimensions": 3,
+                "DistanceFunction": "EUCLIDEAN",
+                "Projection": { "ProjectionType": "ALL" },
+            }}],
+        }),
+    ))
+    .unwrap();
+    let resp = svc
+        .describe_table(&make_request(
+            "DescribeTable",
+            json!({ "TableName": "test-table" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert_eq!(body["Table"]["VectorIndexes"][0]["IndexName"], "added");
+    assert_eq!(
+        body["Table"]["VectorIndexes"][0]["DistanceFunction"],
+        "EUCLIDEAN"
+    );
+
+    svc.update_table(&make_request(
+        "UpdateTable",
+        json!({
+            "TableName": "test-table",
+            "VectorIndexUpdates": [{ "Delete": { "IndexName": "added" } }],
+        }),
+    ))
+    .unwrap();
+    let resp = svc
+        .describe_table(&make_request(
+            "DescribeTable",
+            json!({ "TableName": "test-table" }),
+        ))
+        .unwrap();
+    let body: Value = serde_json::from_slice(resp.body.expect_bytes()).unwrap();
+    assert!(body["Table"].get("VectorIndexes").is_none());
+}
+
+#[test]
+fn search_vectors_ranks_by_cosine_similarity() {
+    let svc = make_service();
+    create_vector_table(&svc, "COSINE");
+    // `near` points the same way as the query, `far` points away.
+    put_vector_item(&svc, "near", &[1.0, 0.0]);
+    put_vector_item(&svc, "diag", &[1.0, 1.0]);
+    put_vector_item(&svc, "far", &[-1.0, 0.0]);
+
+    let body = search(
+        &svc,
+        json!({
+            "TableName": "vec-table",
+            "IndexName": "embedding-index",
+            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "TopK": 2,
+        }),
+    );
+    let results = body["SearchResults"].as_array().unwrap();
+    assert_eq!(results.len(), 2, "TopK caps the result set");
+    assert_eq!(results[0]["Item"]["pk"]["S"], "near");
+    assert_eq!(results[1]["Item"]["pk"]["S"], "diag");
+    // An identical direction scores 1.0 under cosine.
+    assert!((results[0]["Score"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+    assert!(results[0]["Score"].as_f64().unwrap() > results[1]["Score"].as_f64().unwrap());
+}
+
+#[test]
+fn search_vectors_ranks_euclidean_nearest_first() {
+    let svc = make_service();
+    create_vector_table(&svc, "EUCLIDEAN");
+    put_vector_item(&svc, "close", &[0.0, 1.0]);
+    put_vector_item(&svc, "distant", &[10.0, 10.0]);
+
+    let body = search(
+        &svc,
+        json!({
+            "TableName": "vec-table",
+            "IndexName": "embedding-index",
+            "SearchVector": vec_attr(&[0.0, 0.0]),
+            "TopK": 5,
+        }),
+    );
+    let results = body["SearchResults"].as_array().unwrap();
+    // Euclidean is a distance: nearest first, and the score rises with it.
+    assert_eq!(results[0]["Item"]["pk"]["S"], "close");
+    assert!((results[0]["Score"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+    assert!(results[1]["Score"].as_f64().unwrap() > results[0]["Score"].as_f64().unwrap());
+}
+
+#[test]
+fn search_vectors_skips_items_without_a_usable_vector() {
+    let svc = make_service();
+    create_vector_table(&svc, "COSINE");
+    put_vector_item(&svc, "good", &[1.0, 0.0]);
+    // No embedding at all, and an embedding of the wrong width.
+    svc.put_item(&make_request(
+        "PutItem",
+        json!({ "TableName": "vec-table", "Item": { "pk": { "S": "no-vector" } } }),
+    ))
+    .unwrap();
+    put_vector_item(&svc, "wrong-width", &[1.0, 0.0, 0.0]);
+
+    let body = search(
+        &svc,
+        json!({
+            "TableName": "vec-table",
+            "IndexName": "embedding-index",
+            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "TopK": 10,
+        }),
+    );
+    let results = body["SearchResults"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["Item"]["pk"]["S"], "good");
+}
+
+#[test]
+fn search_vectors_honors_projection_and_consumed_capacity() {
+    let svc = make_service();
+    create_vector_table(&svc, "COSINE");
+    put_vector_item(&svc, "only", &[1.0, 0.0]);
+
+    let body = search(
+        &svc,
+        json!({
+            "TableName": "vec-table",
+            "IndexName": "embedding-index",
+            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "TopK": 1,
+            "ProjectionExpression": "pk",
+            "ReturnConsumedCapacity": "TOTAL",
+        }),
+    );
+    let item = &body["SearchResults"][0]["Item"];
+    assert_eq!(item["pk"]["S"], "only");
+    assert!(
+        item.get("embedding").is_none(),
+        "projection drops embedding"
+    );
+    assert!(
+        body["ConsumedCapacity"]["VectorSearchRequestBytes"]
+            .as_f64()
+            .unwrap()
+            > 0.0
+    );
+}
+
+#[test]
+fn search_vectors_validates_index_and_vector() {
+    let svc = make_service();
+    create_vector_table(&svc, "COSINE");
+
+    let err = err_of(svc.search_vectors(&make_request(
+        "SearchVectors",
+        json!({
+            "TableName": "vec-table",
+            "IndexName": "no-such-index",
+            "SearchVector": vec_attr(&[1.0, 0.0]),
+            "TopK": 1,
+        }),
+    )));
+    assert_eq!(err.code(), "ResourceNotFoundException");
+
+    // A query vector of the wrong width cannot be compared at all.
+    let err = err_of(svc.search_vectors(&make_request(
+        "SearchVectors",
+        json!({
+            "TableName": "vec-table",
+            "IndexName": "embedding-index",
+            "SearchVector": vec_attr(&[1.0, 0.0, 0.0]),
+            "TopK": 1,
+        }),
+    )));
+    assert_eq!(err.code(), "ValidationException");
+
+    // TopK is required and at least 1.
+    for top_k in [json!(0), Value::Null] {
+        let mut body = json!({
+            "TableName": "vec-table",
+            "IndexName": "embedding-index",
+            "SearchVector": vec_attr(&[1.0, 0.0]),
+        });
+        if !top_k.is_null() {
+            body["TopK"] = top_k;
+        }
+        let err = err_of(svc.search_vectors(&make_request("SearchVectors", body)));
+        assert_eq!(err.code(), "ValidationException");
+    }
+}
+
+#[test]
+fn create_table_rejects_a_malformed_vector_index() {
+    let svc = make_service();
+    for bad in [
+        json!({ "VectorAttribute": { "AttributeName": "v" }, "Dimensions": 2 }),
+        json!({ "IndexName": "i", "Dimensions": 2 }),
+        json!({ "IndexName": "i", "VectorAttribute": { "AttributeName": "v" }, "Dimensions": 0 }),
+        json!({ "IndexName": "i", "VectorAttribute": { "AttributeName": "v" }, "Dimensions": 2,
+                "DistanceFunction": "MANHATTAN" }),
+    ] {
+        let err = err_of(svc.create_table(&make_request(
+            "CreateTable",
+            json!({
+                "TableName": "bad-vec",
+                "KeySchema": [{ "AttributeName": "pk", "KeyType": "HASH" }],
+                "AttributeDefinitions": [{ "AttributeName": "pk", "AttributeType": "S" }],
+                "BillingMode": "PAY_PER_REQUEST",
+                "VectorIndexes": [bad.clone()],
+            }),
+        )));
+        assert_eq!(err.code(), "ValidationException", "{bad}");
+    }
+}

--- a/crates/fakecloud-dynamodb/src/service/vectors.rs
+++ b/crates/fakecloud-dynamodb/src/service/vectors.rs
@@ -8,14 +8,26 @@
 
 use super::*;
 
-/// Read a DynamoDB `L` of `N` values into a numeric vector. Returns `None`
-/// when the attribute is absent or is not a list of numbers, which is how an
-/// item without a usable vector is skipped rather than scored as zeroes.
-fn as_vector(value: Option<&AttributeValue>) -> Option<Vec<f64>> {
-    let list = value?.get("L")?.as_array()?;
+/// Read a list of DynamoDB `N` values into a numeric vector.
+fn numbers_from(list: &[AttributeValue]) -> Option<Vec<f64>> {
     list.iter()
         .map(|e| e.get("N")?.as_str()?.parse::<f64>().ok())
         .collect()
+}
+
+/// Read an item's vector attribute, which is a DynamoDB `L` of `N` values.
+/// Returns `None` when the attribute is absent or is not a list of numbers,
+/// which is how an item without a usable vector is skipped rather than scored
+/// as zeroes.
+fn item_vector(value: Option<&AttributeValue>) -> Option<Vec<f64>> {
+    numbers_from(value?.get("L")?.as_array()?)
+}
+
+/// Read the request's `SearchVector`. It is modeled as `SearchVectorList` —
+/// a bare list of `AttributeValue` — not an `L`-wrapped attribute, so it is
+/// parsed differently from the item attribute it is compared against.
+fn search_vector(value: Option<&Value>) -> Option<Vec<f64>> {
+    numbers_from(value?.as_array()?)
 }
 
 fn dot(a: &[f64], b: &[f64]) -> f64 {
@@ -52,7 +64,7 @@ impl DynamoDbService {
         let table_name = require_str(&body, "TableName")?;
         let index_name = require_str(&body, "IndexName")?;
 
-        let query_vector = as_vector(body.get("SearchVector")).ok_or_else(|| {
+        let query_vector = search_vector(body.get("SearchVector")).ok_or_else(|| {
             AwsServiceError::aws_error(
                 StatusCode::BAD_REQUEST,
                 "ValidationException",
@@ -114,7 +126,7 @@ impl DynamoDbService {
             .items
             .iter()
             .filter_map(|item| {
-                let candidate = as_vector(item.get(&index.vector_attribute))?;
+                let candidate = item_vector(item.get(&index.vector_attribute))?;
                 // Items whose vector does not match the index width are not
                 // indexed, so they cannot be returned.
                 if candidate.len() as i64 != index.dimensions {

--- a/crates/fakecloud-dynamodb/src/service/vectors.rs
+++ b/crates/fakecloud-dynamodb/src/service/vectors.rs
@@ -1,0 +1,155 @@
+//! Vector similarity search (`SearchVectors`).
+//!
+//! A vector index names one list-valued attribute on the table. `SearchVectors`
+//! reads that attribute off every item, scores it against the query vector with
+//! the index's distance function, and returns the top K. The scoring is real —
+//! cosine, dot-product and Euclidean over the stored numbers — so a search
+//! actually ranks the items the caller wrote.
+
+use super::*;
+
+/// Read a DynamoDB `L` of `N` values into a numeric vector. Returns `None`
+/// when the attribute is absent or is not a list of numbers, which is how an
+/// item without a usable vector is skipped rather than scored as zeroes.
+fn as_vector(value: Option<&AttributeValue>) -> Option<Vec<f64>> {
+    let list = value?.get("L")?.as_array()?;
+    list.iter()
+        .map(|e| e.get("N")?.as_str()?.parse::<f64>().ok())
+        .collect()
+}
+
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Score `candidate` against `query` under `function`. Cosine and dot-product
+/// are similarities (higher is closer); Euclidean is a distance (lower is
+/// closer), which the caller accounts for when ordering.
+fn score(function: &str, query: &[f64], candidate: &[f64]) -> f64 {
+    match function {
+        "DOT_PRODUCT" => dot(query, candidate),
+        "EUCLIDEAN" => query
+            .iter()
+            .zip(candidate)
+            .map(|(x, y)| (x - y) * (x - y))
+            .sum::<f64>()
+            .sqrt(),
+        // COSINE, and the default.
+        _ => {
+            let denom = dot(query, query).sqrt() * dot(candidate, candidate).sqrt();
+            if denom == 0.0 {
+                0.0
+            } else {
+                dot(query, candidate) / denom
+            }
+        }
+    }
+}
+
+impl DynamoDbService {
+    pub(super) fn search_vectors(&self, req: &AwsRequest) -> Result<AwsResponse, AwsServiceError> {
+        let body = Self::parse_body(req)?;
+        let table_name = require_str(&body, "TableName")?;
+        let index_name = require_str(&body, "IndexName")?;
+
+        let query_vector = as_vector(body.get("SearchVector")).ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "SearchVector must be a list of numbers",
+            )
+        })?;
+        if query_vector.is_empty() {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "SearchVector must not be empty",
+            ));
+        }
+        let top_k = body["TopK"].as_i64().ok_or_else(|| {
+            AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "TopK is required",
+            )
+        })?;
+        if top_k < 1 {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                "TopK must be at least 1",
+            ));
+        }
+
+        let accounts = self.state.read();
+        let empty_ddb = crate::state::DynamoDbState::new(&req.account_id, &req.region);
+        let state = accounts.get(&req.account_id).unwrap_or(&empty_ddb);
+        let table = get_table(&state.tables, table_name)?;
+        let index = table
+            .vector_indexes
+            .iter()
+            .find(|i| i.index_name == index_name)
+            .ok_or_else(|| {
+                AwsServiceError::aws_error(
+                    StatusCode::BAD_REQUEST,
+                    "ResourceNotFoundException",
+                    format!("Vector index not found: {index_name}"),
+                )
+            })?;
+        // A query vector of the wrong width cannot be compared with the
+        // indexed vectors at all.
+        if query_vector.len() as i64 != index.dimensions {
+            return Err(AwsServiceError::aws_error(
+                StatusCode::BAD_REQUEST,
+                "ValidationException",
+                format!(
+                    "SearchVector has {} dimensions but index {index_name} expects {}",
+                    query_vector.len(),
+                    index.dimensions
+                ),
+            ));
+        }
+
+        let mut scored: Vec<(f64, &HashMap<String, AttributeValue>)> = table
+            .items
+            .iter()
+            .filter_map(|item| {
+                let candidate = as_vector(item.get(&index.vector_attribute))?;
+                // Items whose vector does not match the index width are not
+                // indexed, so they cannot be returned.
+                if candidate.len() as i64 != index.dimensions {
+                    return None;
+                }
+                Some((
+                    score(&index.distance_function, &query_vector, &candidate),
+                    item,
+                ))
+            })
+            .collect();
+
+        // Euclidean ranks ascending (nearest first); the similarity functions
+        // rank descending.
+        if index.distance_function == "EUCLIDEAN" {
+            scored.sort_by(|a, b| a.0.total_cmp(&b.0));
+        } else {
+            scored.sort_by(|a, b| b.0.total_cmp(&a.0));
+        }
+
+        let results: Vec<Value> = scored
+            .into_iter()
+            .take(top_k as usize)
+            .map(|(s, item)| json!({ "Item": project_item(item, &body), "Score": s }))
+            .collect();
+
+        let mut out = json!({ "SearchResults": results });
+        if return_consumed_mode(&body) != "NONE" {
+            // The read cost is expressed in bytes for vector operations.
+            let bytes = query_vector.len() as f64 * 8.0;
+            out["ConsumedCapacity"] = json!({
+                "VectorSearchRequestBytes": bytes,
+                "VectorWriteRequestBytes": 0.0,
+            });
+        }
+        Self::ok_json(out)
+    }
+}

--- a/crates/fakecloud-dynamodb/src/state.rs
+++ b/crates/fakecloud-dynamodb/src/state.rs
@@ -97,6 +97,22 @@ pub struct LocalSecondaryIndex {
     pub projection: Projection,
 }
 
+/// A vector index: a similarity-search index over one list-valued attribute.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VectorIndex {
+    pub index_name: String,
+    pub index_arn: String,
+    /// The attribute holding each item's vector.
+    pub vector_attribute: String,
+    pub dimensions: i64,
+    /// `VectorDistanceFunction` (COSINE | DOT_PRODUCT | EUCLIDEAN).
+    pub distance_function: String,
+    /// `SearchSchema` entries as `(AttributeName, SearchSchemaElementType)`.
+    pub search_schema: Vec<(String, String)>,
+    pub projection: Projection,
+    pub status: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Projection {
     pub projection_type: String, // ALL, KEYS_ONLY, INCLUDE
@@ -156,6 +172,9 @@ pub struct DynamoTable {
     /// CreateTable and changed via UpdateTable.
     #[serde(default = "default_table_class")]
     pub table_class: String,
+    /// Vector indexes for similarity search, keyed by index name.
+    #[serde(default)]
+    pub vector_indexes: Vec<VectorIndex>,
 }
 
 pub(crate) fn default_table_class() -> String {
@@ -633,6 +652,7 @@ mod tests {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: default_table_class(),
+            vector_indexes: Vec::new(),
         }
     }
 

--- a/crates/fakecloud-dynamodb/src/streams.rs
+++ b/crates/fakecloud-dynamodb/src/streams.rs
@@ -249,6 +249,7 @@ mod tests {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         }
     }
 

--- a/crates/fakecloud-dynamodb/src/streams_dataplane.rs
+++ b/crates/fakecloud-dynamodb/src/streams_dataplane.rs
@@ -446,6 +446,7 @@ mod tests {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         };
         let rec = StreamRecord {
             event_id: "e1".into(),

--- a/crates/fakecloud-dynamodb/src/ttl.rs
+++ b/crates/fakecloud-dynamodb/src/ttl.rs
@@ -235,6 +235,7 @@ mod tests {
             deletion_protection_enabled: false,
             on_demand_throughput: None,
             table_class: "STANDARD".to_string(),
+            vector_indexes: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

`SearchVectors` was modeled but unimplemented (49 variants), and `VectorIndexes` / `VectorIndexUpdates` were **accepted and discarded** - CreateTable returned 200 for a table whose index was never stored, and DescribeTable never mentioned it. Classic write-read loss, flagged in the earlier model-refresh review.

A vector index names one list-valued attribute plus its dimensionality and distance function. `SearchVectors` reads that attribute off every item, scores it against the query vector, and returns the top K with their scores.

### The scoring is real

| Function | Ranking |
|---|---|
| `COSINE` | similarity, descending - an identical direction scores 1.0 |
| `DOT_PRODUCT` | similarity, descending |
| `EUCLIDEAN` | distance, **ascending** - nearest first |

Items with no vector, or a vector of the wrong width, are not indexed, so they are skipped rather than scored as zeroes. `ProjectionExpression` applies to each returned item, and `ReturnConsumedCapacity` reports `VectorCapacity`.

### Table lifecycle

CreateTable stores declared indexes; UpdateTable's `VectorIndexUpdates` honors Create and Delete; DescribeTable returns `VectorIndexes`, omitted entirely when the table has none rather than an empty list. Malformed indexes are rejected up front - missing `IndexName` or `VectorAttribute.AttributeName`, non-positive `Dimensions`, off-enum `DistanceFunction`.

## Tests

Eight new tests: create/describe round-trip (and the omit-when-empty case), UpdateTable create + delete, cosine ranking with a TopK cap, Euclidean nearest-first ordering, skipping unusable vectors, projection + consumed capacity, index/vector/TopK validation, and four malformed-index shapes. Conformance: `dynamodb_vector_search` drives create -> put -> search over raw awsJson1.0.

`cargo test -p fakecloud-dynamodb` 426 passed; `cargo build --workspace`, full workspace test suite, and `clippy --workspace --all-targets` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SearchVectors` support and persists `VectorIndexes` across the DynamoDB table lifecycle. Previously, `CreateTable` accepted indexes but discarded them, and `SearchVectors` was unimplemented.

- `CreateTable` and `UpdateTable` validate and store vector index definitions; `DescribeTable` omits `VectorIndexes` when none exist.
- `SearchVector` accepts a bare list of numeric `AttributeValue`s, while stored vectors remain `L` attributes containing `N` values.
- Supports cosine and dot-product similarity in descending order and Euclidean distance in ascending order, capped by `TopK`.
- Skips items without a usable vector or with the wrong dimensionality.
- Applies `ProjectionExpression` to each result and reports vector request bytes when consumed capacity is requested.
- Rejects missing names, non-positive dimensions, and invalid distance functions.

<sup>Written for commit a621f4a3a27af3a810459c6a5f0e74fbec1f1dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/faiscadev/fakecloud/pull/2500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

